### PR TITLE
ft: implement replication queue populator

### DIFF
--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -36,7 +36,9 @@ const joiSchema = {
                 bucketd: hostPortJoi.keys({
                     raftSession: joi.number().required(),
                 }),
-                dmd: hostPortJoi,
+                dmd: hostPortJoi.keys({
+                    logName: joi.string().default('s3-recordlog'),
+                }),
             },
             destination: {
                 s3: hostPortJoi.required(),

--- a/conf/config.json
+++ b/conf/config.json
@@ -49,7 +49,7 @@
             "queuePopulator": {
                 "cronRule": "*/5 * * * * *",
                 "batchMaxRead": 10000,
-                "zookeeperNamespace": "/backbeat/replication"
+                "zookeeperNamespace": "/backbeat/replication-populator"
             },
             "queueProcessor": {
             }

--- a/extensions/replication/constants.js
+++ b/extensions/replication/constants.js
@@ -1,0 +1,7 @@
+'use strict'; // eslint-disable-line
+
+const constants = {
+    zookeeperReplicationNamespace: '/backbeat/replication',
+};
+
+module.exports = constants;

--- a/extensions/replication/queuePopulator/QueuePopulator.js
+++ b/extensions/replication/queuePopulator/QueuePopulator.js
@@ -1,0 +1,452 @@
+const async = require('async');
+const zookeeper = require('node-zookeeper-client');
+
+const Logger = require('werelogs').Logger;
+
+const arsenal = require('arsenal');
+const errors = require('arsenal').errors;
+const BucketClient = require('bucketclient').RESTClient;
+const { isMasterKey } = require('arsenal/lib/versioning/Version');
+const MetadataFileClient = arsenal.storage.metadata.MetadataFileClient;
+const LogConsumer = arsenal.storage.metadata.LogConsumer;
+
+const BackbeatProducer = require('../../../lib/BackbeatProducer');
+
+class QueuePopulator {
+    /**
+     * Create a queue populator object to activate Cross-Region
+     * Replication from a source S3 server to a kafka topic dedicated
+     * to store replication entries.
+     *
+     * @constructor
+     * @param {Object} zkConfig - zookeeper configuration object
+     * @param {String} zkConfig.host - zookeeper host
+     * @param {Number} zkConfig.port - zookeeper port
+     * @param {Object} repConfig - replication configuration object
+     * @param {String} repConfig.topic - replication topic name
+     * @param {Object} repConfig.source - source configuration
+     * @param {String} repConfig.source.logSource - type of source
+     *   log: "bucketd" (raft log) or "dmd" (bucketfile)
+     * @param {Object} [repConfig.source.bucketd] - bucketd source
+     *   configuration (mandatory if logSource is "bucket")
+     * @param {Object} [repConfig.source.dmd] - dmd source
+     *   configuration (mandatory if logSource is "dmd")
+     * @param {Logger} logConfig - logging configuration object
+     * @param {String} logConfig.logLevel - logging level
+     * @param {Logger} logConfig.dumpLevel - dump level
+     */
+    constructor(zkConfig, repConfig, logConfig) {
+        this.zkConfig = zkConfig;
+        this.repConfig = repConfig;
+        this.logConfig = logConfig;
+
+        this.logger = new Logger('Backbeat:Replication:QueuePopulator',
+                                 { level: logConfig.logLevel,
+                                   dump: logConfig.dumpLevel });
+        this.log = this.logger.newRequestLogger();
+    }
+
+    /**
+     * Open the queue populator
+     *
+     * @param {function} cb - callback function
+     * @return {undefined}
+     */
+    open(cb) {
+        const sourceConfig = this.repConfig.source;
+        let logIdentifier;
+
+        this.logState = {};
+        this.state = {};
+
+        switch (sourceConfig.logSource) {
+        case 'bucketd':
+            this.logState.raftSession = sourceConfig.bucketd.raftSession;
+            logIdentifier = `raft_${this.logState.raftSession}`;
+            break;
+        case 'dmd':
+            this.logState.logName = sourceConfig.dmd.logName;
+            logIdentifier = `bucketFile_${this.logState.logName}`;
+            break;
+        default:
+            this.log.error("bad 'logSource' config value: expect 'bucketd'" +
+                           `or 'dmd', got '${sourceConfig.logSource}'`);
+            return process.nextTick(() => cb(errors.InternalError));
+        }
+        this.pathToLastProcessedSeq =
+            `/logState/${logIdentifier}/lastProcessedSeq`;
+
+        return async.parallel([
+            done => this._setupLogSource(done),
+            done => this._setupProducer(done),
+            done => this._setupZookeeper(done),
+        ], err => {
+            if (err) {
+                this.log.error('Error starting up queuePopulator',
+                               { method: 'QueuePopulator.open',
+                                 error: err, errorStack: err.stack });
+                return cb(err);
+            }
+            return cb();
+        });
+    }
+
+    _setupLogSource(done) {
+        switch (this.repConfig.source.logSource) {
+        case 'bucketd':
+            return this._openRaftLog(done);
+        case 'dmd':
+            return this._openBucketFileLog(done);
+        default:
+            // not reached
+            return undefined;
+        }
+    }
+
+    _openRaftLog(done) {
+        const bucketdConfig = this.repConfig.source.bucketd;
+        this.log.info('initializing raft log handle',
+                      { method: 'QueuePopulator._openRaftLog',
+                        bucketdConfig });
+        const { host, port, raftSession } = bucketdConfig;
+        const bucketClient = new BucketClient(`${host}:${port}`);
+        this.logState.logConsumer = new LogConsumer({ bucketClient,
+                                                      raftSession,
+                                                      logger: this.log });
+        process.nextTick(() => done());
+    }
+
+    _openBucketFileLog(done) {
+        const dmdConfig = this.repConfig.source.dmd;
+        this.log.info('initializing bucketfile log handle',
+                      { method: 'QueuePopulator._openBucketFileLog',
+                        dmdConfig });
+        const mdClient = new MetadataFileClient({
+            host: dmdConfig.host,
+            port: dmdConfig.port,
+            log: this.logConfig,
+        });
+        const logConsumer = mdClient.openRecordLog({
+            logName: dmdConfig.logName,
+        }, err => {
+            if (err) {
+                return done(err);
+            }
+            this.logState.logConsumer = logConsumer;
+            return done();
+        });
+    }
+
+    _setupProducer(done) {
+        const producer = new BackbeatProducer({
+            zookeeper: this.zkConfig,
+            log: this.logConfig,
+            topic: this.repConfig.topic,
+        });
+        producer.once('error', done);
+        producer.once('ready', () => {
+            producer.removeAllListeners('error');
+            producer.on('error', err => {
+                this.log.error('error from backbeat producer',
+                               { error: err });
+            });
+            this.producer = producer;
+            done();
+        });
+    }
+
+    _setupZookeeper(done) {
+        const zkNamespace = this.repConfig.queuePopulator.zookeeperNamespace;
+        const zookeeperUrl =
+                  `${this.zkConfig.host}:${this.zkConfig.port}` +
+                  `${zkNamespace}`;
+        this.log.info('opening zookeeper connection for state ' +
+                      'management',
+                      { zookeeperUrl });
+        const zkClient = zookeeper.createClient(zookeeperUrl);
+        zkClient.connect();
+        this.zkClient = zkClient;
+        this._readLastProcessedSeq((err, seq) => {
+            if (err) {
+                return done(err);
+            }
+            this.lastProcessedSeq = seq;
+            return done();
+        });
+    }
+
+    _writeLastProcessedSeq(done) {
+        const zkClient = this.zkClient;
+        const pathToLastProcessedSeq = this.pathToLastProcessedSeq;
+        const lastProcessedSeq = this.lastProcessedSeq;
+        zkClient.setData(
+            pathToLastProcessedSeq,
+            new Buffer(lastProcessedSeq.toString()), -1,
+            err => {
+                if (err) {
+                    this.log.error(
+                        'error saving last processed sequence number',
+                        { method: 'QueuePopulator._writeLastProcessedSeq',
+                          zkPath: pathToLastProcessedSeq,
+                          lastProcessedSeq });
+                    return done(err);
+                }
+                this.log.debug(
+                    'saved last processed sequence number',
+                    { method: 'QueuePopulator._writeLastProcessedSeq',
+                      zkPath: pathToLastProcessedSeq,
+                      lastProcessedSeq });
+                return done();
+            });
+    }
+
+    _readLastProcessedSeq(done) {
+        const zkClient = this.zkClient;
+        const pathToLastProcessedSeq = this.pathToLastProcessedSeq;
+        this.zkClient.getData(pathToLastProcessedSeq, (err, data) => {
+            if (err) {
+                if (err.name !== 'NO_NODE') {
+                    this.log.error(
+                        'Could not fetch latest processed sequence number',
+                        { method: 'QueuePopulator._readLastProcessedSeq',
+                          error: err,
+                          errorStack: err.stack });
+                    return done(err);
+                }
+                return zkClient.mkdirp(pathToLastProcessedSeq, err => {
+                    if (err) {
+                        this.log.error(
+                            'Could not pre-create path in zookeeper',
+                            { method: 'QueuePopulator._readLastProcessedSeq',
+                              zkPath: pathToLastProcessedSeq,
+                              error: err,
+                              errorStack: err.stack });
+                        return done(err);
+                    }
+                    return done(null, 0);
+                });
+            }
+            if (data) {
+                const lastProcessedSeq = Number.parseInt(data, 10);
+                if (isNaN(lastProcessedSeq)) {
+                    this.log.error(
+                        'invalid latest processed sequence number',
+                        { method: 'QueuePopulator._readLastProcessedSeq',
+                          zkPath: pathToLastProcessedSeq,
+                          lastProcessedSeq: data.toString() });
+                    return done(null, 0);
+                }
+                this.log.debug(
+                    'fetched latest processed sequence number',
+                    { method: 'QueuePopulator._readLastProcessedSeq',
+                      zkPath: pathToLastProcessedSeq,
+                      lastProcessedSeq });
+                return done(null, lastProcessedSeq);
+            }
+            return done(null, 0);
+        });
+    }
+
+    _logEntryToQueueEntry(record, entry) {
+        if (entry.type === 'put' &&
+            entry.key !== undefined && entry.value !== undefined &&
+            ! isMasterKey(entry.key)) {
+            const value = JSON.parse(entry.value);
+            if (value.replicationInfo &&
+                value.replicationInfo.status === 'PENDING') {
+                this.log.trace('queueing entry', { entry });
+                const queueEntry = {
+                    type: entry.type,
+                    bucket: record.db,
+                    key: entry.key,
+                    value: entry.value,
+                };
+                return {
+                    key: entry.key,
+                    message: JSON.stringify(queueEntry),
+                };
+            }
+        }
+        return null;
+    }
+
+    /* eslint-disable no-param-reassign */
+
+    /**
+     * Process log entries, up to the maximum defined in params
+     *
+     * @param {Object} [params] - parameters object
+     * @param {Number} [params.maxRead] - max number of records to process
+     *   from the log. Records may contain multiple entries and all entries
+     *   are not queued, so the number of queued entries is not directly
+     *   related to this number.
+     * @param {function} cb - callback when done processing the
+     *   entries. Called with an error, or null and a statistics object as
+     *   second argument. On success, the statistics contain the following:
+     *     - readRecords {Number} - number of records read
+     *     - readEntries {Number} - number of entries read (records can
+     *       hold multiple entries)
+     *     - queuedEntries {Number} - number of new entries queued in kafka
+     *       topic
+     *     - lastProcessedSeq {Number} - last sequence number read and
+     *       processed from the log
+     *     - processedAll {Boolean} - true if the log has no more unread
+     *       records
+     * @return {undefined}
+     */
+    processLogEntries(params, cb) {
+        const batchState = {
+            logRes: null,
+            logStats: {
+                nbLogRecordsRead: 0,
+                nbLogEntriesRead: 0,
+            },
+            entriesToPublish: [],
+        };
+        async.waterfall([
+            next => this._processReadRecords(params, batchState, next),
+            next => this._processPrepareEntries(batchState, next),
+            next => this._processPublishEntries(batchState, next),
+            next => this._processSaveLastProcessedSeq(batchState, next),
+        ],
+            err => {
+                if (err) {
+                    return cb(err);
+                }
+                const processedAll = !params
+                          || !params.maxRead
+                          || (batchState.logStats.nbLogRecordsRead
+                              < params.maxRead);
+                return cb(null, {
+                    readRecords: batchState.logStats.nbLogRecordsRead,
+                    readEntries: batchState.logStats.nbLogEntriesRead,
+                    queuedEntries: batchState.entriesToPublish.length,
+                    lastProcessedSeq: this.lastProcessedSeq,
+                    processedAll,
+                });
+            });
+        return undefined;
+    }
+
+    _processReadRecords(params, batchState, done) {
+        const readOptions = {};
+        if (this.lastProcessedSeq !== undefined) {
+            readOptions.startSeq = this.lastProcessedSeq + 1;
+        }
+        if (params && params.maxRead !== undefined) {
+            readOptions.limit = params.maxRead;
+        }
+        this.log.debug('reading records', { readOptions });
+        this.logState.logConsumer.readRecords(readOptions, (err, res) => {
+            if (err) {
+                this.log.error(
+                    'error while reading log records',
+                    { method: 'QueuePopulator._processReadRecords',
+                      params, error: err, errorStack: err.stack });
+                return done(err);
+            }
+            this.log.debug(
+                'readRecords callback',
+                { method: 'QueuePopulator._processReadRecords',
+                  params, info: res.info });
+            batchState.logRes = res;
+            return done();
+        });
+    }
+
+    _processPrepareEntries(batchState, done) {
+        const { logRes, logStats } = batchState;
+
+        if (logRes.info.end === null) {
+            return done(null);
+        }
+        logRes.log.on('data', record => {
+            logStats.nbLogRecordsRead += 1;
+            record.entries.forEach(entry => {
+                logStats.nbLogEntriesRead += 1;
+                const queueEntry = this._logEntryToQueueEntry(record, entry);
+                if (queueEntry) {
+                    batchState.entriesToPublish.push(queueEntry);
+                }
+            });
+        });
+        logRes.log.on('error', err => {
+            this.log.error('error fetching entries from log',
+                           { method: 'QueuePopulator._processPrepareEntries',
+                             error: err });
+            return done(err);
+        });
+        logRes.log.on('end', () => {
+            this.log.debug('ending record stream');
+            return done();
+        });
+        return undefined;
+    }
+
+    _processPublishEntries(batchState, done) {
+        const { entriesToPublish, logRes } = batchState;
+
+        if (entriesToPublish.length === 0) {
+            if (logRes.info.end !== null) {
+                batchState.nextLastProcessedSeq = logRes.info.end;
+            }
+            return done();
+        }
+        return this.producer.send(entriesToPublish, err => {
+            if (err) {
+                this.log.error(
+                    'error publishing entries from log',
+                    { method: 'QueuePopulator._processPublishEntries',
+                      error: err, errorStack: err.stack });
+                return done(err);
+            }
+            batchState.nextLastProcessedSeq = logRes.info.end;
+            this.log.debug(
+                'entries published successfully',
+                { method: 'QueuePopulator._processPublishEntries',
+                  entryCount: entriesToPublish.length,
+                  lastProcessedSeq: batchState.nextLastProcessedSeq });
+            return done();
+        });
+    }
+
+    _processSaveLastProcessedSeq(batchState, done) {
+        if (batchState.nextLastProcessedSeq !== undefined &&
+            batchState.nextLastProcessedSeq !== this.lastProcessedSeq) {
+            this.lastProcessedSeq = batchState.nextLastProcessedSeq;
+            return this._writeLastProcessedSeq(done);
+        }
+        return process.nextTick(() => done());
+    }
+
+    /* eslint-enable no-param-reassign */
+
+    processAllLogEntries(params, done) {
+        const self = this;
+        const countersTotal = {
+            readRecords: 0,
+            readEntries: 0,
+            queuedEntries: 0,
+            lastProcessedSeq: this.lastProcessedSeq,
+        };
+        function cbProcess(err, counters) {
+            if (err) {
+                return done(err);
+            }
+            countersTotal.readRecords += counters.readRecords;
+            countersTotal.readEntries += counters.readEntries;
+            countersTotal.queuedEntries += counters.queuedEntries;
+            countersTotal.lastProcessedSeq = counters.lastProcessedSeq;
+            self.log.debug('process batch finished',
+                           { counters, countersTotal });
+            if (counters.processedAll) {
+                return done(null, countersTotal);
+            }
+            return self.processLogEntries(params, cbProcess);
+        }
+        this.processLogEntries(params, cbProcess);
+    }
+}
+
+
+module.exports = QueuePopulator;

--- a/extensions/replication/queuePopulator/task.js
+++ b/extensions/replication/queuePopulator/task.js
@@ -1,0 +1,64 @@
+const async = require('async');
+const schedule = require('node-schedule');
+
+const Logger = require('werelogs').Logger;
+
+const config = require('../../../conf/Config');
+const zkConfig = config.zookeeper;
+const repConfig = config.extensions.replication;
+const QueuePopulator = require('./QueuePopulator');
+
+const logger = new Logger('Backbeat:Replication:task',
+                          { level: config.log.logLevel,
+                            dump: config.log.dumpLevel });
+const log = logger.newRequestLogger();
+
+/* eslint-disable no-param-reassign */
+function queueBatch(queuePopulator, taskState) {
+    if (taskState.batchInProgress) {
+        log.warn('skipping replication batch: ' +
+                 'previous one still in progress');
+        return undefined;
+    }
+    log.debug('start queueing replication batch');
+    taskState.batchInProgress = true;
+    queuePopulator.processAllLogEntries(
+        { maxRead: repConfig.queuePopulator.batchMaxRead },
+        (err, counters) => {
+            if (err) {
+                log.error('an error occurred during replication',
+                          { error: err, errorStack: err.stack });
+            } else {
+                const logFunc = (counters.readRecords > 0 ?
+                                 log.info : log.debug)
+                          .bind(log);
+                logFunc('replication batch finished', { counters });
+            }
+            taskState.batchInProgress = false;
+        });
+    return undefined;
+}
+/* eslint-enable no-param-reassign */
+
+const queuePopulator = new QueuePopulator(zkConfig, repConfig, config.log);
+
+async.waterfall([
+    done => {
+        queuePopulator.open(done);
+    },
+    done => {
+        const taskState = {
+            batchInProgress: false,
+        };
+        schedule.scheduleJob(repConfig.queuePopulator.cronRule, () => {
+            queueBatch(queuePopulator, taskState);
+        });
+        done();
+    },
+], err => {
+    if (err) {
+        log.error('error during queue populator initialization',
+                  { error: err });
+        process.exit(1);
+    }
+});

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -18,7 +18,7 @@ class BackbeatConsumer extends EventEmitter {
     /**
     * constructor
     * @param {Object} config - config
-    * @param {string} topic - Kafka topic to subscribe to
+    * @param {string} config.topic - Kafka topic to subscribe to
     * @param {function} config.queueProcessor - function to invoke to process
     * an item in a queue
     * @param {string} config.groupId - consumer group id. Messages are

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -34,8 +34,8 @@ class BackbeatProducer extends EventEmitter {
     /**
     * constructor
     * @param {Object} config - config
-    * @param {string} topic - Kafka topic to write to
-    * @param {number} [partition] - partition in a topic to write to
+    * @param {string} config.topic - Kafka topic to write to
+    * @param {number} [config.partition] - partition in a topic to write to
     * @param {Object} [config.zookeeper] - zookeeper endpoint config
     * @param {string} config.zookeeper.host - zookeeper host
     * @param {number} config.zookeeper.port - zookeeper port

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --recursive tests/",
+    "queue_populator": "node extensions/replication/queuePopulator/task.js",
+    "test": "mocha --recursive tests/unit",
+    "ft_test": "mocha --recursive tests/functional",
+    "bh_test": "mocha --recursive tests/behavior",
     "lint": "eslint $(git ls-files '*.js')",
     "lint_md": "mdlint $(git ls-files '*.md')"
   },
@@ -21,15 +24,18 @@
   "dependencies": {
     "arsenal": "scality/Arsenal",
     "async": "^2.3.0",
+    "bucketclient": "scality/bucketclient",
     "eslint": "^2.4.0",
     "eslint-config-airbnb": "^6.0.0",
     "eslint-config-scality": "scality/Guidelines",
     "eslint-plugin-react": "^4.2.3",
     "joi": "^10.6",
     "kafka-node": "^1.6.0",
+    "node-schedule": "^1.2.0",
     "werelogs": "scality/werelogs"
   },
   "devDependencies": {
-    "mocha": "^3.3.0"
+    "mocha": "^3.3.0",
+    "aws-sdk": "2.28.0"
   }
 }

--- a/tests/behavior/extensions/replication/queuePopulator.js
+++ b/tests/behavior/extensions/replication/queuePopulator.js
@@ -1,0 +1,192 @@
+const assert = require('assert');
+const async = require('async');
+
+const AWS = require('aws-sdk');
+const S3 = AWS.S3;
+
+const QueuePopulator = require('../../../../extensions/replication' +
+                               '/queuePopulator/QueuePopulator');
+
+const testConfig = require('../../../config.json');
+const testBucket = 'queue-populator-test-bucket';
+
+const s3config = {
+    endpoint: `${testConfig.s3.transport}://` +
+        `${testConfig.s3.host}:${testConfig.s3.port}`,
+    s3ForcePathStyle: true,
+    credentials: new AWS.Credentials(testConfig.s3.accessKey,
+                                     testConfig.s3.secretKey),
+};
+
+describe('queuePopulator', () => {
+    let queuePopulator;
+    let s3;
+    let latestLastProcessedSeq;
+
+    before(done => {
+        s3 = new S3(s3config);
+        async.waterfall([
+            next => {
+                s3.createBucket({
+                    Bucket: testBucket,
+                }, next);
+            },
+            (data, next) => {
+                s3.putBucketVersioning(
+                    { Bucket: testBucket,
+                      VersioningConfiguration: {
+                          Status: 'Enabled',
+                      },
+                    }, next);
+            },
+            (data, next) => {
+                s3.putBucketReplication(
+                    { Bucket: testBucket,
+                      ReplicationConfiguration: {
+                          Role: 'arn:aws:iam::123456789012:role/backbeat',
+                          Rules: [{
+                              Destination: {
+                                  Bucket: 'arn:aws:s3:::dummy-dest-bucket',
+                                  StorageClass: 'STANDARD',
+                              },
+                              Prefix: '',
+                              Status: 'Enabled',
+                          }],
+                      },
+                    }, next);
+            },
+            (data, next) => {
+                queuePopulator = new QueuePopulator(testConfig.zookeeper,
+                                                    testConfig.replication,
+                                                    testConfig.log);
+                queuePopulator.open(next);
+            },
+            next => {
+                queuePopulator.processAllLogEntries({ maxRead: 10 }, next);
+            },
+            (counters, next) => {
+                // we need to save the current last processed sequence
+                // number because the storage backend may have an
+                // existing non-empty log
+                latestLastProcessedSeq = counters.lastProcessedSeq;
+                next();
+            },
+        ], err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+    after(done => {
+        async.waterfall([
+            next => {
+                next();
+            },
+        ], done);
+    });
+
+    it('processAllLogEntries with nothing to do', done => {
+        queuePopulator.processAllLogEntries(
+            { maxRead: 10 }, (err, counters) => {
+                // we need to fetch what is the current last processed
+                // sequence number because the storage backend may
+                // have a non-empty log already
+                latestLastProcessedSeq = counters.lastProcessedSeq;
+                assert.ifError(err);
+                assert.strictEqual(counters.queuedEntries, 0);
+                done();
+            });
+    });
+    it('processAllLogEntries with an object to replicate', done => {
+        async.waterfall([
+            next => {
+                s3.putObject({ Bucket: testBucket,
+                               Key: 'keyToReplicate',
+                               Body: 'howdy',
+                               Tagging: 'mytag=mytagvalue' }, next);
+            },
+            (data, next) => {
+                queuePopulator.processAllLogEntries({ maxRead: 10 }, next);
+            },
+            (counters, next) => {
+                // 2 reads expected: master key and and versioned key
+                // 1 queued: versioned key only
+                assert.deepStrictEqual(counters, {
+                    readRecords: 2,
+                    readEntries: 2,
+                    queuedEntries: 1,
+                    lastProcessedSeq: latestLastProcessedSeq + 2 });
+                latestLastProcessedSeq = counters.lastProcessedSeq;
+                next();
+            },
+        ], err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+    it('processAllLogEntries with an object deletion to replicate', done => {
+        async.waterfall([
+            next => {
+                s3.deleteObject({ Bucket: testBucket,
+                                  Key: 'keyToReplicate' }, next);
+            },
+            (data, next) => {
+                queuePopulator.processAllLogEntries({ maxRead: 10 }, next);
+            },
+            (counters, next) => {
+                // 2 reads expected: master key update + new delete marker
+                // 1 queued: versioned key (delete marker)
+                assert.deepStrictEqual(counters, {
+                    readRecords: 2,
+                    readEntries: 2,
+                    queuedEntries: 1,
+                    lastProcessedSeq: latestLastProcessedSeq + 2 });
+                latestLastProcessedSeq = counters.lastProcessedSeq;
+                next();
+            },
+        ], err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+    it('processAllLogEntries with 100 objects to replicate in 20 batches',
+    function test100objects(done) {
+        this.timeout(10000);
+        async.waterfall([
+            next => {
+                let nbDone = 0;
+                function cbPut(err) {
+                    assert.ifError(err);
+                    ++nbDone;
+                    if (nbDone === 100) {
+                        next();
+                    }
+                }
+                for (let i = 0; i < 100; ++i) {
+                    s3.putObject({
+                        Bucket: testBucket,
+                        Key: `keyToReplicate_${i}`,
+                        Body: 'howdy',
+                        Tagging: 'mytag=mytagvalue',
+                    }, cbPut);
+                }
+            },
+            next => {
+                queuePopulator.processAllLogEntries({ maxRead: 10 }, next);
+            },
+            (counters, next) => {
+                // 2 reads expected: master key and and versioned key
+                // 1 queued: versioned key only
+                assert.deepStrictEqual(counters, {
+                    readRecords: 200,
+                    readEntries: 200,
+                    queuedEntries: 100,
+                    lastProcessedSeq: latestLastProcessedSeq + 200 });
+                latestLastProcessedSeq = counters.lastProcessedSeq;
+                next();
+            },
+        ], err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+});

--- a/tests/config.json
+++ b/tests/config.json
@@ -1,0 +1,37 @@
+{
+    "zookeeper": {
+        "host": "127.0.0.1",
+        "port": 2181
+    },
+    "kafka": {
+        "host": "127.0.0.1",
+        "port": 9092
+    },
+    "s3": {
+        "host": "127.0.0.1",
+        "port": 8000,
+        "transport": "http",
+        "accessKey": "accessKey1",
+        "secretKey": "verySecretKey1"
+    },
+    "replication": {
+        "source": {
+            "logSource": "dmd",
+            "dmd": {
+                "host": "127.0.0.1",
+                "port": 9990
+            }
+        },
+        "topic": "backbeat-test-replication",
+        "groupId": "backbeat-test-replication-group",
+        "queuePopulator": {
+            "cronRule": "*/5 * * * * *",
+            "batchMaxRead": 10000,
+            "zookeeperNamespace": "/backbeat/test/replication-populator"
+        }
+    },
+    "log": {
+        "logLevel": "info",
+        "dumpLevel": "error"
+    }
+}

--- a/tests/functional/BackbeatConsumer.js
+++ b/tests/functional/BackbeatConsumer.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
-const BackbeatProducer = require('../lib/BackbeatProducer');
-const BackbeatConsumer = require('../lib/BackbeatConsumer');
+const BackbeatProducer = require('../../lib/BackbeatProducer');
+const BackbeatConsumer = require('../../lib/BackbeatConsumer');
 const zookeeper = { host: 'localhost', port: 2181 };
 const log = { logLevel: 'info', dumpLevel: 'error' };
 const topic = 'backbeat-consumer-spec';

--- a/tests/functional/BackbeatProducer.js
+++ b/tests/functional/BackbeatProducer.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const { errors } = require('arsenal');
-const BackbeatProducer = require('../lib/BackbeatProducer');
+const BackbeatProducer = require('../../lib/BackbeatProducer');
 const zookeeper = { host: 'localhost', port: 2181 };
 const log = { logLevel: 'info', dumpLevel: 'error' };
 const topic = 'backbeat-producer-spec';
@@ -11,6 +11,8 @@ const multipleMessages = [
     { key: 'qux', message: 'hi' },
 ];
 const oneMessage = [{ key: 'foo', message: 'hello world' }];
+
+
 [
     {
         type: 'partition mechanism',


### PR DESCRIPTION
 - use BackbeatProducer to queue entries
 - add basic functional tests for kafka queueing of a put and delete
 - organize replication code into its extensions/replication directory"
