### PR TITLE
ft: backbeat config support

### DIFF
--- a/conf/Config.js
+++ b/conf/Config.js
@@ -1,0 +1,64 @@
+'use strict'; // eslint-disable-line
+
+const fs = require('fs');
+const path = require('path');
+const joi = require('joi');
+
+const backbeatConfigJoi = require('./config.joi.js');
+
+class Config {
+    constructor() {
+        /*
+         * By default, the config file is "config.json" at the root.
+         * It can be overridden using the BACKBEAT_CONFIG_FILE environment var.
+         */
+        this._basePath = __dirname;
+        if (process.env.BACKBEAT_CONFIG_FILE !== undefined) {
+            this.configPath = process.env.BACKBEAT_CONFIG_FILE;
+        } else {
+            this.configPath = path.join(this._basePath, 'config.json');
+        }
+
+        let config;
+        try {
+            const data = fs.readFileSync(this.configPath,
+              { encoding: 'utf-8' });
+            config = JSON.parse(data);
+        } catch (err) {
+            throw new Error(`could not parse config file: ${err.message}`);
+        }
+
+        const parsedConfig = joi.attempt(config, backbeatConfigJoi,
+                                         'invalid backbeat config');
+
+        // config is validated, safe to assign directly to the config object
+        Object.assign(this, parsedConfig);
+
+        if (this.extensions !== undefined &&
+            this.extensions.replication !== undefined) {
+            // additional target certs checks
+            const { certFilePaths } = this.extensions.replication.destination;
+            const { key, cert, ca } = certFilePaths;
+
+            const makePath = value => (value.startsWith('/') ?
+                                       value : `${this._basePath}/${value}`);
+            const keypath = makePath(key);
+            const certpath = makePath(cert);
+            let capath = undefined;
+            fs.accessSync(keypath, fs.F_OK | fs.R_OK);
+            fs.accessSync(certpath, fs.F_OK | fs.R_OK);
+            if (ca) {
+                capath = makePath(ca);
+                fs.accessSync(capath, fs.F_OK | fs.R_OK);
+            }
+
+            this.extensions.replication.destination.https = {
+                cert: fs.readFileSync(certpath, 'ascii'),
+                key: fs.readFileSync(keypath, 'ascii'),
+                ca: ca ? fs.readFileSync(capath, 'ascii') : undefined,
+            };
+        }
+    }
+}
+
+module.exports = new Config();

--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -1,0 +1,63 @@
+'use strict'; // eslint-disable-line
+
+const joi = require('joi');
+
+const hostPortJoi = joi.object({
+    host: joi.string().required(),
+    port: joi.number().greater(0).required(),
+});
+
+const joiSchema = {
+    zookeeper: hostPortJoi.default({
+        host: '127.0.0.1',
+        port: 2181,
+    }),
+    kafka: hostPortJoi.default({
+        host: '127.0.0.1',
+        port: 9092,
+    }),
+    log: joi.object({
+        logLevel: joi.alternatives()
+            .try('error', 'warn', 'info', 'debug', 'trace'),
+        dumpLevel: joi.alternatives()
+            .try('error', 'warn', 'info', 'debug', 'trace'),
+    })
+        .default({
+            logLevel: 'info',
+            dumpLevel: 'error',
+        }),
+    extensions: {
+        replication: {
+            source: {
+                s3: hostPortJoi.required(),
+                vault: hostPortJoi.required(),
+                logSource: joi.alternatives()
+                    .try('bucketd', 'dmd').required(),
+                bucketd: hostPortJoi.keys({
+                    raftSession: joi.number().required(),
+                }),
+                dmd: hostPortJoi,
+            },
+            destination: {
+                s3: hostPortJoi.required(),
+                vault: hostPortJoi.required(),
+                certFilePaths: joi.object({
+                    key: joi.string().required(),
+                    cert: joi.string().required(),
+                    ca: joi.string().empty(''),
+                }).required(),
+            },
+            topic: joi.string().required(),
+            groupId: joi.string().required(),
+            queuePopulator: {
+                cronRule: joi.string().required(),
+                batchMaxRead: joi.number().default(10000),
+                zookeeperNamespace: joi.string().required(),
+            },
+            queueProcessor: {
+            },
+        },
+    },
+};
+
+module.exports = joiSchema;

--- a/conf/config.json
+++ b/conf/config.json
@@ -1,0 +1,62 @@
+{
+    "zookeeper": {
+        "host": "127.0.0.1",
+        "port": 2181
+    },
+    "kafka": {
+        "host": "127.0.0.1",
+        "port": 9092
+    },
+    "extensions": {
+        "replication": {
+            "source": {
+                "s3": {
+                    "host": "127.0.0.1",
+                    "port": 8000
+                },
+                "vault": {
+                    "host": "127.0.0.1",
+                    "port": 8500
+                },
+                "logSource": "bucketd",
+                "bucketd": {
+                    "host": "127.0.0.1",
+                    "port": 9000,
+                    "raftSession": 1
+                },
+                "dmd": {
+                    "host": "127.0.0.1",
+                    "port": 9990
+                }
+            },
+            "destination": {
+                "s3": {
+                    "host": "127.0.0.2",
+                    "port": 9000
+                },
+                "vault": {
+                    "host": "127.0.0.2",
+                    "port": 9500
+                },
+                "certFilePaths": {
+                    "key": "ssl/key.pem",
+                    "cert": "ssl/cert.crt",
+                    "ca": "ssl/ca.crt"
+                }
+            },
+            "topic": "backbeat-replication",
+            "groupId": "backbeat-replication-group",
+            "queuePopulator": {
+                "cronRule": "*/5 * * * * *",
+                "batchMaxRead": 10000,
+                "zookeeperNamespace": "/backbeat/replication"
+            },
+            "queueProcessor": {
+            }
+        }
+    },
+    "log": {
+        "logLevel": "info",
+        "dumpLevel": "error"
+    }
+}

--- a/conf/ssl/ca.crt
+++ b/conf/ssl/ca.crt
@@ -1,0 +1,1 @@
+Replace me with a proper CA certificate file

--- a/conf/ssl/cert.crt
+++ b/conf/ssl/cert.crt
@@ -1,0 +1,1 @@
+Replace me with a proper certificate file

--- a/conf/ssl/key.pem
+++ b/conf/ssl/key.pem
@@ -1,0 +1,1 @@
+Replace me with a proper private key file

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint-config-airbnb": "^6.0.0",
     "eslint-config-scality": "scality/Guidelines",
     "eslint-plugin-react": "^4.2.3",
+    "joi": "^10.6",
     "kafka-node": "^1.6.0",
     "werelogs": "scality/werelogs"
   },

--- a/tests/unit/conf/Config.js
+++ b/tests/unit/conf/Config.js
@@ -1,0 +1,10 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+
+describe('backbeat config parsing and validation', () => {
+    it('should parse correctly the default config', () => {
+        const config = require('../../../conf/Config');
+        assert.notStrictEqual(config, undefined);
+    });
+});


### PR DESCRIPTION
Uses joi to validate config

This will be used as a config base for both the queue populator and queue processor.
