### PR TITLE
Ft/s3 c 350 replication queue processor

### DIFF
--- a/conf/authdata.json
+++ b/conf/authdata.json
@@ -1,0 +1,17 @@
+{
+    "users": [{
+        "name": "bart",
+        "arn": "aws::iam:123456789012:root",
+        "keys": {
+            "access": "accessKey1",
+            "secret": "verySecretKey1"
+        }
+    }, {
+        "name": "backbeat",
+        "arn": "aws::iam:123456789012:user/backbeat",
+        "keys": {
+            "access": "accessKeyBackbeat",
+            "secret": "verySecretKeyBackbeat"
+        }
+    }]
+}

--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -4,6 +4,12 @@ const joi = require('joi');
 const { hostPortJoi, logJoi, zookeeperJoi } =
           require('../lib/config/configItems.joi.js');
 
+const authJoi = joi.object({
+    type: joi.alternatives().try('local', 'remote').required(),
+    user: joi.string(),
+    vault: hostPortJoi,
+});
+
 const joiSchema = {
     zookeeper: zookeeperJoi,
     kafka: hostPortJoi.default({
@@ -14,8 +20,11 @@ const joiSchema = {
     extensions: {
         replication: {
             source: {
-                s3: hostPortJoi.required(),
-                vault: hostPortJoi.required(),
+                s3: hostPortJoi.keys({
+                    transport: joi.alternatives().try('http', 'https')
+                        .default('https'),
+                }).required(),
+                auth: authJoi.required(),
                 logSource: joi.alternatives()
                     .try('bucketd', 'dmd').required(),
                 bucketd: hostPortJoi.keys({
@@ -26,8 +35,11 @@ const joiSchema = {
                 }),
             },
             destination: {
-                s3: hostPortJoi.required(),
-                vault: hostPortJoi.required(),
+                s3: hostPortJoi.keys({
+                    transport: joi.alternatives().try('http', 'https')
+                        .default('https'),
+                }).required(),
+                auth: authJoi.required(),
                 certFilePaths: joi.object({
                     key: joi.string().required(),
                     cert: joi.string().required(),

--- a/conf/config.json
+++ b/conf/config.json
@@ -13,13 +13,18 @@
             "source": {
                 "s3": {
                     "host": "127.0.0.1",
-                    "port": 8000
+                    "port": 8000,
+                    "transport": "https"
                 },
-                "vault": {
-                    "host": "127.0.0.1",
-                    "port": 8500
+                "auth": {
+                    "type": "local",
+                    "user": "bart",
+                    "vault": {
+                        "host": "127.0.0.1",
+                        "port": 8500
+                    }
                 },
-                "logSource": "bucketd",
+                "logSource": "dmd",
                 "bucketd": {
                     "host": "127.0.0.1",
                     "port": 9000,
@@ -33,11 +38,16 @@
             "destination": {
                 "s3": {
                     "host": "127.0.0.2",
-                    "port": 9000
+                    "port": 9000,
+                    "transport": "https"
                 },
-                "vault": {
-                    "host": "127.0.0.2",
-                    "port": 9500
+                "auth": {
+                    "type": "local",
+                    "user": "backbeat",
+                    "vault": {
+                        "host": "127.0.0.2",
+                        "port": 9500
+                    }
                 },
                 "certFilePaths": {
                     "key": "ssl/key.pem",

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -17,7 +17,8 @@ const QueueEntry = require('../utils/QueueEntry');
 
 class QueueProcessor {
 
-    constructor(sourceConfig, destConfig, repConfig, logConfig) {
+    constructor(zkConfig, sourceConfig, destConfig, repConfig, logConfig) {
+        this.zkConfig = zkConfig;
         this.sourceConfig = sourceConfig;
         this.destConfig = destConfig;
         this.repConfig = repConfig;
@@ -235,12 +236,13 @@ class QueueProcessor {
 
     start() {
         const consumer = new BackbeatConsumer({
+            zookeeper: this.zkConfig,
+            log: this.logConfig,
             topic: this.repConfig.topic,
             groupId: this.repConfig.groupId,
             concurrency: 1, // replication has to process entries in
                             // order, so one at a time
             queueProcessor: this._processEntry.bind(this),
-            log: this.logConfig,
         });
         consumer.on('error', () => {});
         consumer.subscribe();

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -1,0 +1,253 @@
+'use strict'; // eslint-disable-line
+
+const async = require('async');
+const assert = require('assert');
+const AWS = require('aws-sdk');
+
+const Logger = require('werelogs').Logger;
+
+const errors = require('arsenal').errors;
+const jsutil = require('arsenal').jsutil;
+
+const authdata = require('../../../conf/authdata.json');
+
+const BackbeatConsumer = require('../../../lib/BackbeatConsumer');
+const BackbeatClient = require('../../../lib/clients/BackbeatClient');
+const QueueEntry = require('../utils/QueueEntry');
+
+class QueueProcessor {
+
+    constructor(sourceConfig, destConfig, repConfig, logConfig) {
+        this.sourceConfig = sourceConfig;
+        this.destConfig = destConfig;
+        this.repConfig = repConfig;
+        this.logConfig = logConfig;
+
+        this.logger = new Logger('Backbeat:Replication:QueueProcessor',
+                                 { level: logConfig.logLevel,
+                                   dump: logConfig.dumpLevel });
+        this.log = this.logger.newRequestLogger();
+
+        const s3sourceCredProvider =
+                  this._setupCredentialProvider(sourceConfig.auth);
+        const s3destCredProvider =
+                  this._setupCredentialProvider(destConfig.auth);
+
+        this.S3source = new AWS.S3({
+            endpoint: `${sourceConfig.s3.transport}://` +
+                `${sourceConfig.s3.host}:${sourceConfig.s3.port}`,
+            credentialProvider: s3sourceCredProvider,
+            sslEnabled: true,
+            s3ForcePathStyle: true,
+            signatureVersion: 'v4',
+        });
+        this.backbeatSource = new BackbeatClient({
+            endpoint: `${sourceConfig.s3.transport}://` +
+                `${sourceConfig.s3.host}:${sourceConfig.s3.port}`,
+            credentialProvider: s3sourceCredProvider,
+            sslEnabled: true,
+        });
+
+        this.backbeatDest = new BackbeatClient({
+            endpoint: `${destConfig.s3.transport}://` +
+                `${destConfig.s3.host}:${destConfig.s3.port}`,
+            credentialProvider: s3destCredProvider,
+            sslEnabled: true,
+        });
+    }
+
+    _setupCredentialProvider(authConfig) {
+        if (authConfig.type === 'remote') {
+            throw Error('Vault authentication not yet implemented');
+        } else {
+            assert.strictEqual(authConfig.type, 'local');
+            const userInfo = authdata.users.find(
+                user => user.name === authConfig.user);
+            if (userInfo === undefined) {
+                throw Error(`No such user registered: ${authConfig.user}`);
+            }
+            return new AWS.CredentialProviderChain([
+                new AWS.Credentials(userInfo.keys.access,
+                                    userInfo.keys.secret),
+            ]);
+        }
+    }
+
+    _getBucketReplicationRole(entry, cb) {
+        this.log.debug('getting bucket replication',
+                       { entry: entry.getLogInfo() });
+        this.S3source.getBucketReplication(
+            { Bucket: entry.getBucket() }, (err, data) => {
+                if (err) {
+                    this.log.error('error response getting replication ' +
+                                   'configuration from S3',
+                                   { entry: entry.getLogInfo(),
+                                     origin: this.sourceConfig.s3,
+                                     error: err,
+                                     httpStatus: err.statusCode });
+                    return cb(err);
+                }
+                return cb(null, data.ReplicationConfiguration.Role);
+            });
+    }
+
+    _getData(entry, cb) {
+        this.log.debug('getting data', { entry: entry.getLogInfo() });
+        const req = this.S3source.getObject({
+            Bucket: entry.getBucket(),
+            Key: entry.getObjectKey(),
+            VersionId: entry.getEncodedVersionId() });
+        const incomingMsg = req.createReadStream();
+        req.on('error', err => {
+            this.log.error('error response getting data from S3',
+                           { entry: entry.getLogInfo(),
+                             origin: this.sourceConfig.s3,
+                             error: err, httpStatus: err.statusCode });
+            incomingMsg.emit('error', err);
+        });
+        return cb(null, incomingMsg);
+    }
+
+    _putData(entry, sourceStream, cb) {
+        this.log.debug('putting data', { entry: entry.getLogInfo() });
+        const cbOnce = jsutil.once(cb);
+        sourceStream.on('error', err => {
+            this.log.error('error from source S3 server',
+                           { entry: entry.getLogInfo(), error: err });
+            return cbOnce(err);
+        });
+        this.backbeatDest.putData({
+            Bucket: entry.getBucket(),
+            Key: entry.getObjectKey(),
+            ContentLength: entry.getContentLength(),
+            ContentMD5: entry.getContentMD5(),
+            Body: sourceStream,
+        }, (err, data) => {
+            if (err) {
+                this.log.error('error response from destination S3 server',
+                               { entry: entry.getLogInfo(),
+                                 origin: this.destConfig.s3,
+                                 error: err });
+                return cbOnce(err);
+            }
+            return cbOnce(null, data.Locations);
+        });
+    }
+
+    _putMetaData(where, entry, cb) {
+        this.log.debug('putting metadata',
+                       { where, entry: entry.getLogInfo(),
+                         replicationStatus: entry.getReplicationStatus() });
+        const cbOnce = jsutil.once(cb);
+        const target = where === 'source' ?
+                  this.backbeatSource : this.backbeatDest;
+        const mdBlob = entry.getMetadataBlob();
+        target.putMetadata({
+            Bucket: entry.getBucket(),
+            Key: entry.getObjectKey(),
+            ContentLength: Buffer.byteLength(mdBlob),
+            Body: mdBlob,
+        }, (err, data) => {
+            if (err) {
+                this.log.error('error response from S3',
+                               { entry: entry.getLogInfo(),
+                                 origin: this.destConfig.s3,
+                                 error: err });
+                return cbOnce(err);
+            }
+            return cbOnce(null, data);
+        });
+    }
+
+    _processEntry(kafkaEntry, done) {
+        const sourceEntry = QueueEntry.createFromKafkaEntry(kafkaEntry);
+        const destEntry = sourceEntry.toReplicaEntry();
+
+        if (sourceEntry.error) {
+            this.log.error('error processing source entry',
+                           { error: sourceEntry.error });
+            return process.nextTick(() => done(errors.InternalError));
+        }
+        this.log.debug('processing entry',
+                       { entry: sourceEntry.getLogInfo() });
+
+        const _doneProcessingEntry = err => {
+            if (err) {
+                this.log.error('an error occurred while processing entry',
+                               { entry: sourceEntry.getLogInfo() });
+                return done(err);
+            }
+            this.log.info('entry replicated successfully',
+                          { entry: sourceEntry.getLogInfo() });
+            return done(null);
+        };
+
+        const _writeReplicationStatus = err => {
+            if (err) {
+                this.log.warn('replication failed for object',
+                              { entry: sourceEntry.getLogInfo(),
+                                error: err });
+                this._putMetaData('source', sourceEntry.toFailedEntry(),
+                                  _doneProcessingEntry);
+                // TODO: queue entry back in kafka for later retry
+            } else {
+                this.log.debug('replication succeeded for object, updating ' +
+                               'source replication status to COMPLETED',
+                               { entry: sourceEntry.getLogInfo() });
+                this._putMetaData('source', sourceEntry.toCompletedEntry(),
+                                  _doneProcessingEntry);
+            }
+        };
+
+        if (sourceEntry.isDeleteMarker()) {
+            return async.waterfall([
+                next => {
+                    this._getBucketReplicationRole(sourceEntry, next);
+                },
+                // put metadata in target bucket
+                (role, next) => {
+                    // TODO check that bucket role matches role in metadata
+                    this._putMetaData('target', destEntry, next);
+                },
+            ], _writeReplicationStatus);
+        }
+        return async.waterfall([
+            // get data stream from source bucket
+            next => {
+                this._getBucketReplicationRole(sourceEntry, next);
+            },
+            (role, next) => {
+                // TODO check that bucket role matches role in metadata
+                this._getData(sourceEntry, next);
+            },
+            // put data in target bucket
+            (stream, next) => {
+                this._putData(destEntry, stream, next);
+            },
+            // update location, replication status and put metadata in
+            // target bucket
+            (locations, next) => {
+                destEntry.setLocations(locations);
+                this._putMetaData('target', destEntry, next);
+            },
+        ], _writeReplicationStatus);
+    }
+
+    start() {
+        const consumer = new BackbeatConsumer({
+            topic: this.repConfig.topic,
+            groupId: this.repConfig.groupId,
+            concurrency: 1, // replication has to process entries in
+                            // order, so one at a time
+            queueProcessor: this._processEntry.bind(this),
+            log: this.logConfig,
+        });
+        consumer.on('error', () => {});
+        consumer.subscribe();
+
+        this.log.info('queue processor is ready to consume ' +
+                      'replication entries');
+    }
+}
+
+module.exports = QueueProcessor;

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -1,0 +1,13 @@
+'use strict'; // eslint-disable-line
+
+const config = require('../../../conf/Config');
+const repConfig = config.extensions.replication;
+const sourceConfig = repConfig.source;
+const destConfig = repConfig.destination;
+
+const QueueProcessor = require('./QueueProcessor');
+
+const queueProcessor = new QueueProcessor(sourceConfig, destConfig,
+                                          repConfig, config.log);
+
+queueProcessor.start();

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -1,13 +1,15 @@
 'use strict'; // eslint-disable-line
 
 const config = require('../../../conf/Config');
+const zkConfig = config.zookeeper;
 const repConfig = config.extensions.replication;
 const sourceConfig = repConfig.source;
 const destConfig = repConfig.destination;
 
 const QueueProcessor = require('./QueueProcessor');
 
-const queueProcessor = new QueueProcessor(sourceConfig, destConfig,
+const queueProcessor = new QueueProcessor(zkConfig,
+                                          sourceConfig, destConfig,
                                           repConfig, config.log);
 
 queueProcessor.start();

--- a/extensions/replication/utils/QueueEntry.js
+++ b/extensions/replication/utils/QueueEntry.js
@@ -1,0 +1,151 @@
+'use strict'; // eslint-disable-line
+
+const VersionIDUtils = require('arsenal').versioning.VersionID;
+
+const VID_SEP = require('arsenal').versioning.VersioningConstants
+          .VersionId.Separator;
+
+class QueueEntry {
+
+    /**
+     * @constructor
+     * @param {string} bucket - bucket name for entry's object (may be
+     *   source bucket or destination bucket depending on replication
+     *   status)
+     * @param {string} objectKey - entry's object key without version
+     *   suffix
+     * @param {object} objMd - entry's object metadata as a parsed JS
+     *   object
+     */
+    constructor(bucket, objectKey, objMd) {
+        this.bucket = bucket;
+        this.objectKey = objectKey;
+        this.objMd = objMd;
+    }
+
+    checkSanity() {
+        if (typeof this.bucket !== 'string') {
+            return { message: 'missing bucket name' };
+        }
+        if (typeof this.objectKey !== 'string') {
+            return { message: 'missing object key' };
+        }
+        if (typeof this.objMd.replicationInfo !== 'object' ||
+            typeof this.objMd.replicationInfo.destination !== 'string') {
+            return { message: 'malformed source metadata: ' +
+                     'missing destination info' };
+        }
+        if (typeof this.objMd.versionId !== 'string') {
+            return { message: 'malformed source metadata: ' +
+                     'bad or missing versionId' };
+        }
+        if (typeof this.objMd['content-length'] !== 'number') {
+            return { message: 'malformed source metadata: ' +
+                     'bad or missing content-length' };
+        }
+        if (typeof this.objMd['content-md5'] !== 'string') {
+            return { message: 'malformed source metadata: ' +
+                     'bad or missing content-md5' };
+        }
+        return undefined;
+    }
+
+    static _extractVersionedBaseKey(key) {
+        return key.split(VID_SEP)[0];
+    }
+
+    static createFromKafkaEntry(kafkaEntry) {
+        const record = JSON.parse(kafkaEntry.value);
+        const objMd = JSON.parse(record.value);
+        const entry = new QueueEntry(
+            record.bucket,
+            QueueEntry._extractVersionedBaseKey(record.key),
+            objMd);
+        const err = entry.checkSanity();
+        if (err) {
+            return { error: err };
+        }
+        return entry;
+    }
+
+    isDeleteMarker() {
+        return this.objMd.isDeleteMarker;
+    }
+
+    getBucket() {
+        return this.bucket;
+    }
+
+    getObjectKey() {
+        return this.objectKey;
+    }
+
+    getVersionId() {
+        return this.objMd.versionId;
+    }
+
+    getEncodedVersionId() {
+        return VersionIDUtils.encode(this.getVersionId());
+    }
+
+    getMetadataBlob() {
+        return JSON.stringify(this.objMd);
+    }
+
+    getContentLength() {
+        return this.objMd['content-length'];
+    }
+
+    getContentMD5() {
+        return this.objMd['content-md5'];
+    }
+
+    getReplicationStatus() {
+        return this.objMd.replicationInfo.status;
+    }
+
+    getReplicationContent() {
+        return this.objMd.replicationInfo.content;
+    }
+
+    getReplicationDestBucket() {
+        const destBucketArn = this.objMd.replicationInfo.destination;
+        return destBucketArn.split(':').slice(-1)[0];
+    }
+
+    getLogInfo() {
+        return {
+            bucket: this.getBucket(),
+            objectKey: this.getObjectKey(),
+            versionId: this.getVersionId(),
+            isDeleteMarker: this.isDeleteMarker(),
+        };
+    }
+
+    _convertEntry(bucket, repStatus) {
+        const replicationInfo = Object.assign({}, this.objMd.replicationInfo);
+        const replicaMd = Object.assign({}, this.objMd);
+        replicaMd.replicationInfo = replicationInfo;
+        replicaMd.replicationInfo.status = repStatus;
+        return new QueueEntry(bucket, this.objectKey, replicaMd);
+    }
+
+    toReplicaEntry() {
+        const destBucket = this.getReplicationDestBucket();
+        return this._convertEntry(destBucket, 'REPLICA');
+    }
+
+    toCompletedEntry() {
+        return this._convertEntry(this.getBucket(), 'COMPLETED');
+    }
+
+    toFailedEntry() {
+        return this._convertEntry(this.getBucket(), 'FAILED');
+    }
+
+    setLocations(locations) {
+        this.objMd.locations = locations;
+    }
+}
+
+module.exports = QueueEntry;

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -4,7 +4,6 @@ const kafkaLogging = require('kafka-node/logging');
 const async = require('async');
 const joi = require('joi');
 
-const { errors } = require('arsenal');
 const Logger = require('werelogs').Logger;
 kafkaLogging.setLoggerProvider(new Logger('Consumer'));
 
@@ -108,9 +107,7 @@ class BackbeatConsumer extends EventEmitter {
                         partition,
                         offset,
                     });
-                    const error = errors.InternalError
-                        .customizeDescription('error processing entry');
-                    this.emit('error', error, entry);
+                    this.emit('error', err, entry);
                 }
             });
         });

--- a/lib/clients/BackbeatClient.js
+++ b/lib/clients/BackbeatClient.js
@@ -1,0 +1,24 @@
+const AWS = require('aws-sdk');
+const Service = require('aws-sdk').Service;
+
+// for more info, see how S3 client is configured in aws-sdk
+// (clients/s3.js and lib/services/s3.js)
+
+AWS.apiLoader.services.backbeat = {};
+Object.defineProperty(AWS.apiLoader.services.backbeat, '2017-07-01', {
+    get: function get() {
+        const model = require('./backbeat-2017-07-01.api.json');
+        return model;
+    },
+    enumerable: true,
+    configurable: true,
+});
+const BackbeatClient = Service.defineService('backbeat', ['2017-07-01']);
+
+BackbeatClient.prototype.validateService = function validateService() {
+    if (!this.config.region) {
+        this.config.region = 'us-east-1';
+    }
+};
+
+module.exports = BackbeatClient;

--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -1,0 +1,124 @@
+{
+    "version": "1.0",
+    "metadata": {
+        "apiVersion": "2017-07-01",
+        "checksumFormat": "md5",
+        "endpointPrefix": "s3",
+        "globalEndpoint": "127.0.0.1",
+        "protocol": "rest-json",
+        "serviceAbbreviation": "Backbeat",
+        "serviceFullName": "Backbeat Internal Routes",
+        "signatureVersion": "s3",
+        "timestampFormat": "rfc822",
+        "uid": "backbeat-2017-07-01"
+    },
+    "operations": {
+        "PutData": {
+            "http": {
+                "method": "PUT",
+                "requestUri": "/_/backbeat/{Bucket}/{Key+}/data"
+            },
+            "input": {
+                "type": "structure",
+                "required": [
+                    "Bucket",
+                    "Key"
+                ],
+                "members": {
+                    "Bucket": {
+                        "location": "uri",
+                        "locationName": "Bucket"
+                    },
+                    "Key": {
+                        "location": "uri",
+                        "locationName": "Key"
+                    },
+                    "ContentLength": {
+                        "location": "header",
+                        "locationName": "Content-Length",
+                        "type": "long"
+                    },
+                    "ContentMD5": {
+                        "location": "header",
+                        "locationName": "Content-MD5"
+                    },
+                    "Body": {
+                        "streaming": true,
+                        "type": "blob"
+                    }
+                },
+                "payload": "Body"
+            },
+            "output": {
+                "type": "structure",
+                "members": {
+                    "Locations": {
+                        "type": "list",
+                        "member": {
+                            "type": "structure",
+                            "members": {
+                                "key": {
+                                    "type": "string"
+                                },
+                                "dataStoreName": {
+                                    "type": "string"
+                                },
+                                "size": {
+                                    "type": "long"
+                                },
+                                "start": {
+                                    "type": "long"
+                                }
+                            }
+                        }
+                    }
+                },
+                "payload": "Locations"
+            }
+        },
+        "PutMetadata": {
+            "http": {
+                "method": "PUT",
+                "requestUri": "/_/backbeat/{Bucket}/{Key+}/metadata"
+            },
+            "input": {
+                "type": "structure",
+                "required": [
+                    "Bucket",
+                    "Key"
+                ],
+                "members": {
+                    "Bucket": {
+                        "location": "uri",
+                        "locationName": "Bucket"
+                    },
+                    "Key": {
+                        "location": "uri",
+                        "locationName": "Key"
+                    },
+                    "ContentLength": {
+                        "location": "header",
+                        "locationName": "Content-Length",
+                        "type": "long"
+                    },
+                    "ContentMD5": {
+                        "location": "header",
+                        "locationName": "Content-MD5"
+                    },
+                    "Body": {
+                        "type": "blob"
+                    }
+                },
+                "payload": "Body"
+            },
+            "output": {
+                "type": "structure",
+                "members": {
+                    "versionId": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "queue_populator": "node extensions/replication/queuePopulator/task.js",
+    "queue_processor": "node extensions/replication/queueProcessor/task.js",
     "test": "mocha --recursive tests/unit",
     "ft_test": "mocha --recursive tests/functional",
     "bh_test": "mocha --recursive tests/behavior",

--- a/tests/unit/replication/QueueEntry.spec.js
+++ b/tests/unit/replication/QueueEntry.spec.js
@@ -1,0 +1,49 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+
+const QueueEntry =
+          require('../../../extensions/replication/utils/QueueEntry');
+
+describe('QueueEntry helper class', () => {
+    describe('built from Kafka queue entry', () => {
+        /* eslint-disable max-len */
+        const kafkaEntry = {
+            key: 'foo',
+            value: '{"type":"put","bucket":"queue-populator-test-bucket","key":"hosts\\u000098500086134471999999RG001  0","value":"{\\"md-model-version\\":2,\\"owner-display-name\\":\\"Bart\\",\\"owner-id\\":\\"79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be\\",\\"content-length\\":542,\\"content-type\\":\\"text/plain\\",\\"last-modified\\":\\"2017-07-13T02:44:25.519Z\\",\\"content-md5\\":\\"01064f35c238bd2b785e34508c3d27f4\\",\\"x-amz-version-id\\":\\"null\\",\\"x-amz-server-version-id\\":\\"\\",\\"x-amz-storage-class\\":\\"STANDARD\\",\\"x-amz-server-side-encryption\\":\\"\\",\\"x-amz-server-side-encryption-aws-kms-key-id\\":\\"\\",\\"x-amz-server-side-encryption-customer-algorithm\\":\\"\\",\\"x-amz-website-redirect-location\\":\\"\\",\\"acl\\":{\\"Canned\\":\\"private\\",\\"FULL_CONTROL\\":[],\\"WRITE_ACP\\":[],\\"READ\\":[],\\"READ_ACP\\":[]},\\"key\\":\\"\\",\\"location\\":[{\\"key\\":\\"29258f299ddfd65f6108e6cd7bd2aea9fbe7e9e0\\",\\"size\\":542,\\"start\\":0,\\"dataStoreName\\":\\"file\\"}],\\"isDeleteMarker\\":false,\\"tags\\":{},\\"replicationInfo\\":{\\"status\\":\\"PENDING\\",\\"content\\":[\\"DATA\\",\\"METADATA\\"],\\"destination\\":\\"arn:aws:s3:::dummy-dest-bucket\\",\\"storageClass\\":\\"STANDARD\\",\\"role\\":\\"arn:aws:iam::123456789012:role/backbeat\\"},\\"x-amz-meta-s3cmd-attrs\\":\\"uid:0/gname:root/uname:root/gid:0/mode:33188/mtime:1490807629/atime:1499845478/md5:01064f35c238bd2b785e34508c3d27f4/ctime:1490807629\\",\\"versionId\\":\\"98500086134471999999RG001  0\\"}"}',
+        };
+        /* eslint-enable max-len */
+
+        it('should parse a well-formed kafka entry', () => {
+            const entry = QueueEntry.createFromKafkaEntry(kafkaEntry);
+            assert.strictEqual(entry.error, undefined);
+            assert.strictEqual(entry.getBucket(),
+                               'queue-populator-test-bucket');
+            assert.strictEqual(entry.getObjectKey(), 'hosts');
+            assert.strictEqual(entry.getVersionId(),
+                               '98500086134471999999RG001  0');
+            assert.strictEqual(
+                entry.getEncodedVersionId(),
+                '39383530303038363133343437313939393939395247303031202030');
+            assert.strictEqual(entry.getContentLength(), 542);
+            assert.strictEqual(entry.getContentMD5(),
+                               '01064f35c238bd2b785e34508c3d27f4');
+            assert.strictEqual(entry.getReplicationStatus(), 'PENDING');
+            const repContent = entry.getReplicationContent();
+            assert.deepStrictEqual(repContent, ['DATA', 'METADATA']);
+            const destBucket = entry.getReplicationDestBucket();
+            assert.deepStrictEqual(destBucket, 'dummy-dest-bucket');
+        });
+
+        it('should convert a kafka entry\'s replication status', () => {
+            const entry = QueueEntry.createFromKafkaEntry(kafkaEntry);
+            assert.strictEqual(entry.error, undefined);
+
+            const replica = entry.toReplicaEntry();
+            assert.strictEqual(replica.getReplicationStatus(), 'REPLICA');
+
+            const completed = entry.toCompletedEntry();
+            assert.strictEqual(completed.getReplicationStatus(), 'COMPLETED');
+        });
+    });
+});


### PR DESCRIPTION
This is the processing part of backbeat replication:

- get the next entry from Kafka when it is available

- parse the entry, get the role and check that it matches the current bucket replication configuration

- read the data from source with a regular S3 client

- start writing this data to the destination with a custom Backbeat route (`PUT /_/backbeat/.../data`) in a streaming fashion

- when done writing data, update target metadata with a custom Backbeat route (`PUT /_/backbeat/.../metadata`)

- when complete, update source metadata with the replication status, using the same backbeat route (`PUT /_/backbeat/.../metadata`)

- commit current Kafka offset to not re-read the same entry again when restarting the process (done in the `BackbeatConsumer` class)

What remains to be done is the role handling: we need to parse the role field from the bucket replication info to know both the source and replication role ARNs, so that we can use them to get credentials from Vault and do the operations.