### PR TITLE
add zookeeper namespace in backbeat config

### DIFF
--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -1,31 +1,16 @@
 'use strict'; // eslint-disable-line
 
 const joi = require('joi');
-
-const hostPortJoi = joi.object({
-    host: joi.string().required(),
-    port: joi.number().greater(0).required(),
-});
+const { hostPortJoi, logJoi, zookeeperJoi } =
+          require('../lib/config/configItems.joi.js');
 
 const joiSchema = {
-    zookeeper: hostPortJoi.default({
-        host: '127.0.0.1',
-        port: 2181,
-    }),
+    zookeeper: zookeeperJoi,
     kafka: hostPortJoi.default({
         host: '127.0.0.1',
         port: 9092,
     }),
-    log: joi.object({
-        logLevel: joi.alternatives()
-            .try('error', 'warn', 'info', 'debug', 'trace'),
-        dumpLevel: joi.alternatives()
-            .try('error', 'warn', 'info', 'debug', 'trace'),
-    })
-        .default({
-            logLevel: 'info',
-            dumpLevel: 'error',
-        }),
+    log: logJoi,
     extensions: {
         replication: {
             source: {

--- a/conf/config.json
+++ b/conf/config.json
@@ -1,7 +1,8 @@
 {
     "zookeeper": {
         "host": "127.0.0.1",
-        "port": 2181
+        "port": 2181,
+        "namespace": "/backbeat"
     },
     "kafka": {
         "host": "127.0.0.1",
@@ -49,7 +50,7 @@
             "queuePopulator": {
                 "cronRule": "*/5 * * * * *",
                 "batchMaxRead": 10000,
-                "zookeeperNamespace": "/backbeat/replication-populator"
+                "zookeeperNamespace": "/replication-populator"
             },
             "queueProcessor": {
             }

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -1,16 +1,17 @@
-const assert = require('assert');
 const { EventEmitter } = require('events');
 const { ConsumerGroup } = require('kafka-node');
 const kafkaLogging = require('kafka-node/logging');
 const async = require('async');
+const joi = require('joi');
 
 const { errors } = require('arsenal');
 const Logger = require('werelogs').Logger;
 kafkaLogging.setLoggerProvider(new Logger('Consumer'));
+
+const { logJoi, zookeeperJoi } = require('./config/configItems.joi.js');
+
 // controls the number of messages to process in parallel
 const CONCURRENCY_DEFAULT = 1;
-const LOG_DEFAULT = { logLevel: 'info', dumpLevel: 'error' };
-const ZOOKEEPER_DEFAULT = { host: 'localhost', port: 2181 };
 const CLIENT_ID = 'BackbeatConsumer';
 
 class BackbeatConsumer extends EventEmitter {
@@ -26,6 +27,7 @@ class BackbeatConsumer extends EventEmitter {
     * @param {Object} [config.zookeeper] - zookeeper endpoint config
     * @param {string} config.zookeeper.host - zookeeper host
     * @param {number} config.zookeeper.port - zookeeper port
+    * @param {string} config.zookeeper.namespace - zookeeper namespace
     * @param {boolean} [config.ssl] - ssl enabled if ssl === true
     * @param {string} [config.fromOffset] - valid values latest/earliest/none
     * @param {number} [config.concurrency] - represents the number of entries
@@ -38,54 +40,34 @@ class BackbeatConsumer extends EventEmitter {
     */
     constructor(config) {
         super();
-        const { zookeeper, ssl, groupId, fromOffset, topic, queueProcessor,
-            concurrency, fetchMaxBytes, log } = config;
-        assert(typeof topic === 'string', 'config: topic must be a string');
-        assert(typeof groupId === 'string', 'config: groupId must be a string');
-        if (zookeeper !== undefined) {
-            assert(typeof zookeeper === 'object', 'config: zookeeper must be' +
-                'an object');
-            assert(typeof zookeeper.host === 'string', 'config: ' +
-                'zookeeper.host must be a string');
-            assert(typeof zookeeper.port === 'number', 'config: ' +
-                'zookeeper.port must be a number');
-        }
-        if (ssl !== undefined) {
-            assert(typeof ssl === 'boolean', 'config: ssl must be a boolean');
-        }
-        if (fromOffset !== undefined) {
-            assert(typeof fromOffset === 'string', 'config: fromOffset ' +
-                'must be a string');
-            assert(fromOffset === 'latest' || fromOffset === 'earliest' ||
-                fromOffset === 'none', 'config: fromOffset should be one of' +
-                'latest, earliest or none');
-        }
-        if (concurrency !== undefined) {
-            assert(typeof concurrency === 'number' && concurrency > 0,
-                'config: concurrency must be a number and greater than 0');
-        }
-        if (fetchMaxBytes !== undefined) {
-            assert(typeof fetchMaxBytes === 'number', 'config: fetchMaxBytes' +
-                'must be a number');
-        }
-        if (log !== undefined) {
-            assert(typeof log === 'object', 'config: log must be an object');
-            assert(typeof log.logLevel === 'string', 'config: log.logLevel ' +
-                'must be a string');
-            assert(typeof log.dumpLevel === 'string', 'config: log.dumpLevel' +
-                ' must be a string');
-        }
-        const { logLevel, dumpLevel } = log || LOG_DEFAULT;
-        const { host, port } = zookeeper || ZOOKEEPER_DEFAULT;
-        this._zookeeperEndpoint = `${host}:${port}`;
+
+        const configJoi = {
+            log: logJoi,
+            zookeeper: zookeeperJoi,
+            ssl: joi.boolean(),
+            topic: joi.string().required(),
+            groupId: joi.string().required(),
+            queueProcessor: joi.func(),
+            fromOffset: joi.alternatives().try('latest', 'earliest', 'none'),
+            concurrency: joi.number().greater(0).default(CONCURRENCY_DEFAULT),
+            fetchMaxBytes: joi.number(),
+        };
+        const validConfig = joi.attempt(config, configJoi,
+                                        'invalid config params');
+
+        const { log, zookeeper, ssl, topic, groupId, queueProcessor,
+                fromOffset, concurrency, fetchMaxBytes } = validConfig;
+        const { host, port, namespace } = zookeeper;
+
+        this._zookeeperEndpoint = `${host}:${port}${namespace}`;
         this._log = new Logger(CLIENT_ID, {
-            level: logLevel,
-            dump: dumpLevel,
+            level: log.logLevel,
+            dump: log.dumpLevel,
         });
         this._topic = topic;
         this._groupId = groupId;
         this._queueProcessor = queueProcessor;
-        this._concurrency = concurrency || CONCURRENCY_DEFAULT;
+        this._concurrency = concurrency;
         this._messagesConsumed = 0;
         this._consumer = new ConsumerGroup({
             host: this._zookeeperEndpoint,

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -1,9 +1,12 @@
-const assert = require('assert');
 const { EventEmitter } = require('events');
 const { Client, KeyedMessage, Producer } = require('kafka-node');
+const joi = require('joi');
 
 const errors = require('arsenal').errors;
 const Logger = require('werelogs').Logger;
+
+const { logJoi, zookeeperJoi } = require('./config/configItems.joi.js');
+
 /**
 * compression params define compression for log compaction in topics. It is
 * not recommended to enable by default as the compression options tend to
@@ -24,9 +27,6 @@ const KAFKA_PARTITIONER = 0;
 // waits for an ack for messages
 const REQUIRE_ACKS = 1;
 
-const LOG_DEFAULT = { logLevel: 'info', dumpLevel: 'error' };
-const ZOOKEEPER_DEFAULT = { host: 'localhost', port: 2181 };
-
 const CLIENT_ID = 'BackbeatProducer';
 
 class BackbeatProducer extends EventEmitter {
@@ -39,45 +39,32 @@ class BackbeatProducer extends EventEmitter {
     * @param {Object} [config.zookeeper] - zookeeper endpoint config
     * @param {string} config.zookeeper.host - zookeeper host
     * @param {number} config.zookeeper.port - zookeeper port
+    * @param {number} config.zookeeper.namespace - zookeeper namespace
     * @param {object} [config.log] - logger config
     * @param {object} config.log.logLevel - default log level
     * @param {object} config.log.dumpLevel - dump level for logger
     */
     constructor(config) {
         super();
-        const { zookeeper, log, topic, partition, sslOptions } = config;
 
-        assert(typeof topic === 'string', 'config: topic must be a string');
-        if (zookeeper !== undefined) {
-            assert(typeof zookeeper === 'object', 'config: zookeeper must be' +
-                'an object');
-            assert(typeof zookeeper.host === 'string', 'config: ' +
-                'zookeeper.host must be a string');
-            assert(typeof zookeeper.port === 'number', 'config: ' +
-                'zookeeper.port must be a number');
-        }
-        if (sslOptions !== undefined) {
-            assert(typeof sslOptions === 'object', 'config: sslOptions must ' +
-                'be an object');
-        }
-        if (log !== undefined) {
-            assert(typeof log === 'object', 'config: log must be an object');
-            assert(typeof log.logLevel === 'string', 'config: log.logLevel ' +
-                'must be a string');
-            assert(typeof log.dumpLevel === 'string', 'config: log.dumpLevel' +
-                ' must be a string');
-        }
-        if (partition !== undefined) {
-            assert(typeof partition === 'number', 'config: partition must be ' +
-                'a number');
-            this._partition = partition;
-        }
-        const { host, port } = zookeeper || ZOOKEEPER_DEFAULT;
-        const { logLevel, dumpLevel } = log || LOG_DEFAULT;
-        this._zookeeperEndpoint = `${host}:${port}`;
+        const configJoi = {
+            log: logJoi,
+            zookeeper: zookeeperJoi,
+            sslOptions: joi.object(),
+            topic: joi.string().required(),
+            partition: joi.number(),
+        };
+        const validConfig = joi.attempt(config, configJoi,
+                                        'invalid config params');
+        const { log, zookeeper, sslOptions, topic, partition }
+                  = validConfig;
+        const { host, port, namespace } = zookeeper;
+
+        this._partition = partition;
+        this._zookeeperEndpoint = `${host}:${port}${namespace}`;
         this._log = new Logger(CLIENT_ID, {
-            level: logLevel,
-            dump: dumpLevel,
+            level: log.logLevel,
+            dump: log.dumpLevel,
         });
         this._topic = topic;
         this._ready = false;

--- a/lib/config/configItems.joi.js
+++ b/lib/config/configItems.joi.js
@@ -1,0 +1,38 @@
+'use strict'; // eslint-disable-line
+
+const joi = require('joi');
+
+const hostPortJoi = joi.object({
+    host: joi.string().required(),
+    port: joi.number().greater(0).required(),
+});
+
+const logJoi =
+          joi.object({
+              logLevel: joi.alternatives()
+                  .try('error', 'warn', 'info', 'debug', 'trace'),
+              dumpLevel: joi.alternatives()
+                  .try('error', 'warn', 'info', 'debug', 'trace'),
+          }).default({
+              logLevel: 'info',
+              dumpLevel: 'error',
+          });
+
+const zookeeperNamespaceJoi =
+          joi.string().regex(/^(\/[a-zA-Z0-9-]+)*$/).allow('');
+
+const zookeeperJoi = hostPortJoi
+          .keys({
+              namespace: zookeeperNamespaceJoi.required(),
+          }).default({
+              host: '127.0.0.1',
+              port: 2181,
+              namespace: '/backbeat',
+          });
+
+module.exports = {
+    hostPortJoi,
+    logJoi,
+    zookeeperNamespaceJoi,
+    zookeeperJoi,
+};

--- a/tests/config.json
+++ b/tests/config.json
@@ -1,7 +1,8 @@
 {
     "zookeeper": {
         "host": "127.0.0.1",
-        "port": 2181
+        "port": 2181,
+        "namespace": ""
     },
     "kafka": {
         "host": "127.0.0.1",

--- a/tests/functional/BackbeatConsumer.js
+++ b/tests/functional/BackbeatConsumer.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const BackbeatProducer = require('../../lib/BackbeatProducer');
 const BackbeatConsumer = require('../../lib/BackbeatConsumer');
-const zookeeper = { host: 'localhost', port: 2181 };
+const zookeeper = { host: 'localhost', port: 2181, namespace: '' };
 const log = { logLevel: 'info', dumpLevel: 'error' };
 const topic = 'backbeat-consumer-spec';
 const groupId = `replication-group-${Math.random()}`;

--- a/tests/functional/BackbeatProducer.js
+++ b/tests/functional/BackbeatProducer.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const { errors } = require('arsenal');
 const BackbeatProducer = require('../../lib/BackbeatProducer');
-const zookeeper = { host: 'localhost', port: 2181 };
+const zookeeper = { host: 'localhost', port: 2181, namespace: '' };
 const log = { logLevel: 'info', dumpLevel: 'error' };
 const topic = 'backbeat-producer-spec';
 const partition = 0;


### PR DESCRIPTION
For consumer and producer classes, add the zookeeper namespace
(chroot) as zookeeper param, it will have to match what is setup in
Federation.

Also convert constructor params validation to joi-based validation.