### PR TITLE
ft: credentials manager

### DIFF
--- a/credentials/CredentialsManager.js
+++ b/credentials/CredentialsManager.js
@@ -1,0 +1,98 @@
+const { Credentials } = require('aws-sdk');
+const joi = require('joi');
+const vaultclient = require('vaultclient');
+const { Logger } = require('werelogs');
+
+const configJoi = {
+    host: joi.string().required(),
+    port: joi.number().required(),
+    extension: joi.string().required(),
+    roleArn: joi.string().required(),
+};
+/**
+* Manages and refreshes credentials as needed. This class extends AWS'
+* Credentials class and implements the refresh method to refresh credentials
+* once they are expired.
+*/
+class CredentialsManager extends Credentials {
+    /**
+    * constructor
+    * @param {string} host - hostname/ip of Vault server
+    * @param {number} port - port of Vault server
+    * @param {string} extension - name of the extension
+    * @param {string} roleArn - ARN of the role
+    * @return {object} this - current instance
+    */
+    constructor(host, port, extension, roleArn) {
+        super();
+        joi.attempt({ host, port, extension, roleArn }, configJoi);
+
+        this._vaultclient = new vaultclient.Client(host, port);
+        this._log = new Logger('Backbeat').newRequestLogger();
+        this._extension = extension;
+        this._roleArn = roleArn;
+        this.accessKeyId = null;
+        this.secretAccessKey = null;
+        this.sessionToken = null;
+        this.expiration = null;
+        this.expired = true;
+        return this;
+    }
+
+    /**
+    * get credentials from cache or refresh credentials from vault
+    * @param {callback} cb - callback to be called with err or credentials obj
+    *   cb(null, { AccessKeyId, SecretAccessKey, SessionToken })
+    * @return {undefined}
+    */
+    refresh(cb) {
+        this._log.debug('refreshing credentials from vault', {
+            method: 'CredentialsManager.refresh',
+            extension: this._extension,
+            roleArn: this._roleArn,
+        });
+        const roleSessionName = `backbeat-${this._extension}`;
+        return this._vaultclient.assumeRoleBackbeat(this._roleArn,
+            roleSessionName, {}, (err, res) => {
+                if (err) {
+                    this._log.error('error assuming backbeat role', {
+                        error: err,
+                        method: 'CredentialsManager.refresh',
+                    });
+                    return cb(err);
+                }
+                /*
+                    {
+                        data: {
+                            Credentials: {
+                                AccessKeyId: 'xxxxx',
+                    			SecretAccessKey: 'xxxxx',
+                    			SessionToken: 'xxxxx',
+                    			Expiration: 1499389378705
+                    		},
+                    		AssumedRoleUser: 'xxxx'
+                    	},
+                    	code: 200
+                    }
+                */
+                const { AccessKeyId, SecretAccessKey, SessionToken,
+                    Expiration } = res.data.Credentials;
+                this.accessKeyId = AccessKeyId;
+                this.secretAccessKey = SecretAccessKey;
+                this.sessionToken = SessionToken;
+                this.expiration = Expiration;
+                return cb();
+            });
+    }
+
+    /**
+     * check if credentials have expired
+     * @return {boolean} - true if expired, false otherwise
+     */
+    needsRefresh() {
+        return Date.now() > this.expiration || !this.accessKeyId ||
+            !this.secretAccessKey;
+    }
+}
+
+module.exports = CredentialsManager;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "joi": "^10.6",
     "kafka-node": "^1.6.0",
     "node-schedule": "^1.2.0",
+    "vaultclient": "github:scality/vaultclient",
     "werelogs": "scality/werelogs"
   },
   "devDependencies": {

--- a/tests/unit/CredentialsManager.js
+++ b/tests/unit/CredentialsManager.js
@@ -1,0 +1,82 @@
+const assert = require('assert');
+const http = require('http');
+const CredentialsManager = require('../../credentials/CredentialsManager');
+
+const role = 'arn:aws:iam::1234567890:role/backbeat';
+const extension = 'replication';
+const AccessKeyId = 'ABCD1234567890XXXX';
+const SecretAccessKey = 'qscwdvefb1234567890';
+// const AssumedRoleUser = 'arn:aws:sts::1234567890:assumed-role/backbeat/1234';
+const SessionToken = '1234567890-=+asdfg';
+const vaultHost = '127.0.0.1';
+const vaultPort = 8080;
+const server = http.createServer((req, res) => {
+    const Expiration = Date.now() + 1000; // expire on 1 second
+    const payload = JSON.stringify({
+        Credentials: {
+            AccessKeyId,
+            SecretAccessKey,
+            SessionToken,
+            Expiration,
+        },
+    });
+    res.writeHead(200, {
+        'content-type': 'application/json',
+        'content-length': Buffer.byteLength(payload),
+    });
+    res.end(payload);
+});
+
+function _assertCredentials(err, credentialsManager, cb) {
+    if (err) {
+        return cb(err);
+    }
+    const { accessKeyId, secretAccessKey, sessionToken, expired,
+        expiration } = credentialsManager;
+    assert.strictEqual(accessKeyId, AccessKeyId);
+    assert.strictEqual(secretAccessKey, SecretAccessKey);
+    assert.strictEqual(sessionToken, SessionToken);
+    assert.strictEqual(expired, false);
+    assert(expiration > Date.now());
+    return cb();
+}
+
+
+describe('Credentials Manager', () => {
+    let credentialsManager = null;
+    let vaultServer = null;
+    before(done => {
+        credentialsManager = new CredentialsManager(vaultHost, vaultPort, role,
+            extension);
+        vaultServer = server.listen(vaultPort).on('error', done);
+        done();
+    });
+    after(() => {
+        credentialsManager = null;
+        vaultServer.close();
+    });
+
+    it('should be able to acquire credentials on startup', done => {
+        credentialsManager.get(err => _assertCredentials(err,
+            credentialsManager, done));
+    });
+
+    it('should refresh credentials upon expiration', function test(done) {
+        this.timeout(10000);
+        credentialsManager.get(err => {
+            if (err) {
+                return done(err);
+            }
+            // wait for an extra second after timeout to ensure credentials
+            // have expired
+            const retryTimeout = (credentialsManager.expiration - Date.now()) +
+                1000;
+            return setTimeout(() => {
+                assert(credentialsManager.expired === false,
+                    'expected credentials to expire');
+                credentialsManager.get(err => _assertCredentials(err,
+                    credentialsManager, done));
+            }, retryTimeout);
+        });
+    });
+});


### PR DESCRIPTION
This commit introduces a credentials manager which can cache temporary
credentials given by vault and auto-expires them at their expiry time.
The idea is to use one cache manager instance per site, extension, role
combination. The class extends AWS.Credentials which easily plugs into
the usage of AWS SDK S3 methods for Backbeat.