### PR TITLE
Various fixes for MVP

### DIFF
--- a/conf/authdata.json
+++ b/conf/authdata.json
@@ -1,17 +1,21 @@
 {
-    "users": [{
+    "accounts": [{
         "name": "bart",
         "arn": "aws::iam:123456789012:root",
+        "canonicalID": "79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be",
+        "displayName": "bart",
         "keys": {
             "access": "accessKey1",
             "secret": "verySecretKey1"
         }
     }, {
-        "name": "backbeat",
-        "arn": "aws::iam:123456789012:user/backbeat",
+        "name": "lisa",
+        "arn": "aws::iam:123456789013:root",
+        "canonicalID": "79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2bf",
+        "displayName": "lisa",
         "keys": {
-            "access": "accessKeyBackbeat",
-            "secret": "verySecretKeyBackbeat"
+            "access": "accessKey2",
+            "secret": "verySecretKey2"
         }
     }]
 }

--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -5,8 +5,8 @@ const { hostPortJoi, logJoi, zookeeperJoi } =
           require('../lib/config/configItems.joi.js');
 
 const authJoi = joi.object({
-    type: joi.alternatives().try('local', 'remote').required(),
-    user: joi.string(),
+    type: joi.alternatives().try('account', 'role').required(),
+    account: joi.string(),
     vault: hostPortJoi,
 });
 

--- a/conf/config.json
+++ b/conf/config.json
@@ -17,8 +17,8 @@
                     "transport": "https"
                 },
                 "auth": {
-                    "type": "local",
-                    "user": "bart",
+                    "type": "account",
+                    "account": "bart",
                     "vault": {
                         "host": "127.0.0.1",
                         "port": 8500
@@ -42,8 +42,8 @@
                     "transport": "https"
                 },
                 "auth": {
-                    "type": "local",
-                    "user": "backbeat",
+                    "type": "account",
+                    "account": "lisa",
                     "vault": {
                         "host": "127.0.0.2",
                         "port": 9500

--- a/extensions/replication/utils/QueueEntry.js
+++ b/extensions/replication/utils/QueueEntry.js
@@ -113,6 +113,10 @@ class QueueEntry {
         return destBucketArn.split(':').slice(-1)[0];
     }
 
+    getOwnerCanonicalId() {
+        return this.objMd['owner-id'];
+    }
+
     getLogInfo() {
         return {
             bucket: this.getBucket(),
@@ -120,6 +124,15 @@ class QueueEntry {
             versionId: this.getVersionId(),
             isDeleteMarker: this.isDeleteMarker(),
         };
+    }
+
+    setOwner(ownerCanonicalId, ownerDisplayName) {
+        this.objMd['owner-id'] = ownerCanonicalId;
+        this.objMd['owner-display-name'] = ownerDisplayName;
+    }
+
+    setLocation(location) {
+        this.objMd.location = location;
     }
 
     _convertEntry(bucket, repStatus) {
@@ -141,10 +154,6 @@ class QueueEntry {
 
     toFailedEntry() {
         return this._convertEntry(this.getBucket(), 'FAILED');
-    }
-
-    setLocations(locations) {
-        this.objMd.locations = locations;
     }
 }
 

--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -42,6 +42,10 @@
                         "location": "header",
                         "locationName": "Content-MD5"
                     },
+                    "CanonicalID": {
+                        "location": "header",
+                        "locationName": "X-Scal-Canonical-Id"
+                    },
                     "Body": {
                         "streaming": true,
                         "type": "blob"
@@ -52,7 +56,7 @@
             "output": {
                 "type": "structure",
                 "members": {
-                    "Locations": {
+                    "Location": {
                         "type": "list",
                         "member": {
                             "type": "structure",
@@ -73,7 +77,7 @@
                         }
                     }
                 },
-                "payload": "Locations"
+                "payload": "Location"
             }
         },
         "PutMetadata": {


### PR DESCRIPTION
 - set the destination owner ID and display name in metadata before
   putting to the destination

 - transmit the owner ID in the 'x-scal-canonical-id' header when
   putting data

 - parse the comma-separated source and destination roles from bucket
   replication configuration

 - use an abstraction to handle authentication for 'account' and
   'role' auth types. For account type, match the configured local
   user with the role ARN read in the bucket replication
   configuration.

 - rename auth types to 'user' or 'role' for local user (or account)
   authentication or role-based.