### PR TITLE
enhance replication error management

### DIFF
--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -535,7 +535,7 @@ class QueueProcessor {
             // we should retry or give up updating the status.
             if (err.retryable) {
                 return this._retryUpdateReplicationStatus(
-                    updatedSourceEntry, backoffCtx, log, done);
+                    updatedSourceEntry, { backoffCtx, log }, done);
             }
             return done();
         };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "arsenal": "scality/Arsenal",
     "aws-sdk": "2.28.0",
     "async": "^2.3.0",
+    "backo": "^1.1.0",
     "bucketclient": "scality/bucketclient",
     "eslint": "^2.4.0",
     "eslint-config-airbnb": "^6.0.0",


### PR DESCRIPTION
Split error management in two categories: retryable and permanent
failures. The choice is currently based on the 'retryable' field of
the error sent back by the AWS SDK, but it could be refined later.

 - retryable errors get retried indefinitely with an exponential
   back-off algorithm (using 'backo' open-source module, it's simple
   but non-trivial to do properly so makes sense to use a third-party
   module IMO). We may later think about giving up after some (long
   enough) time without success and set the replication status to
   FAILED, not sure we want to though, if the errors are really
   retryable they should eventually succeed.

 - permanent errors lead to the status FAILED being written on the
   source object version.

 - failures to write the replication status also lead to retries.

Tests should be written, but they will be in a later PR as the code
will need instrumentation that will likely conflict with other pending
PRs.