### PR TITLE
cleanup: configure zookeeper endpoint as a string

### DIFF
--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -47,13 +47,13 @@ const joiSchema = {
                 }).required(),
             },
             topic: joi.string().required(),
-            groupId: joi.string().required(),
             queuePopulator: {
                 cronRule: joi.string().required(),
                 batchMaxRead: joi.number().default(10000),
-                zookeeperNamespace: joi.string().required(),
+                zookeeperPath: joi.string().required(),
             },
             queueProcessor: {
+                groupId: joi.string().required(),
             },
         },
     },

--- a/conf/config.json
+++ b/conf/config.json
@@ -1,8 +1,6 @@
 {
     "zookeeper": {
-        "host": "127.0.0.1",
-        "port": 2181,
-        "namespace": "/backbeat"
+        "endpoint": "127.0.0.1:2181/backbeat"
     },
     "kafka": {
         "host": "127.0.0.1",
@@ -56,13 +54,13 @@
                 }
             },
             "topic": "backbeat-replication",
-            "groupId": "backbeat-replication-group",
             "queuePopulator": {
                 "cronRule": "*/5 * * * * *",
                 "batchMaxRead": 10000,
-                "zookeeperNamespace": "/replication-populator"
+                "zookeeperPath": "/replication-populator"
             },
             "queueProcessor": {
+                "groupId": "backbeat-replication-group"
             }
         }
     },

--- a/extensions/replication/queuePopulator/task.js
+++ b/extensions/replication/queuePopulator/task.js
@@ -6,6 +6,7 @@ const Logger = require('werelogs').Logger;
 const config = require('../../../conf/Config');
 const zkConfig = config.zookeeper;
 const repConfig = config.extensions.replication;
+const sourceConfig = config.extensions.replication.source;
 const QueuePopulator = require('./QueuePopulator');
 
 const logger = new Logger('Backbeat:Replication:task',
@@ -40,7 +41,8 @@ function queueBatch(queuePopulator, taskState) {
 }
 /* eslint-enable no-param-reassign */
 
-const queuePopulator = new QueuePopulator(zkConfig, repConfig, config.log);
+const queuePopulator = new QueuePopulator(zkConfig, sourceConfig,
+                                          repConfig, config.log);
 
 async.waterfall([
     done => {

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -105,6 +105,31 @@ function _extractAccountIdFromRole(role) {
 
 class QueueProcessor {
 
+    /**
+     * Create a queue processor object to activate Cross-Region
+     * Replication from a kafka topic dedicated to store replication
+     * entries to a target S3 endpoint.
+     *
+     * @constructor
+     * @param {Object} zkConfig - zookeeper configuration object
+     * @param {string} zkConfig.endpoint - zookeeper endpoint string
+     *   as "host:port[/chroot]"
+     * @param {Object} sourceConfig - source S3 configuration
+     * @param {Object} sourceConfig.s3 - s3 endpoint configuration object
+     * @param {Object} sourceConfig.auth - authentication info on source
+     * @param {Object} destConfig - target S3 configuration
+     * @param {Object} destConfig.s3 - s3 endpoint configuration object
+     * @param {Object} destConfig.auth - authentication info on target
+     * @param {Object} repConfig - replication configuration object
+     * @param {String} repConfig.topic - replication topic name
+     * @param {String} repConfig.queueProcessor - config object
+     *   specific to queue processor
+     * @param {String} repConfig.queueProcessor.groupId - kafka
+     *   consumer group ID
+     * @param {Logger} logConfig - logging configuration object
+     * @param {String} logConfig.logLevel - logging level
+     * @param {Logger} logConfig.dumpLevel - dump level
+     */
     constructor(zkConfig, sourceConfig, destConfig, repConfig, logConfig) {
         this.zkConfig = zkConfig;
         this.sourceConfig = sourceConfig;
@@ -385,7 +410,7 @@ class QueueProcessor {
             zookeeper: this.zkConfig,
             log: this.logConfig,
             topic: this.repConfig.topic,
-            groupId: this.repConfig.groupId,
+            groupId: this.repConfig.queueProcessor.groupId,
             concurrency: 1, // replication has to process entries in
                             // order, so one at a time
             queueProcessor: this._processEntry.bind(this),

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -24,9 +24,8 @@ class BackbeatConsumer extends EventEmitter {
     * @param {string} config.groupId - consumer group id. Messages are
     * distributed among multiple consumers belonging to the same group
     * @param {Object} [config.zookeeper] - zookeeper endpoint config
-    * @param {string} config.zookeeper.host - zookeeper host
-    * @param {number} config.zookeeper.port - zookeeper port
-    * @param {string} config.zookeeper.namespace - zookeeper namespace
+    * @param {string} config.zookeeper.endpoint - zookeeper endpoint
+    * string as "host:port[/chroot]"
     * @param {boolean} [config.ssl] - ssl enabled if ssl === true
     * @param {string} [config.fromOffset] - valid values latest/earliest/none
     * @param {number} [config.concurrency] - represents the number of entries
@@ -56,9 +55,8 @@ class BackbeatConsumer extends EventEmitter {
 
         const { log, zookeeper, ssl, topic, groupId, queueProcessor,
                 fromOffset, concurrency, fetchMaxBytes } = validConfig;
-        const { host, port, namespace } = zookeeper;
 
-        this._zookeeperEndpoint = `${host}:${port}${namespace}`;
+        this._zookeeperEndpoint = zookeeper.endpoint;
         this._log = new Logger(CLIENT_ID, {
             level: log.logLevel,
             dump: log.dumpLevel,

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -37,9 +37,8 @@ class BackbeatProducer extends EventEmitter {
     * @param {string} config.topic - Kafka topic to write to
     * @param {number} [config.partition] - partition in a topic to write to
     * @param {Object} [config.zookeeper] - zookeeper endpoint config
-    * @param {string} config.zookeeper.host - zookeeper host
-    * @param {number} config.zookeeper.port - zookeeper port
-    * @param {number} config.zookeeper.namespace - zookeeper namespace
+    * @param {string} config.zookeeper.endpoint - zookeeper endpoint
+    * string as "host:port[/chroot]"
     * @param {object} [config.log] - logger config
     * @param {object} config.log.logLevel - default log level
     * @param {object} config.log.dumpLevel - dump level for logger
@@ -58,10 +57,9 @@ class BackbeatProducer extends EventEmitter {
                                         'invalid config params');
         const { log, zookeeper, sslOptions, topic, partition }
                   = validConfig;
-        const { host, port, namespace } = zookeeper;
 
         this._partition = partition;
-        this._zookeeperEndpoint = `${host}:${port}${namespace}`;
+        this._zookeeperEndpoint = zookeeper.endpoint;
         this._log = new Logger(CLIENT_ID, {
             level: log.logLevel,
             dump: log.dumpLevel,

--- a/lib/config/configItems.joi.js
+++ b/lib/config/configItems.joi.js
@@ -21,7 +21,13 @@ const logJoi =
 const zookeeperNamespaceJoi =
           joi.string().regex(/^(\/[a-zA-Z0-9-]+)*$/).allow('');
 
-const zookeeperJoi = hostPortJoi
+const zookeeperJoi = joi.object({
+    endpoint: joi.string().regex(/^[a-z0-9-.]+:[0-9]+(\/[a-zA-Z0-9-]+)*$/)
+        .error(new Error('bad zookeeper endpoint, expect a string ' +
+                         'of form "host:port[/chroot]"')),
+});
+
+hostPortJoi
           .keys({
               namespace: zookeeperNamespaceJoi.required(),
           }).default({

--- a/tests/behavior/extensions/replication/queuePopulator.js
+++ b/tests/behavior/extensions/replication/queuePopulator.js
@@ -57,6 +57,7 @@ describe('queuePopulator', () => {
             },
             (data, next) => {
                 queuePopulator = new QueuePopulator(testConfig.zookeeper,
+                                                    testConfig.source,
                                                     testConfig.replication,
                                                     testConfig.log);
                 queuePopulator.open(next);

--- a/tests/functional/BackbeatConsumer.js
+++ b/tests/functional/BackbeatConsumer.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const BackbeatProducer = require('../../lib/BackbeatProducer');
 const BackbeatConsumer = require('../../lib/BackbeatConsumer');
-const zookeeper = { host: 'localhost', port: 2181, namespace: '' };
+const zookeeper = { endpoint: 'localhost:2181' };
 const log = { logLevel: 'info', dumpLevel: 'error' };
 const topic = 'backbeat-consumer-spec';
 const groupId = `replication-group-${Math.random()}`;

--- a/tests/functional/BackbeatProducer.js
+++ b/tests/functional/BackbeatProducer.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const { errors } = require('arsenal');
 const BackbeatProducer = require('../../lib/BackbeatProducer');
-const zookeeper = { host: 'localhost', port: 2181, namespace: '' };
+const zookeeper = { endpoint: 'localhost:2181' };
 const log = { logLevel: 'info', dumpLevel: 'error' };
 const topic = 'backbeat-producer-spec';
 const partition = 0;


### PR DESCRIPTION
In the backbeat config, zookeeper is configured with the whole
endpoint string "host:port/chroot" instead of separate fields. This
will ease integration with Federation.

Also do various other config cleanups:

 - changed name of zookeeperNamespace to zookeeperPath
 - moved 'groupId' config value to 'queueProcessor' config section
 - explicitly provide the source configuration object to queue populator
 - Add JSDoc to queue processor constructor