### PR TITLE
Integrate ProvisionDispatcher class in queue populator

### DIFF
--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -27,9 +27,7 @@ const joiSchema = {
                 auth: authJoi.required(),
                 logSource: joi.alternatives()
                     .try('bucketd', 'dmd').required(),
-                bucketd: hostPortJoi.keys({
-                    raftSession: joi.number().required(),
-                }),
+                bucketd: hostPortJoi,
                 dmd: hostPortJoi.keys({
                     logName: joi.string().default('s3-recordlog'),
                 }),

--- a/conf/config.json
+++ b/conf/config.json
@@ -25,8 +25,7 @@
                 "logSource": "dmd",
                 "bucketd": {
                     "host": "127.0.0.1",
-                    "port": 9000,
-                    "raftSession": 1
+                    "port": 9000
                 },
                 "dmd": {
                     "host": "127.0.0.1",

--- a/extensions/replication/queuePopulator/LogReader.js
+++ b/extensions/replication/queuePopulator/LogReader.js
@@ -1,0 +1,351 @@
+const async = require('async');
+
+const { isMasterKey } = require('arsenal/lib/versioning/Version');
+
+class LogReader {
+
+    /**
+     * Create a log reader object to populate kafka replication topic
+     * from a single log source (e.g. one raft session)
+     *
+     * @constructor
+     * @param {Object} params - constructor params
+     * @param {Object} params.zkClient - zookeeper client object
+     * @param {BackbeatProducer} params.producer - backbeat producer
+     *   for kafka queue
+     * @param {Object} [params.logConsumer] - log consumer object
+     * @param {function} params.logConsumer.readRecords - function
+     *   that fetches records from the log, called by LogReader
+     * @param {String} params.logId - log source unique identifier
+     * @param {Logger} params.logger - logger object
+     */
+    constructor(params) {
+        this.zkClient = params.zkClient;
+        this.producer = params.kafkaProducer;
+        this.logConsumer = params.logConsumer;
+        this.pathToLogOffset = `/logState/${params.logId}/logOffset`;
+        this.logOffset = null;
+        this.log = params.logger;
+    }
+
+    setLogConsumer(logConsumer) {
+        this.logConsumer = logConsumer;
+    }
+
+    /**
+     * prepare the log reader before starting to populate entries
+     *
+     * This function may be overriden by subclasses, if source log
+     * initialization is needed, in which case they must still call
+     * LogReader.setup().
+     *
+     * @param {function} done - callback function
+     * @return {undefined}
+     */
+    setup(done) {
+        this.log.debug('setting up log source',
+                       { method: 'LogReader.setup',
+                         logSource: this.getLogInfo() });
+        this._readLogOffset((err, offset) => {
+            if (err) {
+                this.log.error('log source setup failed',
+                               { method: 'LogReader.setup',
+                                 logSource: this.getLogInfo() });
+                return done(err);
+            }
+            this.logOffset = offset;
+            this.log.info('log reader is ready to populate replication ' +
+                          'queue',
+                          { logSource: this.getLogInfo(),
+                            logOffset: this.logOffset });
+            return done();
+        });
+    }
+
+    /**
+     * get the next offset to fetch from source log (aka. log sequence
+     * number)
+     *
+     * @return {number} the next log offset to fetch
+     */
+    getLogOffset() {
+        return this.logOffset;
+    }
+
+    _readLogOffset(done) {
+        const pathToLogOffset = this.pathToLogOffset;
+        this.zkClient.getData(pathToLogOffset, (err, data) => {
+            if (err) {
+                if (err.name !== 'NO_NODE') {
+                    this.log.error(
+                        'Could not fetch log offset',
+                        { method: 'LogReader._readLogOffset',
+                          error: err, errorStack: err.stack });
+                    return done(err);
+                }
+                return this.zkClient.mkdirp(pathToLogOffset, err => {
+                    if (err) {
+                        this.log.error(
+                            'Could not pre-create path in zookeeper',
+                            { method: 'LogReader._readLogOffset',
+                              zkPath: pathToLogOffset,
+                              error: err, errorStack: err.stack });
+                        return done(err);
+                    }
+                    return done(null, 1);
+                });
+            }
+            if (data) {
+                const logOffset = Number.parseInt(data, 10);
+                if (isNaN(logOffset)) {
+                    this.log.error(
+                        'invalid stored log offset',
+                        { method: 'LogReader._readLogOffset',
+                          zkPath: pathToLogOffset,
+                          logOffset: data.toString() });
+                    return done(null, 1);
+                }
+                this.log.debug(
+                    'fetched current log offset successfully',
+                    { method: 'LogReader._readLogOffset',
+                      zkPath: pathToLogOffset,
+                      logOffset });
+                return done(null, logOffset);
+            }
+            return done(null, 1);
+        });
+    }
+
+    _writeLogOffset(done) {
+        const pathToLogOffset = this.pathToLogOffset;
+        this.zkClient.setData(
+            pathToLogOffset,
+            new Buffer(this.logOffset.toString()), -1,
+            err => {
+                if (err) {
+                    this.log.error(
+                        'error saving log offset',
+                        { method: 'LogReader._writeLogOffset',
+                          zkPath: pathToLogOffset,
+                          logOffset: this.logOffset });
+                    return done(err);
+                }
+                this.log.debug(
+                    'saved log offset',
+                    { method: 'LogReader._writeLogOffset',
+                      zkPath: pathToLogOffset,
+                      logOffset: this.logOffset });
+                return done();
+            });
+    }
+
+    /**
+     * Process log entries, up to the maximum defined in params
+     *
+     * @param {Object} [params] - parameters object
+     * @param {Number} [params.maxRead] - max number of records to process
+     *   from the log. Records may contain multiple entries and all entries
+     *   are not queued, so the number of queued entries is not directly
+     *   related to this number.
+     * @param {function} done - callback when done processing the
+     *   entries. Called with an error, or null and a statistics object as
+     *   second argument. On success, the statistics contain the following:
+     *     - readRecords {Number} - number of records read
+     *     - readEntries {Number} - number of entries read (records can
+     *       hold multiple entries)
+     *     - queuedEntries {Number} - number of new entries queued in kafka
+     *       topic
+     *     - processedAll {Boolean} - true if the log has no more unread
+     *       records
+     * @return {undefined}
+     */
+    processLogEntries(params, done) {
+        const batchState = {
+            logRes: null,
+            logStats: {
+                nbLogRecordsRead: 0,
+                nbLogEntriesRead: 0,
+            },
+            entriesToPublish: [],
+        };
+        async.waterfall([
+            next => this._processReadRecords(params, batchState, next),
+            next => this._processPrepareEntries(batchState, next),
+            next => this._processPublishEntries(batchState, next),
+            next => this._processSaveLogOffset(batchState, next),
+        ],
+            err => {
+                if (err) {
+                    return done(err);
+                }
+                const processedAll = !params
+                          || !params.maxRead
+                          || (batchState.logStats.nbLogRecordsRead
+                              < params.maxRead);
+                return done(null, {
+                    readRecords: batchState.logStats.nbLogRecordsRead,
+                    readEntries: batchState.logStats.nbLogEntriesRead,
+                    queuedEntries: batchState.entriesToPublish.length,
+                    processedAll,
+                });
+            });
+        return undefined;
+    }
+
+    processAllLogEntries(params, done) {
+        const self = this;
+        const countersTotal = {
+            readRecords: 0,
+            readEntries: 0,
+            queuedEntries: 0,
+        };
+        function cbProcess(err, counters) {
+            if (err) {
+                return done(err);
+            }
+            countersTotal.readRecords += counters.readRecords;
+            countersTotal.readEntries += counters.readEntries;
+            countersTotal.queuedEntries += counters.queuedEntries;
+            self.log.debug('process batch finished',
+                           { counters, countersTotal });
+            if (counters.processedAll) {
+                return done(null, countersTotal);
+            }
+            return self.processLogEntries(params, cbProcess);
+        }
+        return self.processLogEntries(params, cbProcess);
+    }
+
+    /* eslint-disable no-param-reassign */
+
+    _processReadRecords(params, batchState, done) {
+        const readOptions = {};
+        if (this.logOffset !== undefined) {
+            readOptions.startSeq = this.logOffset;
+        }
+        if (params && params.maxRead !== undefined) {
+            readOptions.limit = params.maxRead;
+        }
+        this.log.debug('reading records', { readOptions });
+        this.logConsumer.readRecords(readOptions, (err, res) => {
+            if (err) {
+                this.log.error(
+                    'error while reading log records',
+                    { method: 'LogReader._processReadRecords',
+                      params, error: err, errorStack: err.stack });
+                return done(err);
+            }
+            this.log.debug(
+                'readRecords callback',
+                { method: 'LogReader._processReadRecords',
+                  params, info: res.info });
+            batchState.logRes = res;
+            return done();
+        });
+    }
+
+    _logEntryToQueueEntry(record, entry) {
+        if (entry.type === 'put' &&
+            entry.key !== undefined && entry.value !== undefined &&
+            ! isMasterKey(entry.key)) {
+            const value = JSON.parse(entry.value);
+            if (value.replicationInfo &&
+                value.replicationInfo.status === 'PENDING') {
+                this.log.trace('queueing entry', { entry });
+                const queueEntry = {
+                    type: entry.type,
+                    bucket: record.db,
+                    key: entry.key,
+                    value: entry.value,
+                };
+                return {
+                    key: entry.key,
+                    message: JSON.stringify(queueEntry),
+                };
+            }
+        }
+        return null;
+    }
+
+    _processPrepareEntries(batchState, done) {
+        const { logRes, logStats } = batchState;
+
+        if (logRes.info.start === null) {
+            return done(null);
+        }
+        logRes.log.on('data', record => {
+            logStats.nbLogRecordsRead += 1;
+            record.entries.forEach(entry => {
+                logStats.nbLogEntriesRead += 1;
+                const queueEntry = this._logEntryToQueueEntry(record, entry);
+                if (queueEntry) {
+                    batchState.entriesToPublish.push(queueEntry);
+                }
+            });
+        });
+        logRes.log.on('error', err => {
+            this.log.error('error fetching entries from log',
+                           { method: 'LogReader._processPrepareEntries',
+                             error: err });
+            return done(err);
+        });
+        logRes.log.on('end', () => {
+            this.log.debug('ending record stream');
+            return done();
+        });
+        return undefined;
+    }
+
+    _processPublishEntries(batchState, done) {
+        const { entriesToPublish, logRes, logStats } = batchState;
+
+        if (entriesToPublish.length === 0) {
+            if (logRes.info.start !== null) {
+                batchState.nextLogOffset =
+                    logRes.info.start + logStats.nbLogRecordsRead;
+            }
+            return done();
+        }
+        return this.producer.send(entriesToPublish, err => {
+            if (err) {
+                this.log.error(
+                    'error publishing entries from log',
+                    { method: 'LogReader._processPublishEntries',
+                      error: err, errorStack: err.stack });
+                return done(err);
+            }
+            batchState.nextLogOffset =
+                logRes.info.start + logStats.nbLogRecordsRead;
+            this.log.debug(
+                'entries published successfully',
+                { method: 'LogReader._processPublishEntries',
+                  entryCount: entriesToPublish.length,
+                  logOffset: batchState.nextLogOffset });
+            return done();
+        });
+    }
+
+    _processSaveLogOffset(batchState, done) {
+        if (batchState.nextLogOffset !== undefined &&
+            batchState.nextLogOffset !== this.logOffset) {
+            this.logOffset = batchState.nextLogOffset;
+            return this._writeLogOffset(done);
+        }
+        return process.nextTick(() => done());
+    }
+
+    /* eslint-enable no-param-reassign */
+
+    /**
+     * return an object containing useful info about the log
+     * source. The default implementation returns an empty object,
+     * subclasses may override to provide source-specific info.
+     *
+     * @return {object} log info object
+     */
+    getLogInfo() {
+        return {};
+    }
+}
+
+module.exports = LogReader;

--- a/extensions/replication/queuePopulator/QueuePopulator.js
+++ b/extensions/replication/queuePopulator/QueuePopulator.js
@@ -3,14 +3,14 @@ const zookeeper = require('node-zookeeper-client');
 
 const Logger = require('werelogs').Logger;
 
-const arsenal = require('arsenal');
 const errors = require('arsenal').errors;
-const BucketClient = require('bucketclient').RESTClient;
-const { isMasterKey } = require('arsenal/lib/versioning/Version');
-const MetadataFileClient = arsenal.storage.metadata.MetadataFileClient;
-const LogConsumer = arsenal.storage.metadata.LogConsumer;
 
 const BackbeatProducer = require('../../../lib/BackbeatProducer');
+const ProvisionDispatcher =
+          require('../../../lib/provisioning/ProvisionDispatcher');
+const RaftLogReader = require('./RaftLogReader');
+const BucketFileLogReader = require('./BucketFileLogReader');
+
 
 class QueuePopulator {
     /**
@@ -48,6 +48,12 @@ class QueuePopulator {
         this.log = new Logger('Backbeat:Replication:QueuePopulator',
                               { level: logConfig.logLevel,
                                 dump: logConfig.dumpLevel });
+
+        // list of active log readers
+        this.logReaders = [];
+
+        // list of updated log readers, if any
+        this.logReadersUpdate = null;
     }
 
     /**
@@ -57,30 +63,7 @@ class QueuePopulator {
      * @return {undefined}
      */
     open(cb) {
-        let logIdentifier;
-
-        this.logState = {};
-        this.state = {};
-
-        switch (this.sourceConfig.logSource) {
-        case 'bucketd':
-            this.logState.raftSession =
-                this.sourceConfig.bucketd.raftSession;
-            logIdentifier = `raft_${this.logState.raftSession}`;
-            break;
-        case 'dmd':
-            this.logState.logName = this.sourceConfig.dmd.logName;
-            logIdentifier = `bucketFile_${this.logState.logName}`;
-            break;
-        default:
-            this.log.error("bad 'logSource' config value: expect 'bucketd'" +
-                           `or 'dmd', got '${this.sourceConfig.logSource}'`);
-            return process.nextTick(() => cb(errors.InternalError));
-        }
-        this.pathToLogOffset = `/logState/${logIdentifier}/logOffset`;
-
         return async.parallel([
-            done => this._setupLogSource(done),
             done => this._setupProducer(done),
             done => this._setupZookeeper(done),
         ], err => {
@@ -90,57 +73,77 @@ class QueuePopulator {
                                  error: err, errorStack: err.stack });
                 return cb(err);
             }
-            this.log.info('queue populator is ready to populate ' +
-                          'replication queue',
-                          { logOffset: this.logOffset });
+            this._setupLogSources();
             return cb();
         });
     }
 
-    _setupLogSource(done) {
+    /**
+     * Close the queue populator
+     * @param {function} cb - callback function
+     * @return {undefined}
+     */
+    close(cb) {
+        return async.parallel([
+            done => this._closeLogState(done),
+            done => this._closeProducer(done),
+        ], cb);
+    }
+
+    _setupLogSources() {
         switch (this.sourceConfig.logSource) {
         case 'bucketd':
-            return this._openRaftLog(done);
+            // initialization of log source is deferred until the
+            // dispatcher notifies us of which raft sessions we're
+            // responsible for
+            this._subscribeToRaftSessionDispatcher();
+            break;
         case 'dmd':
-            return this._openBucketFileLog(done);
+            this.logReadersUpdate = [
+                new BucketFileLogReader({ zkClient: this.zkClient,
+                                          kafkaProducer: this.producer,
+                                          dmdConfig: this.sourceConfig.dmd,
+                                          logConfig: this.logConfig,
+                                          logger: this.log,
+                                        }),
+            ];
+            break;
         default:
-            // not reached
-            return undefined;
+            throw new Error("bad 'logSource' config value: expect 'bucketd'" +
+                            `or 'dmd', got '${this.sourceConfig.logSource}'`);
         }
     }
 
-    _openRaftLog(done) {
-        const bucketdConfig = this.sourceConfig.bucketd;
-        this.log.info('initializing raft log handle',
-                      { method: 'QueuePopulator._openRaftLog',
-                        bucketdConfig });
-        const { host, port, raftSession } = bucketdConfig;
-        const bucketClient = new BucketClient(`${host}:${port}`);
-        this.logState.logConsumer = new LogConsumer({ bucketClient,
-                                                      raftSession,
-                                                      logger: this.log });
-        process.nextTick(() => done());
-    }
-
-    _openBucketFileLog(done) {
-        const dmdConfig = this.sourceConfig.dmd;
-        this.log.info('initializing bucketfile log handle',
-                      { method: 'QueuePopulator._openBucketFileLog',
-                        dmdConfig });
-        const mdClient = new MetadataFileClient({
-            host: dmdConfig.host,
-            port: dmdConfig.port,
-            log: this.logConfig,
-        });
-        const logConsumer = mdClient.openRecordLog({
-            logName: dmdConfig.logName,
-        }, err => {
+    _subscribeToRaftSessionDispatcher() {
+        const zookeeperUrl =
+                  this.zkConfig.endpoint +
+                  this.repConfig.queuePopulator.zookeeperPath;
+        const zkEndpoint = `${zookeeperUrl}/raft-id-dispatcher`;
+        this.raftIdDispatcher =
+            new ProvisionDispatcher({ endpoint: zkEndpoint },
+                                    this.logConfig);
+        this.raftIdDispatcher.subscribe((err, items) => {
             if (err) {
-                return done(err);
+                this.log.error('error when receiving raft ID provision list',
+                               { zkEndpoint, error: err });
+                return undefined;
             }
-            this.logState.logConsumer = logConsumer;
-            return done();
+            if (items.length === 0) {
+                this.log.info('no raft ID provisioned, idling',
+                              { zkEndpoint });
+            }
+            this.logReadersUpdate = items.map(
+                raftId => new RaftLogReader({
+                    zkClient: this.zkClient,
+                    kafkaProducer: this.producer,
+                    bucketdConfig: this.sourceConfig.bucketd,
+                    raftId,
+                    logger: this.log,
+                }));
+            return undefined;
         });
+        this.log.info('waiting to be provisioned a raft ID',
+                      { zkEndpoint });
     }
 
     _setupProducer(done) {
@@ -167,286 +170,66 @@ class QueuePopulator {
         this.log.info('opening zookeeper connection for persisting ' +
                       'populator state',
                       { zookeeperUrl });
-        const zkClient = zookeeper.createClient(zookeeperUrl);
-        zkClient.connect();
-        this.zkClient = zkClient;
-        this._readLogOffset((err, offset) => {
-            if (err) {
-                return done(err);
-            }
-            this.logOffset = offset;
-            return done();
-        });
+        this.zkClient = zookeeper.createClient(zookeeperUrl);
+        this.zkClient.connect();
+        this.zkClient.on('connected', done);
     }
 
-    _writeLogOffset(done) {
-        const zkClient = this.zkClient;
-        const pathToLogOffset = this.pathToLogOffset;
-        zkClient.setData(
-            pathToLogOffset, new Buffer(this.logOffset.toString()), -1,
-            err => {
+    _setupUpdatedReaders(done) {
+        const newReaders = this.logReadersUpdate;
+        this.logReadersUpdate = null;
+        async.each(newReaders, (logReader, cb) => logReader.setup(cb),
+                   err => {
+                       if (err) {
+                           return done(err);
+                       }
+                       this.logReaders = newReaders;
+                       return done();
+                   });
+    }
+
+    _closeLogState(done) {
+        if (this.raftIdDispatcher !== undefined) {
+            return this.raftIdDispatcher.unsubscribe(done);
+        }
+        return process.nextTick(done);
+    }
+
+    _closeProducer(done) {
+        this.producer.close(done);
+    }
+
+    _processAllLogEntries(params, done) {
+        if (this.logReaders.length === 0) {
+            this.log.debug('queue populator has no configured log source');
+            return process.nextTick(() => done(errors.ServiceUnavailable));
+        }
+        return async.map(
+            this.logReaders,
+            (logReader, done) => logReader.processAllLogEntries(params, done),
+            (err, results) => {
                 if (err) {
-                    this.log.error(
-                        'error saving log offset',
-                        { method: 'QueuePopulator._writeLogOffset',
-                          zkPath: pathToLogOffset,
-                          logOffset: this.logOffset });
                     return done(err);
                 }
-                this.log.debug(
-                    'saved log offset',
-                    { method: 'QueuePopulator._writeLogOffset',
-                      zkPath: pathToLogOffset,
-                      logOffset: this.logOffset });
-                return done();
+                const annotatedResults = results.map(
+                    (result, i) => Object.assign(result, {
+                        logSource: this.logReaders[i].getLogInfo(),
+                        logOffset: this.logReaders[i].getLogOffset(),
+                    }));
+                return done(null, annotatedResults);
             });
     }
-
-    _readLogOffset(done) {
-        const zkClient = this.zkClient;
-        const pathToLogOffset = this.pathToLogOffset;
-        this.zkClient.getData(pathToLogOffset, (err, data) => {
-            if (err) {
-                if (err.name !== 'NO_NODE') {
-                    this.log.error(
-                        'Could not fetch log offset',
-                        { method: 'QueuePopulator._readLogOffset',
-                          error: err, errorStack: err.stack });
-                    return done(err);
-                }
-                return zkClient.mkdirp(pathToLogOffset, err => {
-                    if (err) {
-                        this.log.error(
-                            'Could not pre-create path in zookeeper',
-                            { method: 'QueuePopulator._readLogOffset',
-                              zkPath: pathToLogOffset,
-                              error: err, errorStack: err.stack });
-                        return done(err);
-                    }
-                    return done(null, 1);
-                });
-            }
-            if (data) {
-                const logOffset = Number.parseInt(data, 10);
-                if (isNaN(logOffset)) {
-                    this.log.error(
-                        'invalid stored log offset',
-                        { method: 'QueuePopulator._readLogOffset',
-                          zkPath: pathToLogOffset,
-                          logOffset: data.toString() });
-                    return done(null, 1);
-                }
-                this.log.debug(
-                    'fetched current log offset successfully',
-                    { method: 'QueuePopulator._readLogOffset',
-                      zkPath: pathToLogOffset,
-                      logOffset });
-                return done(null, logOffset);
-            }
-            return done(null, 1);
-        });
-    }
-
-    _logEntryToQueueEntry(record, entry) {
-        if (entry.type === 'put' &&
-            entry.key !== undefined && entry.value !== undefined &&
-            ! isMasterKey(entry.key)) {
-            const value = JSON.parse(entry.value);
-            if (value.replicationInfo &&
-                value.replicationInfo.status === 'PENDING') {
-                this.log.trace('queueing entry', { entry });
-                const queueEntry = {
-                    type: entry.type,
-                    bucket: record.db,
-                    key: entry.key,
-                    value: entry.value,
-                };
-                return {
-                    key: entry.key,
-                    message: JSON.stringify(queueEntry),
-                };
-            }
-        }
-        return null;
-    }
-
-    /* eslint-disable no-param-reassign */
-
-    /**
-     * Process log entries, up to the maximum defined in params
-     *
-     * @param {Object} [params] - parameters object
-     * @param {Number} [params.maxRead] - max number of records to process
-     *   from the log. Records may contain multiple entries and all entries
-     *   are not queued, so the number of queued entries is not directly
-     *   related to this number.
-     * @param {function} cb - callback when done processing the
-     *   entries. Called with an error, or null and a statistics object as
-     *   second argument. On success, the statistics contain the following:
-     *     - readRecords {Number} - number of records read
-     *     - readEntries {Number} - number of entries read (records can
-     *       hold multiple entries)
-     *     - queuedEntries {Number} - number of new entries queued in kafka
-     *       topic
-     *     - logOffset {Number} - next offset (sequence number) to process
-     *       from the log
-     *     - processedAll {Boolean} - true if the log has no more unread
-     *       records
-     * @return {undefined}
-     */
-    processLogEntries(params, cb) {
-        const batchState = {
-            logRes: null,
-            logStats: {
-                nbLogRecordsRead: 0,
-                nbLogEntriesRead: 0,
-            },
-            entriesToPublish: [],
-        };
-        async.waterfall([
-            next => this._processReadRecords(params, batchState, next),
-            next => this._processPrepareEntries(batchState, next),
-            next => this._processPublishEntries(batchState, next),
-            next => this._processSaveLogOffset(batchState, next),
-        ],
-            err => {
-                if (err) {
-                    return cb(err);
-                }
-                const processedAll = !params
-                          || !params.maxRead
-                          || (batchState.logStats.nbLogRecordsRead
-                              < params.maxRead);
-                return cb(null, {
-                    readRecords: batchState.logStats.nbLogRecordsRead,
-                    readEntries: batchState.logStats.nbLogEntriesRead,
-                    queuedEntries: batchState.entriesToPublish.length,
-                    logOffset: this.logOffset,
-                    processedAll,
-                });
-            });
-        return undefined;
-    }
-
-    _processReadRecords(params, batchState, done) {
-        const readOptions = {};
-        if (this.logOffset !== undefined) {
-            readOptions.startSeq = this.logOffset;
-        }
-        if (params && params.maxRead !== undefined) {
-            readOptions.limit = params.maxRead;
-        }
-        this.log.debug('reading records', { readOptions });
-        this.logState.logConsumer.readRecords(readOptions, (err, res) => {
-            if (err) {
-                this.log.error(
-                    'error while reading log records',
-                    { method: 'QueuePopulator._processReadRecords',
-                      params, error: err, errorStack: err.stack });
-                return done(err);
-            }
-            this.log.debug(
-                'readRecords callback',
-                { method: 'QueuePopulator._processReadRecords',
-                  params, info: res.info });
-            batchState.logRes = res;
-            return done();
-        });
-    }
-
-    _processPrepareEntries(batchState, done) {
-        const { logRes, logStats } = batchState;
-
-        if (logRes.info.start === null) {
-            return done(null);
-        }
-        logRes.log.on('data', record => {
-            logStats.nbLogRecordsRead += 1;
-            record.entries.forEach(entry => {
-                logStats.nbLogEntriesRead += 1;
-                const queueEntry = this._logEntryToQueueEntry(record, entry);
-                if (queueEntry) {
-                    batchState.entriesToPublish.push(queueEntry);
-                }
-            });
-        });
-        logRes.log.on('error', err => {
-            this.log.error('error fetching entries from log',
-                           { method: 'QueuePopulator._processPrepareEntries',
-                             error: err });
-            return done(err);
-        });
-        logRes.log.on('end', () => {
-            this.log.debug('ending record stream');
-            return done();
-        });
-        return undefined;
-    }
-
-    _processPublishEntries(batchState, done) {
-        const { entriesToPublish, logRes, logStats } = batchState;
-
-        if (entriesToPublish.length === 0) {
-            if (logRes.info.start !== null) {
-                batchState.nextLogOffset =
-                    logRes.info.start + logStats.nbLogRecordsRead;
-            }
-            return done();
-        }
-        return this.producer.send(entriesToPublish, err => {
-            if (err) {
-                this.log.error(
-                    'error publishing entries from log',
-                    { method: 'QueuePopulator._processPublishEntries',
-                      error: err, errorStack: err.stack });
-                return done(err);
-            }
-            batchState.nextLogOffset =
-                logRes.info.start + logStats.nbLogRecordsRead;
-            this.log.debug(
-                'entries published successfully',
-                { method: 'QueuePopulator._processPublishEntries',
-                  entryCount: entriesToPublish.length,
-                  logOffset: batchState.nextLogOffset });
-            return done();
-        });
-    }
-
-    _processSaveLogOffset(batchState, done) {
-        if (batchState.nextLogOffset !== undefined &&
-            batchState.nextLogOffset !== this.logOffset) {
-            this.logOffset = batchState.nextLogOffset;
-            return this._writeLogOffset(done);
-        }
-        return process.nextTick(() => done());
-    }
-
-    /* eslint-enable no-param-reassign */
 
     processAllLogEntries(params, done) {
-        const self = this;
-        const countersTotal = {
-            readRecords: 0,
-            readEntries: 0,
-            queuedEntries: 0,
-            logOffset: this.logOffset,
-        };
-        function cbProcess(err, counters) {
-            if (err) {
-                return done(err);
-            }
-            countersTotal.readRecords += counters.readRecords;
-            countersTotal.readEntries += counters.readEntries;
-            countersTotal.queuedEntries += counters.queuedEntries;
-            countersTotal.logOffset = counters.logOffset;
-            self.log.debug('process batch finished',
-                           { counters, countersTotal });
-            if (counters.processedAll) {
-                return done(null, countersTotal);
-            }
-            return self.processLogEntries(params, cbProcess);
+        if (this.logReadersUpdate !== null) {
+            return this._setupUpdatedReaders(err => {
+                if (err) {
+                    return done(err);
+                }
+                return this._processAllLogEntries(params, done);
+            });
         }
-        this.processLogEntries(params, cbProcess);
+        return this._processAllLogEntries(params, done);
     }
 }
 

--- a/extensions/replication/queuePopulator/RaftLogReader.js
+++ b/extensions/replication/queuePopulator/RaftLogReader.js
@@ -1,0 +1,29 @@
+const arsenal = require('arsenal');
+const LogConsumer = arsenal.storage.metadata.LogConsumer;
+const BucketClient = require('bucketclient').RESTClient;
+
+const LogReader = require('./LogReader');
+
+class RaftLogReader extends LogReader {
+    constructor(params) {
+        const { zkClient, kafkaProducer, bucketdConfig, raftId, logger }
+                  = params;
+        const { host, port } = bucketdConfig;
+        logger.info('initializing raft log reader',
+                    { method: 'RaftLogReader.constructor',
+                      bucketdConfig, raftId });
+        const bucketClient = new BucketClient(`${host}:${port}`);
+        const logConsumer = new LogConsumer({ bucketClient,
+                                              raftSession: raftId,
+                                              logger });
+        super({ zkClient, kafkaProducer, logConsumer,
+                logId: `raft_${raftId}`, logger });
+        this.raftId = raftId;
+    }
+
+    getLogInfo() {
+        return { raftId: this.raftId };
+    }
+}
+
+module.exports = RaftLogReader;

--- a/extensions/replication/queuePopulator/task.js
+++ b/extensions/replication/queuePopulator/task.js
@@ -15,28 +15,29 @@ const logger = new Logger('Backbeat:Replication:task',
 const log = logger.newRequestLogger();
 
 /* eslint-disable no-param-reassign */
-function queueBatch(queuePopulator, taskState) {
-    if (taskState.batchInProgress) {
-        log.warn('skipping replication batch: ' +
-                 'previous one still in progress');
+function queueBatch(queuePopulator, batchInProgress) {
+    if (batchInProgress) {
+        log.warn('skipping replication batch: previous one still in progress');
         return undefined;
     }
     log.debug('start queueing replication batch');
-    taskState.batchInProgress = true;
-    queuePopulator.processAllLogEntries(
-        { maxRead: repConfig.queuePopulator.batchMaxRead },
-        (err, counters) => {
-            if (err) {
-                log.error('an error occurred during replication',
-                          { error: err, errorStack: err.stack });
-            } else {
-                const logFunc = (counters.readRecords > 0 ?
-                                 log.info : log.debug)
-                          .bind(log);
-                logFunc('replication batch finished', { counters });
-            }
-            taskState.batchInProgress = false;
-        });
+    batchInProgress = true;
+    const maxRead = repConfig.queuePopulator.batchMaxRead;
+    queuePopulator.processAllLogEntries({ maxRead }, (err, counters) => {
+        batchInProgress = false;
+        if (err && !err.ServiceUnavailable) {
+            log.error('an error occurred during replication', {
+                method: 'QueuePopulator::task.queueBatch',
+                error: err,
+                errorStack: err.stack,
+            });
+            return undefined;
+        }
+        const logFunc = (counters.some(counter => counter.readRecords > 0) ?
+            log.info : log.debug).bind(log);
+        logFunc('replication batch finished', { counters });
+        return undefined;
+    });
     return undefined;
 }
 /* eslint-enable no-param-reassign */
@@ -45,22 +46,27 @@ const queuePopulator = new QueuePopulator(zkConfig, sourceConfig,
                                           repConfig, config.log);
 
 async.waterfall([
+    done => queuePopulator.open(done),
     done => {
-        queuePopulator.open(done);
-    },
-    done => {
-        const taskState = {
-            batchInProgress: false,
-        };
+        const batchInProgress = false;
         schedule.scheduleJob(repConfig.queuePopulator.cronRule, () => {
-            queueBatch(queuePopulator, taskState);
+            queueBatch(queuePopulator, batchInProgress);
         });
         done();
     },
 ], err => {
     if (err) {
-        log.error('error during queue populator initialization',
-                  { error: err });
+        log.error('error during queue populator initialization', {
+            method: 'QueuePopulator::task',
+            error: err,
+        });
         process.exit(1);
     }
+});
+
+process.on('SIGTERM', () => {
+    log.info('received SIGTERM, exiting');
+    queuePopulator.close(() => {
+        process.exit(0);
+    });
 });

--- a/tests/config.json
+++ b/tests/config.json
@@ -1,8 +1,6 @@
 {
     "zookeeper": {
-        "host": "127.0.0.1",
-        "port": 2181,
-        "namespace": ""
+        "endpoint": "127.0.0.1:2181"
     },
     "kafka": {
         "host": "127.0.0.1",
@@ -20,7 +18,8 @@
             "logSource": "dmd",
             "dmd": {
                 "host": "127.0.0.1",
-                "port": 9990
+                "port": 9990,
+                "logName": "s3-recordlog"
             }
         },
         "topic": "backbeat-test-replication",
@@ -28,7 +27,7 @@
         "queuePopulator": {
             "cronRule": "*/5 * * * * *",
             "batchMaxRead": 10000,
-            "zookeeperNamespace": "/backbeat/test/replication-populator"
+            "zookeeperPath": "/backbeat/test/replication-populator"
         }
     },
     "log": {


### PR DESCRIPTION
Follow-up of https://github.com/scality/backbeat/pull/23.

Use the ProvisionDispatcher class to configure the queue populator so that it manages one or more raft session IDs. Make it dynamic so that a running queue populator can switch to another set of raft session
IDs any time (if the dispatcher reassigns a new one, after a failure for example), or can become idle as well if no raft ID is assigned from zookeeper.

Add support for graceful handling of SIGTERM, to unsubscribe from the dispatcher so that the dispatcher can quickly notify other queue populators to take over the unmanaged raft IDs.
