### PR TITLE
bf: call newRequestLogger() for every entry to process

### DIFF
--- a/extensions/replication/queuePopulator/QueuePopulator.js
+++ b/extensions/replication/queuePopulator/QueuePopulator.js
@@ -48,7 +48,6 @@ class QueuePopulator {
         this.logger = new Logger('Backbeat:Replication:QueuePopulator',
                                  { level: logConfig.logLevel,
                                    dump: logConfig.dumpLevel });
-        this.log = this.logger.newRequestLogger();
     }
 
     /**


### PR DESCRIPTION
Instead of calling newRequestLogger() once for the lifetime of the
queue populator, only create the Logger object once, and create a new
request logger object for every entry processed from Kafka.

This enables to keep track of logs more easily for each processed
entry, and more importantly, shall fix an issue that @ThibaultRiviere
mentioned in another PR, which is that a request logger keeps every
log in memory in order to dump all logs when an error occurs. For the
queue processor, it would mean exhausting memory eventually with a
single long-lived request logger object.