### PR TITLE
bf: fix error when populator has no log source

### DIFF
--- a/extensions/replication/queuePopulator/QueuePopulator.js
+++ b/extensions/replication/queuePopulator/QueuePopulator.js
@@ -3,8 +3,6 @@ const zookeeper = require('node-zookeeper-client');
 
 const Logger = require('werelogs').Logger;
 
-const errors = require('arsenal').errors;
-
 const BackbeatProducer = require('../../../lib/BackbeatProducer');
 const ProvisionDispatcher =
           require('../../../lib/provisioning/ProvisionDispatcher');
@@ -200,10 +198,6 @@ class QueuePopulator {
     }
 
     _processAllLogEntries(params, done) {
-        if (this.logReaders.length === 0) {
-            this.log.debug('queue populator has no configured log source');
-            return process.nextTick(() => done(errors.ServiceUnavailable));
-        }
         return async.map(
             this.logReaders,
             (logReader, done) => logReader.processAllLogEntries(params, done),

--- a/extensions/replication/queuePopulator/task.js
+++ b/extensions/replication/queuePopulator/task.js
@@ -25,7 +25,7 @@ function queueBatch(queuePopulator, batchInProgress) {
     const maxRead = repConfig.queuePopulator.batchMaxRead;
     queuePopulator.processAllLogEntries({ maxRead }, (err, counters) => {
         batchInProgress = false;
-        if (err && !err.ServiceUnavailable) {
+        if (err) {
             log.error('an error occurred during replication', {
                 method: 'QueuePopulator::task.queueBatch',
                 error: err,


### PR DESCRIPTION
Don't return ServiceUnavailable in this case, return a success with an empty
array of results