### PR TITLE
ft: use a bootstrap list for source/target S3 and Vault

### DIFF
--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -1,13 +1,15 @@
 'use strict'; // eslint-disable-line
 
 const joi = require('joi');
-const { hostPortJoi, logJoi, zookeeperJoi } =
+const { hostPortJoi, hostsListJoi, logJoi, zookeeperJoi } =
           require('../lib/config/configItems.joi.js');
 
 const authJoi = joi.object({
     type: joi.alternatives().try('account', 'role').required(),
     account: joi.string(),
-    vault: hostPortJoi,
+    vault: joi.object({
+        hosts: hostsListJoi.required(),
+    }),
 });
 
 const joiSchema = {
@@ -20,7 +22,8 @@ const joiSchema = {
     extensions: {
         replication: {
             source: {
-                s3: hostPortJoi.keys({
+                s3: joi.object({
+                    hosts: hostsListJoi.required(),
                     transport: joi.alternatives().try('http', 'https')
                         .default('http'),
                 }).required(),
@@ -33,7 +36,8 @@ const joiSchema = {
                 }),
             },
             destination: {
-                s3: hostPortJoi.keys({
+                s3: joi.object({
+                    hosts: hostsListJoi.required(),
                     transport: joi.alternatives().try('http', 'https')
                         .default('http'),
                 }).required(),

--- a/conf/config.json
+++ b/conf/config.json
@@ -10,16 +10,24 @@
         "replication": {
             "source": {
                 "s3": {
-                    "host": "127.0.0.1",
-                    "port": 8000,
+                    "hosts": [
+                        {
+                            "host": "127.0.0.1",
+                            "port": 8000
+                        }
+                    ],
                     "transport": "https"
                 },
                 "auth": {
                     "type": "account",
                     "account": "bart",
                     "vault": {
-                        "host": "127.0.0.1",
-                        "port": 8500
+                        "hosts": [
+                            {
+                                "host": "127.0.0.1",
+                                "port": 8500
+                            }
+                        ]
                     }
                 },
                 "logSource": "dmd",
@@ -34,16 +42,24 @@
             },
             "destination": {
                 "s3": {
-                    "host": "127.0.0.2",
-                    "port": 9000,
+                    "hosts": [
+                        {
+                            "host": "127.0.0.2",
+                            "port": 9000
+                        }
+                    ],
                     "transport": "https"
                 },
                 "auth": {
                     "type": "account",
                     "account": "lisa",
                     "vault": {
-                        "host": "127.0.0.2",
-                        "port": 9500
+                        "hosts": [
+                            {
+                                "host": "127.0.0.2",
+                                "port": 9500
+                            }
+                        ]
                     }
                 },
                 "certFilePaths": {

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -72,7 +72,8 @@ class _AccountAuthManager {
 class _RoleAuthManager {
     constructor(authConfig, roleArn, log) {
         this._log = log;
-        const { host, port } = authConfig.vault;
+        // FIXME use bootstrap list
+        const { host, port } = authConfig.vault.hosts[0];
         this._vaultclient = new VaultClient(host, port);
         this._credentials = new CredentialsManager(host, port,
                                                    'replication', roleArn);
@@ -302,13 +303,17 @@ class QueueProcessor {
     }
 
     _setupClients(sourceRole, targetRole, log) {
+        const sourceS3 = this.sourceConfig.s3.hosts[0];
+        // FIXME use bootstrap list
+        const destS3 = this.destConfig.s3.hosts[0];
+
         this.s3sourceAuthManager =
             this._createAuthManager(this.sourceConfig.auth, sourceRole, log);
         this.s3destAuthManager =
             this._createAuthManager(this.destConfig.auth, targetRole, log);
         this.S3source = new AWS.S3({
             endpoint: `${this.sourceConfig.s3.transport}://` +
-                `${this.sourceConfig.s3.host}:${this.sourceConfig.s3.port}`,
+                `${sourceS3.host}:${sourceS3.port}`,
             credentials:
             this.s3sourceAuthManager.getCredentials(),
             sslEnabled: true,
@@ -318,7 +323,7 @@ class QueueProcessor {
         });
         this.backbeatSource = new BackbeatClient({
             endpoint: `${this.sourceConfig.s3.transport}://` +
-                `${this.sourceConfig.s3.host}:${this.sourceConfig.s3.port}`,
+                `${sourceS3.host}:${sourceS3.port}`,
             credentials:
             this.s3sourceAuthManager.getCredentials(),
             sslEnabled: true,
@@ -327,7 +332,7 @@ class QueueProcessor {
 
         this.backbeatDest = new BackbeatClient({
             endpoint: `${this.destConfig.s3.transport}://` +
-                `${this.destConfig.s3.host}:${this.destConfig.s3.port}`,
+                `${destS3.host}:${destS3.port}`,
             credentials:
             this.s3destAuthManager.getCredentials(),
             sslEnabled: true,

--- a/lib/config/configItems.joi.js
+++ b/lib/config/configItems.joi.js
@@ -7,6 +7,8 @@ const hostPortJoi = joi.object({
     port: joi.number().greater(0).required(),
 });
 
+const hostsListJoi = joi.array().min(1).items(hostPortJoi);
+
 const logJoi =
           joi.object({
               logLevel: joi.alternatives()
@@ -38,6 +40,7 @@ hostPortJoi
 
 module.exports = {
     hostPortJoi,
+    hostsListJoi,
     logJoi,
     zookeeperNamespaceJoi,
     zookeeperJoi,

--- a/tests/config.json
+++ b/tests/config.json
@@ -7,8 +7,12 @@
         "port": 9092
     },
     "s3": {
-        "host": "127.0.0.1",
-        "port": 8000,
+        "hosts": [
+            {
+                "host": "127.0.0.1",
+                "port": 8000
+            }
+        ],
         "transport": "http",
         "accessKey": "accessKey1",
         "secretKey": "verySecretKey1"

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -389,15 +389,15 @@ describe('queue processor error management with mocking', () => {
         queueProcessor = new QueueProcessor(
             {} /* zkConfig not needed */,
             { auth: { type: 'role',
-                      vault: { host: constants.source.vault,
-                               port: 7777 } },
-              s3: { host: constants.source.s3,
-                    port: 7777, transport: 'http' } },
+                      vault: { hosts: [{ host: constants.source.vault,
+                                         port: 7777 }] } },
+              s3: { hosts: [{ host: constants.source.s3,
+                              port: 7777 }], transport: 'http' } },
             { auth: { type: 'role',
-                      vault: { host: constants.target.vault,
-                               port: 7777 } },
-              s3: { host: constants.target.s3,
-                    port: 7777, transport: 'http' } },
+                      vault: { hosts: [{ host: constants.target.vault,
+                                         port: 7777 }] } },
+              s3: { hosts: [{ host: constants.target.s3,
+                              port: 7777 }], transport: 'http' } },
             {} /* repConfig not needed */,
             { logLevel: 'info', dumpLevel: 'error' });
 


### PR DESCRIPTION
For now, only the first element of the list is used, this will allow
to update Federation to provide a list of hosts in the meantime, later
we will refine to actually use multiple hosts from the list.

For source it does not matter but some of the code shares processing
of host/port from conf, so it makes more sense to have both source and
destination use the same convention in config.