### PR TITLE
fix: g++ syntax for circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,11 @@ machine:
     services:
         - docker
     environment:
-        CXX: G++-4.9
+        CXX: g++-4.9
+
+dependencies:
+    pre:
+        - rm -rf node_modules
 
 test:
     override:


### PR DESCRIPTION
Oops, please see following comment for reference:
https://github.com/scality/backbeat/pull/36#issuecomment-320962020

Also following @alexandre-merle advice, removing node_modules and reinstalling