### PR TITLE
ft: update backbeat S3 routes

### DIFF
--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -16,7 +16,7 @@
         "PutData": {
             "http": {
                 "method": "PUT",
-                "requestUri": "/_/backbeat/{Bucket}/{Key+}/data"
+                "requestUri": "/_/backbeat/data/{Bucket}/{Key+}"
             },
             "input": {
                 "type": "structure",
@@ -86,7 +86,7 @@
         "PutMetadata": {
             "http": {
                 "method": "PUT",
-                "requestUri": "/_/backbeat/{Bucket}/{Key+}/metadata"
+                "requestUri": "/_/backbeat/metadata/{Bucket}/{Key+}"
             },
             "input": {
                 "type": "structure",

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -158,7 +158,7 @@ class S3Mock extends TestConfigurator {
                     }),
                     putMetadata: () => ({
                         method: 'PUT',
-                        path: `/_/backbeat/${this.getParam('source.bucket')}/${this.getParam('key')}/metadata`,
+                        path: `/_/backbeat/metadata/${this.getParam('source.bucket')}/${this.getParam('key')}`,
                         query: {},
                         handler: () => this._putMetadataSource,
                     }),
@@ -178,13 +178,13 @@ class S3Mock extends TestConfigurator {
                 s3: {
                     putData: () => ({
                         method: 'PUT',
-                        path: `/_/backbeat/${this.getParam('target.bucket')}/${this.getParam('key')}/data`,
+                        path: `/_/backbeat/data/${this.getParam('target.bucket')}/${this.getParam('key')}`,
                         query: {},
                         handler: () => this._putData,
                     }),
                     putMetadata: () => ({
                         method: 'PUT',
-                        path: `/_/backbeat/${this.getParam('target.bucket')}/${this.getParam('key')}/metadata`,
+                        path: `/_/backbeat/metadata/${this.getParam('target.bucket')}/${this.getParam('key')}`,
                         query: {},
                         handler: () => this._putMetadataTarget,
                     }),


### PR DESCRIPTION
This commit updates the Backbeat S3 routes to match new format which
gives flexibility over the admin namespace on S3.