### PR TITLE
bf: no reset of '_ready' flag on producer error

### DIFF
--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -80,7 +80,6 @@ class BackbeatProducer extends EventEmitter {
             this.emit('ready');
         });
         this._producer.on('error', error => {
-            this._ready = false;
             this._log.error('error with producer', {
                 error: error.message,
                 method: 'BackbeatProducer.constructor',


### PR DESCRIPTION
Since errors may occur at any time, especially at startup when kafka
is not yet listening, we should not reset the _ready flag which is
initially set to true when zookeeper is up and running on port 2181
and could return kafka's configuration with success, even though port
9092 is not yet ready.

We observed a backtrace saying 'producer is not ready yet' in a loop
on the queue populator, which required restarting the container, we
suspect that this is the cause but haven't confirmed yet. In any case
this fixes a real bug that may happen in other cases of errors.