### PR TITLE
S3C-781 logging enhancements

### DIFF
--- a/tests/unit/CredentialsManager.js
+++ b/tests/unit/CredentialsManager.js
@@ -52,7 +52,7 @@ describe('Credentials Manager', () => {
             undefined, undefined, undefined, undefined, undefined, undefined,
             undefined, proxyPath);
         credentialsManager = new CredentialsManager(vaultclient, role,
-            extension);
+            extension, ['test', 'CredentialsManager', 'requids']);
         vaultServer = server.listen(vaultPort).on('error', done);
         done();
     });


### PR DESCRIPTION
Note: based on PR https://github.com/scality/backbeat/pull/66.

     - request uids forwarding: backbeat queue processor now sends the
       request uids for the current processed entry to S3 and Vault
       routes, through a custom X-Scal-Request-Uids header.
    
     - call log.end() when done processing an entry, so that elapsed time
       is logged
    
     - modify 'retryTotalTime' to 'retryTotalMs' logged value when giving
       up retries, to be consistent with 'elapsed_ms' format
