### PR TITLE
use ObjectMD class

### DIFF
--- a/extensions/replication/utils/QueueEntry.js
+++ b/extensions/replication/utils/QueueEntry.js
@@ -1,7 +1,6 @@
 'use strict'; // eslint-disable-line
 
-const VersionIDUtils = require('arsenal').versioning.VersionID;
-
+const ObjectMD = require('arsenal').models.ObjectMD;
 const VID_SEP = require('arsenal').versioning.VersioningConstants
           .VersionId.Separator;
 
@@ -9,7 +8,7 @@ function _extractVersionedBaseKey(key) {
     return key.split(VID_SEP)[0];
 }
 
-class QueueEntry {
+class QueueEntry extends ObjectMD {
 
     /**
      * @constructor
@@ -18,14 +17,17 @@ class QueueEntry {
      *   status)
      * @param {string} objectVersionedKey - entry's object key with
      *   version suffix
-     * @param {object} objMd - entry's object metadata as a parsed JS
-     *   object
+     * @param {object} objMd - entry's object metadata
      */
     constructor(bucket, objectVersionedKey, objMd) {
+        super(objMd);
         this.bucket = bucket;
         this.objectVersionedKey = objectVersionedKey;
         this.objectKey = _extractVersionedBaseKey(objectVersionedKey);
-        this.objMd = objMd;
+    }
+
+    clone() {
+        return new QueueEntry(this.bucket, this.objectVersionedKey, this);
     }
 
     checkSanity() {
@@ -34,23 +36,6 @@ class QueueEntry {
         }
         if (typeof this.objectKey !== 'string') {
             return { message: 'missing object key' };
-        }
-        if (typeof this.objMd.replicationInfo !== 'object' ||
-            typeof this.objMd.replicationInfo.destination !== 'string') {
-            return { message: 'malformed source metadata: ' +
-                     'missing destination info' };
-        }
-        if (typeof this.objMd.versionId !== 'string') {
-            return { message: 'malformed source metadata: ' +
-                     'bad or missing versionId' };
-        }
-        if (typeof this.objMd['content-length'] !== 'number') {
-            return { message: 'malformed source metadata: ' +
-                     'bad or missing content-length' };
-        }
-        if (typeof this.objMd['content-md5'] !== 'string') {
-            return { message: 'malformed source metadata: ' +
-                     'bad or missing content-md5' };
         }
         return undefined;
     }
@@ -71,12 +56,13 @@ class QueueEntry {
         }
     }
 
-    isDeleteMarker() {
-        return this.objMd.isDeleteMarker;
-    }
-
     getBucket() {
         return this.bucket;
+    }
+
+    setBucket(bucket) {
+        this.bucket = bucket;
+        return this;
     }
 
     getObjectKey() {
@@ -87,142 +73,32 @@ class QueueEntry {
         return this.objectVersionedKey;
     }
 
-    getVersionId() {
-        return this.objMd.versionId;
-    }
-
-    getEncodedVersionId() {
-        return VersionIDUtils.encode(this.getVersionId());
-    }
-
-    getMetadataBlob() {
-        return JSON.stringify(this.objMd);
-    }
-
-    getContentLength() {
-        return this.objMd['content-length'];
-    }
-
-    getContentMD5() {
-        return this.objMd['content-md5'];
-    }
-
-    getReplicationStatus() {
-        return this.objMd.replicationInfo.status;
-    }
-
-    getReplicationContent() {
-        return this.objMd.replicationInfo.content;
-    }
-
-    getReplicationRoles() {
-        return this.objMd.replicationInfo.role;
-    }
-
-    getReplicationStorageType() {
-        return this.objMd.replicationInfo.storageType;
-    }
-
-    getReplicationStorageClass() {
-        return this.objMd.replicationInfo.storageClass;
-    }
-
-    getReplicationDestBucket() {
-        const destBucketArn = this.objMd.replicationInfo.destination;
-        return destBucketArn.split(':').slice(-1)[0];
-    }
-
-    getOwnerCanonicalId() {
-        return this.objMd['owner-id'];
-    }
-
     getLogInfo() {
         return {
             bucket: this.getBucket(),
             objectKey: this.getObjectKey(),
             versionId: this.getVersionId(),
-            isDeleteMarker: this.isDeleteMarker(),
+            isDeleteMarker: this.getIsDeleteMarker(),
         };
     }
 
-    getLocation() {
-        const { location } = this.objMd;
-        return Array.isArray(location) ? location : [];
-    }
-
-    buildLocationKey(location, dataLocation) {
-        const { key, dataStoreName } = dataLocation;
-        return Object.assign({}, location, { key, dataStoreName });
-    }
-
-    getDataStoreETag(location) {
-        return location.dataStoreETag;
-    }
-
-    getPartNumber(location) {
-        return Number.parseInt(location.dataStoreETag.split(':')[0], 10);
-    }
-
-    getPartETag(location) {
-        return location.dataStoreETag.split(':')[1];
-    }
-
-    getPartSize(location) {
-        return location.size;
-    }
-
-    // Object metadata may contain multiple elements for a single part if
-    // the part was originally copied from another MPU. Here we reduce the
-    // locations array to a single element for each part.
-    getReducedLocations() {
-        const locations = this.getLocation();
-        const reducedLocations = [];
-        let partTotal = 0;
-        for (let i = 0; i < locations.length; i++) {
-            const currPart = locations[i];
-            const currPartNum = this.getPartNumber(currPart);
-            const nextPart = locations[i + 1];
-            const nextPartNum = nextPart ?
-                      this.getPartNumber(nextPart) : undefined;
-            if (currPartNum === nextPartNum) {
-                partTotal += this.getPartSize(currPart);
-            } else {
-                currPart.size = partTotal + this.getPartSize(currPart);
-                reducedLocations.push(currPart);
-                partTotal = 0;
-            }
-        }
-        return reducedLocations;
-    }
-
-    setOwner(ownerCanonicalId, ownerDisplayName) {
-        this.objMd['owner-id'] = ownerCanonicalId;
-        this.objMd['owner-display-name'] = ownerDisplayName;
-    }
-
-    setLocation(location) {
-        this.objMd.location = location;
-    }
-
-    _convertEntry(bucket, repStatus) {
-        const replicationInfo = Object.assign({}, this.objMd.replicationInfo);
-        const replicaMd = Object.assign({}, this.objMd);
-        replicaMd.replicationInfo = replicationInfo;
-        replicaMd.replicationInfo.status = repStatus;
-        return new QueueEntry(bucket, this.objectVersionedKey, replicaMd);
-    }
-
     toReplicaEntry() {
-        const destBucket = this.getReplicationDestBucket();
-        return this._convertEntry(destBucket, 'REPLICA');
+        const newEntry = this.clone();
+        newEntry.setBucket(this.getReplicationTargetBucket());
+        newEntry.setReplicationStatus('REPLICA');
+        return newEntry;
     }
 
     toCompletedEntry() {
-        return this._convertEntry(this.getBucket(), 'COMPLETED');
+        const newEntry = this.clone();
+        newEntry.setReplicationStatus('COMPLETED');
+        return newEntry;
     }
 
     toFailedEntry() {
-        return this._convertEntry(this.getBucket(), 'FAILED');
+        const newEntry = this.clone();
+        newEntry.setReplicationStatus('FAILED');
+        return newEntry;
     }
 }
 

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -35,7 +35,7 @@ function buildLocations(keysArray, bodiesArray, options) {
         locations.push(location);
         start += bodiesArray[i].length;
     }
-    return locations;
+    return (locations.length > 0 ? locations : null);
 }
 
 const XML_CHARACTER_MAP = {
@@ -534,7 +534,7 @@ class S3Mock extends TestConfigurator {
                            this.getParam('target.canonicalId'));
 
         if (req.headers['x-scal-replication-content'] === 'METADATA') {
-            assert.deepStrictEqual(parsedMd.location, []);
+            assert.deepStrictEqual(parsedMd.location, null);
         } else {
             assert.deepStrictEqual(parsedMd.location,
                                    this.getParam('target.md.location'));

--- a/tests/unit/replication/QueueEntry.spec.js
+++ b/tests/unit/replication/QueueEntry.spec.js
@@ -20,12 +20,12 @@ describe('QueueEntry helper class', () => {
                 entry.getEncodedVersionId(),
                 '39383530303038363133343437313939393939395247303031202030');
             assert.strictEqual(entry.getContentLength(), 542);
-            assert.strictEqual(entry.getContentMD5(),
+            assert.strictEqual(entry.getContentMd5(),
                                '01064f35c238bd2b785e34508c3d27f4');
             assert.strictEqual(entry.getReplicationStatus(), 'PENDING');
             const repContent = entry.getReplicationContent();
             assert.deepStrictEqual(repContent, ['DATA', 'METADATA']);
-            const destBucket = entry.getReplicationDestBucket();
+            const destBucket = entry.getReplicationTargetBucket();
             assert.deepStrictEqual(destBucket, 'dummy-dest-bucket');
         });
 
@@ -61,13 +61,13 @@ describe('QueueEntry helper class', () => {
                     dataStoreETag: '2:9ca655158ca025aa00a818b6b81f9e48',
                 },
             ];
-            entry.objMd.location = locations;
+            entry.setLocation(locations);
             assert.deepStrictEqual(entry.getReducedLocations(), locations);
         });
 
         it('should reduce an array when first part is > 1 element', () => {
             const entry = QueueEntry.createFromKafkaEntry(kafkaEntry);
-            entry.objMd.location = [
+            entry.setLocation([
                 {
                     key: 'd1d1e055b19eb5a61adb8a665e626ff589cff233',
                     size: 1,
@@ -89,7 +89,7 @@ describe('QueueEntry helper class', () => {
                     dataStoreName: 'file',
                     dataStoreETag: '2:9ca655158ca025aa00a818b6b81f9e48',
                 },
-            ];
+            ]);
             assert.deepStrictEqual(entry.getReducedLocations(), [
                 {
                     key: 'deebfb287cfcee1d137b0136562d2d776ba491e1',
@@ -110,7 +110,7 @@ describe('QueueEntry helper class', () => {
 
         it('should reduce an array when second part is > 1 element', () => {
             const entry = QueueEntry.createFromKafkaEntry(kafkaEntry);
-            entry.objMd.location = [
+            entry.setLocation([
                 {
                     key: 'd1d1e055b19eb5a61adb8a665e626ff589cff233',
                     size: 1,
@@ -132,7 +132,7 @@ describe('QueueEntry helper class', () => {
                     dataStoreName: 'file',
                     dataStoreETag: '2:9ca655158ca025aa00a818b6b81f9e48',
                 },
-            ];
+            ]);
             assert.deepStrictEqual(entry.getReducedLocations(), [
                 {
                     key: 'd1d1e055b19eb5a61adb8a665e626ff589cff233',
@@ -153,7 +153,7 @@ describe('QueueEntry helper class', () => {
 
         it('should reduce an array when multiple parts are > 1 element', () => {
             const entry = QueueEntry.createFromKafkaEntry(kafkaEntry);
-            entry.objMd.location = [
+            entry.setLocation([
                 {
                     key: 'd1d1e055b19eb5a61adb8a665e626ff589cff233',
                     size: 1,
@@ -182,7 +182,7 @@ describe('QueueEntry helper class', () => {
                     dataStoreName: 'file',
                     dataStoreETag: '2:9ca655158ca025aa00a818b6b81f9e48',
                 },
-            ];
+            ]);
             assert.deepStrictEqual(entry.getReducedLocations(), [
                 {
                     key: 'd1d1e055b19eb5a61adb8a665e626ff589cff233',


### PR DESCRIPTION
Depends on Arsenal PR https://github.com/scality/Arsenal/pull/326

cleanup: use ObjectMD class for QueueEntry helper
    
Since QueueEntry is essentially holding metadata from the entry, plus
a few additional info, make it inherit from ObjectMD so we get access
to all its getters/setters directly.
    
Also use ObjectMDLocation class to manipulate location info.

Most helpers removed from QueueEntry have been moved to Arsenal ObjectMD/ObjectMDLocation.
