### PR TITLE
bf: remove decodeURIComponent() in QueueEntry

### DIFF
--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -487,7 +487,7 @@ class QueueProcessor {
         sourceReq.on('error', err => {
             // eslint-disable-next-line no-param-reassign
             err.origin = 'source';
-            if (err.ObjNotFound || err.code === 'ObjNotFound') {
+            if (err.statusCode === 404) {
                 return doneOnce(err);
             }
             log.error('an error occurred on getObject from S3',
@@ -501,7 +501,7 @@ class QueueProcessor {
         });
         const incomingMsg = sourceReq.createReadStream();
         incomingMsg.on('error', err => {
-            if (err.ObjNotFound || err.code === 'ObjNotFound') {
+            if (err.statusCode === 404) {
                 return doneOnce(errors.ObjNotFound);
             }
             // eslint-disable-next-line no-param-reassign

--- a/extensions/replication/utils/QueueEntry.js
+++ b/extensions/replication/utils/QueueEntry.js
@@ -57,8 +57,7 @@ class QueueEntry {
     static createFromKafkaEntry(kafkaEntry) {
         try {
             const record = JSON.parse(kafkaEntry.value);
-            const decodedKey = decodeURIComponent(record.key);
-            const key = QueueEntry._extractVersionedBaseKey(decodedKey);
+            const key = QueueEntry._extractVersionedBaseKey(record.key);
             const objMd = JSON.parse(record.value);
             const entry = new QueueEntry(record.bucket, key, objMd);
             const err = entry.checkSanity();

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -153,13 +153,13 @@ class S3Mock extends TestConfigurator {
                     }),
                     getObject: () => ({
                         method: 'GET',
-                        path: `/${this.getParam('source.bucket')}/${this.getParam('key')}`,
+                        path: `/${this.getParam('source.bucket')}/${this.getParam('encodedKey')}`,
                         query: {},
                         handler: () => this._getObject,
                     }),
                     putMetadata: () => ({
                         method: 'PUT',
-                        path: `/_/backbeat/metadata/${this.getParam('source.bucket')}/${this.getParam('key')}`,
+                        path: `/_/backbeat/metadata/${this.getParam('source.bucket')}/${this.getParam('encodedKey')}`,
                         query: {},
                         handler: () => this._putMetadataSource,
                     }),
@@ -178,13 +178,13 @@ class S3Mock extends TestConfigurator {
             target: {
                 putData: () => ({
                     method: 'PUT',
-                    path: `/_/backbeat/data/${this.getParam('target.bucket')}/${this.getParam('key')}`,
+                    path: `/_/backbeat/data/${this.getParam('target.bucket')}/${this.getParam('encodedKey')}`,
                     query: {},
                     handler: () => this._putData,
                 }),
                 putMetadata: () => ({
                     method: 'PUT',
-                    path: `/_/backbeat/metadata/${this.getParam('target.bucket')}/${this.getParam('key')}`,
+                    path: `/_/backbeat/metadata/${this.getParam('target.bucket')}/${this.getParam('encodedKey')}`,
                     query: {},
                     handler: () => this._putMetadataTarget,
                 }),
@@ -242,7 +242,8 @@ class S3Mock extends TestConfigurator {
                                        this.getParam('partsContents')),
                 },
             },
-            key: 'key_to_replicate',
+            key: 'key_to_replicate_with_some_utf8_䆩鈁櫨㟔罳_and_encoded_chars_%EA%9D%8B',
+            encodedKey: () => encodeURIComponent(this.getParam('key')),
             nbParts: 1,
             versionId: '98498980852335999999RG001  100',
             roleSessionName: 'backbeat-replication',


### PR DESCRIPTION
This call was not decoding a previously encoded value, only the kafka
record key was encoded, not the key stored in the queue entry JSON.

Also fix how 404 errors are detected on the source side (if the source object
does not exist): S3 client does not necessarily return a proper ObjNotFound
code, so just check for 404 HTTP code.