### PR TITLE
ft: auto-create zookeeper base path for zenko

### DIFF
--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -18,6 +18,7 @@ const transportJoi = joi.alternatives().try('http', 'https')
 const joiSchema = {
     zookeeper: {
         connectionString: joi.string().required(),
+        autoCreateNamespace: joi.boolean().default(false),
     },
     kafka: {
         hosts: joi.string().required(),

--- a/conf/config.json
+++ b/conf/config.json
@@ -1,6 +1,7 @@
 {
     "zookeeper": {
-        "connectionString": "127.0.0.1:2181/backbeat"
+        "connectionString": "127.0.0.1:2181/backbeat",
+        "autoCreateNamespace": false
     },
     "kafka": {
         "hosts": "127.0.0.1:9092"

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -796,7 +796,7 @@ class QueueProcessor {
 
     start() {
         const consumer = new BackbeatConsumer({
-            zookeeper: this.zkConfig,
+            zookeeper: { connectionString: this.zkConfig.connectionString },
             topic: this.repConfig.topic,
             groupId: this.repConfig.queueProcessor.groupId,
             concurrency: 1, // replication has to process entries in

--- a/lib/clients/zookeeper.js
+++ b/lib/clients/zookeeper.js
@@ -1,0 +1,57 @@
+const zookeeper = require('node-zookeeper-client');
+
+/**
+ * wrapper around createClient() from node-zookeeper-client module,
+ * with the following enhancements:
+ *
+ *  - emits a 'ready' event when the zookeeper client is ready
+ *  - takes an additional option "autoCreateNamespace"
+ *
+ * @param {string} connectionString - connection string to zookeeper
+ *   (e.g. 'localhost:2181/backbeat')
+ * @param {object} [options] - an object to set the client
+ *   options. Currently available options are:
+ * @param {number} [options.sessionTimeout] - session timeout in
+ *   milliseconds, defaults to 30 seconds.
+ * @param {number} [options.spinDelay] - the delay (in milliseconds)
+ *   between each connection attempts.
+ * @param {number} [options.retries] - the number of retry attempts
+ *   for connection loss exception.
+ * @param {boolean} [options.autoCreateNamespace] - when true, ensure
+ *   namespace (chroot) base path is created if not exists
+ *
+ * @return {node-zookeeper-client.Client} a zookeeper client handle
+ */
+function createClient(connectionString, options) {
+    const zkClient = zookeeper.createClient(connectionString, options);
+    zkClient.once('connected', () => {
+        // for some reason zkClient.exists() does not return
+        // NO_NODE when base path does not exist, hence use
+        // getData() instead
+        zkClient.getData('/', err => {
+            if (err && err.name !== 'NO_NODE') {
+                return zkClient.emit('error', err);
+            }
+            // NO_NODE error and autoCreateNamespace is enabled
+            if (err && options && options.autoCreateNamespace) {
+                const nsIndex = connectionString.indexOf('/');
+                const hostPort = connectionString.slice(0, nsIndex);
+                const namespace = connectionString.slice(nsIndex);
+                const rootZkClient = zookeeper.createClient(hostPort, options);
+                rootZkClient.connect();
+                return rootZkClient.mkdirp(namespace, err => {
+                    if (err && err.name !== 'NODE_EXISTS') {
+                        return zkClient.emit('error');
+                    }
+                    return zkClient.emit('ready');
+                });
+            }
+            return zkClient.emit('ready');
+        });
+    });
+    return zkClient;
+}
+
+module.exports = {
+    createClient,
+};


### PR DESCRIPTION
Auto-create queue populator base path on zookeeper if it does not
exist, when starting up the queue populator deployed previously with
docker swarm for zenko.

Since docker and docker swarm do not provide an easy way to run
specific commands at deployment time, especially conditioned to
containers being up and running first, in order to ensure zookeeper
base paths are created initially, we wrap the zookeeper client handle
creation with some custom code to do this.

This is enabled only in zenko mode with docker swarm deployment,
default options (including Federation-based deployment) do not change
the existing behavior which is to not create the base path if it does
not exist (and then further zookeeper commands shall fail with NO_NODE
errors).