### PR TITLE
use default port 80 in round-robin

### DIFF
--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -166,7 +166,8 @@ class QueueProcessor {
         // FIXME support multiple destination sites
         if (destConfig.bootstrapList.length > 0) {
             this.destHosts =
-                new RoundRobin(destConfig.bootstrapList[0].servers);
+                new RoundRobin(destConfig.bootstrapList[0].servers,
+                               { defaultPort: 80 });
         } else {
             this.destHosts = null;
         }


### PR DESCRIPTION
Use port 80 when not specified in bootstrap list items for backbeat target.

Depends on Arsenal PR https://github.com/scality/Arsenal/pull/332