### PR TITLE
ft: increase concurrency of Queue Processor

### DIFF
--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -799,8 +799,7 @@ class QueueProcessor {
             zookeeper: this.zkConfig,
             topic: this.repConfig.topic,
             groupId: this.repConfig.queueProcessor.groupId,
-            concurrency: 1, // replication has to process entries in
-                            // order, so one at a time
+            concurrency: 10, // versioning can support out of order updates
             queueProcessor: this.processKafkaEntry.bind(this),
             fetchMaxBytes: CONSUMER_FETCH_MAX_BYTES,
         });


### PR DESCRIPTION
This commit increases the concurrency of the queue processor to process multiple entries (currently set at 10) at once. It's possible that the requests arrive at the destination out of order but that should be ok since Versioning algorithm supports out of order updates. One more side effect of this change is that Consumer offsets are committed per batch, which means if we fail processing an entry in a batch we may re-process the batch. This shifts the expectation from EXACTLY ONCE to AT LEAST ONCE delivery which should be ok in our case since metadata updates are immutable. However data orphans may be an issue which can be handled by a different strategy.