### PR TITLE
bf: fix use of keyed partitioning

### DIFF
--- a/extensions/replication/queuePopulator/LogReader.js
+++ b/extensions/replication/queuePopulator/LogReader.js
@@ -259,7 +259,7 @@ class LogReader {
                     value: entry.value,
                 };
                 return {
-                    key: encodeURIComponent(entry.key),
+                    key: encodeURIComponent(`${record.db}/${entry.key}`),
                     message: JSON.stringify(queueEntry),
                 };
             }

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -128,13 +128,17 @@ class BackbeatProducer extends EventEmitter {
                 cb(errors.InternalError);
             });
         }
-        const messages = this._partition === undefined ?
-            entries.map(item => new KeyedMessage(item.key, item.message)) :
-            entries.map(item => item.message);
-        const payload = [{
-            topic: this._topic,
-            messages,
-        }];
+        const payload = this._partition === undefined ?
+                  entries.map(item => ({
+                      topic: this._topic,
+                      messages: new KeyedMessage(item.key, item.message),
+                      key: item.key,
+                  })) :
+                  entries.map(item => ({
+                      topic: this._topic,
+                      messages: item.message,
+                      partition: this._partition,
+                  }));
         this._client.refreshMetadata([this._topic], () =>
             this._producer.send(payload, err => {
                 if (err) {


### PR DESCRIPTION
The kafka-node API was misused, resulting in keyed partitioning being
not used: the key has to be part of the individual payload items, not
the 'messages' list. Also fix the provided key to include the bucket
name (may lead to slightly better dispersion across partitions).