### PR TITLE
replication echo mode

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -36,7 +36,8 @@
             "destination": {
                 "transport": "http",
                 "bootstrapList": [
-                    { "site": "sf", "servers": ["127.0.0.1:8443"]}
+                    { "site": "sf", "servers": ["127.0.0.1:8443"],
+                      "echo": false }
                 ],
                 "certFilePaths": {
                     "key": "ssl/key.pem",

--- a/extensions/replication/queuePopulator/LogReader.js
+++ b/extensions/replication/queuePopulator/LogReader.js
@@ -249,28 +249,19 @@ class LogReader {
         // FIXME: copied from S3, move those values to arsenal from
         // S3/constants.js and use them
         const excluded = {
-            usersBucket: 'users..bucket',
-            oldUsersBucket: 'namespaceusersbucket',
             mpuBucketPrefix: 'mpuShadowBucket',
         };
-
         if (entry.type === 'put' &&
             entry.key !== undefined && entry.value !== undefined) {
             const isVersionedKey = !isMasterKey(entry.key);
-            const metaStoreOp = record.db === '__metastore';
-            if (isVersionedKey || metaStoreOp) {
+            const bucketOp = record.db === 'users..bucket';
+            if (isVersionedKey || bucketOp) {
                 const value = JSON.parse(entry.value);
                 if ((isVersionedKey &&
                      value.replicationInfo &&
                      value.replicationInfo.status === 'PENDING') ||
-                    (metaStoreOp &&
-                     entry.key !== excluded.usersBucket &&
-                     entry.key !== excluded.oldUsersBucket &&
-                     !entry.key.startsWith(excluded.mpuBucketPrefix) &&
-                     !value.transient &&
-                     !value.deleted &&
-                     !value.versioningConfiguration &&
-                     !value.replicationConfiguration)) {
+                    (bucketOp &&
+                     !entry.key.startsWith(excluded.mpuBucketPrefix))) {
                     this.log.trace('queueing entry',
                                    { key: entry.key,
                                      bucket: record.db });

--- a/extensions/replication/queueProcessor/AdminAuthManager.js
+++ b/extensions/replication/queueProcessor/AdminAuthManager.js
@@ -1,0 +1,28 @@
+const errors = require('arsenal').errors;
+
+class AdminAuthManager {
+    constructor(vaultClient, log) {
+        this._log = log;
+        this._vaultclient = vaultClient;
+    }
+
+    lookupAccountAttributes(accountId, cb) {
+        this._vaultclient.getCanonicalIdsByAccountIds(
+            [accountId], { reqUid: this._log.getSerializedUids() },
+            (err, res) => {
+                if (err) {
+                    return cb(err);
+                }
+                if (!res || !res.message || !res.message.body
+                    || res.message.body.length === 0) {
+                    return cb(errors.AccountNotFound);
+                }
+                return cb(null, {
+                    canonicalID: res.message.body[0].canonicalId,
+                    displayName: res.message.body[0].name,
+                });
+            });
+    }
+}
+
+module.exports = AdminAuthManager;

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -99,7 +99,7 @@ class QueueProcessor {
     }
 
     _loadAdminCreds() {
-        const adminCredsJSON = fs.readFileSync('conf/admin-backbeat.json');
+        const adminCredsJSON = fs.readFileSync('/conf/admin-backbeat.json');
         const adminCredsObj = JSON.parse(adminCredsJSON);
         const accessKey = Object.keys(adminCredsObj)[0];
         const secretKey = adminCredsObj[accessKey];

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -1,6 +1,7 @@
 'use strict'; // eslint-disable-line
 
 const http = require('http');
+const fs = require('fs');
 
 const Logger = require('werelogs').Logger;
 
@@ -12,6 +13,7 @@ const BackbeatConsumer = require('../../../lib/BackbeatConsumer');
 const QueueEntry = require('../utils/QueueEntry');
 const ReplicationTaskScheduler = require('./ReplicationTaskScheduler');
 const QueueProcessorTask = require('./QueueProcessorTask');
+const SetupBucketTask = require('./SetupBucketTask');
 
 /**
 * Given that the largest object JSON from S3 is about 1.6 MB and adding some
@@ -66,13 +68,26 @@ class QueueProcessor {
             this.destHosts =
                 new RoundRobin(destConfig.bootstrapList[0].servers,
                                { defaultPort: 80 });
+            if (destConfig.bootstrapList[0].echo) {
+                this.logger.info('starting in echo mode');
+                this._loadAdminCreds();
+                this.accountCredsCache = {};
+            }
         } else {
             this.destHosts = null;
         }
 
         if (sourceConfig.auth.type === 'role') {
-            const { host, port } = sourceConfig.auth.vault;
-            this.sourceVault = new VaultClient(host, port);
+            const { host, port, adminPort } = sourceConfig.auth.vault;
+            this.sourceS3Vault = new VaultClient(host, port);
+            if (this.adminCreds) {
+                this.sourceAdminVault = new VaultClient(
+                    host, adminPort,
+                    undefined, undefined, undefined, undefined,
+                    undefined,
+                    this.adminCreds.accessKey,
+                    this.adminCreds.secretKey);
+            }
         }
         if (destConfig.auth.type === 'role') {
             // vault client cache per destination
@@ -83,6 +98,14 @@ class QueueProcessor {
             (ctx, done) => ctx.task.processQueueEntry(ctx.entry, done));
     }
 
+    _loadAdminCreds() {
+        const adminCredsJSON = fs.readFileSync('conf/admin-backbeat.json');
+        const adminCredsObj = JSON.parse(adminCredsJSON);
+        const accessKey = Object.keys(adminCredsObj)[0];
+        const secretKey = adminCredsObj[accessKey];
+        this.adminCreds = { accessKey, secretKey };
+    }
+
     getStateVars() {
         return {
             sourceConfig: this.sourceConfig,
@@ -91,8 +114,11 @@ class QueueProcessor {
             destHosts: this.destHosts,
             sourceHTTPAgent: this.sourceHTTPAgent,
             destHTTPAgent: this.destHTTPAgent,
-            sourceVault: this.sourceVault,
+            sourceAdminVault: this.sourceAdminVault,
+            sourceS3Vault: this.sourceS3Vault,
             destVaults: this.destVaults,
+            adminCreds: this.adminCreds,
+            accountCredsCache: this.accountCredsCache,
             logger: this.logger,
         };
     }
@@ -130,9 +156,18 @@ class QueueProcessor {
                               { error: sourceEntry.error });
             return process.nextTick(() => done(errors.InternalError));
         }
+        // FIXME support multiple destinations
+        if ((this.destConfig.bootstrapList.length === 0 ||
+             !this.destConfig.bootstrapList[0].echo) &&
+            sourceEntry.isPutBucketOp()) {
+            // ignore
+            return done();
+        }
+        const task = sourceEntry.isPutBucketOp() ?
+                  new SetupBucketTask(this) :
+                  new QueueProcessorTask(this);
         return this.taskScheduler.push(
-            { task: new QueueProcessorTask(this),
-              entry: sourceEntry },
+            { task, entry: sourceEntry },
             `${sourceEntry.getBucket()}/${sourceEntry.getObjectVersionedKey()}`,
             done);
     }

--- a/extensions/replication/queueProcessor/QueueProcessorTask.js
+++ b/extensions/replication/queueProcessor/QueueProcessorTask.js
@@ -52,7 +52,7 @@ class QueueProcessorTask {
         }
         let vaultClient;
         if (where === 'source') {
-            vaultClient = this.sourceVault;
+            vaultClient = this.sourceS3Vault;
         } else { // target
             const { host, port } = this.destHosts.pickHost();
             const key = `${host}:${port}`;
@@ -60,8 +60,8 @@ class QueueProcessorTask {
                 this.destVaults[key] = new VaultClient(
                     host, port,
                     undefined, undefined, undefined, undefined,
-                    undefined, undefined, undefined, undefined,
-                    proxyPath);
+                    undefined, undefined, undefined,
+                    undefined, proxyPath);
             }
             vaultClient = this.destVaults[key];
         }

--- a/extensions/replication/queueProcessor/SetupBucketTask.js
+++ b/extensions/replication/queueProcessor/SetupBucketTask.js
@@ -1,0 +1,493 @@
+const async = require('async');
+const AWS = require('aws-sdk');
+
+const VaultClient = require('vaultclient').Client;
+
+const { proxyPath } = require('../constants');
+
+const trustPolicy = {
+    Version: '2012-10-17',
+    Statement: [
+        {
+            Effect: 'Allow',
+            Principal: {
+                Service: 'backbeat',
+            },
+            Action: 'sts:AssumeRole',
+        },
+    ],
+};
+
+function _buildResourcePolicy(source, target) {
+    return {
+        Version: '2012-10-17',
+        Statement: [
+            {
+                Effect: 'Allow',
+                Action: [
+                    's3:GetObjectVersion',
+                    's3:GetObjectVersionAcl',
+                ],
+                Resource: [
+                    `arn:aws:s3:::${source}/*`,
+                ],
+            },
+            {
+                Effect: 'Allow',
+                Action: [
+                    's3:ListBucket',
+                    's3:GetReplicationConfiguration',
+                ],
+                Resource: [
+                    `arn:aws:s3:::${source}`,
+                ],
+            },
+            {
+                Effect: 'Allow',
+                Action: [
+                    's3:ReplicateObject',
+                    's3:ReplicateDelete',
+                ],
+                Resource: `arn:aws:s3:::${target}/*`,
+            },
+        ],
+    };
+}
+
+class SetupBucketTask {
+    /**
+     * Process a single replication entry
+     *
+     * @constructor
+     * @param {QueueProcessor} qp - queue processor instance
+     */
+    constructor(qp) {
+        Object.assign(this, qp.getStateVars());
+
+        this.sourceRole = null;
+        this.targetRole = null;
+        this.destBackbeatHost = null;
+        this.s3sourceAuthManager = null;
+        this.s3destAuthManager = null;
+        this.S3source = null;
+        this.backbeatSource = null;
+        this.backbeatDest = null;
+    }
+
+    _getDestAdminVaultClient() {
+        const { host } = this.destHosts.pickHost();
+        // FIXME this should go through the nginx proxy eventually
+        // XXX we're using the source vault port in place of the
+        // destination port to avoid having to extend the config,
+        // until we can use nginx for vault admin
+        const { adminPort } = this.sourceConfig.auth.vault;
+        const key = `${host}:${adminPort}`;
+        if (this.destVaults[key] === undefined) {
+            this.destVaults[key] = new VaultClient(
+                host, adminPort,
+                undefined, undefined, undefined, undefined,
+                undefined,
+                this.adminCreds.accessKey,
+                this.adminCreds.secretKey);
+        }
+        return this.destVaults[key];
+    }
+
+    _getDestS3VaultClient() {
+        const { host, port } = this.destHosts.pickHost();
+        const key = `${host}:${port}`;
+        if (this.destVaults[key] === undefined) {
+            this.destVaults[key] = new VaultClient(
+                host, port,
+                undefined, undefined, undefined, undefined,
+                undefined, undefined, undefined,
+                undefined, proxyPath);
+        }
+        return this.destVaults[key];
+    }
+
+    _getSourceAccountCreds(sourceEntry, log, done) {
+        const displayName = sourceEntry.getOwnerDisplayName();
+        const canonicalId = sourceEntry.getOwnerCanonicalId();
+        let email;
+        let accountCreds;
+
+        async.waterfall([
+            done => this.sourceS3Vault.getEmailAddresses(
+                [canonicalId], { reqUid: log.getSerializedUids() }, done),
+            (res, done) => {
+                email = res.message.body[canonicalId];
+                accountCreds = this.accountCredsCache[canonicalId];
+                if (accountCreds) {
+                    return done(null, null);
+                }
+                return this.sourceAdminVault.generateAccountAccessKey(
+                    displayName, done);
+            }, (res, done) => {
+                if (res) {
+                    accountCreds = {
+                        accessKeyId: res.id,
+                        secretAccessKey: res.value,
+                    };
+                    this.accountCredsCache[canonicalId] = accountCreds;
+                }
+                return done();
+            },
+        ], err => {
+            if (err) {
+                return done(err);
+            }
+            return done(null, email, accountCreds);
+        });
+    }
+
+    _getTargetAccountCreds(sourceEntry, email, log, done) {
+        const displayName = sourceEntry.getOwnerDisplayName();
+        let canonicalId;
+        let accountCreds;
+        const destAdminVault = this._getDestAdminVaultClient();
+        const destS3Vault = this._getDestS3VaultClient();
+
+        async.waterfall([
+            done => destS3Vault.getCanonicalIds(
+                [email], { reqUid: log.getSerializedUids() }, done),
+            (res, done) => {
+                if (res.message.body[email] === 'NotFound') {
+                    return destAdminVault.createAccount(displayName, { email },
+                                                        done);
+                }
+                return done(null,
+                            { account: {
+                                canonicalId: res.message.body[email],
+                            } });
+            }, (res, done) => {
+                canonicalId = res.account.canonicalId;
+                accountCreds = this.accountCredsCache[canonicalId];
+                if (accountCreds) {
+                    return done(null, null);
+                }
+                return destAdminVault.generateAccountAccessKey(displayName,
+                                                               done);
+            }, (res, done) => {
+                if (res) {
+                    accountCreds = {
+                        accessKeyId: res.id,
+                        secretAccessKey: res.value,
+                    };
+                    this.accountCredsCache[canonicalId] = accountCreds;
+                }
+                return done();
+            },
+        ], err => {
+            if (err) {
+                return done(err);
+            }
+            return done(null, accountCreds);
+        });
+    }
+
+    _setupClients(srcAccessCreds, tgtAccessCreds) {
+        // Disable retries, use our own retry policy (mandatory for
+        // putData route in order to fetch data again from source).
+
+        const sourceS3 = this.sourceConfig.s3;
+        const destS3 = this.destHosts.pickHost();
+        // XXX port used for both source and destination IAM servers
+        // to avoid changing the config format (will be obsolete when
+        // nginx is used for destination IAM)
+        const iamPort = this.sourceConfig.auth.vault.adminPort;
+        this._s3Clients = {
+            source: new AWS.S3({
+                endpoint: `${this.sourceConfig.transport}://` +
+                    `${sourceS3.host}:${sourceS3.port}`,
+                credentials: srcAccessCreds,
+                sslEnabled: this.sourceConfig.transport === 'https',
+                s3ForcePathStyle: true,
+                signatureVersion: 'v4',
+                httpOptions: { agent: this.sourceHTTPAgent, timeout: 0 },
+                maxRetries: 0,
+            }),
+            target: new AWS.S3({
+                endpoint: `${this.destConfig.transport}://` +
+                    `${destS3.host}:${destS3.port}`,
+                credentials: tgtAccessCreds,
+                sslEnabled: this.destConfig.transport === 'https',
+                s3ForcePathStyle: true,
+                signatureVersion: 'v4',
+                httpOptions: { agent: this.destHTTPAgent, timeout: 0 },
+                maxRetries: 0,
+            }),
+        };
+        // FIXME this should go through the nginx proxy eventually
+        this._iamClients = {
+            source: new AWS.IAM({
+                endpoint: `${this.sourceConfig.transport}://` +
+                    `${sourceS3.host}:${iamPort}`,
+                credentials: srcAccessCreds,
+                sslEnabled: this.sourceConfig.transport === 'https',
+                region: 'us-east-2',
+                signatureCache: false,
+                httpOptions: { agent: this.sourceHTTPAgent, timeout: 0 },
+                maxRetries: 0,
+            }),
+            target: new AWS.IAM({
+                endpoint: `${this.destConfig.transport}://` +
+                    `${destS3.host}:${iamPort}`,
+                credentials: tgtAccessCreds,
+                sslEnabled: this.destConfig.transport === 'https',
+                region: 'us-east-2',
+                signatureCache: false,
+                httpOptions: { agent: this.destHTTPAgent, timeout: 0 },
+                maxRetries: 0,
+            }),
+        };
+    }
+
+    _createBucket(where, log, cb) {
+        const bucket = where === 'source' ? this._sourceBucket :
+            this._targetBucket;
+        this._s3Clients[where].createBucket({ Bucket: bucket }, (err, res) => {
+            if (err && err.code !== 'BucketAlreadyOwnedByYou') {
+                log.error('error creating a bucket', {
+                    bucket: where === 'source' ? this._sourceBucket :
+                        this._targetBucket,
+                    errCode: err.code,
+                    error: err.message,
+                    method: '_SetupReplication._createBucket',
+                });
+                return cb(err);
+            }
+            if (err && err.code === 'BucketAlreadyOwnedByYou') {
+                log.debug('Bucket already exists. Continuing setup.', {
+                    bucket: where === 'source' ? this._sourceBucket :
+                        this._targetBucket,
+                    errCode: err.code,
+                    error: err.message,
+                    method: '_SetupReplication._createBucket',
+                });
+            } else {
+                log.debug('Created bucket', {
+                    bucket: where === 'source' ? this._sourceBucket :
+                        this._targetBucket,
+                    method: '_SetupReplication._createBucket',
+                });
+            }
+            return cb(null, res);
+        });
+    }
+
+    _createRole(where, log, cb) {
+        const params = {
+            AssumeRolePolicyDocument: JSON.stringify(trustPolicy),
+            RoleName: `bb-replication-${Date.now()}`,
+            Path: '/',
+        };
+
+        this._iamClients[where].createRole(params, (err, res) => {
+            if (err) {
+                log.error('error creating a role', {
+                    bucket: where === 'source' ? this._sourceBucket :
+                        this._targetBucket,
+                    errCode: err.code,
+                    error: err.message,
+                    method: '_SetupReplication._createRole',
+                });
+                return cb(err);
+            }
+            log.debug('Created role', {
+                bucket: where === 'source' ? this._sourceBucket :
+                    this._targetBucket,
+                method: '_createRole',
+            });
+            return cb(null, res);
+        });
+    }
+
+    _createPolicy(where, log, cb) {
+        const params = {
+            PolicyDocument: JSON.stringify(
+                _buildResourcePolicy(this._sourceBucket, this._targetBucket)),
+            PolicyName: `bb-replication-${Date.now()}`,
+        };
+        this._iamClients[where].createPolicy(params, (err, res) => {
+            if (err) {
+                log.error('error creating policy', {
+                    bucket: where === 'source' ? this._sourceBucket :
+                        this._targetBucket,
+                    errCode: err.code,
+                    error: err.message,
+                    method: '_SetupReplication._createPolicy',
+                });
+                return cb(err);
+            }
+            log.debug('Created policy', {
+                bucket: where === 'source' ? this._sourceBucket :
+                    this._targetBucket,
+                method: '_createPolicy',
+            });
+            return cb(null, res);
+        });
+    }
+
+    _enableVersioning(where, log, cb) {
+        const bucket = where === 'source' ? this._sourceBucket :
+            this._targetBucket;
+        const params = {
+            Bucket: bucket,
+            VersioningConfiguration: {
+                Status: 'Enabled',
+            },
+        };
+        this._s3Clients[where].putBucketVersioning(params, (err, res) => {
+            if (err) {
+                log.error('error enabling versioning', {
+                    bucket: where === 'source' ? this._sourceBucket :
+                        this._targetBucket,
+                    errCode: err.code,
+                    error: err.message,
+                    method: '_SetupReplication._enableVersioning',
+                });
+                return cb(err);
+            }
+            log.debug('Versioning enabled', {
+                bucket: where === 'source' ? this._sourceBucket :
+                    this._targetBucket,
+                method: '_enableVersioning',
+            });
+            return cb(null, res);
+        });
+    }
+
+    _attachResourcePolicy(policyArn, roleName, where, log, cb) {
+        const params = {
+            PolicyArn: policyArn,
+            RoleName: roleName,
+        };
+        this._iamClients[where].attachRolePolicy(params, (err, res) => {
+            if (err) {
+                log.error('error attaching resource policy', {
+                    bucket: where === 'source' ? this._sourceBucket :
+                        this._targetBucket,
+                    errCode: err.code,
+                    error: err.message,
+                    method: '_SetupReplication._attachResourcePolicy',
+                });
+                return cb(err);
+            }
+            log.debug('Attached resource policy', {
+                bucket: where === 'source' ? this._sourceBucket :
+                    this._targetBucket,
+                method: '_attachResourcePolicy',
+            });
+            return cb(null, res);
+        });
+    }
+
+    _enableReplication(roleArns, log, cb) {
+        const params = {
+            Bucket: this._sourceBucket,
+            ReplicationConfiguration: {
+                Role: roleArns,
+                Rules: [{
+                    Destination: {
+                        Bucket: `arn:aws:s3:::${this._targetBucket}`,
+                    },
+                    Prefix: '',
+                    Status: 'Enabled',
+                }],
+            },
+        };
+        this._s3Clients.source.putBucketReplication(params, (err, res) => {
+            if (err) {
+                log.error('error enabling replication', {
+                    errCode: err.code,
+                    error: err.message,
+                    method: '_SetupReplication._enableReplication',
+                });
+                return cb(err);
+            }
+            log.debug('Bucket replication enabled', {
+                method: '_enableReplication',
+            });
+            return cb(null, res);
+        });
+    }
+
+    processQueueEntry(sourceEntry, done) {
+        const log = this.logger.newRequestLogger();
+        let email;
+        let srcCreds;
+        let tgtCreds;
+        let sourceRole;
+        let targetRole;
+        let sourcePolicyArn;
+        let targetPolicyArn;
+
+        this._sourceBucket = sourceEntry.getObjectKey();
+        this._targetBucket = sourceEntry.getObjectKey();
+
+        async.waterfall([
+            done => this._getSourceAccountCreds(sourceEntry, log, done),
+            (_email, _srcCreds, done) => {
+                email = _email;
+                srcCreds = _srcCreds;
+                this._getTargetAccountCreds(sourceEntry, email, log, done);
+            },
+            (_tgtCreds, done) => {
+                tgtCreds = _tgtCreds;
+                this._setupClients(srcCreds, tgtCreds);
+                done();
+            },
+            done => async.series({
+                targetBucket: done => this._createBucket(
+                    'target', log, done),
+                sourceRole: done => this._createRole('source', log, done),
+                targetRole: done => this._createRole('target', log, done),
+                sourcePolicy: done => this._createPolicy('source', log, done),
+                targetPolicy: done => this._createPolicy('target', log, done),
+            }, done),
+            (data, next) => {
+                sourceRole = data.sourceRole.Role;
+                targetRole = data.targetRole.Role;
+                sourcePolicyArn = data.sourcePolicy.Policy.Arn;
+                targetPolicyArn = data.targetPolicy.Policy.Arn;
+                const roleArns = `${sourceRole.Arn},${targetRole.Arn}`;
+                async.series([
+                    done => this._enableVersioning('source', log, done),
+                    done => this._enableVersioning('target', log, done),
+                    done => this._attachResourcePolicy(sourcePolicyArn,
+                                                       sourceRole.RoleName,
+                                                       'source', log, done),
+                    done => this._attachResourcePolicy(targetPolicyArn,
+                                                       targetRole.RoleName,
+                                                       'target', log, done),
+                    done => this._enableReplication(roleArns, log, done),
+                ], next);
+            },
+        ], err => {
+            if (err) {
+                log.end().error(
+                    'echo mode: error during replication configuration',
+                    { bucket: sourceEntry.getObjectKey(),
+                      userName: sourceEntry.getOwnerDisplayName(),
+                      userEmail: email,
+                      error: err,
+                    });
+                return done(err);
+            }
+            log.end().info(
+                'echo mode: configured replication for bucket',
+                { bucket: sourceEntry.getObjectKey(),
+                  userName: sourceEntry.getOwnerDisplayName(),
+                  userEmail: email,
+                  sourceRoleArn: sourceRole.Arn,
+                  targetRoleArn: targetRole.Arn,
+                  sourcePolicyArn,
+                  targetPolicyArn,
+                });
+            return done();
+        });
+    }
+}
+
+module.exports = SetupBucketTask;

--- a/extensions/replication/utils/QueueEntry.js
+++ b/extensions/replication/utils/QueueEntry.js
@@ -24,7 +24,7 @@ class QueueEntry {
     constructor(bucket, objectVersionedKey, objMd) {
         this.bucket = bucket;
         this.objectVersionedKey = objectVersionedKey;
-        if (bucket === '__metastore') {
+        if (bucket === 'users..bucket') {
             this.objectKey = objectVersionedKey;
         } else {
             this.objectKey = _extractVersionedBaseKey(objectVersionedKey);
@@ -39,7 +39,7 @@ class QueueEntry {
         if (typeof this.objectKey !== 'string') {
             return { message: 'missing object key' };
         }
-        if (this.bucket !== '__metastore') {
+        if (this.bucket !== 'users..bucket') {
             if (typeof this.objMd.replicationInfo !== 'object' ||
                 typeof this.objMd.replicationInfo.destination !== 'string') {
                 return { message: 'malformed source metadata: ' +
@@ -78,7 +78,7 @@ class QueueEntry {
     }
 
     isPutBucketOp() {
-        return this.bucket === '__metastore';
+        return this.bucket === 'users..bucket';
     }
 
     isDeleteMarker() {
@@ -135,12 +135,12 @@ class QueueEntry {
     }
 
     getOwnerCanonicalId() {
-        return this.objMd[this.isPutBucketOp() ? 'owner' : 'owner-id'];
+        return this.objMd['owner-id'];
     }
 
     getOwnerDisplayName() {
-        return this.objMd[this.isPutBucketOp() ?
-                          'ownerDisplayName' : 'owner-display-name'];
+        return (this._ownerDisplayName ?
+                this._ownerDisplayName : this.objMd['owner-display-name']);
     }
 
     getLogInfo() {
@@ -203,11 +203,8 @@ class QueueEntry {
     }
 
     setOwner(ownerCanonicalId, ownerDisplayName) {
-        this.objMd[this.isPutBucketOp() ? 'owner' : 'owner-id']
-            = ownerCanonicalId;
-        this.objMd[this.isPutBucketOp() ?
-                   'ownerDisplayName' : 'owner-display-name']
-            = ownerDisplayName;
+        this.objMd['owner-id'] = ownerCanonicalId;
+        this.objMd['owner-display-name'] = ownerDisplayName;
     }
 
     setLocation(location) {

--- a/lib/config/configItems.joi.js
+++ b/lib/config/configItems.joi.js
@@ -11,6 +11,7 @@ const bootstrapListJoi = joi.array().items(
     joi.object({
         site: joi.string().required(),
         servers: joi.array().items(joi.string()),
+        echo: joi.boolean().default(false),
     })
 );
 


### PR DESCRIPTION
    ft: implement "echo" replication mode
    
    !POC only!
    
    This mode processes the "create bucket" entries on the source to
    configures CRR automatically for this bucket through backbeat
    (including creating the destination account if it does not exist, then
    basically what does the replication.js setup script).
    
    The destination bucket has the same name than on the source, and the
    owner account has the same display name and email address (but a
    different user ID and canonical ID since on a different Vault).

Depends on https://github.com/scality/backbeat/pull/93
