### PR TITLE
ft: Add backbeat api route healthcheck

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,4 +21,5 @@ test:
         - npm run --silent lint_md
         - npm run --silent lint
         - npm test
+        - TEST_SWITCH=1 npm start & bash tests/utils/wait_for_local_port.bash 8900 40 && npm run ft_server_test
         - npm run ft_test

--- a/index.js
+++ b/index.js
@@ -1,0 +1,17 @@
+'use strict'; // eslint-disable-line strict
+
+const werelogs = require('werelogs');
+
+const runServer = require('./lib/api/BackbeatServer');
+
+const Config = process.env.TEST_SWITCH !== '1' ? require('./conf/Config') :
+    require('./tests/config.json');
+
+const Logger = werelogs.Logger;
+
+werelogs.configure({
+    level: Config.log.logLevel,
+    dump: Config.log.dumpLevel,
+});
+
+runServer(Config, Logger);

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -90,6 +90,14 @@ class BackbeatProducer extends EventEmitter {
     }
 
     /**
+    * get external modules kafka client
+    * @return {kafka-node.Client} - external kafka client instance
+    */
+    getKafkaClient() {
+        return this._client;
+    }
+
+    /**
     * create topic - works only when auto.create.topics.enable=true for the
     * Kafka server. It sends a metadata request to the server which will create
     * the topic

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -1,0 +1,209 @@
+'use strict'; // eslint-disable-line strict
+
+const async = require('async');
+const zookeeper = require('node-zookeeper-client');
+
+const { errors } = require('arsenal');
+
+const BackbeatProducer = require('../BackbeatProducer');
+const routes = require('./routes');
+
+// In-Sync Replicas
+const ISRS = 3;
+
+/**
+ * Class representing Backbeat API endpoints and internals
+ *
+ * @class
+ */
+class BackbeatAPI {
+    /**
+     * @constructor
+     * @param {object} config - configurations for setup
+     * @param {werelogs.Logger} logger - Logger object
+     */
+    constructor(config, logger) {
+        this._zkConfig = config.zookeeper;
+        this._repConfig = config.extensions.replication;
+        this._crrTopic = this._repConfig.topic;
+        this._crrStatusTopic = this._repConfig.replicationStatusTopic;
+        this._metricsTopic = config.metrics.topic;
+        this._queuePopulator = config.queuePopulator;
+        this._kafkaHost = config.kafka.hosts;
+        this._logger = logger;
+
+        this._crrProducer = null;
+        this._crrStatusProducer = null;
+        this._metricProducer = null;
+        this._zkClient = null;
+    }
+
+    /**
+     * Check if incoming request is valid
+     * @param {string} route - request route
+     * @return {boolean} true/false
+     */
+    isValidRoute(route) {
+        return routes.some(r => r.path.includes(route));
+    }
+
+    /**
+     * Check if Zookeeper and Producer are connected
+     * @return {boolean} true/false
+     */
+    isConnected() {
+        return this._zkClient.getState().name === 'SYNC_CONNECTED'
+            && this._checkProducersReady();
+    }
+
+    _checkProducersReady() {
+        return this._crrProducer.isReady() && this._metricProducer.isReady()
+            && this._crrStatusProducer.isReady();
+    }
+
+    _getConnectionDetails() {
+        return {
+            zookeeper: {
+                status: this._zkClient.getState().name === 'SYNC_CONNECTED' ?
+                    'ok' : 'error',
+                details: this._zkClient.getState(),
+            },
+            kafkaProducer: {
+                status: this._checkProducersReady() ? 'ok' : 'error',
+            },
+        };
+    }
+
+    /**
+     * Checks health of in-sync replicas
+     * @param {object} md - topic metadata object
+     * @return {boolean} true if ISR health is ok
+     */
+    _checkISRHealth(md) {
+        // eslint-disable-next-line consistent-return
+        const keys = Object.keys(md);
+        for (let i = 0; i < keys.length; i++) {
+            if (md[keys[i]].isr && md[keys[i]].isr.length !== ISRS) {
+                return 'error';
+            }
+        }
+        return 'ok';
+    }
+
+    /**
+     * Get Kafka healthcheck
+     * @param {function} cb - callback(error, data)
+     * @return {undefined}
+     */
+    healthcheck(cb) {
+        const client = this._crrProducer.getKafkaClient();
+
+        // TODO: refactor by calling specific topic
+        client.loadMetadataForTopics([], (err, res) => {
+            if (err) {
+                this._logger.error('error getting healthcheck');
+                return cb(errors.InternalError
+                    .customizeDescription('error getting healthcheck metadata' +
+                    ' for topics'));
+            }
+            const response = res.map(i => (Object.assign({}, i)));
+            const connections = {};
+            const topicMD = {};
+            response.forEach((obj, idx) => {
+                if (obj.metadata && obj.metadata[this._repConfig.topic]) {
+                    let copy;
+                    try {
+                        copy = JSON.parse(JSON.stringify(obj.metadata[
+                            this._repConfig.topic]));
+                        topicMD.metadata = copy;
+                        response.splice(idx, 1);
+                    } catch (e) {
+                        this._logger.error('error getting topic metadata');
+                    }
+                }
+            });
+            response.push(topicMD);
+
+            if (topicMD.metadata) {
+                connections.isrHealth = this._checkISRHealth(topicMD.metadata);
+            }
+
+            Object.assign(connections, this._getConnectionDetails());
+            response.push({
+                internalConnections: connections,
+            });
+
+            return cb(null, response);
+        });
+    }
+
+    setupInternals(cb) {
+        async.parallel([
+            done => this._setZookeeper(done),
+            done => this._setProducer(this._metricsTopic, (err, producer) => {
+                if (err) {
+                    return done(err);
+                }
+                this._metricProducer = producer;
+                return done();
+            }),
+            done => this._setProducer(this._crrTopic, (err, producer) => {
+                if (err) {
+                    return done(err);
+                }
+                this._crrProducer = producer;
+                return done();
+            }),
+            done => this._setProducer(this._crrStatusTopic, (err, producer) => {
+                if (err) {
+                    return done(err);
+                }
+                this._crrStatusProducer = producer;
+                return done();
+            }),
+        ], err => {
+            if (err) {
+                this._logger.error('error setting up internal clients');
+                return cb(err);
+            }
+            this._logger.info('BackbeatAPI setup ready');
+            return cb();
+        });
+    }
+
+    _setProducer(topic, cb) {
+        const producer = new BackbeatProducer({
+            zookeeper: { connectionString: this._zkConfig.connectionString },
+            topic,
+        });
+
+        producer.once('error', cb);
+        producer.once('ready', () => {
+            producer.removeAllListeners('error');
+            producer.on('error', error => {
+                this._logger.error('error from backbeat producer', { error });
+            });
+            return cb(null, producer);
+        });
+    }
+
+    _setZookeeper(cb) {
+        const populatorZkPath = this._queuePopulator.zookeeperPath;
+        const zookeeperUrl =
+            `${this._zkConfig.connectionString}${populatorZkPath}`;
+
+        const zkClient = zookeeper.createClient(zookeeperUrl, {
+            autoCreateNamespace: this._zkConfig.autoCreateNamespace,
+        });
+        zkClient.connect();
+
+        zkClient.once('error', cb);
+        zkClient.once('connected', () => {
+            zkClient.removeAllListeners('error');
+            this._zkClient = zkClient;
+            return cb();
+        });
+    }
+}
+
+module.exports = BackbeatAPI;

--- a/lib/api/BackbeatRequest.js
+++ b/lib/api/BackbeatRequest.js
@@ -1,0 +1,124 @@
+'use strict'; // eslint-disable-line strict
+
+/**
+ * Class representing a Backbeat API Request
+ *
+ * @class
+ */
+class BackbeatRequest {
+    /**
+     * @constructor
+     * @param {http.IncomingMessage} req - request object
+     * @param {http.ServerResponse} res - response object
+     * @param {Logger.newRequestLogger} log - logger object
+     */
+    constructor(req, res, log) {
+        this._request = req;
+        this._response = res;
+        this._log = log;
+        this._route = req.url;
+        this._statusCode = 0;
+        this._error = null;
+    }
+
+    /**
+     * Get logger object
+     * @return {object} Logger object
+     */
+    getLog() {
+        return this._log;
+    }
+
+    /**
+     * Set logger object
+     * @param {object} log - new Logger object
+     * @return {BackbeatRequest} itself
+     */
+    setLog(log) {
+        this._log = log;
+        return this;
+    }
+
+    /**
+     * Get http request object
+     * @return {object} Http request object
+     */
+    getRequest() {
+        return this._request;
+    }
+
+    /**
+     * Set http request object
+     * @param {object} request - new Http request object
+     * @return {BackbeatRequest} itself
+     */
+    setRequest(request) {
+        this._request = request;
+        return this;
+    }
+
+    /**
+     * Get http response object
+     * @return {object} Http response object
+     */
+    getResponse() {
+        return this._response;
+    }
+
+    /**
+     * Set http response object
+     * @param {object} response - new Http response object
+     * @return {BackbeatRequest} itself
+     */
+    setResponse(response) {
+        this._response = response;
+        return this;
+    }
+
+    /**
+     * Get status code of request
+     * @return {number} Http status code
+     */
+    getStatusCode() {
+        return this._statusCode;
+    }
+
+    /**
+     * Set status code of request
+     * @param {number} code - new Http status code
+     * @return {BackbeatRequest} itself
+     */
+    setStatusCode(code) {
+        this._statusCode = code;
+        return this;
+    }
+
+    /**
+     * Get route
+     * @return {string} current route
+     */
+    getRoute() {
+        return this._route;
+    }
+
+    /**
+     * Set route
+     * @param {string} route - new route string
+     * @return {BackbeatRequest} itself
+     */
+    setRoute(route) {
+        this._route = route;
+        return this;
+    }
+
+    /**
+     * Status check to see if valid request
+     * @return {boolean} valid status check
+     */
+    getStatus() {
+        return ((this._statusCode >= 200 && this._statusCode < 300)
+            && !this._error);
+    }
+}
+
+module.exports = BackbeatRequest;

--- a/lib/api/BackbeatServer.js
+++ b/lib/api/BackbeatServer.js
@@ -1,0 +1,220 @@
+'use strict'; // eslint-disable-line strict
+
+const http = require('http');
+
+const { Clustering, errors, ipCheck } = require('arsenal');
+
+const BackbeatRequest = require('./BackbeatRequest');
+const BackbeatAPI = require('./BackbeatAPI');
+
+const WORKERS = 1;
+
+class BackbeatServer {
+    /**
+     * @constructor
+     * @param {Worker} [worker=null] - Track the worker using cluster
+     * @param {object} config - configurations for server setup
+     * @param {werelogs.Logger} logger - Logger object
+     * @param {BackbeatAPI} backbeatAPI - BackbeatAPI instance
+     */
+    constructor(worker, config, logger, backbeatAPI) {
+        this.server = null;
+        this.worker = worker;
+        this._config = config;
+        this._port = config.port;
+        this._logger = logger;
+        this.backbeatAPI = backbeatAPI;
+    }
+
+    /**
+     * Last log message to send per incoming request
+     * @param {werelogs.newRequestLogger} logger - request logger
+     * @param {object} req - request object
+     * @param {object} res - response object
+     * @return {undefined}
+     */
+    _logRequestEnd(logger, req, res) {
+        const info = {
+            clientIp: req.socket.remoteAddress,
+            clientPort: req.socket.remotePort,
+            httpMethod: req.method,
+            httpURL: req.url,
+            httpCode: res.statusCode,
+            httpMessage: res.statusMessage,
+        };
+        logger.end('finished handling request', info);
+    }
+
+    /**
+     * Check if incoming request is valid
+     * @param {object} req - incoming request object
+     * @param {BackbeatRequest} backbeatRequest - Backbeat request object
+     * @return {boolean} true if no errors
+     */
+    _isValidRequest(req, backbeatRequest) {
+        const allowIp = ipCheck.ipMatchCidrList(
+            this._config.healthChecks.allowFrom, req.socket.remoteAddress);
+        if (!allowIp) {
+            return this._errorResponse(errors.AccessDenied
+                .customizeDescription('invalid origin ip request'),
+                backbeatRequest);
+        }
+
+        if (!this.backbeatAPI.isValidRoute(backbeatRequest.getRoute())
+            || !backbeatRequest.getRoute().startsWith('/_/')) {
+            return this._errorResponse(errors.RouteNotFound
+                .customizeDescription(`path ${backbeatRequest.getRoute()} does `
+                    + 'not exist'), backbeatRequest);
+        }
+
+        if (req.method !== 'GET') {
+            // So far the API should only be receiving GET requests
+            return this._errorResponse(errors.MethodNotAllowed
+                .customizeDescription('invalid http verb'),
+                backbeatRequest);
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if Kafka Producer and Zookeeper are working properly
+     * @param {BackbeatRequest} backbeatRequest - Backbeat request object
+     * @return {boolean} true if no errors
+     */
+    _areConditionsOk(backbeatRequest) {
+        if (!this.backbeatAPI.isConnected()) {
+            return this._errorResponse(errors.InternalError
+                .customizeDescription('error connecting to internal client'),
+                backbeatRequest);
+        }
+
+        return true;
+    }
+
+    /**
+     * Server's error response handler
+     * @param {arsenal.ArsenalError} err - arsenal error object
+     * @param {BackbeatRequest} backbeatRequest - Backbeat request object
+     * @return {undefined}
+     */
+    _errorResponse(err, backbeatRequest) {
+        backbeatRequest.setStatusCode(err.code);
+        this._response(err, backbeatRequest);
+    }
+
+    /**
+     * Server incoming request handler
+     * @param {object} req - request object
+     * @param {object} res - response object
+     * @return {undefined}
+     */
+    _requestListener(req, res) {
+        req.socket.setNoDelay();
+        const bbRequest = new BackbeatRequest(req, res,
+            this._logger.newRequestLogger());
+
+        // check request conditions and all internal conditions here
+        if (this._isValidRequest(req, bbRequest)
+        && this._areConditionsOk(bbRequest)) {
+            bbRequest.setStatusCode(200)
+                .setRoute(bbRequest.getRoute().slice(3));
+
+            this.backbeatAPI[bbRequest.getRoute()]((err, data) => {
+                if (err) {
+                    this._errorResponse(err, bbRequest);
+                } else {
+                    this._response(data, bbRequest);
+                }
+            });
+        }
+    }
+
+    /**
+     * Server's response to the client
+     * @param {object} data - response to send to client
+     * @param {BackbeatRequest} backbeatRequest - Backbeat request object
+     * @return {object} res - response object
+     */
+    _response(data, backbeatRequest) {
+        const log = backbeatRequest.getLog();
+        const req = backbeatRequest.getRequest();
+        const res = backbeatRequest.getResponse();
+        log.trace('writing HTTP response', {
+            method: 'BackbeatServer._response',
+        });
+        const code = backbeatRequest.getStatusCode();
+        const payload = Buffer.from(JSON.stringify(data), 'utf8');
+
+        res.writeHead(code, {
+            'Content-Type': 'application/json',
+            'Content-Length': payload.length,
+        });
+        this._logRequestEnd(log, req, res);
+        return res.end(payload);
+    }
+
+    /**
+     * start BackbeatServer
+     * @return {undefined}
+     */
+    start() {
+        this.server = http.createServer((req, res) => {
+            this._requestListener(req, res);
+        });
+
+        this.server.on('listening', () => {
+            const addr = this.server.address() || {
+                address: '0.0.0.0',
+                port: this._port,
+            };
+            this._logger.trace('server started', {
+                address: addr.address,
+                port: addr.port,
+                pid: process.pid,
+            });
+        });
+        this.server.listen(this._port);
+    }
+
+    /*
+     * stop BackbeatServer and exit running process properly
+     */
+    stop() {
+        this._logger.info(`worker ${this.worker} shutting down`);
+        this.server.close();
+        process.exit(0);
+    }
+}
+
+/**
+ * start the backbeat API server
+ * @param {object} config - location of config file
+ * @param {werelogs.Logger} Logger - Logger object
+ * @param {function} cb - callback function
+ * @return {undefined}
+ */
+function run(config, Logger) {
+    const logger = new Logger('BackbeatServer');
+    const apiLogger = new Logger('BackbeatAPI');
+    const cluster = new Clustering(WORKERS, logger);
+    const backbeatAPI = new BackbeatAPI(config, apiLogger);
+
+    backbeatAPI.setupInternals(err => {
+        if (err) {
+            logger.error('internal error, please try again', {
+                error: err,
+            });
+            process.exit(1);
+        } else {
+            cluster.start(worker => {
+                const server = new BackbeatServer(worker, config.server, logger,
+                    backbeatAPI);
+                process.on('SIGINT', () => server.stop());
+                server.start();
+            });
+        }
+    });
+}
+
+module.exports = run;

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -1,0 +1,10 @@
+/*
+    This file contains all unique details about API routes exposed by Backbeats
+    API server.
+*/
+
+module.exports = [
+    {
+        path: '/_/healthcheck',
+    },
+];

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
     "queue_processor": "node extensions/replication/queueProcessor/task.js",
     "replication_status_processor": "node extensions/replication/replicationStatusProcessor/task.js",
     "test": "mocha --recursive tests/unit",
-    "ft_test": "mocha --recursive tests/functional",
+    "ft_test": "mocha --recursive $(find tests/functional -name '*.js' ! -name 'BackbeatServer.js')",
+    "ft_server_test": "mocha tests/functional/api/BackbeatServer.js",
     "bh_test": "mocha --recursive tests/behavior",
     "lint": "eslint $(git ls-files '*.js')",
-    "lint_md": "mdlint $(git ls-files '*.md')"
+    "lint_md": "mdlint $(git ls-files '*.md')",
+    "start": "node index.js"
   },
   "repository": {
     "type": "git",

--- a/tests/config.json
+++ b/tests/config.json
@@ -1,6 +1,10 @@
 {
     "zookeeper": {
-        "connectionString": "127.0.0.1:2181"
+        "connectionString": "127.0.0.1:2181",
+        "autoCreateNamespace": true
+    },
+    "kafka": {
+        "hosts": "127.0.0.1:9092"
     },
     "queuePopulator": {
         "cronRule": "*/5 * * * * *",
@@ -16,9 +20,6 @@
     "kafka": {
         "hosts": "127.0.0.1:9092"
     },
-    "metrics": {
-        "topic": "backbeat-test-metrics"
-    },
     "s3": {
         "host": "127.0.0.1",
         "port": 8000,
@@ -29,12 +30,23 @@
     "extensions": {
         "replication": {
             "topic": "backbeat-test-replication",
+            "replicationStatusTopic": "backbeat-test-replication-status",
             "groupId": "backbeat-test-replication-group"
         }
     },
     "log": {
         "logLevel": "info",
         "dumpLevel": "error"
+    },
+    "metrics": {
+        "topic": "backbeat-metrics"
+    },
+    "server": {
+        "healthChecks": {
+            "allowFrom": ["127.0.0.1/8", "::1"]
+        },
+        "host": "127.0.0.1",
+        "port": 8900
     },
     "redis": {
         "name": "backbeat-test",

--- a/tests/functional/api/BackbeatServer.js
+++ b/tests/functional/api/BackbeatServer.js
@@ -1,0 +1,101 @@
+const assert = require('assert');
+const http = require('http');
+
+const config = require('../../config.json');
+const { Client, Producer } = require('kafka-node');
+
+const defaultOptions = {
+    host: config.server.host,
+    port: config.server.port,
+    method: 'GET',
+};
+
+function getUrl(options, path) {
+    return `http://${options.host}:${options.port}${path}`;
+}
+
+describe('Backbeat Server', () => {
+    describe('healthcheck route', () => {
+        let data;
+        let resCode;
+        before(done => {
+            const kafkaClient = new Client(config.zookeeper.connectionString,
+                'TestClient');
+            const testProducer = new Producer(kafkaClient);
+            testProducer.createTopics([
+                config.extensions.replication.topic,
+                config.extensions.replication.replicationStatusTopic,
+            ], false, () => {});
+
+            const url = getUrl(defaultOptions, '/_/healthcheck');
+
+            http.get(url, res => {
+                resCode = res.statusCode;
+
+                let rawData = '';
+                res.on('data', chunk => {
+                    rawData += chunk;
+                });
+                res.on('end', () => {
+                    data = JSON.parse(rawData);
+                    done();
+                });
+            });
+        });
+
+        it('should get a response with data', done => {
+            assert(Object.keys(data).length > 0);
+            assert.equal(resCode, 200);
+            return done();
+        });
+
+        it('should have valid keys', done => {
+            const keys = [].concat(...data.map(d => Object.keys(d)));
+
+            assert(keys.includes('metadata'));
+            assert(keys.includes('internalConnections'));
+            return done();
+        });
+
+        it('should be healthy', done => {
+            // NOTE: isrHealth is not checked here because circleci
+            // kafka will have one ISR only. Maybe isrHealth should
+            // be a test for end-to-end
+            let internalConnections;
+            data.forEach(obj => {
+                if (Object.keys(obj).includes('internalConnections')) {
+                    internalConnections = obj.internalConnections;
+                }
+            });
+            Object.keys(internalConnections).forEach(key => {
+                assert.ok(internalConnections[key]);
+            });
+
+            return done();
+        });
+    });
+
+    it('should get a 404 route not found error response', done => {
+        const url = getUrl(defaultOptions, '/_/invalidpath');
+
+        http.get(url, res => {
+            assert.equal(res.statusCode, 404);
+            done();
+        });
+    });
+
+    it('should get a 405 method not allowed from invalid http verb', done => {
+        const options = Object.assign({}, defaultOptions);
+        options.method = 'POST';
+        options.path = '/_/healthcheck';
+
+        const req = http.request(options, res => {
+            assert.equal(res.statusCode, 405);
+        });
+        req.on('error', err => {
+            assert.ifError(err);
+        });
+        req.end();
+        done();
+    });
+});

--- a/tests/utils/wait_for_local_port.bash
+++ b/tests/utils/wait_for_local_port.bash
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+wait_for_local_port() {
+    local port=$1
+    local timeout=$2
+    local count=0
+    local ret=1
+    echo "waiting for BackbeatServer:$port"
+    while [[ "$ret" -eq "1" && "$count" -lt "$timeout" ]] ; do
+        nc -z -w 1 localhost $port
+        ret=$?
+        if [ ! "$ret" -eq "0" ]; then
+            echo -n .
+            sleep 1
+            count=$(($count+1))
+        fi
+    done
+
+    echo ""
+
+    if [[ "$count" -eq "$timeout" ]]; then
+        echo "Server did not start in less than $timeout seconds. Exiting..."
+        exit 1
+    fi
+    sleep 5
+
+    echo "Server got ready in ~${count} seconds. Starting test now..."
+}
+
+wait_for_local_port $1 $2


### PR DESCRIPTION
Add `/_/healthcheck` route

In order to run the server, it is required to run zookeeper and kafka

NOTE: This PR is still using the SOHU-Co/kafka-node module


Sample output:
`
[{"0":{"nodeId":0,"host":"na-node1","port":9092},"1":{"nodeId":1,"host":"na-node2","port":9092},"2":{"nodeId":2,"host":"na-node3","port":9092},"3":{"nodeId":3,"host":"na-node4","port":9092},"4":{"nodeId":4,"host":"na-node5","port":9092}},{"metadata":{"0":{"topic":"backbeat-replication","partition":0,"leader":4,"replicas":[0,1,4],"isr":[1,4,0]},"1":{"topic":"backbeat-replication","partition":1,"leader":1,"replicas":[0,1,2],"isr":[1,2,0]},"2":{"topic":"backbeat-replication","partition":2,"leader":1,"replicas":[1,2,3],"isr":[1,2,3]},"3":{"topic":"backbeat-replication","partition":3,"leader":2,"replicas":[2,3,4],"isr":[3,2,4]},"4":{"topic":"backbeat-replication","partition":4,"leader":3,"replicas":[0,3,4],"isr":[4,3,0]}}},{"internalConnections":{"isrHealth":"ok","zookeeper":{"status":"ok","details":{"name":"SYNC_CONNECTED","code":3}},"kafkaProducer":{"status":"ok"}}}]
`