### PR TITLE
ft: serialize all ops on object

### DIFF
--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -137,7 +137,7 @@ class QueueProcessor {
                 new MultipleBackendTask(this) : new QueueProcessorTask(this),
             entry: sourceEntry,
         },
-        `${sourceEntry.getBucket()}/${sourceEntry.getObjectVersionedKey()}`,
+        `${sourceEntry.getBucket()}/${sourceEntry.getObjectKey()}`,
         done);
     }
 }

--- a/extensions/replication/queueProcessor/ReplicationTaskScheduler.js
+++ b/extensions/replication/queueProcessor/ReplicationTaskScheduler.js
@@ -2,21 +2,21 @@ const async = require('async');
 
 /**
  * Schedule replication tasks for replicated buckets, by ensuring that
- * all updates to the same version of an object are serialized
+ * all updates to the same object are serialized
 */
 class ReplicationTaskScheduler {
     constructor(processingFunc) {
         this._processingFunc = processingFunc;
-        this._runningTasksByVersionedKey = {};
+        this._runningTasksByMasterKey = {};
     }
 
-    push(entry, versionedKey, done) {
-        let queue = this._runningTasksByVersionedKey[versionedKey];
+    push(entry, masterKey, done) {
+        let queue = this._runningTasksByMasterKey[masterKey];
         if (queue === undefined) {
             queue = async.queue(this._processingFunc);
             queue.drain =
-                () => delete this._runningTasksByVersionedKey[versionedKey];
-            this._runningTasksByVersionedKey[versionedKey] = queue;
+                () => delete this._runningTasksByMasterKey[masterKey];
+            this._runningTasksByMasterKey[masterKey] = queue;
         }
         queue.push(entry, done);
     }

--- a/tests/unit/replication/ReplicationTaskScheduler.spec.js
+++ b/tests/unit/replication/ReplicationTaskScheduler.spec.js
@@ -26,14 +26,13 @@ describe('replication task scheduler', () => {
             }
         }
         for (let i = 0; i < 10; ++i) {
-            objects.push({ versionedKey: `key_with_version_${i}`,
-                          value: -1 });
+            objects.push({ objectKey: `key_${i}`, value: -1 });
             // the following inner operations shall be executed in
-            // order because they have the same versionedKey (passed
+            // order because they have the same objectKey (passed
             // to taskScheduler.push())
             for (let j = 0; j < 10; ++j) {
                 taskScheduler.push({ object: objects[i], setValueTo: j },
-                                   objects[i].versionedKey, doneFunc);
+                                   objects[i].objectKey, doneFunc);
             }
         }
     });


### PR DESCRIPTION
Ensure serialization of operations at object level instead of for
every version of the object, so that the ordering guarantees are valid
for AWS backend as well.