### PR TITLE
ft: support for aws-s3 replication endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ updates in a FIFO order.
 
 Please refer to the ****[Design document](/DESIGN.md)****
 
+- [CRR from CloudServer to AWS S3 workflow](/docs/crr-to-aws-s3.md)
+
 ## QUICKSTART
 
 This guide assumes the following:

--- a/conf/config.json
+++ b/conf/config.json
@@ -41,7 +41,8 @@
             "destination": {
                 "transport": "http",
                 "bootstrapList": [
-                    { "site": "sf", "servers": ["127.0.0.1:8443"]}
+                    { "site": "sf", "servers": ["127.0.0.1:8443"]},
+                    { "site": "us-east-1", "type": "aws_s3" }
                 ],
                 "certFilePaths": {
                     "key": "ssl/key.pem",

--- a/docs/crr-to-aws-s3.md
+++ b/docs/crr-to-aws-s3.md
@@ -54,7 +54,7 @@ env_replication_endpoints:
 * Upon acquiring an entry to replicate, the task sends a GET Object ?versionId
   request to CloudServer
 
-* The steam is piped to PUT /_/backbeat Data request with header
+* The stream is piped to PUT /_/backbeat Data request with header
   `x-scal-replication-storage-type: aws_s3`
 
 * Upon receiving 200, read `x-amz-scal-version-id` from the header and send PUT

--- a/lib/config/configItems.joi.js
+++ b/lib/config/configItems.joi.js
@@ -7,12 +7,18 @@ const hostPortJoi = joi.object({
     port: joi.number().greater(0).required(),
 });
 
+const bootstrapServers = joi.object({
+    site: joi.string().required(),
+    servers: joi.array().items(joi.string()),
+});
+
+const bootstrapCloudBackend = joi.object({
+    site: joi.string().required(),
+    type: joi.string().valid('aws_s3'),
+});
+
 const bootstrapListJoi = joi.array().items(
-    joi.object({
-        site: joi.string().required(),
-        servers: joi.array().items(joi.string()),
-    })
-);
+    bootstrapServers, bootstrapCloudBackend);
 
 const logJoi =
           joi.object({

--- a/tests/unit/conf/Config.js
+++ b/tests/unit/conf/Config.js
@@ -1,10 +1,10 @@
 'use strict'; // eslint-disable-line
 
 const assert = require('assert');
+const config = require('../../../conf/Config');
 
 describe('backbeat config parsing and validation', () => {
     it('should parse correctly the default config', () => {
-        const config = require('../../../conf/Config');
         assert.notStrictEqual(config, undefined);
     });
 });


### PR DESCRIPTION
With this commit, bootstrapList expects the endpoint to have site/type or site/servers combination. Currently the only allowed type is aws_s3.