### PR TITLE
Ft/S3C-354 add metrics accumulation

### DIFF
--- a/bin/queuePopulator.js
+++ b/bin/queuePopulator.js
@@ -7,6 +7,7 @@ const config = require('../conf/Config');
 const zkConfig = config.zookeeper;
 const extConfigs = config.extensions;
 const qpConfig = config.queuePopulator;
+const mConfig = config.metrics;
 const QueuePopulator = require('../lib/queuePopulator/QueuePopulator');
 
 const log = new werelogs.Logger('Backbeat:QueuePopulator');
@@ -41,7 +42,8 @@ function queueBatch(queuePopulator, taskState) {
 }
 /* eslint-enable no-param-reassign */
 
-const queuePopulator = new QueuePopulator(zkConfig, qpConfig, extConfigs);
+const queuePopulator = new QueuePopulator(zkConfig, qpConfig, mConfig,
+    extConfigs);
 
 async.waterfall([
     done => queuePopulator.open(done),

--- a/extensions/replication/ReplicationQueuePopulator.js
+++ b/extensions/replication/ReplicationQueuePopulator.js
@@ -51,6 +51,8 @@ class ReplicationQueuePopulator extends QueuePopulatorExtension {
         this.publish(this.repConfig.topic,
                      `${queueEntry.getBucket()}/${queueEntry.getObjectKey()}`,
                      JSON.stringify(entry));
+
+        this._incrementMetrics(entry.bucket, queueEntry.getBytesMetric());
     }
 }
 

--- a/extensions/replication/constants.js
+++ b/extensions/replication/constants.js
@@ -4,6 +4,9 @@ const constants = {
     zookeeperReplicationNamespace: '/backbeat/replication',
     proxyVaultPath: '/_/backbeat/vault',
     proxyIAMPath: '/_/backbeat/iam',
+    metricsExtension: 'crr',
+    metricsTypeQueued: 'queued',
+    metricsTypeProcessed: 'processed',
 };
 
 module.exports = constants;

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -11,7 +11,7 @@ const RoundRobin = require('arsenal').network.RoundRobin;
 const BackbeatProducer = require('../../../lib/BackbeatProducer');
 const BackbeatConsumer = require('../../../lib/BackbeatConsumer');
 const VaultClientCache = require('../../../lib/clients/VaultClientCache');
-const QueueEntry = require('../utils/QueueEntry');
+const QueueEntry = require('../../../lib/models/QueueEntry');
 const ReplicationTaskScheduler = require('../utils/ReplicationTaskScheduler');
 const ReplicateObject = require('../tasks/ReplicateObject');
 const MultipleBackendTask = require('../tasks/MultipleBackendTask');
@@ -20,7 +20,12 @@ const EchoBucket = require('../tasks/EchoBucket');
 const ObjectQueueEntry = require('../utils/ObjectQueueEntry');
 const BucketQueueEntry = require('../utils/BucketQueueEntry');
 
-const { proxyVaultPath, proxyIAMPath } = require('../constants');
+const {
+    proxyVaultPath,
+    proxyIAMPath,
+    metricsExtension,
+    metricsTypeProcessed,
+} = require('../constants');
 
 /**
 * Given that the largest object JSON from S3 is about 1.6 MB and adding some
@@ -40,7 +45,7 @@ class QueueProcessor extends EventEmitter {
      *
      * @constructor
      * @param {Object} zkConfig - zookeeper configuration object
-     * @param {string} zkConfig.connectionString - zookeeper connection string
+     * @param {String} zkConfig.connectionString - zookeeper connection string
      *   as "host:port[/chroot]"
      * @param {Object} sourceConfig - source S3 configuration
      * @param {Object} sourceConfig.s3 - s3 endpoint configuration object
@@ -57,8 +62,10 @@ class QueueProcessor extends EventEmitter {
      *   number of seconds before giving up retries of an entry
      *   replication
      * @param {String} site - site name
+     * @param {MetricsProducer} mProducer - instance of metrics producer
      */
-    constructor(zkConfig, sourceConfig, destConfig, repConfig, site) {
+    constructor(zkConfig, sourceConfig, destConfig, repConfig, site,
+    mProducer) {
         super();
         this.zkConfig = zkConfig;
         this.sourceConfig = sourceConfig;
@@ -70,6 +77,7 @@ class QueueProcessor extends EventEmitter {
         this.replicationStatusProducer = null;
         this._consumer = null;
         this.site = site;
+        this._mProducer = mProducer;
 
         this.echoMode = false;
 
@@ -249,6 +257,18 @@ class QueueProcessor extends EventEmitter {
                 });
                 this._consumer.on('error', () => {});
                 this._consumer.subscribe();
+
+                this._consumer.on('metrics', data => {
+                    // i.e. data = { my-bucket: { ops: 1, bytes: 124 } }
+                    this._mProducer.publishMetrics(data, metricsTypeProcessed,
+                        metricsExtension, err => {
+                            this.logger.trace('error occurred in publishing ' +
+                            'metrics', {
+                                error: err,
+                                method: 'QueueProcessor.start',
+                            });
+                        });
+                });
             }
             this.logger.info('queue processor is ready to consume ' +
                              'replication entries');

--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -9,7 +9,7 @@ const BackbeatConsumer = require('../../../lib/BackbeatConsumer');
 const VaultClientCache = require('../../../lib/clients/VaultClientCache');
 const ReplicationTaskScheduler = require('../utils/ReplicationTaskScheduler');
 const UpdateReplicationStatus = require('../tasks/UpdateReplicationStatus');
-const QueueEntry = require('../utils/QueueEntry');
+const QueueEntry = require('../../../lib/models/QueueEntry');
 const ObjectQueueEntry = require('../utils/ObjectQueueEntry');
 
 /**

--- a/extensions/replication/utils/ObjectQueueEntry.js
+++ b/extensions/replication/utils/ObjectQueueEntry.js
@@ -3,7 +3,10 @@ const VID_SEP = require('arsenal').versioning.VersioningConstants
           .VersionId.Separator;
 
 function _extractVersionedBaseKey(key) {
-    return key.split(VID_SEP)[0];
+    if (key) {
+        return key.split(VID_SEP)[0];
+    }
+    return '';
 }
 
 function _getGlobalReplicationStatus(data) {
@@ -76,6 +79,18 @@ class ObjectQueueEntry extends ObjectMD {
 
     getCanonicalKey() {
         return `${this.getBucket()}/${this.getObjectKey()}`;
+    }
+
+    /**
+     * Get total bytes of this object entry
+     * @return {number} total bytes
+     */
+    getBytesMetric() {
+        const locations = this.getReducedLocations();
+        if (locations) {
+            return locations.reduce((sum, item) => sum + item.size, 0);
+        }
+        return 0;
     }
 
     getObjectKey() {

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -8,6 +8,10 @@ const BackbeatProducer = require('./BackbeatProducer');
 const Logger = require('werelogs').Logger;
 kafkaLogging.setLoggerProvider(new Logger('Consumer'));
 
+const QueueEntry = require('./models/QueueEntry');
+
+const CRR_TOPIC = require('../conf/Config').extensions.replication.topic;
+
 // controls the number of messages to process in parallel
 const CONCURRENCY_DEFAULT = 1;
 const CLIENT_ID = 'BackbeatConsumer';
@@ -60,6 +64,10 @@ class BackbeatConsumer extends EventEmitter {
         this._queueProcessor = queueProcessor;
         this._concurrency = concurrency;
         this._messagesConsumed = 0;
+
+        // metrics - consumption
+        this._metricsStore = {};
+
         this._consumer = new ConsumerGroup({
             host: this._zookeeperEndpoint,
             ssl,
@@ -100,6 +108,23 @@ class BackbeatConsumer extends EventEmitter {
                         offset,
                     });
                     this.emit('error', err, entry);
+                } else if (entry.topic === CRR_TOPIC) {
+                    const qEntry = QueueEntry.createFromKafkaEntry(entry);
+                    if (!qEntry.error && qEntry.getReducedLocations) {
+                        const locations = qEntry.getReducedLocations();
+                        const bytes = locations.reduce((sum, item) =>
+                            sum + item.size, 0);
+
+                        if (!this._metricsStore[qEntry.bucket]) {
+                            this._metricsStore[qEntry.bucket] = {
+                                ops: 1,
+                                bytes,
+                            };
+                        } else {
+                            this._metricsStore[qEntry.bucket].ops++;
+                            this._metricsStore[qEntry.bucket].bytes += bytes;
+                        }
+                    }
                 }
             });
         });
@@ -115,6 +140,10 @@ class BackbeatConsumer extends EventEmitter {
             }], () => {
                 this.emit('consumed', count);
                 this._messagesConsumed = 0;
+
+                this.emit('metrics', this._metricsStore);
+                this._metricsStore = {};
+
                 this._consumer.resume();
             });
         };

--- a/lib/MetricsProducer.js
+++ b/lib/MetricsProducer.js
@@ -1,0 +1,67 @@
+'use strict'; // eslint-disable-line strict
+
+const async = require('async');
+const { Logger } = require('werelogs');
+
+const BackbeatProducer = require('./BackbeatProducer');
+const MetricsModel = require('./models/MetricsModel');
+
+class MetricsProducer {
+    /**
+    * @constructor
+    * @param {Object} zkConfig - zookeeper configurations
+    * @param {Object} mConfig - metrics configurations
+    */
+    constructor(zkConfig, mConfig) {
+        this._zkConfig = zkConfig;
+        this._topic = mConfig.topic;
+
+        this._producer = null;
+        this._log = new Logger('MetricsProducer');
+    }
+
+    setupProducer(done) {
+        const producer = new BackbeatProducer({
+            zookeeper: { connectionString: this._zkConfig.connectionString },
+            topic: this._topic,
+        });
+        producer.once('error', done);
+        producer.once('ready', () => {
+            producer.removeAllListeners('error');
+            producer.on('error', err => {
+                this._log.error('error from backbeat producer',
+                               { error: err });
+            });
+            this._producer = producer;
+            done();
+        });
+    }
+
+    /**
+     * @param {Object} extMetrics - an object where keys are all buckets for a
+     *   given extension and values are the metrics for the bucket
+     *   (i.e. { my-bucket: { ops: 1, bytes: 124 } } )
+     * @param {String} type - type of metric (queueud or processed)
+     * @param {String} ext - extension (i.e. 'crr')
+     * @param {function} cb - callback
+     * @return {undefined}
+     */
+    publishMetrics(extMetrics, type, ext, cb) {
+        async.each(Object.keys(extMetrics), (bucketName, done) => {
+            const { ops, bytes } = extMetrics[bucketName];
+            const message = new MetricsModel(ops, bytes, ext, type,
+                bucketName).serialize();
+            this._producer.send([{ message }], err => {
+                if (err) {
+                    // Using trace here because errors are already logged in
+                    // BackbeatProducer. This is to log to see source of caller
+                    this._log.trace(`error publishing ${type} metrics for` +
+                        `extension metrics ${ext}`);
+                }
+                done();
+            });
+        }, cb);
+    }
+}
+
+module.exports = MetricsProducer;

--- a/lib/models/MetricsModel.js
+++ b/lib/models/MetricsModel.js
@@ -1,0 +1,34 @@
+'use strict'; // eslint-disable-line strict
+
+class MetricsModel {
+    /**
+     * constructor
+     * @param {Number} ops - number of operations
+     * @param {Number} bytes - data size in bytes
+     * @param {String} extension - extension
+     * @param {String} type - operation indicator (queued or processed)
+     * @param {String} bucket - bucket name
+     */
+
+    constructor(ops, bytes, extension, type, bucket) {
+        this._timestamp = Date.now();
+        this._ops = ops;
+        this._bytes = bytes;
+        this._extension = extension;
+        this._type = type;
+        this._bucket = bucket;
+    }
+
+    serialize() {
+        return JSON.stringify({
+            timestamp: this._timestamp,
+            ops: this._ops,
+            bytes: this._bytes,
+            extension: this._extension,
+            type: this._type,
+            bucket: this._bucket,
+        });
+    }
+}
+
+module.exports = MetricsModel;

--- a/lib/models/QueueEntry.js
+++ b/lib/models/QueueEntry.js
@@ -1,7 +1,9 @@
 const { usersBucket } = require('arsenal').constants;
 
-const ObjectQueueEntry = require('./ObjectQueueEntry');
-const BucketQueueEntry = require('./BucketQueueEntry');
+const ObjectQueueEntry =
+    require('../../extensions/replication/utils/ObjectQueueEntry');
+const BucketQueueEntry =
+    require('../../extensions/replication/utils/BucketQueueEntry');
 
 class QueueEntry {
 

--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -2,6 +2,9 @@ const async = require('async');
 
 const BackbeatProducer = require('../BackbeatProducer');
 
+const { metricsExtension, metricsTypeQueued } =
+    require('../../extensions/replication/constants');
+
 class LogReader {
 
     /**
@@ -19,6 +22,8 @@ class LogReader {
      * @param {Logger} params.logger - logger object
      * @param {QueuePopulatorExtension[]} params.extensions - array of
      *   queue populator extension modules
+     * @param {MetricsProducer} params.metricsProducer - instance of metrics
+     *   producer
      */
     constructor(params) {
         this.zkClient = params.zkClient;
@@ -29,6 +34,7 @@ class LogReader {
         this.log = params.logger;
         this._producers = {};
         this._extensions = params.extensions;
+        this._mProducer = params.metricsProducer;
     }
 
     _setEntryBatch(entryBatch) {
@@ -297,6 +303,7 @@ class LogReader {
             this._setEntryBatch(entriesToPublish);
             record.entries.forEach(entry => {
                 logStats.nbLogEntriesRead += 1;
+
                 this._processLogEntry(batchState, record, entry);
             });
             this._unsetEntryBatch();
@@ -368,7 +375,21 @@ class LogReader {
                 batchState.publishedEntries[topic] = topicEntries;
                 return done();
             });
-        }, done);
+        }, err => {
+            // TODO: On error, produce error metrics
+            if (err) {
+                return done(err);
+            }
+            // NOTE: Currently on CRR extension is in `this._extensions`
+            this._extensions.forEach(ext => {
+                const extMetrics = ext.getAndResetMetrics();
+                if (Object.keys(extMetrics).length > 0) {
+                    this._mProducer.publishMetrics(extMetrics,
+                        metricsTypeQueued, metricsExtension, () => {});
+                }
+            });
+            return done();
+        });
     }
 
     _processSaveLogOffset(batchState, done) {

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -6,7 +6,7 @@ const zookeeper = require('../clients/zookeeper');
 const ProvisionDispatcher = require('../provisioning/ProvisionDispatcher');
 const RaftLogReader = require('./RaftLogReader');
 const BucketFileLogReader = require('./BucketFileLogReader');
-
+const MetricsProducer = require('../MetricsProducer');
 
 class QueuePopulator {
     /**
@@ -15,7 +15,7 @@ class QueuePopulator {
      *
      * @constructor
      * @param {Object} zkConfig - zookeeper configuration object
-     * @param {string} zkConfig.connectionString - zookeeper
+     * @param {String} zkConfig.connectionString - zookeeper
      *   connection string as "host:port[/chroot]"
      * @param {Object} qpConfig - queue populator configuration
      * @param {String} qpConfig.zookeeperPath - sub-path to use for
@@ -26,12 +26,15 @@ class QueuePopulator {
      *   configuration (mandatory if logSource is "bucket")
      * @param {Object} [qpConfig.dmd] - dmd source
      *   configuration (mandatory if logSource is "dmd")
+     * @param {Object} mConfig - metrics configuration object
+     * @param {String} mConfig.topic - metrics topic
      * @param {Object} extConfigs - configuration of extensions: keys
      *   are extension names and values are extension's config object.
      */
-    constructor(zkConfig, qpConfig, extConfigs) {
+    constructor(zkConfig, qpConfig, mConfig, extConfigs) {
         this.zkConfig = zkConfig;
         this.qpConfig = qpConfig;
+        this.mConfig = mConfig;
         this.extConfigs = extConfigs;
 
         this.log = new Logger('Backbeat:QueuePopulator');
@@ -41,6 +44,8 @@ class QueuePopulator {
 
         // list of updated log readers, if any
         this.logReadersUpdate = null;
+        // metrics producer
+        this._mProducer = null;
     }
 
     /**
@@ -51,16 +56,26 @@ class QueuePopulator {
      */
     open(cb) {
         this._loadExtensions();
-        this._setupZookeeper(err => {
+        async.series([
+            next => this._setupZookeeper(() => {
+                this._setupLogSources();
+                next();
+            }),
+            next => this._setupMetricsProducer(next),
+        ], err => {
             if (err) {
                 this.log.error('error starting up queue populator',
                     { method: 'QueuePopulator.open',
                         error: err });
                 return cb(err);
             }
-            this._setupLogSources();
             return cb();
         });
+    }
+
+    _setupMetricsProducer(cb) {
+        this._mProducer = new MetricsProducer(this.zkConfig, this.mConfig);
+        this._mProducer.setupProducer(cb);
     }
 
     /**
@@ -121,6 +136,7 @@ class QueuePopulator {
                     raftId,
                     logger: this.log,
                     extensions: this._extensions,
+                    metricsProducer: this._mProducer,
                 }));
             return undefined;
         });

--- a/lib/queuePopulator/QueuePopulatorExtension.js
+++ b/lib/queuePopulator/QueuePopulatorExtension.js
@@ -11,6 +11,9 @@ class QueuePopulatorExtension {
     constructor(params) {
         this.log = params.logger;
         this._batch = null;
+
+        // metrics
+        this._metricsStore = {};
     }
 
     /**
@@ -72,6 +75,34 @@ class QueuePopulatorExtension {
 
     unsetBatch() {
         this._batch = null;
+    }
+
+    /**
+     * Get currently stored metrics and reset the counters
+     * @return {Object} metrics accumulated since last called
+     */
+    getAndResetMetrics() {
+        const tempStore = this._metricsStore;
+        this._metricsStore = {};
+        return tempStore;
+    }
+
+    /**
+     * Set or accumulate metrics based on bucket
+     * @param {String} bucket - name of bucket
+     * @param {Number} bytes - total bytes to set or increment by
+     * @return {undefined}
+     */
+    _incrementMetrics(bucket, bytes) {
+        if (!this._metricsStore[bucket]) {
+            this._metricsStore[bucket] = {
+                ops: 1,
+                bytes,
+            };
+        } else {
+            this._metricsStore[bucket].ops++;
+            this._metricsStore[bucket].bytes += bytes;
+        }
     }
 }
 

--- a/lib/queuePopulator/RaftLogReader.js
+++ b/lib/queuePopulator/RaftLogReader.js
@@ -7,7 +7,7 @@ const LogReader = require('./LogReader');
 class RaftLogReader extends LogReader {
     constructor(params) {
         const { zkClient, zkConfig, bucketdConfig,
-                raftId, logger, extensions } = params;
+                raftId, logger, extensions, metricsProducer } = params;
         const { host, port } = bucketdConfig;
         logger.info('initializing raft log reader',
             { method: 'RaftLogReader.constructor',
@@ -17,7 +17,7 @@ class RaftLogReader extends LogReader {
             raftSession: raftId,
             logger });
         super({ zkClient, zkConfig, logConsumer, logId: `raft_${raftId}`,
-                logger, extensions });
+                logger, extensions, metricsProducer });
         this.raftId = raftId;
     }
 

--- a/tests/config.json
+++ b/tests/config.json
@@ -16,6 +16,9 @@
     "kafka": {
         "hosts": "127.0.0.1:9092"
     },
+    "metrics": {
+        "topic": "backbeat-test-metrics"
+    },
     "s3": {
         "host": "127.0.0.1",
         "port": 8000,
@@ -32,5 +35,9 @@
     "log": {
         "logLevel": "info",
         "dumpLevel": "error"
+    },
+    "redis": {
+        "name": "backbeat-test",
+        "password": ""
     }
 }

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -616,6 +616,10 @@ class S3Mock extends TestConfigurator {
     }
 }
 
+class MetricsMock {
+    publishMetrics() {}
+}
+
 /* eslint-enable max-len */
 
 describe('queue processor functional tests with mocking', () => {
@@ -628,6 +632,7 @@ describe('queue processor functional tests with mocking', () => {
         this.timeout(60000);
         const serverList =
                   constants.target.hosts.map(h => `${h.host}:${h.port}`);
+
         queueProcessor = new QueueProcessor(
             { connectionString: 'localhost:2181' },
             { auth: { type: 'role',
@@ -648,7 +653,7 @@ describe('queue processor functional tests with mocking', () => {
                   retryTimeoutS: 5,
                   groupId: 'backbeat-func-test-group-id',
               },
-            }, 'sf');
+          }, 'sf', new MetricsMock());
         queueProcessor.start({ disableConsumer: true });
         // create the replication status processor only when the queue
         // processor is ready, so that we ensure the replication

--- a/tests/unit/replication/QueueEntry.spec.js
+++ b/tests/unit/replication/QueueEntry.spec.js
@@ -3,7 +3,7 @@
 const assert = require('assert');
 
 const QueueEntry =
-          require('../../../extensions/replication/utils/QueueEntry');
+          require('../../../lib/models/QueueEntry');
 const kafkaEntry = require('../../utils/kafkaEntry');
 
 describe('QueueEntry helper class', () => {


### PR DESCRIPTION
This PR adds metrics accumulation.

Metrics (ops and bytes) are acquired on population and processing of replication objects. These metrics are accumulated and stored into Kafka, and then will eventually be consumed and stored within Redis. This PR addresses the first part of accumulation and storing into Kafka.