### PR TITLE
Ft/S3C-354 add metrics consumer

### DIFF
--- a/bin/queuePopulator.js
+++ b/bin/queuePopulator.js
@@ -8,6 +8,7 @@ const zkConfig = config.zookeeper;
 const extConfigs = config.extensions;
 const qpConfig = config.queuePopulator;
 const mConfig = config.metrics;
+const rConfig = config.redis;
 const QueuePopulator = require('../lib/queuePopulator/QueuePopulator');
 
 const log = new werelogs.Logger('Backbeat:QueuePopulator');
@@ -43,7 +44,7 @@ function queueBatch(queuePopulator, taskState) {
 /* eslint-enable no-param-reassign */
 
 const queuePopulator = new QueuePopulator(zkConfig, qpConfig, mConfig,
-    extConfigs);
+    rConfig, extConfigs);
 
 async.waterfall([
     done => queuePopulator.open(done),

--- a/extensions/replication/constants.js
+++ b/extensions/replication/constants.js
@@ -7,6 +7,12 @@ const constants = {
     metricsExtension: 'crr',
     metricsTypeQueued: 'queued',
     metricsTypeProcessed: 'processed',
+    redisKeys: {
+        ops: 'bb:crr:ops',
+        bytes: 'bb:crr:bytes',
+        opsDone: 'bb:crr:opsdone',
+        bytesDone: 'bb:crr:bytesdone',
+    },
 };
 
 module.exports = constants;

--- a/lib/MetricsConsumer.js
+++ b/lib/MetricsConsumer.js
@@ -1,0 +1,98 @@
+'use strict'; // eslint-disable-line strict
+
+const Logger = require('werelogs').Logger;
+const { RedisClient, StatsClient } = require('arsenal').metrics;
+
+const BackbeatConsumer = require('./BackbeatConsumer');
+const redisKeys = require('../extensions/replication/constants').redisKeys;
+
+// StatsClient constant defaults
+const INTERVAL = 300; // 5 minutes;
+const EXPIRY = 900; // 15 minutes
+
+// BackbeatConsumer constant defaults
+const CONSUMER_FETCH_MAX_BYTES = 5000020;
+const CONCURRENCY = 10;
+
+class MetricsConsumer {
+    /**
+     * @constructor
+     * @param {object} rConfig - redis configurations
+     * @param {string} rConfig.host - redis host
+     * @param {number} rConfig.port - redis port
+     * @param {object} mConfig - metrics configurations
+     * @param {string} mConfig.topic - metrics topic name
+     * @param {object} zkConfig - zookeeper configurations
+     * @param {string} zkConfig.connectionString - zookeeper connection string
+     *   as "host:port[/chroot]"
+     */
+    constructor(rConfig, mConfig, zkConfig) {
+        this.mConfig = mConfig;
+        this.zkConfig = zkConfig;
+
+        this.logger = new Logger('Backbeat:MetricsConsumer');
+
+        const redisClient = new RedisClient(rConfig, this.logger);
+        this._statsClient = new StatsClient(redisClient, INTERVAL,
+            EXPIRY);
+    }
+
+    start() {
+        const consumer = new BackbeatConsumer({
+            zookeeper: { connectionString: this.zkConfig.connectionString },
+            topic: this.mConfig.topic,
+            groupId: 'backbeat-metrics-group',
+            concurrency: CONCURRENCY,
+            queueProcessor: this.processKafkaEntry.bind(this),
+            fetchMaxBytes: CONSUMER_FETCH_MAX_BYTES,
+        });
+        consumer.on('error', () => {});
+        consumer.subscribe();
+
+        this.logger.info('metrics processor is ready to consume entries');
+    }
+
+    processKafkaEntry(kafkaEntry, done) {
+        let data;
+        try {
+            data = JSON.parse(kafkaEntry.value);
+        } catch (err) {
+            this.logger.error('error processing metrics entry', {
+                method: 'MetricsConsumer.processKafkaEntry',
+                error: err,
+            });
+            return done();
+        }
+        /*
+            data = {
+                timestamp: 1509416671977,
+                ops: 5,
+                bytes: 195,
+                extension: 'crr',
+                type: 'processed'
+            }
+        */
+        if (data.type === 'processed') {
+            this._sendRequest(redisKeys.opsDone, data.ops);
+            this._sendRequest(redisKeys.bytesDone, data.bytes);
+        } else if (data.type === 'queued') {
+            this._sendRequest(redisKeys.ops, data.ops);
+            this._sendRequest(redisKeys.bytes, data.bytes);
+        } else {
+            // unknown type
+            this.logger.error('unknown type field encountered in metrics '
+            + 'consumer', {
+                method: 'MetricsConsumer.processKafkaEntry',
+                dataType: data.type,
+                data,
+            });
+        }
+        return done();
+    }
+
+    _sendRequest(key, value) {
+        this._statsClient.reportNewRequest(key, value);
+    }
+}
+
+module.exports = MetricsConsumer;

--- a/lib/queuePopulator/BucketFileLogReader.js
+++ b/lib/queuePopulator/BucketFileLogReader.js
@@ -5,10 +5,11 @@ const LogReader = require('./LogReader');
 
 class BucketFileLogReader extends LogReader {
     constructor(params) {
-        const { zkClient, zkConfig, dmdConfig,
-                logger, extensions } = params;
+        const { zkClient, zkConfig, dmdConfig, logger,
+            extensions, metricsProducer } = params;
         super({ zkClient, zkConfig, logConsumer: null,
-            logId: `bucketFile_${dmdConfig.logName}`, logger, extensions });
+            logId: `bucketFile_${dmdConfig.logName}`, logger, extensions,
+            metricsProducer });
 
         this._dmdConfig = dmdConfig;
         this._log = logger;

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -7,6 +7,7 @@ const ProvisionDispatcher = require('../provisioning/ProvisionDispatcher');
 const RaftLogReader = require('./RaftLogReader');
 const BucketFileLogReader = require('./BucketFileLogReader');
 const MetricsProducer = require('../MetricsProducer');
+const MetricsConsumer = require('../MetricsConsumer');
 
 class QueuePopulator {
     /**
@@ -27,14 +28,16 @@ class QueuePopulator {
      * @param {Object} [qpConfig.dmd] - dmd source
      *   configuration (mandatory if logSource is "dmd")
      * @param {Object} mConfig - metrics configuration object
-     * @param {String} mConfig.topic - metrics topic
+     * @param {string} mConfig.topic - metrics topic
+     * @param {Object} rConfig - redis configuration object
      * @param {Object} extConfigs - configuration of extensions: keys
      *   are extension names and values are extension's config object.
      */
-    constructor(zkConfig, qpConfig, mConfig, extConfigs) {
+    constructor(zkConfig, qpConfig, mConfig, rConfig, extConfigs) {
         this.zkConfig = zkConfig;
         this.qpConfig = qpConfig;
         this.mConfig = mConfig;
+        this.rConfig = rConfig;
         this.extConfigs = extConfigs;
 
         this.log = new Logger('Backbeat:QueuePopulator');
@@ -44,8 +47,9 @@ class QueuePopulator {
 
         // list of updated log readers, if any
         this.logReadersUpdate = null;
-        // metrics producer
+        // metrics clients
         this._mProducer = null;
+        this._mConsumer = null;
     }
 
     /**
@@ -61,7 +65,7 @@ class QueuePopulator {
                 this._setupLogSources();
                 next();
             }),
-            next => this._setupMetricsProducer(next),
+            next => this._setupMetricsClients(next),
         ], err => {
             if (err) {
                 this.log.error('error starting up queue populator',
@@ -73,7 +77,13 @@ class QueuePopulator {
         });
     }
 
-    _setupMetricsProducer(cb) {
+    _setupMetricsClients(cb) {
+        // Metrics Consumer
+        this._mConsumer = new MetricsConsumer(this.rConfig, this.mConfig,
+            this.zkConfig);
+        this._mConsumer.start();
+
+        // Metrics Producer
         this._mProducer = new MetricsProducer(this.zkConfig, this.mConfig);
         this._mProducer.setupProducer(cb);
     }
@@ -102,6 +112,7 @@ class QueuePopulator {
                     dmdConfig: this.qpConfig.dmd,
                     logger: this.log,
                     extensions: this._extensions,
+                    metricsProducer: this._mProducer,
                 }),
             ];
             break;


### PR DESCRIPTION
This PR relies on https://github.com/scality/backbeat/pull/125

This PR is focused on consuming the metrics from Kafka and storing to Redis.

These Redis metric keys will be exposed by the Backbeat Server/API (https://github.com/scality/backbeat/pull/102) through to-be-built routes.