### PR TITLE
bf: don't overwrite part size in locations

### DIFF
--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -452,11 +452,11 @@ class QueueProcessor {
             const nextPart = locations[i + 1];
             const nextPartNum = nextPart ?
                 sourceEntry.getPartNumber(nextPart) : undefined;
-            if (currPartNum === nextPartNum) {
-                partTotal += sourceEntry.getPartSize(currPart);
-            } else {
-                currPart.size = partTotal += sourceEntry.getPartSize(currPart);
-                reducedLocations.push(currPart);
+            partTotal += sourceEntry.getPartSize(currPart);
+            if (currPartNum !== nextPartNum) {
+                const consolidatedPart = Object.assign({}, currPart,
+                                                       { size: partTotal });
+                reducedLocations.push(consolidatedPart);
                 partTotal = 0;
             }
         }


### PR DESCRIPTION
When fetching locations, don't modify the original array of locations
when constructing the reduced locations array, to not induce
side-effects when reusing the original array (e.g to fetch the same
reduced locations again for another get/put cycle).

7.1 fix only, no need for forward port as master has a different
implementation and is not affected.