### PR TITLE
FIX: Source should get destination version for AWS

### DIFF
--- a/extensions/replication/queueProcessor/MultipleBackendTask.js
+++ b/extensions/replication/queueProcessor/MultipleBackendTask.js
@@ -380,112 +380,47 @@ class MultipleBackendTask extends QueueProcessorTask {
         });
     }
 
-    _getAndPutObjectTagging(sourceEntry, destEntry, log, cb) {
+    _putObjectTagging(sourceEntry, destEntry, log, cb) {
         this._retry({
             actionDesc: 'send object tagging XML data',
             entry: sourceEntry,
-            actionFunc: done => this._getAndPutObjectTaggingOnce(
-               sourceEntry, destEntry, log, done),
+            actionFunc: done => this._putObjectTaggingOnce(
+                sourceEntry, destEntry, log, done),
             shouldRetryFunc: err => err.retryable,
             log,
         }, cb);
     }
 
-    _getAndPutObjectTaggingOnce(sourceEntry, destEntry, log, cb) {
+    _putObjectTaggingOnce(sourceEntry, destEntry, log, cb) {
         const doneOnce = jsutil.once(cb);
         log.debug('replicating object tags', {
             entry: sourceEntry.getLogInfo(),
         });
-        const sourceReq = this.S3source.getObjectTagging({
-            Bucket: sourceEntry.getBucket(),
-            Key: sourceEntry.getObjectKey(),
-            VersionId: sourceEntry.getEncodedVersionId(),
-        });
-        attachReqUids(sourceReq, log);
-        sourceReq.on('error', err => {
-            // eslint-disable-next-line no-param-reassign
-            err.origin = 'source';
-            if (err.statusCode === 404) {
-                log.error('the source object was not found', {
-                    method: 'MultipleBackendTask._getAndPutObjectTaggingOnce',
-                    entry: sourceEntry.getLogInfo(),
-                    origin: 'source',
-                    peer: this.sourceConfig.s3,
+        const destReq = this.backbeatSource
+            .multipleBackendPutObjectTagging({
+                Bucket: destEntry.getBucket(),
+                Key: destEntry.getObjectKey(),
+                StorageType: destEntry.getReplicationStorageType(),
+                StorageClass: destEntry.getReplicationStorageClass(),
+                DataStoreVersionId:
+                    destEntry.getReplicationDataStoreVersionId(),
+                Tags: JSON.stringify(destEntry.getTags()),
+                SourceBucket: sourceEntry.getBucket(),
+                SourceVersionId: sourceEntry.getVersionId(),
+            });
+        attachReqUids(destReq, log);
+        return destReq.send((err, data) => {
+            if (err) {
+                log.error('an error occurred putting object tagging to S3', {
+                    method: 'MultipleBackendTask._putObjectTaggingOnce',
+                    entry: destEntry.getLogInfo(),
+                    origin: 'target',
                     error: err.message,
-                    httpStatus: err.statusCode,
                 });
                 return doneOnce(err);
             }
-            log.error('an error occurred on getObject from S3', {
-                method: 'MultipleBackendTask._getAndPutObjectTaggingOnce',
-                entry: sourceEntry.getLogInfo(),
-                origin: 'source',
-                peer: this.sourceConfig.s3,
-                error: err.message,
-                httpStatus: err.statusCode,
-            });
-            return doneOnce(err);
-        });
-        const incomingMsg = sourceReq.createReadStream();
-        incomingMsg.on('error', err => {
-            if (err.statusCode === 404) {
-                log.error('the source object was not found', {
-                    method: 'MultipleBackendTask._getAndPutObjectTaggingOnce',
-                    entry: sourceEntry.getLogInfo(),
-                    origin: 'source',
-                    peer: this.sourceConfig.s3,
-                    error: err.message,
-                    httpStatus: err.statusCode,
-                });
-                return doneOnce(errors.ObjNotFound);
-            }
-            // eslint-disable-next-line no-param-reassign
-            err.origin = 'source';
-            log.error('an error occurred when streaming data from S3', {
-                entry: destEntry.getLogInfo(),
-                method: 'MultipleBackendTask._getAndPutObjectTaggingOnce',
-                origin: 'source',
-                peer: this.sourceConfig.s3,
-                error: err.message,
-            });
-            return doneOnce(err);
-        });
-        const data = [];
-        incomingMsg.on('data', chunk => data.push(chunk.toString()));
-        incomingMsg.on('end', () => {
-            const tagsXML = data.join('');
-            log.debug('putting object tagging', {
-                entry: destEntry.getLogInfo(),
-            });
-            const destReq = this.backbeatSource
-                .multipleBackendPutObjectTagging({
-                    Bucket: destEntry.getBucket(),
-                    Key: destEntry.getObjectKey(),
-                    ContentLength: tagsXML.length,
-                    StorageType: destEntry.getReplicationStorageType(),
-                    StorageClass: destEntry.getReplicationStorageClass(),
-                    DataStoreVersionId:
-                        destEntry.getReplicationDataStoreVersionId(),
-                    Body: tagsXML,
-                });
-            attachReqUids(destReq, log);
-            return destReq.send(err => {
-                if (err) {
-                    // eslint-disable-next-line no-param-reassign
-                    err.origin = 'source';
-                    log.error('an error occurred putting object tagging to ' +
-                    'S3', {
-                        method:
-                           'MultipleBackendTask._getAndPutObjectTaggingOnce',
-                        entry: destEntry.getLogInfo(),
-                        origin: 'target',
-                        peer: this.destBackbeatHost,
-                        error: err.message,
-                    });
-                    return doneOnce(err);
-                }
-                return doneOnce();
-            });
+            sourceEntry.setReplicationDataStoreVersionId(data.versionId);
+            return doneOnce();
         });
     }
 
@@ -511,12 +446,12 @@ class MultipleBackendTask extends QueueProcessorTask {
             StorageType: destEntry.getReplicationStorageType(),
             StorageClass: destEntry.getReplicationStorageClass(),
             DataStoreVersionId: destEntry.getReplicationDataStoreVersionId(),
+            SourceBucket: sourceEntry.getBucket(),
+            SourceVersionId: sourceEntry.getVersionId(),
         });
         attachReqUids(destReq, log);
-        return destReq.send(err => {
+        return destReq.send((err, data) => {
             if (err) {
-                // eslint-disable-next-line no-param-reassign
-                err.origin = 'source';
                 log.error('an error occurred on deleting object tagging', {
                     method: 'MultipleBackendTask._deleteObjectTaggingOnce',
                     entry: destEntry.getLogInfo(),
@@ -526,6 +461,7 @@ class MultipleBackendTask extends QueueProcessorTask {
                 });
                 return doneOnce(err);
             }
+            sourceEntry.setReplicationDataStoreVersionId(data.versionId);
             return doneOnce();
         });
     }
@@ -610,7 +546,7 @@ class MultipleBackendTask extends QueueProcessorTask {
                         destEntry, log, next);
                 }
                 if (content.includes('PUT_TAGGING')) {
-                    return this._getAndPutObjectTagging(sourceEntry, destEntry,
+                    return this._putObjectTagging(sourceEntry, destEntry,
                         log, next);
                 }
                 if (content.includes('DELETE_TAGGING')) {

--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -399,11 +399,6 @@
                         "location": "uri",
                         "locationName": "Key"
                     },
-                    "ContentLength": {
-                        "location": "header",
-                        "locationName": "Content-Length",
-                        "type": "long"
-                    },
                     "StorageType": {
                         "location": "header",
                         "locationName": "X-Scal-Storage-Type"
@@ -416,6 +411,18 @@
                         "location": "header",
                         "locationName": "X-Scal-Data-Store-Version-Id"
                     },
+                    "Tags": {
+                        "location": "header",
+                        "locationName": "X-Scal-Tags"
+                    },
+                    "SourceBucket": {
+                        "location": "header",
+                        "locationName": "X-Scal-Source-Bucket"
+                    },
+                    "SourceVersionId": {
+                        "location": "header",
+                        "locationName": "X-Scal-Source-Version-Id"
+                    },
                     "Body": {
                         "type": "blob"
                     }
@@ -424,7 +431,11 @@
             },
             "output": {
                 "type": "structure",
-                "members": {}
+                "members": {
+                    "versionId": {
+                        "type": "string"
+                    }
+                }
             }
         },
         "MultipleBackendDeleteObjectTagging": {
@@ -460,6 +471,14 @@
                         "location": "header",
                         "locationName": "X-Scal-Data-Store-Version-Id"
                     },
+                    "SourceBucket": {
+                        "location": "header",
+                        "locationName": "X-Scal-Source-Bucket"
+                    },
+                    "SourceVersionId": {
+                        "location": "header",
+                        "locationName": "X-Scal-Source-Version-Id"
+                    },
                     "Body": {
                         "type": "blob"
                     }
@@ -468,7 +487,11 @@
             },
             "output": {
                 "type": "structure",
-                "members": {}
+                "members": {
+                    "versionId": {
+                        "type": "string"
+                    }
+                }
             }
         },
         "PutMetadata": {


### PR DESCRIPTION
Depends on https://github.com/scality/S3/pull/1010.

Object tagging operations that are made before the source object has completed replication do not have the `datastoreVersionId` in the Kafka entry. 

Because all operations for the multiple backend are serialized, when any tagging operation is being replicated we can guarantee that the source object's metadata will have been updated at this point. Hence we send the source bucket and source version ID for cloud server to retrieve the information before making the request to an external location. Also, we can eliminate a GET request for the source object's tags because they are already available in the Kafka entry.