### PR TITLE
bf: remove pause() call on Kafka errors

### DIFF
--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -119,7 +119,6 @@ class BackbeatConsumer extends EventEmitter {
         };
 
         this._consumer.on('error', error => {
-            this._consumer.pause();
             this._log.error('error subscribing to topic', {
                 error,
                 method: 'BackbeatConsumer.subscribe',


### PR DESCRIPTION
It's not necessary to pause the consumer when the Kafka client returns
errors, and it may block the consumption for no good reason, so better
remove it.