### PR TITLE
Ft/S3C-1001 add metric routes

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,7 @@ machine:
         version: 6.9.5
     services:
         - docker
+        - redis
     environment:
         CXX: g++-4.9
 

--- a/extensions/replication/constants.js
+++ b/extensions/replication/constants.js
@@ -1,5 +1,7 @@
 'use strict'; // eslint-disable-line
 
+const testIsOn = process.env.TEST_SWITCH === '1';
+
 const constants = {
     zookeeperReplicationNamespace: '/backbeat/replication',
     proxyVaultPath: '/_/backbeat/vault',
@@ -8,10 +10,10 @@ const constants = {
     metricsTypeQueued: 'queued',
     metricsTypeProcessed: 'processed',
     redisKeys: {
-        ops: 'bb:crr:ops',
-        bytes: 'bb:crr:bytes',
-        opsDone: 'bb:crr:opsdone',
-        bytesDone: 'bb:crr:bytesdone',
+        ops: testIsOn ? 'test:bb:ops' : 'bb:crr:ops',
+        bytes: testIsOn ? 'test:bb:bytes' : 'bb:crr:bytes',
+        opsDone: testIsOn ? 'test:bb:opsdone' : 'bb:crr:opsdone',
+        bytesDone: testIsOn ? 'test:bb:bytesdone' : 'bb:crr:bytesdone',
     },
 };
 

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -6,10 +6,8 @@ const zookeeper = require('node-zookeeper-client');
 const { errors } = require('arsenal');
 
 const BackbeatProducer = require('../BackbeatProducer');
+const Healthcheck = require('./Healthcheck');
 const routes = require('./routes');
-
-// In-Sync Replicas
-const ISRS = 3;
 
 /**
  * Class representing Backbeat API endpoints and internals
@@ -35,6 +33,7 @@ class BackbeatAPI {
         this._crrProducer = null;
         this._crrStatusProducer = null;
         this._metricProducer = null;
+        this._healthcheck = null;
         this._zkClient = null;
     }
 
@@ -61,33 +60,13 @@ class BackbeatAPI {
             && this._crrStatusProducer.isReady();
     }
 
-    _getConnectionDetails() {
-        return {
-            zookeeper: {
-                status: this._zkClient.getState().name === 'SYNC_CONNECTED' ?
-                    'ok' : 'error',
-                details: this._zkClient.getState(),
-            },
-            kafkaProducer: {
-                status: this._checkProducersReady() ? 'ok' : 'error',
-            },
-        };
-    }
-
     /**
-     * Checks health of in-sync replicas
-     * @param {object} md - topic metadata object
-     * @return {boolean} true if ISR health is ok
+     * Check if Zookeeper and Producer are connected
+     * @return {boolean} true/false
      */
-    _checkISRHealth(md) {
-        // eslint-disable-next-line consistent-return
-        const keys = Object.keys(md);
-        for (let i = 0; i < keys.length; i++) {
-            if (md[keys[i]].isr && md[keys[i]].isr.length !== ISRS) {
-                return 'error';
-            }
-        }
-        return 'ok';
+    isConnected() {
+        return this._zkClient.getState().name === 'SYNC_CONNECTED'
+            && this._checkProducersReady();
     }
 
     /**
@@ -96,47 +75,20 @@ class BackbeatAPI {
      * @return {undefined}
      */
     healthcheck(cb) {
-        const client = this._crrProducer.getKafkaClient();
-
-        // TODO: refactor by calling specific topic
-        client.loadMetadataForTopics([], (err, res) => {
+        return this._healthcheck.getHealthcheck((err, data) => {
             if (err) {
-                this._logger.error('error getting healthcheck');
-                return cb(errors.InternalError
-                    .customizeDescription('error getting healthcheck metadata' +
-                    ' for topics'));
+                this._logger.error('error getting healthcheck', err);
+                return cb(errors.InternalError);
             }
-            const response = res.map(i => (Object.assign({}, i)));
-            const connections = {};
-            const topicMD = {};
-            response.forEach((obj, idx) => {
-                if (obj.metadata && obj.metadata[this._repConfig.topic]) {
-                    let copy;
-                    try {
-                        copy = JSON.parse(JSON.stringify(obj.metadata[
-                            this._repConfig.topic]));
-                        topicMD.metadata = copy;
-                        response.splice(idx, 1);
-                    } catch (e) {
-                        this._logger.error('error getting topic metadata');
-                    }
-                }
-            });
-            response.push(topicMD);
-
-            if (topicMD.metadata) {
-                connections.isrHealth = this._checkISRHealth(topicMD.metadata);
-            }
-
-            Object.assign(connections, this._getConnectionDetails());
-            response.push({
-                internalConnections: connections,
-            });
-
-            return cb(null, response);
+            return cb(null, data);
         });
     }
 
+    /**
+     * Setup internals
+     * @param {function} cb - callback(error)
+     * @return {undefined}
+     */
     setupInternals(cb) {
         async.parallel([
             done => this._setZookeeper(done),
@@ -166,6 +118,9 @@ class BackbeatAPI {
                 this._logger.error('error setting up internal clients');
                 return cb(err);
             }
+            this._healthcheck = new Healthcheck(this._repConfig, this._zkClient,
+                this._crrProducer, this._crrStatusProducer,
+                this._metricProducer);
             this._logger.info('BackbeatAPI setup ready');
             return cb();
         });

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -4,10 +4,16 @@ const async = require('async');
 const zookeeper = require('node-zookeeper-client');
 
 const { errors } = require('arsenal');
+const { RedisClient, StatsClient } = require('arsenal').metrics;
 
 const BackbeatProducer = require('../BackbeatProducer');
 const Healthcheck = require('./Healthcheck');
 const routes = require('./routes');
+
+// StatsClient constant defaults
+// TODO: This should be moved to constants file
+const INTERVAL = 300; // 5 minutes
+const EXPIRY = 900; // 15 minutes
 
 /**
  * Class representing Backbeat API endpoints and internals
@@ -19,8 +25,9 @@ class BackbeatAPI {
      * @constructor
      * @param {object} config - configurations for setup
      * @param {werelogs.Logger} logger - Logger object
+     * @param {object} optional - optional fields
      */
-    constructor(config, logger) {
+    constructor(config, logger, optional) {
         this._zkConfig = config.zookeeper;
         this._repConfig = config.extensions.replication;
         this._crrTopic = this._repConfig.topic;
@@ -28,6 +35,7 @@ class BackbeatAPI {
         this._metricsTopic = config.metrics.topic;
         this._queuePopulator = config.queuePopulator;
         this._kafkaHost = config.kafka.hosts;
+        this._redisConfig = config.redis;
         this._logger = logger;
 
         this._crrProducer = null;
@@ -35,6 +43,18 @@ class BackbeatAPI {
         this._metricProducer = null;
         this._healthcheck = null;
         this._zkClient = null;
+
+        // TODO: this should rely on the data stored in Redis and not an
+        //  internal timer
+        if (optional && optional.timer) {
+            // set to old date so routes below will use EXPIRY
+            this._internalStart = new Date(1);
+        } else {
+            this._internalStart = Date.now();
+        }
+
+        const redisClient = new RedisClient(this._redisConfig, this._logger);
+        this._statsClient = new StatsClient(redisClient, INTERVAL, EXPIRY);
     }
 
     /**
@@ -71,10 +91,11 @@ class BackbeatAPI {
 
     /**
      * Get Kafka healthcheck
+     * @param {object} details - route details from lib/api/routes.js
      * @param {function} cb - callback(error, data)
      * @return {undefined}
      */
-    healthcheck(cb) {
+    getHealthcheck(details, cb) {
         return this._healthcheck.getHealthcheck((err, data) => {
             if (err) {
                 this._logger.error('error getting healthcheck', err);
@@ -82,6 +103,191 @@ class BackbeatAPI {
             }
             return cb(null, data);
         });
+    }
+
+    /**
+     * Get data points which are the keys used to query Redis
+     * @param {object} details - route details from lib/api/routes.js
+     * @param {array} data - provides already fetched data in order of
+     *   dataPoints mentioned for each route in lib/api/routes.js. This can be
+     *   undefined.
+     * @param {function} cb - callback(error, data), where data returns
+     *   data stored in Redis.
+     * @return {array} dataPoints array defined in lib/api/routes.js
+     */
+    _getData(details, data, cb) {
+        if (!data) {
+            const dataPoints = details.dataPoints;
+            return this._queryStats(dataPoints, cb);
+        }
+        return cb(null, data);
+    }
+
+    /**
+     * Get replication backlog in ops count and size in MB
+     * @param {object} details - route details from lib/api/routes.js
+     * @param {function} cb - callback(error, data)
+     * @param {array} data - optional field providing already fetched data
+     *   in order of dataPoints mentioned for each route in lib/api/routes.js
+     * @return {undefined}
+     */
+    getBacklog(details, cb, data) {
+        this._getData(details, data, (err, res) => {
+            if (err || res.length !== details.dataPoints.length) {
+                this._logger.error('error occurred getting backlog', {
+                    method: 'BackbeatAPI.backlog',
+                });
+                return cb(errors.InternalError);
+            }
+            const d = res.map(r => r.requests);
+
+            let opsBacklog = d[0] - d[1];
+            if (opsBacklog < 0) opsBacklog = 0;
+            let bytesBacklog = d[2] - d[3];
+            if (bytesBacklog < 0) bytesBacklog = 0;
+            const response = {
+                backlog: {
+                    description: 'Number of incomplete replication ' +
+                        'operations (count) and number of incomplete MB ' +
+                        'transferred (size)',
+                    results: {
+                        count: opsBacklog,
+                        size: (bytesBacklog / 1000).toFixed(2),
+                    },
+                },
+            };
+            return cb(null, response);
+        });
+    }
+
+    /**
+     * Get completed replicated stats by ops count and size in MB
+     * @param {object} details - route details from lib/api/routes.js
+     * @param {function} cb - callback(error, data)
+     * @param {array} data - optional field providing already fetched data
+     *   in order of dataPoints mentioned for each route in lib/api/routes.js
+     * @return {undefined}
+     */
+    getCompletions(details, cb, data) {
+        this._getData(details, data, (err, res) => {
+            if (err || res.length !== details.dataPoints.length) {
+                this._logger.error('error getting replication completions', {
+                    method: 'BackbeatAPI.completions',
+                });
+                return cb(errors.InternalError);
+            }
+
+            // Find if time since start is less than EXPIRY time
+            const timeSinceStart = Math.floor(
+                (Date.now() - this._internalStart) / 1000);
+            // if timeSinceStart, then round the number to nearest 10's
+            const timeDisplay = timeSinceStart < EXPIRY ?
+                (Math.ceil(timeSinceStart / 10) * 10) : EXPIRY;
+
+            const response = {
+                completions: {
+                    description: 'Number of completed replication operations ' +
+                        '(count) and number of MB transferred (size) in the ' +
+                        `last ${timeDisplay} seconds`,
+                    results: {
+                        count: res[0].requests,
+                        size: (res[1].requests / 1000).toFixed(2),
+                    },
+                },
+            };
+            return cb(null, response);
+        });
+    }
+
+    /**
+     * Get current throughput in ops/sec and MB/sec
+     * Throughput is the number of units processed in a given time
+     * @param {object} details - route details from lib/api/routes.js
+     * @param {function} cb - callback(error, data)
+     * @param {array} data - optional field providing already fetched data
+     *   in order of dataPoints mentioned for each route in lib/api/routes.js
+     * @return {undefined}
+     */
+    getThroughput(details, cb, data) {
+        this._getData(details, data, (err, res) => {
+            if (err) {
+                this._logger.error('error getting throughput', {
+                    method: 'BackbeatAPI.throughput',
+                });
+                return cb(errors.InternalError);
+            }
+
+            const [opsThroughput, bytesThroughput] = res.map(r => {
+                // Find if time since start is less than r.sampleDuration
+                const timeSinceStart = Math.floor(
+                    (Date.now() - this._internalStart) / 1000);
+                if (timeSinceStart < r.sampleDuration) {
+                    return (r.requests / timeSinceStart).toFixed(2);
+                }
+                return (r.requests / r.sampleDuration).toFixed(2);
+            });
+
+            const response = {
+                throughput: {
+                    description: 'Current throughput for replication ' +
+                        'operations in ops/sec (count) and MB/sec (size)',
+                    results: {
+                        count: opsThroughput,
+                        size: (bytesThroughput / 1000).toFixed(2),
+                    },
+                },
+            };
+            return cb(null, response);
+        });
+    }
+
+    /**
+     * Get all metrics
+     * @param {object} details - route details from lib/api/routes.js
+     * @param {function} cb = callback(error, data)
+     * @param {array} data - optional field providing already fetched data
+     *   in order of dataPoints mentioned for each route in lib/api/routes.js
+     * @return {undefined}
+     */
+    getAllMetrics(details, cb, data) {
+        this._getData(details, data, (err, res) => {
+            if (err || res.length !== details.dataPoints.length) {
+                this._logger.error('error getting all metrics', {
+                    method: 'BackbeatAPI.getAllMetrics',
+                });
+                return cb(errors.InternalError);
+            }
+            // res = [ ops, ops_done, bytes, bytes_done ]
+            return async.parallel([
+                done => this.getBacklog({ dataPoints: new Array(4) }, done,
+                    res),
+                done => this.getCompletions({ dataPoints: new Array(2) }, done,
+                    [res[1], res[3]]),
+                done => this.getThroughput({ dataPoints: new Array(2) }, done,
+                    [res[1], res[3]]),
+            ], (err, results) => {
+                if (err) {
+                    this._logger.error('error getting all metrics', {
+                        method: 'BackbeatAPI.getAllMetrics',
+                    });
+                    return cb(errors.InternalError);
+                }
+                const store = Object.assign({}, ...results);
+                return cb(null, store);
+            });
+        });
+    }
+
+    /**
+     * Query StatsClient for all ops given
+     * @param {array} ops - array of redis key names to query
+     * @param {function} cb - callback(err, res)
+     * @return {undefined}
+     */
+    _queryStats(ops, cb) {
+        return async.map(ops, (op, done) => {
+            this._statsClient.getStats(this._logger, op, done);
+        }, cb);
     }
 
     /**

--- a/lib/api/BackbeatServer.js
+++ b/lib/api/BackbeatServer.js
@@ -6,6 +6,7 @@ const { Clustering, errors, ipCheck } = require('arsenal');
 
 const BackbeatRequest = require('./BackbeatRequest');
 const BackbeatAPI = require('./BackbeatAPI');
+const routes = require('./routes');
 
 const WORKERS = 1;
 
@@ -117,10 +118,13 @@ class BackbeatServer {
         // check request conditions and all internal conditions here
         if (this._isValidRequest(req, bbRequest)
         && this._areConditionsOk(bbRequest)) {
-            bbRequest.setStatusCode(200)
-                .setRoute(bbRequest.getRoute().slice(3));
+            bbRequest.setStatusCode(200);
 
-            this.backbeatAPI[bbRequest.getRoute()]((err, data) => {
+            const routeDetails = routes.find(route =>
+                route.path === bbRequest.getRoute());
+            const requestMethod = routeDetails.method;
+
+            this.backbeatAPI[requestMethod](routeDetails, (err, data) => {
                 if (err) {
                     this._errorResponse(err, bbRequest);
                 } else {
@@ -198,7 +202,10 @@ function run(config, Logger) {
     const logger = new Logger('BackbeatServer');
     const apiLogger = new Logger('BackbeatAPI');
     const cluster = new Clustering(WORKERS, logger);
-    const backbeatAPI = new BackbeatAPI(config, apiLogger);
+
+    const isTest = process.env.TEST_SWITCH;
+    const backbeatAPI = new BackbeatAPI(config, apiLogger,
+        { timer: isTest });
 
     backbeatAPI.setupInternals(err => {
         if (err) {

--- a/lib/api/Healthcheck.js
+++ b/lib/api/Healthcheck.js
@@ -1,0 +1,114 @@
+'use strict'; // eslint-disable-line strict
+
+const IN_SYNC_REPLICAS = 3;
+
+/**
+ * Handles healthcheck routes
+ *
+ * @class
+ */
+class Healthcheck {
+    /**
+     * @constructor
+     * @param {object} repConfig - extensions.replication configs
+     * @param {node-zookeeper-client.Client} zkClient - zookeeper client
+     * @param {BackbeatProducer} crrProducer - producer for CRR topic
+     * @param {BackbeatProducer} crrStatusProducer - CRR status producer
+     * @param {BackbeatProducer} metricProducer - producer for metric
+     */
+    constructor(repConfig, zkClient, crrProducer, crrStatusProducer,
+    metricProducer) {
+        this._repConfig = repConfig;
+        this._zkClient = zkClient;
+        this._crrProducer = crrProducer;
+        this._crrStatusProducer = crrStatusProducer;
+        this._metricProducer = metricProducer;
+    }
+
+    _checkProducersReady() {
+        return this._crrProducer.isReady() && this._metricProducer.isReady()
+            && this._crrStatusProducer.isReady();
+    }
+
+    _getConnectionDetails() {
+        return {
+            zookeeper: {
+                status: this._zkClient.getState().name === 'SYNC_CONNECTED' ?
+                    'ok' : 'error',
+                details: this._zkClient.getState(),
+            },
+            kafkaProducer: {
+                status: this._checkProducersReady() ? 'ok' : 'error',
+            },
+        };
+    }
+
+    /**
+     * Checks health of in-sync replicas
+     * @param {object} md - topic metadata object
+     * @return {string} 'ok' if ISR is healthy, else 'error'
+     */
+    _checkISRHealth(md) {
+        // eslint-disable-next-line consistent-return
+        const keys = Object.keys(md);
+        for (let i = 0; i < keys.length; i++) {
+            if (md[keys[i]].isr &&
+            md[keys[i]].isr.length !== IN_SYNC_REPLICAS) {
+                return 'error';
+            }
+        }
+        return 'ok';
+    }
+
+    /**
+     * Builds the healthcheck response
+     * @param {function} cb - callback(error, data)
+     * @return {undefined}
+     */
+    getHealthcheck(cb) {
+        const client = this._crrProducer.getKafkaClient();
+
+        // TODO: refactor by calling specific topic
+        client.loadMetadataForTopics([], (err, res) => {
+            if (err) {
+                const error = {
+                    method: 'Healthcheck.getHealthcheck',
+                    error: 'error getting healthcheck metadata for topics',
+                };
+                return cb(error);
+            }
+            const response = res.map(i => (Object.assign({}, i)));
+            const connections = {};
+            const topicMD = {};
+            response.forEach((obj, idx) => {
+                if (obj.metadata && obj.metadata[this._repConfig.topic]) {
+                    let copy;
+                    try {
+                        copy = JSON.parse(JSON.stringify(obj.metadata[
+                            this._repConfig.topic]));
+                        topicMD.metadata = copy;
+                        response.splice(idx, 1);
+                    } catch (e) {
+                        this._logger.error('error getting topic metadata', {
+                            error: e.message,
+                        });
+                    }
+                }
+            });
+            response.push(topicMD);
+
+            if (topicMD.metadata) {
+                connections.isrHealth = this._checkISRHealth(topicMD.metadata);
+            }
+
+            Object.assign(connections, this._getConnectionDetails());
+            response.push({
+                internalConnections: connections,
+            });
+
+            return cb(null, response);
+        });
+    }
+}
+
+module.exports = Healthcheck;

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -3,8 +3,33 @@
     API server.
 */
 
+const redisKeys = require('../../extensions/replication/constants').redisKeys;
+
 module.exports = [
     {
         path: '/_/healthcheck',
+        method: 'getHealthcheck',
+    },
+    {
+        path: '/_/metrics/backlog',
+        method: 'getBacklog',
+        dataPoints: [redisKeys.ops, redisKeys.opsDone, redisKeys.bytes,
+            redisKeys.bytesDone],
+    },
+    {
+        path: '/_/metrics/completions',
+        method: 'getCompletions',
+        dataPoints: [redisKeys.opsDone, redisKeys.bytesDone],
+    },
+    {
+        path: '/_/metrics/throughput',
+        method: 'getThroughput',
+        dataPoints: [redisKeys.opsDone, redisKeys.bytesDone],
+    },
+    {
+        path: '/_/metrics',
+        method: 'getAllMetrics',
+        dataPoints: [redisKeys.ops, redisKeys.opsDone, redisKeys.bytes,
+            redisKeys.bytesDone],
     },
 ];

--- a/tests/functional/api/BackbeatServer.js
+++ b/tests/functional/api/BackbeatServer.js
@@ -1,8 +1,20 @@
 const assert = require('assert');
 const http = require('http');
+const Redis = require('ioredis');
+const { Client, Producer } = require('kafka-node');
+
+const { RedisClient, StatsClient } = require('arsenal').metrics;
 
 const config = require('../../config.json');
-const { Client, Producer } = require('kafka-node');
+const allRoutes = require('../../../lib/api/routes');
+const redisConfig = { host: '127.0.0.1', port: 6379 };
+
+const fakeLogger = {
+    trace: () => {},
+    error: () => {},
+    info: () => {},
+    debug: () => {},
+};
 
 const defaultOptions = {
     host: config.server.host,
@@ -12,6 +24,37 @@ const defaultOptions = {
 
 function getUrl(options, path) {
     return `http://${options.host}:${options.port}${path}`;
+}
+
+function getRequest(path, done) {
+    const params = {
+        host: '127.0.0.1',
+        port: 8900,
+        method: 'GET',
+        path,
+    };
+    // eslint-disable-next-line
+    const req = http.request(params, res => {
+        if (res.statusCode !== 200) {
+            return done(res);
+        }
+
+        const chunks = [];
+        res.on('data', chunk => {
+            chunks.push(chunk);
+        });
+        res.on('end', () => {
+            let body;
+            try {
+                body = JSON.parse(Buffer.concat(chunks).toString());
+            } catch (e) {
+                return done(e);
+            }
+            return done(null, body);
+        });
+    });
+    req.on('error', err => done(err));
+    req.end();
 }
 
 describe('Backbeat Server', () => {
@@ -75,12 +118,112 @@ describe('Backbeat Server', () => {
         });
     });
 
-    it('should get a 404 route not found error response', done => {
+    describe('metrics routes', () => {
+        const interval = 100;
+        const expiry = 300;
+        const OPS = 'test:bb:ops';
+        const BYTES = 'test:bb:bytes';
+        const OPS_DONE = 'test:bb:opsdone';
+        const BYTES_DONE = 'test:bb:bytesdone';
+
+        let redisClient;
+        let statsClient;
+        let redis;
+
+        before(done => {
+            redis = new Redis();
+            redisClient = new RedisClient(redisConfig, fakeLogger);
+            statsClient = new StatsClient(redisClient, interval, expiry);
+            done();
+        });
+
+        afterEach(() => {
+            redis.keys('test:bb:*').then(keys => {
+                const pipeline = redis.pipeline();
+                keys.forEach(key => {
+                    pipeline.del(key);
+                });
+                return pipeline.exec();
+            });
+        });
+
+        allRoutes.forEach(route => {
+            if (route.path.indexOf('healthcheck') === -1) {
+                it(`should get a 200 response for route: ${route.path}`,
+                done => {
+                    const url = getUrl(defaultOptions, route.path);
+
+                    http.get(url, res => {
+                        assert.equal(res.statusCode, 200);
+                        done();
+                    });
+                });
+
+                it(`should get correct data keys for route: ${route.path}`,
+                done => {
+                    getRequest(route.path, (err, res) => {
+                        assert.ifError(err);
+                        const key = Object.keys(res)[0];
+                        assert(res[key].description);
+                        assert.equal(typeof res[key].description, 'string');
+
+                        assert(res[key].results);
+                        assert.deepEqual(Object.keys(res[key].results),
+                            ['count', 'size']);
+                        done();
+                    });
+                });
+            }
+        });
+
+        it('should get the right data for route: /_/metrics/backlog',
+        done => {
+            statsClient.reportNewRequest(OPS, 5);
+            statsClient.reportNewRequest(BYTES, 7100);
+
+            getRequest('/_/metrics/backlog', (err, res) => {
+                assert.ifError(err);
+                const key = Object.keys(res)[0];
+                assert.equal(res[key].results.count, 5);
+                assert.equal(res[key].results.size, 7.10);
+                done();
+            });
+        });
+
+        it('should get the right data for route: /_/metrics/completions',
+        done => {
+            statsClient.reportNewRequest(OPS_DONE, 12);
+            statsClient.reportNewRequest(BYTES_DONE, 1970);
+
+            getRequest('/_/metrics/completions', (err, res) => {
+                assert.ifError(err);
+                const key = Object.keys(res)[0];
+                assert.equal(res[key].results.count, 12);
+                assert.equal(res[key].results.size, 1.97);
+                done();
+            });
+        });
+
+        it('should get the right data for route: /_/metrics/throughput',
+        done => {
+            statsClient.reportNewRequest(OPS_DONE, 300);
+            statsClient.reportNewRequest(BYTES_DONE, 187400);
+
+            getRequest('/_/metrics/throughput', (err, res) => {
+                assert.ifError(err);
+                const key = Object.keys(res)[0];
+                assert.equal(res[key].results.count, 0.33);
+                assert.equal(res[key].results.size, 0.21);
+                done();
+            });
+        });
+    });
+
+    it('should get a 404 route not found error response', () => {
         const url = getUrl(defaultOptions, '/_/invalidpath');
 
         http.get(url, res => {
             assert.equal(res.statusCode, 404);
-            done();
         });
     });
 


### PR DESCRIPTION
This PR to be merged after https://github.com/scality/backbeat/pull/153
Need to drop a commit before merging. Redis configs defined in
https://github.com/scality/backbeat/pull/125 needed for this PR.

This PR is focused on exposing metrics from Redis to API routes defined.

Example output for the "getAllMetrics" route:

`
{"backlog":{"description":"Number of incomplete replication operations (count) and number of incomplete MB transferred (size)","results":{"count":0,"size":"0.00"}},"completions":{"description":"Number of completed replication operations (count) and number of MB transferred (size) in the last 900 seconds","results":{"count":0,"size":"0.00"}},"throughput":{"description":"Current throughput for replication operations in ops/sec (count) and MB/sec (size)","results":{"count":"0.00","size":"0.00"}}}
`