### PR TITLE
bf: allow retries on errors in CredentialsManager.refresh()

### DIFF
--- a/credentials/CredentialsManager.js
+++ b/credentials/CredentialsManager.js
@@ -62,7 +62,15 @@ class CredentialsManager extends Credentials {
                     // instead of passing a possibly global arsenal
                     // error returned by vault client, because AWS
                     // client is transforming it its own way.
-                    return cb(err.customizeDescription(err.description));
+                    const newErr = err.customizeDescription(err.description);
+
+                    // Stick with the AWS SDK way of returning whether
+                    // the error is retryable
+                    newErr.retryable =
+                        (err.InternalError || err.code === 'InternalError' ||
+                         err.ServiceUnavailable ||
+                         err.code === 'ServiceUnavailable');
+                    return cb(newErr);
                 }
                 /*
                     {

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -786,7 +786,8 @@ describe('queue processor functional tests with mocking', () => {
                     });
                 });
 
-            ['getAccountsCanonicalIds'].forEach(action => {
+            ['getAccountsCanonicalIds',
+            'assumeRoleBackbeat'].forEach(action => {
                 [errors.InternalError].forEach(error => {
                     it(`should retry on ${error.code} (${error.message}) ` +
                     `from target Vault on ${action}`, done => {


### PR DESCRIPTION
Set the 'retryable' field in the errors generated from
CredentialsManager.refresh() when relevant, to be in sync with AWS SDK
behavior, which is also how the calling code of the SDK checks whether
it should retry the request.

The criteria are when the error is an InternalError or
ServiceUnavailble we retry, otherwise we don't.