### PR TITLE
bf: credentials refresh missing retry

### DIFF
--- a/credentials/CredentialsManager.js
+++ b/credentials/CredentialsManager.js
@@ -67,9 +67,12 @@ class CredentialsManager extends Credentials {
                     // Stick with the AWS SDK way of returning whether
                     // the error is retryable
                     newErr.retryable =
-                        (err.InternalError || err.code === 'InternalError' ||
+                        (err.InternalError ||
+                         err.code === 'InternalError' ||
+                         err.code === 500 ||
                          err.ServiceUnavailable ||
-                         err.code === 'ServiceUnavailable');
+                         err.code === 'ServiceUnavailable' ||
+                         err.code === 503);
                     return cb(newErr);
                 }
                 /*


### PR DESCRIPTION
There is another case of missing retry in credentials refresh, when
the error code itself is 500: support retries when the error code
field is numeric 500 or 503.

Here's the log trace in backbeat processor seen during tests which did not trigger a retry:

```
/opt/logs/scality-backbeat/logs/processor-2-0.log:{"name":"Backbeat:Replication:QueueProcessor","method":"QueueProcessor._setupRoles","entry":{"bucket":"jonathan-bucket1","objectKey":"CF00","versionId":"98487475265477999999RG001  80.133153.93","isDeleteMarker":false},"origin":"source","peer":{"host":"localhost","port":8000},"error":"Missing credentials in config","time":1512524767177,"req_id":"b984c939d54da6041f25","level":"error","message":"error getting replication configuration from S3","hostname":"s3-node-na-0.novalocal","pid":39}
/opt/logs/scality-backbeat/logs/processor-2-0.log:{"name":"Backbeat","method":"CredentialsManager.refresh","extension":"replication","roleArn":"arn:aws:iam::667800536867:role/backbeat-source","time":1512524767179,"req_id":"b984c939d54da6041f25:455ea3894d48af0c1abe","level":"debug","message":"refreshing credentials from vault","hostname":"s3-node-na-0.novalocal","pid":39}
/opt/logs/scality-backbeat/logs/processor-2-0.log:{"name":"Backbeat","error":{"code":500,"description":"Server error: the request processing has failed because of an unknown error, exception or failure.","ServiceFailure":true},"method":"CredentialsManager.refresh","time":1512524770548,"req_id":"b984c939d54da6041f25:455ea3894d48af0c1abe","level":"error","message":"error assuming backbeat role","hostname":"s3-node-na-0.novalocal","pid":39}
/opt/logs/scality-backbeat/logs/processor-2-0.log:{"name":"Backbeat:Replication:QueueProcessor","entry":{"bucket":"jonathan-bucket1","objectKey":"CF00","versionId":"98487475265477999999RG001  80.133153.93","isDeleteMarker":false},"error":"Server error: the request processing has failed because of an unknown error, exception or failure.","time":1512524767178,"req_id":"b984c939d54da6041f25","level":"debug","message":"replication failed permanently for object, updating replication status to FAILED","hostname":"s3-node-na-0.novalocal","pid":39}
/opt/logs/scality-backbeat/logs/processor-2-0.log:{"name":"Backbeat:Replication:QueueProcessor","where":"source","entry":{"bucket":"jonathan-bucket1","objectKey":"CF00","versionId":"98487475265477999999RG001  80.133153.93","isDeleteMarker":false},"replicationStatus":"FAILED","time":1512524767178,"req_id":"b984c939d54da6041f25","level":"debug","message":"putting metadata","hostname":"s3-node-na-0.novalocal","pid":39}
```
