### PR TITLE
ft: support specifying partition in entries

### DIFF
--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -128,17 +128,23 @@ class BackbeatProducer extends EventEmitter {
                 cb(errors.InternalError);
             });
         }
-        const payload = this._partition === undefined ?
-                  entries.map(item => ({
-                      topic: this._topic,
-                      messages: new KeyedMessage(item.key, item.message),
-                      key: item.key,
-                  })) :
-                  entries.map(item => ({
-                      topic: this._topic,
-                      messages: item.message,
-                      partition: this._partition,
-                  }));
+
+        const payload = entries.map(item => {
+            if (item.partition !== undefined || this._partition !== undefined) {
+                // specifiying partition takes precedence
+                return {
+                    topic: this._topic,
+                    messages: item.message,
+                    partition: item.partition || this._partition,
+                };
+            }
+            return {
+                topic: this._topic,
+                messages: new KeyedMessage(item.key, item.message),
+                key: item.key,
+            };
+        });
+
         this._client.refreshMetadata([this._topic], () =>
             this._producer.send(payload, err => {
                 if (err) {


### PR DESCRIPTION
To support deep healthcheck, where I want to produce to all
partitions, allow for specifying a partition within an entry.