### PR TITLE
rf: single producer for all clusters

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,4 +21,5 @@ test:
         - npm run --silent lint_md
         - npm run --silent lint
         - npm test
+        - TEST_SWITCH=1 npm start & bash wait_for_local_port.bash 8900 40 && npm run ft_server_test
         - npm run ft_test

--- a/conf/Config.js
+++ b/conf/Config.js
@@ -58,6 +58,11 @@ class Config {
                 ca: ca ? fs.readFileSync(capath, 'ascii') : undefined,
             };
         }
+
+        const healthChecks = config.server.healthChecks.allowFrom;
+        if (healthChecks && healthChecks.length === 0) {
+            this.healthChecks = { allowFrom: ['127.0.0.1/8', '::1'] };
+        }
     }
 }
 

--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -34,6 +34,9 @@ const joiSchema = {
         }),
     },
     log: logJoi,
+    metrics: {
+        topic: joi.string().required(),
+    },
     extensions: {
         replication: {
             source: {
@@ -59,6 +62,13 @@ const joiSchema = {
                 concurrency: joi.number().greater(0).default(10),
             },
         },
+    },
+    server: {
+        healthChecks: joi.object({
+            allowFrom: joi.array().items(joi.string()).default([]),
+        }).required(),
+        host: joi.string().required(),
+        port: joi.number().default(8900),
     },
 };
 

--- a/conf/config.json
+++ b/conf/config.json
@@ -20,6 +20,9 @@
             "port": 9990
         }
     },
+    "metrics": {
+        "topic": "backbeat-metrics"
+    },
     "extensions": {
         "replication": {
             "source": {
@@ -65,5 +68,12 @@
     "log": {
         "logLevel": "info",
         "dumpLevel": "error"
+    },
+    "server": {
+        "healthChecks": {
+            "allowFrom": ["127.0.0.1/8", "::1"]
+        },
+        "host": "127.0.0.1",
+        "port": 8900
     }
 }

--- a/index.js
+++ b/index.js
@@ -1,0 +1,17 @@
+'use strict'; // eslint-disable-line strict
+
+const werelogs = require('werelogs');
+
+const runServer = require('./lib/api/BackbeatServer');
+
+const Config = process.env.TEST_SWITCH !== '1' ? require('./conf/Config') :
+    require('./tests/config.json');
+
+const Logger = werelogs.Logger;
+
+werelogs.configure({
+    level: Config.log.logLevel,
+    dump: Config.log.dumpLevel,
+});
+
+runServer(Config, Logger);

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -90,6 +90,14 @@ class BackbeatProducer extends EventEmitter {
     }
 
     /**
+    * get external modules producer client
+    * @return {kafka-node.Producer} - external producer client instance
+    */
+    getProducer() {
+        return this._producer;
+    }
+
+    /**
     * create topic - works only when auto.create.topics.enable=true for the
     * Kafka server. It sends a metadata request to the server which will create
     * the topic

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -1,11 +1,9 @@
 'use strict'; // eslint-disable-line strict
 
-const async = require('async');
 const zookeeper = require('node-zookeeper-client');
 
 const { errors } = require('arsenal');
 
-const BackbeatProducer = require('../BackbeatProducer');
 const routes = require('./routes');
 
 // In-Sync Replicas
@@ -21,16 +19,17 @@ class BackbeatAPI {
      * @constructor
      * @param {object} config - configurations for setup
      * @param {werelogs.Logger} logger - Logger object
+     * @param {BackbeatProducer} crrProducer - producer for CRR topic
+     * @param {BackbeatProducer} metricProducer - producer for metric topic
      */
-    constructor(config, logger) {
+    constructor(config, logger, crrProducer, metricProducer) {
         this._zkConfig = config.zookeeper;
-        this._topic = config.metrics.topic;
         this._repConfig = config.extensions.replication;
         this._queuePopulator = config.queuePopulator;
-        this._kafkaHost = config.kafka.hosts;
         this._logger = logger;
 
-        this._producer = null;
+        this._crrProducer = crrProducer;
+        this._metricProducer = metricProducer;
         this._zkClient = null;
     }
 
@@ -49,7 +48,7 @@ class BackbeatAPI {
      */
     isConnected() {
         return this._zkClient.getState().name === 'SYNC_CONNECTED'
-            && this._producer.isReady();
+            && this._crrProducer.isReady() && this._metricProducer.isReady();
     }
 
     _getConnectionDetails() {
@@ -60,7 +59,8 @@ class BackbeatAPI {
                 details: this._zkClient.getState(),
             },
             kafkaProducer: {
-                status: this._producer.isReady() ? 'ok' : 'error',
+                status: (this._crrProducer.isReady() &&
+                    this._metricProducer.isReady()) ? 'ok' : 'error',
             },
         };
     }
@@ -87,7 +87,7 @@ class BackbeatAPI {
      * @return {undefined}
      */
     healthcheck(cb) {
-        const client = this._producer.getProducer().client;
+        const client = this._crrProducer.getProducer().client;
 
         client.loadMetadataForTopics([], (err, res) => {
             if (err) {
@@ -121,40 +121,7 @@ class BackbeatAPI {
         });
     }
 
-    setupInternals(cb) {
-        async.series([
-            next => this._setZookeeper(next),
-            next => this._setProducer(next),
-        ], err => {
-            if (err) {
-                this._logger.error('error setting up internal clients');
-                return cb(err);
-            }
-            this._logger.info('BackbeatAPI setup ready');
-            return cb();
-        });
-    }
-
-    _setProducer(cb) {
-        const producer = new BackbeatProducer({
-            zookeeper: { connectionString: this._zkConfig.connectionString },
-            topic: this._topic,
-        });
-
-        producer.once('error', cb);
-        producer.once('ready', () => {
-            producer.removeAllListeners('error');
-            producer.on('error', err => {
-                this._logger.error('error from backbeat producer', {
-                    error: err,
-                });
-            });
-            this._producer = producer;
-            return cb();
-        });
-    }
-
-    _setZookeeper(cb) {
+    setZookeeper(cb) {
         const populatorZkPath = this._queuePopulator.zookeeperPath;
         const zookeeperUrl =
             `${this._zkConfig.connectionString}${populatorZkPath}`;

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -1,0 +1,179 @@
+'use strict'; // eslint-disable-line strict
+
+const async = require('async');
+const zookeeper = require('node-zookeeper-client');
+
+const { errors } = require('arsenal');
+
+const BackbeatProducer = require('../BackbeatProducer');
+const routes = require('./routes');
+
+// In-Sync Replicas
+const ISRS = 3;
+
+/**
+ * Class representing Backbeat API endpoints and internals
+ *
+ * @class
+ */
+class BackbeatAPI {
+    /**
+     * @constructor
+     * @param {object} config - configurations for setup
+     * @param {werelogs.Logger} logger - Logger object
+     */
+    constructor(config, logger) {
+        this._zkConfig = config.zookeeper;
+        this._topic = config.metrics.topic;
+        this._repConfig = config.extensions.replication;
+        this._queuePopulator = config.queuePopulator;
+        this._kafkaHost = config.kafka.hosts;
+        this._logger = logger;
+
+        this._producer = null;
+        this._zkClient = null;
+    }
+
+    /**
+     * Check if incoming request is valid
+     * @param {string} route - request route
+     * @return {boolean} true/false
+     */
+    isValidRoute(route) {
+        return routes.map(route => route.path).includes(route);
+    }
+
+    /**
+     * Check if Zookeeper and Producer are connected
+     * @return {boolean} true/false
+     */
+    isConnected() {
+        return this._zkClient.getState().name === 'SYNC_CONNECTED'
+            && this._producer.isReady();
+    }
+
+    _getConnectionDetails() {
+        return {
+            zookeeper: {
+                status: this._zkClient.getState().name === 'SYNC_CONNECTED' ?
+                    'ok' : 'error',
+                details: this._zkClient.getState(),
+            },
+            kafkaProducer: {
+                status: this._producer.isReady() ? 'ok' : 'error',
+            },
+        };
+    }
+
+    /**
+     * Checks health of in-sync replicas
+     * @param {object} md - topic metadata object
+     * @return {boolean} true if ISR health is ok
+     */
+    _checkISRHealth(md) {
+        // eslint-disable-next-line consistent-return
+        const keys = Object.keys(md);
+        for (let i = 0; i < keys.length; i++) {
+            if (md[keys[i]].isr && md[keys[i]].isr.length !== ISRS) {
+                return 'error';
+            }
+        }
+        return 'ok';
+    }
+
+    /**
+     * Get Kafka healthcheck
+     * @param {function} cb - callback(error, data)
+     * @return {undefined}
+     */
+    healthcheck(cb) {
+        const client = this._producer.getProducer().client;
+
+        client.loadMetadataForTopics([], (err, res) => {
+            if (err) {
+                this._logger.trace('error getting healthcheck');
+                return cb(errors.InternalError);
+            }
+            const response = res.map(i => (Object.assign({}, i)));
+            const connections = {};
+            try {
+                const topicMD = {};
+                response.forEach((obj, idx) => {
+                    if (obj.metadata && obj.metadata[this._repConfig.topic]) {
+                        const copy = JSON.parse(JSON.stringify(obj.metadata[
+                            this._repConfig.topic]));
+                        topicMD.metadata = copy;
+                        response.splice(idx, 1);
+                    }
+                });
+                response.push(topicMD);
+
+                connections.isrHealth = this._checkISRHealth(topicMD.metadata);
+            } finally {
+                Object.assign(connections, this._getConnectionDetails());
+
+                response.push({
+                    internalConnections: connections,
+                });
+
+                return cb(null, response);
+            }
+        });
+    }
+
+    setupInternals(cb) {
+        async.series([
+            next => this._setZookeeper(next),
+            next => this._setProducer(next),
+        ], err => {
+            if (err) {
+                this._logger.error('error setting up internal clients');
+                return cb(err);
+            }
+            this._logger.info('BackbeatAPI setup ready');
+            return cb();
+        });
+    }
+
+    _setProducer(cb) {
+        const producer = new BackbeatProducer({
+            zookeeper: { connectionString: this._zkConfig.connectionString },
+            topic: this._topic,
+        });
+
+        producer.once('error', cb);
+        producer.once('ready', () => {
+            producer.removeAllListeners('error');
+            producer.on('error', err => {
+                this._logger.error('error from backbeat producer', {
+                    error: err,
+                });
+            });
+            this._producer = producer;
+            return cb();
+        });
+    }
+
+    _setZookeeper(cb) {
+        const populatorZkPath = this._queuePopulator.zookeeperPath;
+        const zookeeperUrl =
+            `${this._zkConfig.connectionString}${populatorZkPath}`;
+
+        const zkClient = zookeeper.createClient(zookeeperUrl, {
+            autoCreateNamespace: this._zkConfig.autoCreateNamespace,
+        });
+        zkClient.connect();
+
+        zkClient.once('error', cb);
+        zkClient.once('state', event => {
+            if (event.name !== 'SYNC_CONNECTED' || event.code !== 3) {
+                return cb('error setting up zookeeper');
+            }
+            zkClient.removeAllListeners('error');
+            this._zkClient = zkClient;
+            return cb();
+        });
+    }
+}
+
+module.exports = BackbeatAPI;

--- a/lib/api/BackbeatRequest.js
+++ b/lib/api/BackbeatRequest.js
@@ -1,0 +1,118 @@
+'use strict'; // eslint-disable-line strict
+
+/**
+ * Class representing a Backbeat API Request
+ *
+ * @class
+ */
+class BackbeatRequest {
+    constructor() {
+        this._log = null;
+        this._request = null;
+        this._response = null;
+        this._statusCode = 0;
+        this._route = null;
+        this._error = null;
+    }
+
+    /**
+     * Get logger object
+     * @return {object} Logger object
+     */
+    getLog() {
+        return this._log;
+    }
+
+    /**
+     * Set logger object
+     * @param {object} log - new Logger object
+     * @return {BackbeatRequest} itself
+     */
+    setLog(log) {
+        this._log = log;
+        return this;
+    }
+
+    /**
+     * Get http request object
+     * @return {object} Http request object
+     */
+    getRequest() {
+        return this._request;
+    }
+
+    /**
+     * Set http request object
+     * @param {object} request - new Http request object
+     * @return {BackbeatRequest} itself
+     */
+    setRequest(request) {
+        this._request = request;
+        return this;
+    }
+
+    /**
+     * Get http response object
+     * @return {object} Http response object
+     */
+    getResponse() {
+        return this._response;
+    }
+
+    /**
+     * Set http response object
+     * @param {object} response - new Http response object
+     * @return {BackbeatRequest} itself
+     */
+    setResponse(response) {
+        this._response = response;
+        return this;
+    }
+
+    /**
+     * Get status code of request
+     * @return {number} Http status code
+     */
+    getStatusCode() {
+        return this._statusCode;
+    }
+
+    /**
+     * Set status code of request
+     * @param {number} code - new Http status code
+     * @return {BackbeatRequest} itself
+     */
+    setStatusCode(code) {
+        this._statusCode = code;
+        return this;
+    }
+
+    /**
+     * Get route
+     * @return {string} current route
+     */
+    getRoute() {
+        return this._route;
+    }
+
+    /**
+     * Set route
+     * @param {string} route - new route string
+     * @return {BackbeatRequest} itself
+     */
+    setRoute(route) {
+        this._route = route;
+        return this;
+    }
+
+    /**
+     * Status check to see if valid request
+     * @return {boolean} valid status check
+     */
+    getStatus() {
+        return ((this._statusCode >= 200 && this._statusCode < 300)
+            && !this._error);
+    }
+}
+
+module.exports = BackbeatRequest;

--- a/lib/api/BackbeatServer.js
+++ b/lib/api/BackbeatServer.js
@@ -1,0 +1,225 @@
+'use strict'; // eslint-disable-line strict
+
+const http = require('http');
+
+const { Clustering, errors, ipCheck } = require('arsenal');
+
+const BackbeatRequest = require('./BackbeatRequest');
+const BackbeatAPI = require('./BackbeatAPI');
+
+const WORKERS = 4;
+
+class BackbeatServer {
+    /**
+     * @constructor
+     * @param {Worker} [worker=null] - Track the worker using cluster
+     * @param {object} config - configurations for server setup
+     * @param {werelogs.Logger} logger - Logger object
+     * @param {BackbeatAPI} backbeatAPI - BackbeatAPI instance
+     */
+    constructor(worker, config, logger, backbeatAPI) {
+        this.server = null;
+        this.worker = worker;
+        this._config = config;
+        this._port = config.port;
+        this._logger = logger;
+        this.backbeatAPI = backbeatAPI;
+    }
+
+    /**
+     * Last log message to send per incoming request
+     * @param {werelogs.newRequestLogger} logger - request logger
+     * @param {object} req - request object
+     * @param {object} res - response object
+     * @return {undefined}
+     *
+     * @static
+     */
+    static logRequestEnd(logger, req, res) {
+        const info = {
+            clientIp: req.socket.remoteAddress,
+            clientPort: req.socket.remotePort,
+            httpMethod: req.method,
+            httpURL: req.url,
+            httpCode: res.statusCode,
+            httpMessage: res.statusMessage,
+        };
+        logger.end('finished handling request', info);
+    }
+
+    /**
+     * Check if incoming request is valid
+     * @param {object} req - incoming request object
+     * @param {BackbeatRequest} backbeatRequest - Backbeat request object
+     * @return {boolean} true if no errors
+     */
+    _isValidRequest(req, backbeatRequest) {
+        const allowIp = ipCheck.ipMatchCidrList(
+            this._config.healthChecks.allowFrom, req.socket.remoteAddress);
+        if (!allowIp) {
+            return this._errorResponse(errors.AccessDenied
+                .customizeDescription('invalid origin ip request'),
+                backbeatRequest);
+        }
+
+        if (!this.backbeatAPI.isValidRoute(backbeatRequest.getRoute())
+            || !backbeatRequest.getRoute().startsWith('/_/')) {
+            return this._errorResponse(errors.RouteNotFound
+                .customizeDescription(`path ${backbeatRequest.getRoute()} does `
+                    + 'not exist'), backbeatRequest);
+        }
+
+        if (req.method !== 'GET') {
+            // So far the API should only be receiving GET requests
+            return this._errorResponse(errors.MethodNotAllowed
+                .customizeDescription('invalid http verb'),
+                backbeatRequest);
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if Kafka Producer and Zookeeper are working properly
+     * @param {BackbeatRequest} backbeatRequest - Backbeat request object
+     * @return {boolean} true if no errors
+     */
+    _areConditionsOk(backbeatRequest) {
+        if (!this.backbeatAPI.isConnected()) {
+            return this._errorResponse(errors.InternalError
+                .customizeDescription('error connecting to internal client'),
+                backbeatRequest);
+        }
+
+        return true;
+    }
+
+    /**
+     * Server's error response handler
+     * @param {arsenal.ArsenalError} err - arsenal error object
+     * @param {BackbeatRequest} backbeatRequest - Backbeat request object
+     * @return {undefined}
+     */
+    _errorResponse(err, backbeatRequest) {
+        backbeatRequest.setStatusCode(err.code);
+        this._response(err, backbeatRequest);
+    }
+
+    /**
+     * Server incoming request handler
+     * @param {object} req - request object
+     * @param {object} res - response object
+     * @return {undefined}
+     */
+    _requestListener(req, res) {
+        req.socket.setNoDelay();
+        const bbRequest = new BackbeatRequest()
+            .setRequest(req)
+            .setResponse(res)
+            .setLog(this._logger.newRequestLogger())
+            .setRoute(req.url);
+
+        // check request conditions and all internal conditions here
+        if (this._isValidRequest(req, bbRequest)
+        && this._areConditionsOk(bbRequest)) {
+            bbRequest.setStatusCode(200)
+                .setRoute(bbRequest.getRoute().slice(3));
+
+            this.backbeatAPI[bbRequest.getRoute()]((err, data) => {
+                if (err) {
+                    this._errorResponse(err, bbRequest);
+                } else {
+                    this._response(data, bbRequest);
+                }
+            });
+        }
+    }
+
+    /**
+     * Server's response to the client
+     * @param {object} data - response to send to client
+     * @param {BackbeatRequest} backbeatRequest - Backbeat request object
+     * @return {object} res - response object
+     */
+    _response(data, backbeatRequest) {
+        const log = backbeatRequest.getLog();
+        const req = backbeatRequest.getRequest();
+        const res = backbeatRequest.getResponse();
+        log.trace('writing HTTP response', {
+            method: 'BackbeatServer._response',
+        });
+        const code = backbeatRequest.getStatusCode();
+        const payload = Buffer.from(JSON.stringify(data), 'utf8');
+
+        res.writeHead(code, {
+            'Content-Type': 'application/json',
+            'Content-Length': payload.length,
+        });
+        BackbeatServer.logRequestEnd(log, req, res);
+        return res.end(payload);
+    }
+
+    /**
+     * start BackbeatServer
+     * @return {undefined}
+     */
+    start() {
+        this.server = http.createServer((req, res) => {
+            this._requestListener(req, res);
+        });
+
+        this.server.on('listening', () => {
+            const addr = this.server.address() || {
+                address: '0.0.0.0',
+                port: this._port,
+            };
+            this._logger.trace('server started', {
+                address: addr.address,
+                port: addr.port,
+                pid: process.pid,
+            });
+        });
+        this.server.listen(this._port);
+    }
+
+    /*
+     * stop BackbeatServer and exit running process properly
+     */
+    stop() {
+        this._logger.info(`worker ${this.worker} shutting down`);
+        this.server.close();
+        process.exit(0);
+    }
+}
+
+/**
+ * start the backbeat API server
+ * @param {object} config - location of config file
+ * @param {werelogs.Logger} Logger - Logger object
+ * @param {function} cb - callback function
+ * @return {undefined}
+ */
+function run(config, Logger) {
+    const logger = new Logger('BackbeatServer');
+    const apiLogger = new Logger('BackbeatAPI');
+    const cluster = new Clustering(WORKERS, logger);
+    const backbeatAPI = new BackbeatAPI(config, apiLogger);
+
+    backbeatAPI.setupInternals(err => {
+        if (err) {
+            logger.error('internal error, please try again', {
+                error: err,
+            });
+            process.exit(1);
+        } else {
+            cluster.start(worker => {
+                const server = new BackbeatServer(worker, config.server, logger,
+                    backbeatAPI);
+                process.on('SIGINT', () => server.stop());
+                server.start();
+            });
+        }
+    });
+}
+
+module.exports = run;

--- a/lib/api/BackbeatServer.js
+++ b/lib/api/BackbeatServer.js
@@ -1,9 +1,11 @@
 'use strict'; // eslint-disable-line strict
 
+const async = require('async');
 const http = require('http');
 
 const { Clustering, errors, ipCheck } = require('arsenal');
 
+const BackbeatProducer = require('../BackbeatProducer');
 const BackbeatRequest = require('./BackbeatRequest');
 const BackbeatAPI = require('./BackbeatAPI');
 
@@ -203,9 +205,40 @@ function run(config, Logger) {
     const logger = new Logger('BackbeatServer');
     const apiLogger = new Logger('BackbeatAPI');
     const cluster = new Clustering(WORKERS, logger);
-    const backbeatAPI = new BackbeatAPI(config, apiLogger);
+    let backbeatAPI;
 
-    backbeatAPI.setupInternals(err => {
+    // Two producers are created, one for each topic
+    const crrProducer = new BackbeatProducer({
+        zookeeper: { connectionString: config.zookeeper.connectionString },
+        topic: config.extensions.replication.topic,
+    });
+    const metricProducer = new BackbeatProducer({
+        zookeeper: { connectionString: config.zookeeper.connectionString },
+        topic: config.metrics.topic,
+    });
+
+    async.series([
+        next => {
+            crrProducer.once('error', next);
+            crrProducer.once('ready', () => {
+                crrProducer.removeAllListeners('error');
+                next();
+            });
+        },
+        next => {
+            metricProducer.once('error', next);
+            metricProducer.once('ready', () => {
+                metricProducer.removeAllListeners('error');
+                next();
+            });
+        },
+        next => {
+            backbeatAPI = new BackbeatAPI(config, apiLogger, crrProducer,
+                metricProducer);
+            next();
+        },
+        next => backbeatAPI.setZookeeper(next),
+    ], err => {
         if (err) {
             logger.error('internal error, please try again', {
                 error: err,

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -1,0 +1,10 @@
+/*
+    This file contains all unique details about API routes exposed by Backbeats
+    API server.
+*/
+
+module.exports = [
+    {
+        path: '/_/healthcheck',
+    },
+];

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
     "queue_populator": "node bin/queuePopulator.js",
     "queue_processor": "node extensions/replication/queueProcessor/task.js",
     "test": "mocha --recursive tests/unit",
-    "ft_test": "mocha --recursive tests/functional",
+    "ft_test": "mocha --recursive $(find tests/functional -name '*.js' ! -name 'BackbeatServer.js')",
+    "ft_server_test": "mocha tests/functional/api/BackbeatServer.js",
     "bh_test": "mocha --recursive tests/behavior",
     "lint": "eslint $(git ls-files '*.js')",
-    "lint_md": "mdlint $(git ls-files '*.md')"
+    "lint_md": "mdlint $(git ls-files '*.md')",
+    "start": "node index.js"
   },
   "repository": {
     "type": "git",

--- a/tests/config.json
+++ b/tests/config.json
@@ -1,6 +1,7 @@
 {
     "zookeeper": {
-        "connectionString": "127.0.0.1:2181"
+        "connectionString": "127.0.0.1:2181",
+        "autoCreateNamespace": true
     },
     "queuePopulator": {
         "cronRule": "*/5 * * * * *",
@@ -15,6 +16,9 @@
     },
     "kafka": {
         "hosts": "127.0.0.1:9092"
+    },
+    "metrics": {
+        "topic": "backbeat-metrics"
     },
     "s3": {
         "host": "127.0.0.1",
@@ -32,5 +36,12 @@
     "log": {
         "logLevel": "info",
         "dumpLevel": "error"
+    },
+    "server": {
+        "healthChecks": {
+            "allowFrom": ["127.0.0.1/8", "::1"]
+        },
+        "host": "127.0.0.1",
+        "port": 8900
     }
 }

--- a/tests/functional/api/BackbeatServer.js
+++ b/tests/functional/api/BackbeatServer.js
@@ -1,0 +1,102 @@
+const assert = require('assert');
+const http = require('http');
+
+const config = require('../../config.json');
+
+const defaultOptions = {
+    host: config.server.host,
+    port: config.server.port,
+    method: 'GET',
+};
+
+function getUrl(options, path) {
+    return `http://${options.host}:${options.port}${path}`;
+}
+
+describe('Backbeat Server', () => {
+    it('should get a response', done => {
+        const url = getUrl(defaultOptions, '/');
+
+        http.get(url, res => {
+            assert(res.statusCode);
+            assert(res.constructor.name === 'IncomingMessage');
+            return done();
+        });
+    });
+
+    describe('healthcheck route', () => {
+        let data;
+        let resCode;
+        before(done => {
+            const url = getUrl(defaultOptions, '/_/healthcheck');
+
+            http.get(url, res => {
+                resCode = res.statusCode;
+
+                let rawData = '';
+                res.on('data', chunk => {
+                    rawData += chunk;
+                });
+                res.on('end', () => {
+                    data = JSON.parse(rawData);
+                    done();
+                });
+            });
+        });
+
+        it('should get a response with data', done => {
+            assert(Object.keys(data).length > 0);
+            assert.equal(resCode, 200);
+            return done();
+        });
+
+        it('should have valid keys', done => {
+            const keys = [].concat(...data.map(d => Object.keys(d)));
+
+            assert(keys.includes('metadata'));
+            assert(keys.includes('internalConnections'));
+            return done();
+        });
+
+        it('should be healthy', done => {
+            // NOTE: isrHealth is not checked here because circleci
+            // kafka will have one ISR only. Maybe isrHealth should
+            // be a test for end-to-end
+            let internalConnections;
+            data.forEach(obj => {
+                if (Object.keys(obj).includes('internalConnections')) {
+                    internalConnections = obj.internalConnections;
+                }
+            });
+            Object.keys(internalConnections).forEach(key => {
+                assert.ok(internalConnections[key]);
+            });
+
+            return done();
+        });
+    });
+
+    it('should get a 404 route not found error response', done => {
+        const url = getUrl(defaultOptions, '/_/invalidpath');
+
+        http.get(url, res => {
+            assert.equal(res.statusCode, 404);
+            done();
+        });
+    });
+
+    it('should get a 405 method not allowed from invalid http verb', done => {
+        const options = Object.assign({}, defaultOptions);
+        options.method = 'POST';
+        options.path = '/_/healthcheck';
+
+        const req = http.request(options, res => {
+            assert.equal(res.statusCode, 405);
+        });
+        req.on('error', err => {
+            assert.ifError(err);
+        });
+        req.end();
+        done();
+    });
+});

--- a/wait_for_local_port.bash
+++ b/wait_for_local_port.bash
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+wait_for_local_port() {
+    local port=$1
+    local timeout=$2
+    local count=0
+    local ret=1
+    echo "waiting for BackbeatServer:$port"
+    while [[ "$ret" -eq "1" && "$count" -lt "$timeout" ]] ; do
+        nc -z -w 1 localhost $port
+        ret=$?
+        if [ ! "$ret" -eq "0" ]; then
+            echo -n .
+            sleep 1
+            count=$(($count+1))
+        fi
+    done
+
+    echo ""
+
+    if [[ "$count" -eq "$timeout" ]]; then
+        echo "Server did not start in less than $timeout seconds. Exiting..."
+        exit 1
+    fi
+    sleep 5
+
+    echo "Server got ready in ~${count} seconds. Starting test now..."
+}
+
+wait_for_local_port $1 $2


### PR DESCRIPTION
Multiple producers were being created for each cluster.
Rather, instantiating a single producer per topic
would be more efficient.

Also, I realized I created a producer for a metric topic only.
Instead, I should be checking the health of producers of all
topics, including metrics topic.

Should be merged after https://github.com/scality/backbeat/pull/102