### PR TITLE
rf: move healthcheck

### DIFF
--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -6,10 +6,8 @@ const zookeeper = require('node-zookeeper-client');
 const { errors } = require('arsenal');
 
 const BackbeatProducer = require('../BackbeatProducer');
+const Healthcheck = require('./Healthcheck');
 const routes = require('./routes');
-
-// In-Sync Replicas
-const ISRS = 3;
 
 /**
  * Class representing Backbeat API endpoints and internals
@@ -35,6 +33,7 @@ class BackbeatAPI {
         this._crrProducer = null;
         this._crrStatusProducer = null;
         this._metricProducer = null;
+        this._healthcheck = null;
         this._zkClient = null;
     }
 
@@ -61,33 +60,13 @@ class BackbeatAPI {
             && this._crrStatusProducer.isReady();
     }
 
-    _getConnectionDetails() {
-        return {
-            zookeeper: {
-                status: this._zkClient.getState().name === 'SYNC_CONNECTED' ?
-                    'ok' : 'error',
-                details: this._zkClient.getState(),
-            },
-            kafkaProducer: {
-                status: this._checkProducersReady() ? 'ok' : 'error',
-            },
-        };
-    }
-
     /**
-     * Checks health of in-sync replicas
-     * @param {object} md - topic metadata object
-     * @return {boolean} true if ISR health is ok
+     * Check if Zookeeper and Producer are connected
+     * @return {boolean} true/false
      */
-    _checkISRHealth(md) {
-        // eslint-disable-next-line consistent-return
-        const keys = Object.keys(md);
-        for (let i = 0; i < keys.length; i++) {
-            if (md[keys[i]].isr && md[keys[i]].isr.length !== ISRS) {
-                return 'error';
-            }
-        }
-        return 'ok';
+    isConnected() {
+        return this._zkClient.getState().name === 'SYNC_CONNECTED'
+            && this._checkProducersReady();
     }
 
     /**
@@ -96,47 +75,20 @@ class BackbeatAPI {
      * @return {undefined}
      */
     healthcheck(cb) {
-        const client = this._crrProducer.getKafkaClient();
-
-        // TODO: refactor by calling specific topic
-        client.loadMetadataForTopics([], (err, res) => {
+        return this._healthcheck.getHealthcheck((err, data) => {
             if (err) {
-                this._logger.error('error getting healthcheck');
-                return cb(errors.InternalError
-                    .customizeDescription('error getting healthcheck metadata' +
-                    ' for topics'));
+                this._logger.error('error getting healthcheck', err);
+                return cb(errors.InternalError);
             }
-            const response = res.map(i => (Object.assign({}, i)));
-            const connections = {};
-            const topicMD = {};
-            response.forEach((obj, idx) => {
-                if (obj.metadata && obj.metadata[this._repConfig.topic]) {
-                    let copy;
-                    try {
-                        copy = JSON.parse(JSON.stringify(obj.metadata[
-                            this._repConfig.topic]));
-                        topicMD.metadata = copy;
-                        response.splice(idx, 1);
-                    } catch (e) {
-                        this._logger.error('error getting topic metadata');
-                    }
-                }
-            });
-            response.push(topicMD);
-
-            if (topicMD.metadata) {
-                connections.isrHealth = this._checkISRHealth(topicMD.metadata);
-            }
-
-            Object.assign(connections, this._getConnectionDetails());
-            response.push({
-                internalConnections: connections,
-            });
-
-            return cb(null, response);
+            return cb(null, data);
         });
     }
 
+    /**
+     * Setup internals
+     * @param {function} cb - callback(error)
+     * @return {undefined}
+     */
     setupInternals(cb) {
         async.parallel([
             done => this._setZookeeper(done),
@@ -166,6 +118,9 @@ class BackbeatAPI {
                 this._logger.error('error setting up internal clients');
                 return cb(err);
             }
+            this._healthcheck = new Healthcheck(this._repConfig, this._zkClient,
+                this._crrProducer, this._crrStatusProducer,
+                this._metricProducer);
             this._logger.info('BackbeatAPI setup ready');
             return cb();
         });

--- a/lib/api/Healthcheck.js
+++ b/lib/api/Healthcheck.js
@@ -1,0 +1,114 @@
+'use strict'; // eslint-disable-line strict
+
+const IN_SYNC_REPLICAS = 3;
+
+/**
+ * Handles healthcheck routes
+ *
+ * @class
+ */
+class Healthcheck {
+    /**
+     * @constructor
+     * @param {object} repConfig - extensions.replication configs
+     * @param {node-zookeeper-client.Client} zkClient - zookeeper client
+     * @param {BackbeatProducer} crrProducer - producer for CRR topic
+     * @param {BackbeatProducer} crrStatusProducer - CRR status producer
+     * @param {BackbeatProducer} metricProducer - producer for metric
+     */
+    constructor(repConfig, zkClient, crrProducer, crrStatusProducer,
+    metricProducer) {
+        this._repConfig = repConfig;
+        this._zkClient = zkClient;
+        this._crrProducer = crrProducer;
+        this._crrStatusProducer = crrStatusProducer;
+        this._metricProducer = metricProducer;
+    }
+
+    _checkProducersReady() {
+        return this._crrProducer.isReady() && this._metricProducer.isReady()
+            && this._crrStatusProducer.isReady();
+    }
+
+    _getConnectionDetails() {
+        return {
+            zookeeper: {
+                status: this._zkClient.getState().name === 'SYNC_CONNECTED' ?
+                    'ok' : 'error',
+                details: this._zkClient.getState(),
+            },
+            kafkaProducer: {
+                status: this._checkProducersReady() ? 'ok' : 'error',
+            },
+        };
+    }
+
+    /**
+     * Checks health of in-sync replicas
+     * @param {object} md - topic metadata object
+     * @return {string} 'ok' if ISR is healthy, else 'error'
+     */
+    _checkISRHealth(md) {
+        // eslint-disable-next-line consistent-return
+        const keys = Object.keys(md);
+        for (let i = 0; i < keys.length; i++) {
+            if (md[keys[i]].isr &&
+            md[keys[i]].isr.length !== IN_SYNC_REPLICAS) {
+                return 'error';
+            }
+        }
+        return 'ok';
+    }
+
+    /**
+     * Builds the healthcheck response
+     * @param {function} cb - callback(error, data)
+     * @return {undefined}
+     */
+    getHealthcheck(cb) {
+        const client = this._crrProducer.getKafkaClient();
+
+        // TODO: refactor by calling specific topic
+        client.loadMetadataForTopics([], (err, res) => {
+            if (err) {
+                const error = {
+                    method: 'Healthcheck.getHealthcheck',
+                    error: 'error getting healthcheck metadata for topics',
+                };
+                return cb(error);
+            }
+            const response = res.map(i => (Object.assign({}, i)));
+            const connections = {};
+            const topicMD = {};
+            response.forEach((obj, idx) => {
+                if (obj.metadata && obj.metadata[this._repConfig.topic]) {
+                    let copy;
+                    try {
+                        copy = JSON.parse(JSON.stringify(obj.metadata[
+                            this._repConfig.topic]));
+                        topicMD.metadata = copy;
+                        response.splice(idx, 1);
+                    } catch (e) {
+                        this._logger.error('error getting topic metadata', {
+                            error: e.message,
+                        });
+                    }
+                }
+            });
+            response.push(topicMD);
+
+            if (topicMD.metadata) {
+                connections.isrHealth = this._checkISRHealth(topicMD.metadata);
+            }
+
+            Object.assign(connections, this._getConnectionDetails());
+            response.push({
+                internalConnections: connections,
+            });
+
+            return cb(null, response);
+        });
+    }
+}
+
+module.exports = Healthcheck;


### PR DESCRIPTION
Move healthcheck functions to its own class and add 
`BackbeatAPI.setup` for handling all internal setup for 
the api.

This is mainly in preparation for deep healthcheck where
I want to isolate all healthcheck related methods to its
own class

Should be merged after https://github.com/scality/backbeat/pull/152