### PR TITLE
Ft/S3C-979 add deep healthcheck

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -21,4 +21,5 @@ test:
         - npm run --silent lint_md
         - npm run --silent lint
         - npm test
+        - TEST_SWITCH=1 npm start & bash tests/utils/wait_for_local_port.bash 8900 40 && npm run ft_server_test
         - npm run ft_test

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -307,7 +307,13 @@ class QueueProcessor extends EventEmitter {
      * @return {undefined}
      */
     processKafkaEntry(kafkaEntry, done) {
+        // if (kafkaEntry.key && kafkaEntry.key.startsWith('deephealthcheck')) {
+        //     return process.nextTick(() => done());
+        // }
         const sourceEntry = QueueEntry.createFromKafkaEntry(kafkaEntry);
+        if (sourceEntry.healthcheck) {
+            return process.nextTick(() => done());
+        }
         if (sourceEntry.error) {
             this.logger.error('error processing source entry',
                               { error: sourceEntry.error });

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -307,9 +307,6 @@ class QueueProcessor extends EventEmitter {
      * @return {undefined}
      */
     processKafkaEntry(kafkaEntry, done) {
-        // if (kafkaEntry.key && kafkaEntry.key.startsWith('deephealthcheck')) {
-        //     return process.nextTick(() => done());
-        // }
         const sourceEntry = QueueEntry.createFromKafkaEntry(kafkaEntry);
         if (sourceEntry.healthcheck) {
             return process.nextTick(() => done());

--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -137,6 +137,9 @@ class ReplicationStatusProcessor {
      */
     processKafkaEntry(kafkaEntry, done) {
         const sourceEntry = QueueEntry.createFromKafkaEntry(kafkaEntry);
+        if (sourceEntry.healthcheck) {
+            return process.nextTick(() => done());
+        }
         if (sourceEntry.error) {
             this.logger.error('error processing source entry',
                               { error: sourceEntry.error });

--- a/index.js
+++ b/index.js
@@ -1,0 +1,17 @@
+'use strict'; // eslint-disable-line strict
+
+const werelogs = require('werelogs');
+
+const runServer = require('./lib/api/BackbeatServer');
+
+const Config = process.env.TEST_SWITCH !== '1' ? require('./conf/Config') :
+    require('./tests/config.json');
+
+const Logger = werelogs.Logger;
+
+werelogs.configure({
+    level: Config.log.logLevel,
+    dump: Config.log.dumpLevel,
+});
+
+runServer(Config, Logger);

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -90,6 +90,14 @@ class BackbeatProducer extends EventEmitter {
     }
 
     /**
+    * get external modules kafka client
+    * @return {kafka-node.Client} - external kafka client instance
+    */
+    getKafkaClient() {
+        return this._client;
+    }
+
+    /**
     * create topic - works only when auto.create.topics.enable=true for the
     * Kafka server. It sends a metadata request to the server which will create
     * the topic

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -136,17 +136,23 @@ class BackbeatProducer extends EventEmitter {
                 cb(errors.InternalError);
             });
         }
-        const payload = this._partition === undefined ?
-                  entries.map(item => ({
-                      topic: this._topic,
-                      messages: new KeyedMessage(item.key, item.message),
-                      key: item.key,
-                  })) :
-                  entries.map(item => ({
-                      topic: this._topic,
-                      messages: item.message,
-                      partition: this._partition,
-                  }));
+
+        const payload = entries.map(item => {
+            if (item.partition !== undefined || this._partition !== undefined) {
+                // specifiying partition takes precedence
+                return {
+                    topic: this._topic,
+                    messages: item.message,
+                    partition: item.partition || this._partition,
+                };
+            }
+            return {
+                topic: this._topic,
+                messages: new KeyedMessage(item.key, item.message),
+                key: item.key,
+            };
+        });
+
         this._client.refreshMetadata([this._topic], () =>
             this._producer.send(payload, err => {
                 if (err) {

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -69,9 +69,7 @@ class BackbeatAPI {
     healthcheck(cb) {
         return this._healthcheck.getHealthcheck((err, data) => {
             if (err) {
-                this._logger.error('error getting healthcheck', {
-                    error: err.message,
-                });
+                this._logger.error('error getting healthcheck', err);
                 return cb(errors.InternalError);
             }
             return cb(null, data);

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -1,0 +1,205 @@
+'use strict'; // eslint-disable-line strict
+
+const async = require('async');
+const zookeeper = require('node-zookeeper-client');
+
+const { errors } = require('arsenal');
+
+const BackbeatProducer = require('../BackbeatProducer');
+const routes = require('./routes');
+
+// In-Sync Replicas
+const ISRS = 3;
+
+/**
+ * Class representing Backbeat API endpoints and internals
+ *
+ * @class
+ */
+class BackbeatAPI {
+    /**
+     * @constructor
+     * @param {object} config - configurations for setup
+     * @param {werelogs.Logger} logger - Logger object
+     */
+    constructor(config, logger) {
+        this._zkConfig = config.zookeeper;
+        this._repConfig = config.extensions.replication;
+        this._crrTopic = this._repConfig.topic;
+        this._crrStatusTopic = this._repConfig.replicationStatusTopic;
+        this._metricsTopic = config.metrics.topic;
+        this._queuePopulator = config.queuePopulator;
+        this._kafkaHost = config.kafka.hosts;
+        this._logger = logger;
+
+        this._crrProducer = null;
+        this._crrStatusProducer = null;
+        this._metricProducer = null;
+        this._zkClient = null;
+    }
+
+    /**
+     * Check if incoming request is valid
+     * @param {string} route - request route
+     * @return {boolean} true/false
+     */
+    isValidRoute(route) {
+        return routes.some(r => r.path.includes(route));
+    }
+
+    /**
+     * Check if Zookeeper and Producer are connected
+     * @return {boolean} true/false
+     */
+    isConnected() {
+        return this._zkClient.getState().name === 'SYNC_CONNECTED'
+            && this._checkProducersReady();
+    }
+
+    _checkProducersReady() {
+        return this._crrProducer.isReady() && this._metricProducer.isReady()
+            && this._crrStatusProducer.isReady();
+    }
+
+    _getConnectionDetails() {
+        return {
+            zookeeper: {
+                status: this._zkClient.getState().name === 'SYNC_CONNECTED' ?
+                    'ok' : 'error',
+                details: this._zkClient.getState(),
+            },
+            kafkaProducer: {
+                status: this._checkProducersReady() ? 'ok' : 'error',
+            },
+        };
+    }
+
+    /**
+     * Checks health of in-sync replicas
+     * @param {object} md - topic metadata object
+     * @return {boolean} true if ISR health is ok
+     */
+    _checkISRHealth(md) {
+        // eslint-disable-next-line consistent-return
+        const keys = Object.keys(md);
+        for (let i = 0; i < keys.length; i++) {
+            if (md[keys[i]].isr && md[keys[i]].isr.length !== ISRS) {
+                return 'error';
+            }
+        }
+        return 'ok';
+    }
+
+    /**
+     * Get Kafka healthcheck
+     * @param {function} cb - callback(error, data)
+     * @return {undefined}
+     */
+    healthcheck(cb) {
+        const client = this._crrProducer.getKafkaClient();
+
+        client.loadMetadataForTopics([], (err, res) => {
+            if (err) {
+                this._logger.trace('error getting healthcheck');
+                return cb(errors.InternalError);
+            }
+            const response = res.map(i => (Object.assign({}, i)));
+            const connections = {};
+            try {
+                const topicMD = {};
+                response.forEach((obj, idx) => {
+                    if (obj.metadata && obj.metadata[this._repConfig.topic]) {
+                        const copy = JSON.parse(JSON.stringify(obj.metadata[
+                            this._repConfig.topic]));
+                        topicMD.metadata = copy;
+                        response.splice(idx, 1);
+                    }
+                });
+                response.push(topicMD);
+
+                connections.isrHealth = this._checkISRHealth(topicMD.metadata);
+            } finally {
+                Object.assign(connections, this._getConnectionDetails());
+
+                response.push({
+                    internalConnections: connections,
+                });
+
+                return cb(null, response);
+            }
+        });
+    }
+
+    setupInternals(cb) {
+        async.parallel([
+            done => this._setZookeeper(done),
+            done => this._setProducer(this._metricsTopic, (err, producer) => {
+                if (err) {
+                    return done(err);
+                }
+                this._metricProducer = producer;
+                return done();
+            }),
+            done => this._setProducer(this._crrTopic, (err, producer) => {
+                if (err) {
+                    return done(err);
+                }
+                this._crrProducer = producer;
+                return done();
+            }),
+            done => this._setProducer(this._crrStatusTopic, (err, producer) => {
+                if (err) {
+                    return done(err);
+                }
+                this._crrStatusProducer = producer;
+                return done();
+            }),
+        ], err => {
+            if (err) {
+                this._logger.error('error setting up internal clients');
+                return cb(err);
+            }
+            this._logger.info('BackbeatAPI setup ready');
+            return cb();
+        });
+    }
+
+    _setProducer(topic, cb) {
+        const producer = new BackbeatProducer({
+            zookeeper: { connectionString: this._zkConfig.connectionString },
+            topic,
+        });
+
+        producer.once('error', cb);
+        producer.once('ready', () => {
+            producer.removeAllListeners('error');
+            producer.on('error', err => {
+                this._logger.error('error from backbeat producer', {
+                    error: err,
+                });
+                return cb(err);
+            });
+            return cb(null, producer);
+        });
+    }
+
+    _setZookeeper(cb) {
+        const populatorZkPath = this._queuePopulator.zookeeperPath;
+        const zookeeperUrl =
+            `${this._zkConfig.connectionString}${populatorZkPath}`;
+
+        const zkClient = zookeeper.createClient(zookeeperUrl, {
+            autoCreateNamespace: this._zkConfig.autoCreateNamespace,
+        });
+        zkClient.connect();
+
+        zkClient.once('error', cb);
+        zkClient.once('connected', () => {
+            zkClient.removeAllListeners('error');
+            this._zkClient = zkClient;
+            return cb();
+        });
+    }
+}
+
+module.exports = BackbeatAPI;

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -6,10 +6,8 @@ const zookeeper = require('node-zookeeper-client');
 const { errors } = require('arsenal');
 
 const BackbeatProducer = require('../BackbeatProducer');
+const Healthcheck = require('./Healthcheck');
 const routes = require('./routes');
-
-// In-Sync Replicas
-const ISRS = 3;
 
 /**
  * Class representing Backbeat API endpoints and internals
@@ -35,6 +33,7 @@ class BackbeatAPI {
         this._crrProducer = null;
         this._crrStatusProducer = null;
         this._metricProducer = null;
+        this._healthcheck = null;
         this._zkClient = null;
     }
 
@@ -61,33 +60,13 @@ class BackbeatAPI {
             && this._crrStatusProducer.isReady();
     }
 
-    _getConnectionDetails() {
-        return {
-            zookeeper: {
-                status: this._zkClient.getState().name === 'SYNC_CONNECTED' ?
-                    'ok' : 'error',
-                details: this._zkClient.getState(),
-            },
-            kafkaProducer: {
-                status: this._checkProducersReady() ? 'ok' : 'error',
-            },
-        };
-    }
-
     /**
-     * Checks health of in-sync replicas
-     * @param {object} md - topic metadata object
-     * @return {boolean} true if ISR health is ok
+     * Check if Zookeeper and Producer are connected
+     * @return {boolean} true/false
      */
-    _checkISRHealth(md) {
-        // eslint-disable-next-line consistent-return
-        const keys = Object.keys(md);
-        for (let i = 0; i < keys.length; i++) {
-            if (md[keys[i]].isr && md[keys[i]].isr.length !== ISRS) {
-                return 'error';
-            }
-        }
-        return 'ok';
+    isConnected() {
+        return this._zkClient.getState().name === 'SYNC_CONNECTED'
+            && this._checkProducersReady();
     }
 
     /**
@@ -96,40 +75,22 @@ class BackbeatAPI {
      * @return {undefined}
      */
     healthcheck(cb) {
-        const client = this._crrProducer.getKafkaClient();
-
-        client.loadMetadataForTopics([], (err, res) => {
+        return this._healthcheck.getHealthcheck((err, data) => {
             if (err) {
-                this._logger.trace('error getting healthcheck');
+                this._logger.error('error getting healthcheck', {
+                    error: err.message,
+                });
                 return cb(errors.InternalError);
             }
-            const response = res.map(i => (Object.assign({}, i)));
-            const connections = {};
-            try {
-                const topicMD = {};
-                response.forEach((obj, idx) => {
-                    if (obj.metadata && obj.metadata[this._repConfig.topic]) {
-                        const copy = JSON.parse(JSON.stringify(obj.metadata[
-                            this._repConfig.topic]));
-                        topicMD.metadata = copy;
-                        response.splice(idx, 1);
-                    }
-                });
-                response.push(topicMD);
-
-                connections.isrHealth = this._checkISRHealth(topicMD.metadata);
-            } finally {
-                Object.assign(connections, this._getConnectionDetails());
-
-                response.push({
-                    internalConnections: connections,
-                });
-
-                return cb(null, response);
-            }
+            return cb(null, data);
         });
     }
 
+    /**
+     * Setup internals
+     * @param {function} cb - callback(error)
+     * @return {undefined}
+     */
     setupInternals(cb) {
         async.parallel([
             done => this._setZookeeper(done),
@@ -159,6 +120,9 @@ class BackbeatAPI {
                 this._logger.error('error setting up internal clients');
                 return cb(err);
             }
+            this._healthcheck = new Healthcheck(this._repConfig, this._zkClient,
+                this._crrProducer, this._crrStatusProducer,
+                this._metricProducer);
             this._logger.info('BackbeatAPI setup ready');
             return cb();
         });

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -35,6 +35,7 @@ class BackbeatAPI {
         this._metricProducer = null;
         this._healthcheck = null;
         this._zkClient = null;
+        this._probe = null;
     }
 
     /**
@@ -61,15 +62,6 @@ class BackbeatAPI {
     }
 
     /**
-     * Check if Zookeeper and Producer are connected
-     * @return {boolean} true/false
-     */
-    isConnected() {
-        return this._zkClient.getState().name === 'SYNC_CONNECTED'
-            && this._checkProducersReady();
-    }
-
-    /**
      * Get Kafka healthcheck
      * @param {function} cb - callback(error, data)
      * @return {undefined}
@@ -80,6 +72,21 @@ class BackbeatAPI {
                 this._logger.error('error getting healthcheck', {
                     error: err.message,
                 });
+                return cb(errors.InternalError);
+            }
+            return cb(null, data);
+        });
+    }
+
+    /**
+     * Get Kafka healthcheck
+     * @param {function} cb - callback(error, data)
+     * @return {undefined}
+     */
+    deepHealthcheck(cb) {
+        return this._healthcheck.getDeepHealthcheck((err, data) => {
+            if (err) {
+                this._logger.error('error getting deep healthcheck', err);
                 return cb(errors.InternalError);
             }
             return cb(null, data);
@@ -120,8 +127,8 @@ class BackbeatAPI {
                 this._logger.error('error setting up internal clients');
                 return cb(err);
             }
-            this._healthcheck = new Healthcheck(this._repConfig, this._zkClient,
-                this._crrProducer, this._crrStatusProducer,
+            this._healthcheck = new Healthcheck(this._repConfig, this._zkConfig,
+                this._zkClient, this._crrProducer, this._crrStatusProducer,
                 this._metricProducer);
             this._logger.info('BackbeatAPI setup ready');
             return cb();

--- a/lib/api/BackbeatRequest.js
+++ b/lib/api/BackbeatRequest.js
@@ -1,0 +1,118 @@
+'use strict'; // eslint-disable-line strict
+
+/**
+ * Class representing a Backbeat API Request
+ *
+ * @class
+ */
+class BackbeatRequest {
+    constructor() {
+        this._log = null;
+        this._request = null;
+        this._response = null;
+        this._statusCode = 0;
+        this._route = null;
+        this._error = null;
+    }
+
+    /**
+     * Get logger object
+     * @return {object} Logger object
+     */
+    getLog() {
+        return this._log;
+    }
+
+    /**
+     * Set logger object
+     * @param {object} log - new Logger object
+     * @return {BackbeatRequest} itself
+     */
+    setLog(log) {
+        this._log = log;
+        return this;
+    }
+
+    /**
+     * Get http request object
+     * @return {object} Http request object
+     */
+    getRequest() {
+        return this._request;
+    }
+
+    /**
+     * Set http request object
+     * @param {object} request - new Http request object
+     * @return {BackbeatRequest} itself
+     */
+    setRequest(request) {
+        this._request = request;
+        return this;
+    }
+
+    /**
+     * Get http response object
+     * @return {object} Http response object
+     */
+    getResponse() {
+        return this._response;
+    }
+
+    /**
+     * Set http response object
+     * @param {object} response - new Http response object
+     * @return {BackbeatRequest} itself
+     */
+    setResponse(response) {
+        this._response = response;
+        return this;
+    }
+
+    /**
+     * Get status code of request
+     * @return {number} Http status code
+     */
+    getStatusCode() {
+        return this._statusCode;
+    }
+
+    /**
+     * Set status code of request
+     * @param {number} code - new Http status code
+     * @return {BackbeatRequest} itself
+     */
+    setStatusCode(code) {
+        this._statusCode = code;
+        return this;
+    }
+
+    /**
+     * Get route
+     * @return {string} current route
+     */
+    getRoute() {
+        return this._route;
+    }
+
+    /**
+     * Set route
+     * @param {string} route - new route string
+     * @return {BackbeatRequest} itself
+     */
+    setRoute(route) {
+        this._route = route;
+        return this;
+    }
+
+    /**
+     * Status check to see if valid request
+     * @return {boolean} valid status check
+     */
+    getStatus() {
+        return ((this._statusCode >= 200 && this._statusCode < 300)
+            && !this._error);
+    }
+}
+
+module.exports = BackbeatRequest;

--- a/lib/api/BackbeatServer.js
+++ b/lib/api/BackbeatServer.js
@@ -122,8 +122,13 @@ class BackbeatServer {
         // check request conditions and all internal conditions here
         if (this._isValidRequest(req, bbRequest)
         && this._areConditionsOk(bbRequest)) {
+            // Below is refactored in PR#139. For now, using a hacky way
+            // to add deep healthcheck
             bbRequest.setStatusCode(200)
                 .setRoute(bbRequest.getRoute().slice(3));
+            if (bbRequest.getRoute() === 'healthcheck/deep') {
+                bbRequest.setRoute('deepHealthcheck');
+            }
 
             this.backbeatAPI[bbRequest.getRoute()]((err, data) => {
                 if (err) {

--- a/lib/api/BackbeatServer.js
+++ b/lib/api/BackbeatServer.js
@@ -1,0 +1,225 @@
+'use strict'; // eslint-disable-line strict
+
+const http = require('http');
+
+const { Clustering, errors, ipCheck } = require('arsenal');
+
+const BackbeatRequest = require('./BackbeatRequest');
+const BackbeatAPI = require('./BackbeatAPI');
+
+const WORKERS = 1;
+
+class BackbeatServer {
+    /**
+     * @constructor
+     * @param {Worker} [worker=null] - Track the worker using cluster
+     * @param {object} config - configurations for server setup
+     * @param {werelogs.Logger} logger - Logger object
+     * @param {BackbeatAPI} backbeatAPI - BackbeatAPI instance
+     */
+    constructor(worker, config, logger, backbeatAPI) {
+        this.server = null;
+        this.worker = worker;
+        this._config = config;
+        this._port = config.port;
+        this._logger = logger;
+        this.backbeatAPI = backbeatAPI;
+    }
+
+    /**
+     * Last log message to send per incoming request
+     * @param {werelogs.newRequestLogger} logger - request logger
+     * @param {object} req - request object
+     * @param {object} res - response object
+     * @return {undefined}
+     *
+     * @static
+     */
+    static logRequestEnd(logger, req, res) {
+        const info = {
+            clientIp: req.socket.remoteAddress,
+            clientPort: req.socket.remotePort,
+            httpMethod: req.method,
+            httpURL: req.url,
+            httpCode: res.statusCode,
+            httpMessage: res.statusMessage,
+        };
+        logger.end('finished handling request', info);
+    }
+
+    /**
+     * Check if incoming request is valid
+     * @param {object} req - incoming request object
+     * @param {BackbeatRequest} backbeatRequest - Backbeat request object
+     * @return {boolean} true if no errors
+     */
+    _isValidRequest(req, backbeatRequest) {
+        const allowIp = ipCheck.ipMatchCidrList(
+            this._config.healthChecks.allowFrom, req.socket.remoteAddress);
+        if (!allowIp) {
+            return this._errorResponse(errors.AccessDenied
+                .customizeDescription('invalid origin ip request'),
+                backbeatRequest);
+        }
+
+        if (!this.backbeatAPI.isValidRoute(backbeatRequest.getRoute())
+            || !backbeatRequest.getRoute().startsWith('/_/')) {
+            return this._errorResponse(errors.RouteNotFound
+                .customizeDescription(`path ${backbeatRequest.getRoute()} does `
+                    + 'not exist'), backbeatRequest);
+        }
+
+        if (req.method !== 'GET') {
+            // So far the API should only be receiving GET requests
+            return this._errorResponse(errors.MethodNotAllowed
+                .customizeDescription('invalid http verb'),
+                backbeatRequest);
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if Kafka Producer and Zookeeper are working properly
+     * @param {BackbeatRequest} backbeatRequest - Backbeat request object
+     * @return {boolean} true if no errors
+     */
+    _areConditionsOk(backbeatRequest) {
+        if (!this.backbeatAPI.isConnected()) {
+            return this._errorResponse(errors.InternalError
+                .customizeDescription('error connecting to internal client'),
+                backbeatRequest);
+        }
+
+        return true;
+    }
+
+    /**
+     * Server's error response handler
+     * @param {arsenal.ArsenalError} err - arsenal error object
+     * @param {BackbeatRequest} backbeatRequest - Backbeat request object
+     * @return {undefined}
+     */
+    _errorResponse(err, backbeatRequest) {
+        backbeatRequest.setStatusCode(err.code);
+        this._response(err, backbeatRequest);
+    }
+
+    /**
+     * Server incoming request handler
+     * @param {object} req - request object
+     * @param {object} res - response object
+     * @return {undefined}
+     */
+    _requestListener(req, res) {
+        req.socket.setNoDelay();
+        const bbRequest = new BackbeatRequest()
+            .setRequest(req)
+            .setResponse(res)
+            .setLog(this._logger.newRequestLogger())
+            .setRoute(req.url);
+
+        // check request conditions and all internal conditions here
+        if (this._isValidRequest(req, bbRequest)
+        && this._areConditionsOk(bbRequest)) {
+            bbRequest.setStatusCode(200)
+                .setRoute(bbRequest.getRoute().slice(3));
+
+            this.backbeatAPI[bbRequest.getRoute()]((err, data) => {
+                if (err) {
+                    this._errorResponse(err, bbRequest);
+                } else {
+                    this._response(data, bbRequest);
+                }
+            });
+        }
+    }
+
+    /**
+     * Server's response to the client
+     * @param {object} data - response to send to client
+     * @param {BackbeatRequest} backbeatRequest - Backbeat request object
+     * @return {object} res - response object
+     */
+    _response(data, backbeatRequest) {
+        const log = backbeatRequest.getLog();
+        const req = backbeatRequest.getRequest();
+        const res = backbeatRequest.getResponse();
+        log.trace('writing HTTP response', {
+            method: 'BackbeatServer._response',
+        });
+        const code = backbeatRequest.getStatusCode();
+        const payload = Buffer.from(JSON.stringify(data), 'utf8');
+
+        res.writeHead(code, {
+            'Content-Type': 'application/json',
+            'Content-Length': payload.length,
+        });
+        BackbeatServer.logRequestEnd(log, req, res);
+        return res.end(payload);
+    }
+
+    /**
+     * start BackbeatServer
+     * @return {undefined}
+     */
+    start() {
+        this.server = http.createServer((req, res) => {
+            this._requestListener(req, res);
+        });
+
+        this.server.on('listening', () => {
+            const addr = this.server.address() || {
+                address: '0.0.0.0',
+                port: this._port,
+            };
+            this._logger.trace('server started', {
+                address: addr.address,
+                port: addr.port,
+                pid: process.pid,
+            });
+        });
+        this.server.listen(this._port);
+    }
+
+    /*
+     * stop BackbeatServer and exit running process properly
+     */
+    stop() {
+        this._logger.info(`worker ${this.worker} shutting down`);
+        this.server.close();
+        process.exit(0);
+    }
+}
+
+/**
+ * start the backbeat API server
+ * @param {object} config - location of config file
+ * @param {werelogs.Logger} Logger - Logger object
+ * @param {function} cb - callback function
+ * @return {undefined}
+ */
+function run(config, Logger) {
+    const logger = new Logger('BackbeatServer');
+    const apiLogger = new Logger('BackbeatAPI');
+    const cluster = new Clustering(WORKERS, logger);
+    const backbeatAPI = new BackbeatAPI(config, apiLogger);
+
+    backbeatAPI.setupInternals(err => {
+        if (err) {
+            logger.error('internal error, please try again', {
+                error: err,
+            });
+            process.exit(1);
+        } else {
+            cluster.start(worker => {
+                const server = new BackbeatServer(worker, config.server, logger,
+                    backbeatAPI);
+                process.on('SIGINT', () => server.stop());
+                server.start();
+            });
+        }
+    });
+}
+
+module.exports = run;

--- a/lib/api/Healthcheck.js
+++ b/lib/api/Healthcheck.js
@@ -1,0 +1,107 @@
+'use strict'; // eslint-disable-line strict
+
+// In-Sync Replicas
+const ISRS = 3;
+
+/**
+ * Handles healthcheck routes
+ *
+ * @class
+ */
+class Healthcheck {
+    /**
+     * @constructor
+     * @param {object} repConfig - extensions.replication configs
+     * @param {node-zookeeper-client.Client} zkClient - zookeeper client
+     * @param {BackbeatProducer} crrProducer - producer for CRR topic
+     * @param {BackbeatProducer} crrStatusProducer - CRR status producer
+     * @param {BackbeatProducer} metricProducer - producer for metric
+     */
+    constructor(repConfig, zkClient, crrProducer, crrStatusProducer,
+    metricProducer) {
+        this._repConfig = repConfig;
+        this._zkClient = zkClient;
+        this._crrProducer = crrProducer;
+        this._crrStatusProducer = crrStatusProducer;
+        this._metricProducer = metricProducer;
+    }
+
+    _checkProducersReady() {
+        return this._crrProducer.isReady() && this._metricProducer.isReady()
+            && this._crrStatusProducer.isReady();
+    }
+
+    _getConnectionDetails() {
+        return {
+            zookeeper: {
+                status: this._zkClient.getState().name === 'SYNC_CONNECTED' ?
+                    'ok' : 'error',
+                details: this._zkClient.getState(),
+            },
+            kafkaProducer: {
+                status: this._checkProducersReady() ? 'ok' : 'error',
+            },
+        };
+    }
+
+    /**
+     * Checks health of in-sync replicas
+     * @param {object} md - topic metadata object
+     * @return {string} 'ok' if ISR is healthy, else 'error'
+     */
+    _checkISRHealth(md) {
+        // eslint-disable-next-line consistent-return
+        const keys = Object.keys(md);
+        for (let i = 0; i < keys.length; i++) {
+            if (md[keys[i]].isr && md[keys[i]].isr.length !== ISRS) {
+                return 'error';
+            }
+        }
+        return 'ok';
+    }
+
+    /**
+     * Builds the healthcheck response
+     * @param {function} cb - callback(error, data)
+     * @return {undefined}
+     */
+    getHealthcheck(cb) {
+        const client = this._crrProducer.getKafkaClient();
+
+        client.loadMetadataForTopics([], (err, res) => {
+            if (err) {
+                const error = {
+                    method: 'Healthcheck.getHealthcheck',
+                    message: 'error calling Kafka loadMetadataForTopics',
+                };
+                return cb(error);
+            }
+            const response = res.map(i => (Object.assign({}, i)));
+            const connections = {};
+            try {
+                const topicMD = {};
+                response.forEach((obj, idx) => {
+                    if (obj.metadata && obj.metadata[this._repConfig.topic]) {
+                        const copy = JSON.parse(JSON.stringify(obj.metadata[
+                            this._repConfig.topic]));
+                        topicMD.metadata = copy;
+                        response.splice(idx, 1);
+                    }
+                });
+                response.push(topicMD);
+
+                connections.isrHealth = this._checkISRHealth(topicMD.metadata);
+            } finally {
+                Object.assign(connections, this._getConnectionDetails());
+
+                response.push({
+                    internalConnections: connections,
+                });
+
+                return cb(null, response);
+            }
+        });
+    }
+}
+
+module.exports = Healthcheck;

--- a/lib/api/Healthcheck.js
+++ b/lib/api/Healthcheck.js
@@ -1,7 +1,19 @@
 'use strict'; // eslint-disable-line strict
 
+const async = require('async');
+const uuid = require('uuid/v4');
+
+const BackbeatConsumer = require('../BackbeatConsumer');
+const Probe = require('./Probe');
+
 // In-Sync Replicas
 const ISRS = 3;
+
+const CONSUMER_FETCH_MAX_BYTES = 5000020;
+
+// Time limit for deep healthcheck
+const DH_TIMELIMIT = 60000;  // 1 minute
+const DH_INTERVAL = 500; // retry intervals
 
 /**
  * Handles healthcheck routes
@@ -12,14 +24,16 @@ class Healthcheck {
     /**
      * @constructor
      * @param {object} repConfig - extensions.replication configs
+     * @param {object} zkConfig - zookeeper configs
      * @param {node-zookeeper-client.Client} zkClient - zookeeper client
      * @param {BackbeatProducer} crrProducer - producer for CRR topic
      * @param {BackbeatProducer} crrStatusProducer - CRR status producer
      * @param {BackbeatProducer} metricProducer - producer for metric
      */
-    constructor(repConfig, zkClient, crrProducer, crrStatusProducer,
+    constructor(repConfig, zkConfig, zkClient, crrProducer, crrStatusProducer,
     metricProducer) {
         this._repConfig = repConfig;
+        this._zkConfig = zkConfig;
         this._zkClient = zkClient;
         this._crrProducer = crrProducer;
         this._crrStatusProducer = crrStatusProducer;
@@ -100,6 +114,174 @@ class Healthcheck {
 
                 return cb(null, response);
             }
+        });
+    }
+
+    /**
+     * Get deep healthcheck
+     * A deep healthcheck will send entries to BackbeatProducer to produce to
+     * Kafka, catch these entries using the same global Kafka topic used for
+     * Backbeat CRR, but using a new BackbeatConsumer for each health request
+     * @param {function} cb - callback(error, data)
+     * @return {undefined}
+     */
+    getDeepHealthcheck(cb) {
+        if (this._probe !== null) {
+            // TODO: Based on previous request, given how deep healthcheck
+            //  currently works, cannot handle parallel requests above cluster
+            //  count. Will need to refactor this
+            const error = {
+                method: 'Healthcheck.getDeepHealthcheck',
+                error: 'Another request still processing',
+            };
+            return cb(error);
+        }
+        if (!this._crrProducer || !this._crrStatusProducer) {
+            const error = {
+                method: 'Healthcheck.getDeepHealthcheck',
+                error: 'Backbeat Producer not set',
+            };
+            return cb(error);
+        }
+
+        const start = Date.now();
+        const id = `deephealthcheck-${uuid().replace(/-/g, '')}`;
+        this._probe = new Probe(id);
+
+        return async.waterfall([
+            done => this._getTopicPartitions(done),
+            (partitions, done) => {
+                this._probe.setupStore(partitions);
+                this._createEntries(id, partitions, done);
+            },
+            (entries, done) => this._crrProducer.send(entries, done),
+            done => this._createConsumer('deephealthcheck-group', done),
+        ], (err, consumer) => {
+            if (err || consumer === undefined) {
+                const error = {
+                    method: 'Healthcheck.getDeepHealthcheck',
+                    error: err,
+                };
+                return cb(error);
+            }
+            this._probe.on('collect', (partition, id) => {
+                if (id === this._probe.getId()) {
+                    this._probe.setStoreData(partition, 'ok');
+                }
+            });
+
+            return async.retry({
+                times: Number.parseInt(DH_TIMELIMIT / DH_INTERVAL, 10),
+                interval: DH_INTERVAL,
+                errorFilter: err => err === 'retry',
+            },
+            this._waitAndCheck.bind(this, start),
+            (err, elapsed) => {
+                if (err) {
+                    // replace all undefined values as 'error'
+                    this._probe.setStoreErrors();
+                }
+                this._probe.setStoreData('timeElapsed', elapsed);
+
+                // cleanup
+                const response = this._probe.getStore();
+                this._probe.removeAllListeners();
+                this._probe = null;
+                consumer.close(() => {});
+
+                return cb(null, response);
+            });
+        });
+    }
+
+    /**
+     * Create a new Backbeat Consumer
+     * @param {string} groupId - group id name
+     * @param {function} cb - callback(error, response)
+     * @return {undefined}
+     */
+    _createConsumer(groupId, cb) {
+        const consumer = new BackbeatConsumer({
+            zookeeper: { connectionString: this._zkConfig.connectionString },
+            topic: this._repConfig.topic,
+            groupId,
+            concurrency: this._repConfig.queueProcessor.concurrency,
+            queueProcessor: this._processKafkaEntry.bind(this),
+            fetchMaxBytes: CONSUMER_FETCH_MAX_BYTES,
+        });
+        consumer.on('error', () => {});
+        consumer.subscribe();
+        return cb(null, consumer);
+    }
+
+    /**
+     * Create kafka entries to send to BackbeatProducer for deep healthcheck
+     * @param {string} id - unique identifier for the deep healthcheck request
+     * @param {array} partitions - array of kafka topic partitions
+     * @param {function} cb - callback(error, data)
+     * @return {undefined}
+     */
+    _createEntries(id, partitions, cb) {
+        const entries = partitions.map(partition => ({
+            partition,
+            message: '{"healthcheckKey":true}',
+            key: id,
+        }));
+
+        return cb(null, entries);
+    }
+
+    /**
+     * Get kafka topic partitions
+     * @param {function} cb - callback(error, data)
+     * @return {undefined}
+     */
+    _getTopicPartitions(cb) {
+        const client = this._crrProducer.getKafkaClient();
+
+        client.loadMetadataForTopics([], (err, res) => {
+            if (err) {
+                const error = {
+                    method: 'Healthcheck._getTopicPartitions',
+                    error: err,
+                };
+                return cb(error);
+            }
+            const partitions = Object.keys(res[0]).map(i =>
+                Number.parseInt(i, 10));
+            return cb(null, partitions);
+        });
+    }
+
+    _processKafkaEntry(kafkaEntry) {
+        // Here, I will be receiving all kafka entries
+        // only capture entries with set property `healthcheckKey`
+        const healthcheckEntry = JSON.parse(kafkaEntry.value).healthcheckKey;
+        if (healthcheckEntry) {
+            // I want to access partition # and return healthy for
+            // that partition
+            this._probe.emit('collect', kafkaEntry.partition, kafkaEntry.key);
+        }
+
+        // Possibly use `kafkaEntry.topic` to check health of important topics
+        // and keep track of which topic it is.
+        // if (kafkaEntry.topic === this._repConfig.topic)
+    }
+
+    _waitAndCheck(start, cb) {
+        setTimeout(() => {
+            const now = Date.now();
+            const elapsed = now - start;
+            if (this._probe.checkStore() === 0) {
+                // all done, success
+                return cb(null, elapsed);
+            }
+
+            if (elapsed > DH_TIMELIMIT) {
+                // time limit exceeded
+                return cb('stop', elapsed);
+            }
+            return cb('retry');
         });
     }
 }

--- a/lib/api/Healthcheck.js
+++ b/lib/api/Healthcheck.js
@@ -86,7 +86,7 @@ class Healthcheck {
             if (err) {
                 const error = {
                     method: 'Healthcheck.getHealthcheck',
-                    message: 'error calling Kafka loadMetadataForTopics',
+                    error: 'error calling Kafka loadMetadataForTopics',
                 };
                 return cb(error);
             }
@@ -161,6 +161,7 @@ class Healthcheck {
                 const error = {
                     method: 'Healthcheck.getDeepHealthcheck',
                     error: err,
+                    consumerOK: consumer !== undefined,
                 };
                 return cb(error);
             }

--- a/lib/api/Probe.js
+++ b/lib/api/Probe.js
@@ -1,0 +1,81 @@
+'use strict'; // eslint-disable-line strict
+
+const { EventEmitter } = require('events');
+
+/**
+ * Probe used for deep healthchecks to store data and catch event data
+ *
+ * @class
+ */
+class Probe extends EventEmitter {
+    /**
+     * @constructor
+     * @param {string} id - uuid assigned to a probe
+     */
+    constructor(id) {
+        super();
+        this.id = id;
+        this.store = null;
+    }
+
+    /**
+     * Get the number of undefined values for partitions in store
+     * @return {number} - count of current unset values for partitions
+     */
+    checkStore() {
+        let count = 0;
+        Object.keys(this.store).forEach(partition => {
+            if (this.store[partition] === undefined) {
+                count++;
+            }
+        });
+        return count;
+    }
+
+    /**
+     * Get unique identifier
+     * @return {string} unique identifier for this probe
+     */
+    getId() {
+        return this.id;
+    }
+
+    /**
+     * Get store, can be null
+     * @return {object|null} - internal store data for this probe
+     */
+    getStore() {
+        return this.store;
+    }
+
+    setStoreData(key, value) {
+        this.store[key] = value;
+    }
+
+    /**
+     * Set all undefined values in store to 'error'
+     * @return {undefined}
+     */
+    setStoreErrors() {
+        for (const partition in this.store) {
+            if (this.store[partition] === undefined) {
+                this.setStoreData(partition, 'error');
+            }
+        }
+    }
+
+    /**
+     * Initial setup for internal store, setting all values to undefined
+     * @param {array} partitions - array of partition numbers
+     * @return {undefined}
+     */
+    setupStore(partitions) {
+        this.store = partitions.reduce((store, partition) => {
+            // eslint-disable-next-line
+            store[partition] = undefined;
+            return store;
+        }, {});
+    }
+}
+
+module.exports = Probe;

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -7,4 +7,7 @@ module.exports = [
     {
         path: '/_/healthcheck',
     },
+    {
+        path: '/_/healthcheck/deep',
+    },
 ];

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -1,0 +1,10 @@
+/*
+    This file contains all unique details about API routes exposed by Backbeats
+    API server.
+*/
+
+module.exports = [
+    {
+        path: '/_/healthcheck',
+    },
+];

--- a/lib/models/QueueEntry.js
+++ b/lib/models/QueueEntry.js
@@ -19,6 +19,9 @@ class QueueEntry {
     static createFromKafkaEntry(kafkaEntry) {
         try {
             const record = JSON.parse(kafkaEntry.value);
+            if (record.healthcheckKey) {
+                return { healthcheck: true };
+            }
             if (record.bootstrapId) {
                 return { error: 'bootstrap entry' };
             }

--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
     "queue_processor": "node extensions/replication/queueProcessor/task.js",
     "replication_status_processor": "node extensions/replication/replicationStatusProcessor/task.js",
     "test": "mocha --recursive tests/unit",
-    "ft_test": "mocha --recursive tests/functional",
+    "ft_test": "mocha --recursive $(find tests/functional -name '*.js' ! -name 'BackbeatServer.js')",
+    "ft_server_test": "mocha tests/functional/api/BackbeatServer.js",
     "bh_test": "mocha --recursive tests/behavior",
     "lint": "eslint $(git ls-files '*.js')",
-    "lint_md": "mdlint $(git ls-files '*.md')"
+    "lint_md": "mdlint $(git ls-files '*.md')",
+    "start": "node index.js"
   },
   "repository": {
     "type": "git",

--- a/tests/config.json
+++ b/tests/config.json
@@ -1,6 +1,10 @@
 {
     "zookeeper": {
-        "connectionString": "127.0.0.1:2181"
+        "connectionString": "127.0.0.1:2181",
+        "autoCreateNamespace": true
+    },
+    "kafka": {
+        "hosts": "127.0.0.1:9092"
     },
     "queuePopulator": {
         "cronRule": "*/5 * * * * *",
@@ -16,9 +20,6 @@
     "kafka": {
         "hosts": "127.0.0.1:9092"
     },
-    "metrics": {
-        "topic": "backbeat-test-metrics"
-    },
     "s3": {
         "host": "127.0.0.1",
         "port": 8000,
@@ -29,12 +30,23 @@
     "extensions": {
         "replication": {
             "topic": "backbeat-test-replication",
+            "replicationStatusTopic": "backbeat-test-replication-status",
             "groupId": "backbeat-test-replication-group"
         }
     },
     "log": {
         "logLevel": "info",
         "dumpLevel": "error"
+    },
+    "metrics": {
+        "topic": "backbeat-metrics"
+    },
+    "server": {
+        "healthChecks": {
+            "allowFrom": ["127.0.0.1/8", "::1"]
+        },
+        "host": "127.0.0.1",
+        "port": 8900
     },
     "redis": {
         "name": "backbeat-test",

--- a/tests/functional/api/BackbeatServer.js
+++ b/tests/functional/api/BackbeatServer.js
@@ -1,0 +1,92 @@
+const assert = require('assert');
+const http = require('http');
+
+const config = require('../../config.json');
+
+const defaultOptions = {
+    host: config.server.host,
+    port: config.server.port,
+    method: 'GET',
+};
+
+function getUrl(options, path) {
+    return `http://${options.host}:${options.port}${path}`;
+}
+
+describe('Backbeat Server', () => {
+    describe('healthcheck route', () => {
+        let data;
+        let resCode;
+        before(done => {
+            const url = getUrl(defaultOptions, '/_/healthcheck');
+
+            http.get(url, res => {
+                resCode = res.statusCode;
+
+                let rawData = '';
+                res.on('data', chunk => {
+                    rawData += chunk;
+                });
+                res.on('end', () => {
+                    data = JSON.parse(rawData);
+                    done();
+                });
+            });
+        });
+
+        it('should get a response with data', done => {
+            assert(Object.keys(data).length > 0);
+            assert.equal(resCode, 200);
+            return done();
+        });
+
+        it('should have valid keys', done => {
+            const keys = [].concat(...data.map(d => Object.keys(d)));
+
+            assert(keys.includes('metadata'));
+            assert(keys.includes('internalConnections'));
+            return done();
+        });
+
+        it('should be healthy', done => {
+            // NOTE: isrHealth is not checked here because circleci
+            // kafka will have one ISR only. Maybe isrHealth should
+            // be a test for end-to-end
+            let internalConnections;
+            data.forEach(obj => {
+                if (Object.keys(obj).includes('internalConnections')) {
+                    internalConnections = obj.internalConnections;
+                }
+            });
+            Object.keys(internalConnections).forEach(key => {
+                assert.ok(internalConnections[key]);
+            });
+
+            return done();
+        });
+    });
+
+    it('should get a 404 route not found error response', done => {
+        const url = getUrl(defaultOptions, '/_/invalidpath');
+
+        http.get(url, res => {
+            assert.equal(res.statusCode, 404);
+            done();
+        });
+    });
+
+    it('should get a 405 method not allowed from invalid http verb', done => {
+        const options = Object.assign({}, defaultOptions);
+        options.method = 'POST';
+        options.path = '/_/healthcheck';
+
+        const req = http.request(options, res => {
+            assert.equal(res.statusCode, 405);
+        });
+        req.on('error', err => {
+            assert.ifError(err);
+        });
+        req.end();
+        done();
+    });
+});

--- a/tests/utils/wait_for_local_port.bash
+++ b/tests/utils/wait_for_local_port.bash
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+wait_for_local_port() {
+    local port=$1
+    local timeout=$2
+    local count=0
+    local ret=1
+    echo "waiting for BackbeatServer:$port"
+    while [[ "$ret" -eq "1" && "$count" -lt "$timeout" ]] ; do
+        nc -z -w 1 localhost $port
+        ret=$?
+        if [ ! "$ret" -eq "0" ]; then
+            echo -n .
+            sleep 1
+            count=$(($count+1))
+        fi
+    done
+
+    echo ""
+
+    if [[ "$count" -eq "$timeout" ]]; then
+        echo "Server did not start in less than $timeout seconds. Exiting..."
+        exit 1
+    fi
+    sleep 5
+
+    echo "Server got ready in ~${count} seconds. Starting test now..."
+}
+
+wait_for_local_port $1 $2


### PR DESCRIPTION
The goal is to use BackbeatProducer and BackbeatConsumer 
using the same replication topic, sending a message to every 
available partition, "consuming" the message, and returning 
a status for each partition.

Current PR only shows if a partition is working or not 
(i.e. `ok` || `error`) and also shows elapsed time to show how 
long the healthcheck took. 

Currently, a deep healthcheck max time for checking is set 
to 1 minute and interval checks of 500 milliseconds. These 
are hard-coded as a constant and can be changed to 
requested value.
Also, deep healthchecks can only be handled in parallel
depending on number of clusters. This is a TODO fix.

Need to drop https://github.com/scality/backbeat/commit/dfd85f5e675fc350650de62bd05ed66c5950c67e
and should be merged after https://github.com/scality/backbeat/pull/153