### PR TITLE
bf: send dest req only on success

### DIFF
--- a/extensions/replication/queueProcessor/MultipleBackendTask.js
+++ b/extensions/replication/queueProcessor/MultipleBackendTask.js
@@ -155,20 +155,22 @@ class MultipleBackendTask extends QueueProcessorTask {
             Body: incomingMsg,
         });
         attachReqUids(destReq, log);
-        return destReq.send((err, data) => {
-            if (err) {
-                // eslint-disable-next-line no-param-reassign
-                err.origin = 'source';
-                log.error('an error occurred on putting MPU part to S3', {
-                    method: 'MultipleBackendTask._getAndPutMPUPartOnce',
-                    entry: destEntry.getLogInfo(),
-                    origin: 'target',
-                    peer: this.destBackbeatHost,
-                    error: err.message,
-                });
-                return doneOnce(err);
-            }
-            return doneOnce(null, data);
+        incomingMsg.once('data', () => {
+            destReq.send((err, data) => {
+                if (err) {
+                    // eslint-disable-next-line no-param-reassign
+                    err.origin = 'source';
+                    log.error('an error occurred on putting MPU part to S3', {
+                        method: 'MultipleBackendTask._getAndPutMPUPartOnce',
+                        entry: destEntry.getLogInfo(),
+                        origin: 'target',
+                        peer: this.destBackbeatHost,
+                        error: err.message,
+                    });
+                    return doneOnce(err);
+                }
+                return doneOnce(null, data);
+            });
         });
     }
 
@@ -362,21 +364,23 @@ class MultipleBackendTask extends QueueProcessorTask {
             Body: incomingMsg,
         });
         attachReqUids(destReq, log);
-        return destReq.send((err, data) => {
-            if (err) {
-                // eslint-disable-next-line no-param-reassign
-                err.origin = 'source';
-                log.error('an error occurred on putData to S3', {
-                    method: 'MultipleBackendTask._getAndPutPartOnce',
-                    entry: destEntry.getLogInfo(),
-                    origin: 'target',
-                    peer: this.destBackbeatHost,
-                    error: err.message,
-                });
-                return doneOnce(err);
-            }
-            sourceEntry.setReplicationDataStoreVersionId(data.versionId);
-            return doneOnce(null, data);
+        incomingMsg.once('data', () => {
+            destReq.send((err, data) => {
+                if (err) {
+                    // eslint-disable-next-line no-param-reassign
+                    err.origin = 'source';
+                    log.error('an error occurred on putData to S3', {
+                        method: 'MultipleBackendTask._getAndPutPartOnce',
+                        entry: destEntry.getLogInfo(),
+                        origin: 'target',
+                        peer: this.destBackbeatHost,
+                        error: err.message,
+                    });
+                    return doneOnce(err);
+                }
+                sourceEntry.setReplicationDataStoreVersionId(data.versionId);
+                return doneOnce(null, data);
+            });
         });
     }
 

--- a/extensions/replication/queueProcessor/MultipleBackendTask.js
+++ b/extensions/replication/queueProcessor/MultipleBackendTask.js
@@ -155,7 +155,7 @@ class MultipleBackendTask extends QueueProcessorTask {
             Body: incomingMsg,
         });
         attachReqUids(destReq, log);
-        incomingMsg.once('data', () => {
+        incomingMsg.once('end', () => {
             destReq.send((err, data) => {
                 if (err) {
                     // eslint-disable-next-line no-param-reassign
@@ -364,7 +364,7 @@ class MultipleBackendTask extends QueueProcessorTask {
             Body: incomingMsg,
         });
         attachReqUids(destReq, log);
-        incomingMsg.once('data', () => {
+        incomingMsg.once('end', () => {
             destReq.send((err, data) => {
                 if (err) {
                     // eslint-disable-next-line no-param-reassign

--- a/extensions/replication/queueProcessor/MultipleBackendTask.js
+++ b/extensions/replication/queueProcessor/MultipleBackendTask.js
@@ -155,7 +155,7 @@ class MultipleBackendTask extends QueueProcessorTask {
             Body: incomingMsg,
         });
         attachReqUids(destReq, log);
-        incomingMsg.once('end', () => {
+        incomingMsg.once('readable', () => {
             destReq.send((err, data) => {
                 if (err) {
                     // eslint-disable-next-line no-param-reassign
@@ -364,7 +364,7 @@ class MultipleBackendTask extends QueueProcessorTask {
             Body: incomingMsg,
         });
         attachReqUids(destReq, log);
-        incomingMsg.once('end', () => {
+        incomingMsg.once('readable', () => {
             destReq.send((err, data) => {
                 if (err) {
                     // eslint-disable-next-line no-param-reassign

--- a/extensions/replication/queueProcessor/QueueProcessorTask.js
+++ b/extensions/replication/queueProcessor/QueueProcessorTask.js
@@ -371,7 +371,10 @@ class QueueProcessorTask {
             Body: incomingMsg,
         });
         attachReqUids(destReq, log);
-        incomingMsg.once('end', () => {
+        process.stdout.write('printing from QPT._getAndPutPartOnce\n');
+        process.stdout.write(incomingMsg.eventNames().join(', '));
+        process.stdout.write('\n');
+        incomingMsg.once('readable', () => {
             destReq.send((err, data) => {
                 if (err) {
                     // eslint-disable-next-line no-param-reassign

--- a/extensions/replication/queueProcessor/QueueProcessorTask.js
+++ b/extensions/replication/queueProcessor/QueueProcessorTask.js
@@ -371,7 +371,7 @@ class QueueProcessorTask {
             Body: incomingMsg,
         });
         attachReqUids(destReq, log);
-        incomingMsg.once('data', () => {
+        incomingMsg.once('end', () => {
             destReq.send((err, data) => {
                 if (err) {
                     // eslint-disable-next-line no-param-reassign

--- a/extensions/replication/queueProcessor/QueueProcessorTask.js
+++ b/extensions/replication/queueProcessor/QueueProcessorTask.js
@@ -371,21 +371,23 @@ class QueueProcessorTask {
             Body: incomingMsg,
         });
         attachReqUids(destReq, log);
-        return destReq.send((err, data) => {
-            if (err) {
-                // eslint-disable-next-line no-param-reassign
-                err.origin = 'target';
-                log.error('an error occurred on putData to S3',
-                    { method: 'QueueProcessor._getAndPutData',
-                        entry: destEntry.getLogInfo(),
-                        part,
-                        origin: 'target',
-                        peer: this.destBackbeatHost,
-                        error: err.message });
-                return doneOnce(err);
-            }
-            partObj.setDataLocation(data.Location[0]);
-            return doneOnce(null, partObj.getValue());
+        incomingMsg.once('data', () => {
+            destReq.send((err, data) => {
+                if (err) {
+                    // eslint-disable-next-line no-param-reassign
+                    err.origin = 'target';
+                    log.error('an error occurred on putData to S3',
+                        { method: 'QueueProcessor._getAndPutData',
+                            entry: destEntry.getLogInfo(),
+                            part,
+                            origin: 'target',
+                            peer: this.destBackbeatHost,
+                            error: err.message });
+                    return doneOnce(err);
+                }
+                partObj.setDataLocation(data.Location[0]);
+                return doneOnce(null, partObj.getValue());
+            });
         });
     }
 


### PR DESCRIPTION
Before sending destination request, ensure that source
data is properly received. Although errors were being logged,
they were not returned and instead the request was still
sent and status on destination was still set to REPLICA.
The error that appeared in integration was 'socket hang up'