### PR TITLE
ft: support for get and put metadata blob

### DIFF
--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -569,6 +569,44 @@
                     }
                 }
             }
+        },
+        "GetMetadata": {
+            "http": {
+                "method": "GET",
+                "requestUri": "/_/backbeat/metadata/{Bucket}/{Key+}"
+            },
+            "input": {
+                "type": "structure",
+                "required": [
+                    "Bucket",
+                    "Key",
+                    "VersionId"
+                ],
+                "members": {
+                    "Bucket": {
+                        "location": "uri",
+                        "locationName": "Bucket"
+                    },
+                    "Key": {
+                        "location": "uri",
+                        "locationName": "Key"
+                    },
+                    "VersionId": {
+                        "type": "string",
+                        "documentation": "VersionId used to reference a specific version of the object.",
+                        "location": "querystring",
+                        "locationName": "versionId"
+                    }
+                }
+            },
+            "output": {
+                "type": "structure",
+                "members": {
+                    "Body": {
+                        "type": "string"
+                    }
+                }
+            }
         }
     }
 }

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -167,6 +167,12 @@ class S3Mock extends TestConfigurator {
                         query: {},
                         handler: () => this._putMetadataSource,
                     }),
+                    getMetadata: () => ({
+                        method: 'GET',
+                        path: `/_/backbeat/metadata/${this.getParam('source.bucket')}/${this.getParam('encodedKey')}`,
+                        query: { versionId: VersionIDUtils.encode(this.getParam('versionId')) },
+                        handler: () => this._getMetadataSource,
+                    }),
                 },
                 vault: {
                     assumeRoleBackbeat: () => ({
@@ -569,6 +575,14 @@ class S3Mock extends TestConfigurator {
         res.end();
         this.onPutSourceMd();
         this.onPutSourceMd = null;
+    }
+
+    _getMetadataSource(req, url, query, res) {
+        assert(query.versionId);
+        res.writeHead(200);
+        res.end(JSON.stringify({
+            Body: JSON.parse(this.getParam('kafkaEntry.value')).value,
+        }));
     }
 }
 


### PR DESCRIPTION
With the introduction of one to many crr, there will be a status update for each backend.
Since there will be multiple requests to the source to update the replication status, it's important
to get the latest copy of the metadata blob as previous updates would render the copy it's holding stale.