### PR TITLE
ft: introduce processing status

### DIFF
--- a/extensions/replication/utils/ObjectQueueEntry.js
+++ b/extensions/replication/utils/ObjectQueueEntry.js
@@ -16,7 +16,7 @@ function _getGobalReplicationStatus(data) {
             return 'FAILED';
         }
         if (statuses.includes('PENDING')) {
-            return 'PENDING';
+            return 'PROCESSING';
         }
     }
     return 'COMPLETED';


### PR DESCRIPTION
To ensure interim updates to object metadata to not be picked by
QueuePopulator, introduce PROCESSING status to indicate the in-progress
CRR to multiple backends