### PR TITLE
bf: fix concurrency issue with log reader

### DIFF
--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -35,8 +35,8 @@ class LogReader {
         this._extensions.forEach(ext => ext.setBatch(entryBatch));
     }
 
-    _endEntryBatch() {
-        this._extensions.forEach(ext => ext.endBatch());
+    _unsetEntryBatch() {
+        this._extensions.forEach(ext => ext.unsetBatch());
     }
 
     setLogConsumer(logConsumer) {
@@ -288,14 +288,18 @@ class LogReader {
             return done(null);
         }
 
-        this._setEntryBatch(entriesToPublish);
-
         logRes.log.on('data', record => {
+            this.log.debug('received log data',
+                           { nbEntries: record.entries.length,
+                             info: logRes.info });
             logStats.nbLogRecordsRead += 1;
+
+            this._setEntryBatch(entriesToPublish);
             record.entries.forEach(entry => {
                 logStats.nbLogEntriesRead += 1;
                 this._processLogEntry(batchState, record, entry);
             });
+            this._unsetEntryBatch();
         });
         logRes.log.on('error', err => {
             this.log.error('error fetching entries from log',
@@ -304,8 +308,7 @@ class LogReader {
             return done(err);
         });
         logRes.log.on('end', () => {
-            this.log.debug('ending record stream');
-            this._endEntryBatch();
+            this.log.debug('ending record stream', { info: logRes.info });
             return done();
         });
         return undefined;

--- a/lib/queuePopulator/QueuePopulatorExtension.js
+++ b/lib/queuePopulator/QueuePopulatorExtension.js
@@ -63,14 +63,14 @@ class QueuePopulatorExtension {
     /**
      * Internal use by QueuePopulator
      *
-     * @param {Object} batch - batch to publish
+     * @param {Object} batch - current batch to be published
      * @return {undefined}
      */
     setBatch(batch) {
         this._batch = batch;
     }
 
-    endBatch() {
+    unsetBatch() {
         this._batch = null;
     }
 }


### PR DESCRIPTION
Call QueuePopulatorExtension.setBatch() every time new entries are received,
because multiple readers can be intermingled sending their respective data,
and although the LogReader class is managing a single reader, the extensions
`batch` field is global to all readers, so it has to be set every time.

Note that this fix is only required with streamed log reader (i.e. with https://github.com/scality/bucketclient/pull/126 and https://github.com/scality/Arsenal/pull/379)