### PR TITLE
ft: update config with lifecycle params

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -6,6 +6,19 @@
     "kafka": {
         "hosts": "127.0.0.1:9092"
     },
+    "s3": {
+        "host": "127.0.0.1",
+        "port": 8000
+    },
+    "auth": {
+        "type": "account",
+        "account": "bart",
+        "vault": {
+            "host": "127.0.0.1",
+            "port": 8500,
+            "adminPort": 8600
+        }
+    },
     "queuePopulator": {
         "cronRule": "*/5 * * * * *",
         "batchMaxRead": 10000,
@@ -66,6 +79,29 @@
                 "groupId": "backbeat-replication-group",
                 "retryTimeoutS": 300,
                 "concurrency": 10
+            }
+        },
+        "lifecycle": {
+            "zookeeperPath": "/lifecycle",
+            "bucketTasksTopic": "backbeat-lifecycle-bucket-tasks",
+            "objectTasksTopic": "backbeat-lifecycle-object-tasks",
+            "conductor": {
+                "cronRule": "0 */5 * * * *"
+            },
+            "producer": {
+                "groupId": "backbeat-lifecycle-producer-group",
+                "retryTimeoutS": 300,
+                "concurrency": 10
+            },
+            "consumer": {
+                "groupId": "backbeat-lifecycle-consumer-group",
+                "retryTimeoutS": 300,
+                "concurrency": 10
+            },
+            "rules": {
+                "expiration": {
+                    "enabled": true
+                }
             }
         }
     },

--- a/extensions/lifecycle/LifecycleConfigValidator.js
+++ b/extensions/lifecycle/LifecycleConfigValidator.js
@@ -1,0 +1,31 @@
+const joi = require('joi');
+
+const joiSchema = {
+    zookeeperPath: joi.string().required(),
+    bucketTasksTopic: joi.string().required(),
+    objectTasksTopic: joi.string().required(),
+    conductor: {
+        cronRule: joi.string().required(),
+    },
+    producer: {
+        groupId: joi.string().required(),
+        retryTimeoutS: joi.number().default(300),
+        concurrency: joi.number().greater(0).default(10),
+    },
+    consumer: {
+        groupId: joi.string().required(),
+        retryTimeoutS: joi.number().default(300),
+        concurrency: joi.number().greater(0).default(10),
+    },
+    rules: {
+        expiration: {
+            enabled: joi.boolean().default(true),
+        },
+    },
+};
+
+function configValidator(backbeatConfig, extConfig) {
+    return joi.attempt(extConfig, joiSchema);
+}
+
+module.exports = configValidator;

--- a/extensions/lifecycle/index.js
+++ b/extensions/lifecycle/index.js
@@ -1,0 +1,7 @@
+const LifecycleConfigValidator = require('./LifecycleConfigValidator');
+
+module.exports = {
+    name: 'lifecycle',
+    version: '1.0.0',
+    configValidator: LifecycleConfigValidator,
+};


### PR DESCRIPTION
Add config params related to lifecycle components: kafka topics, conductor,
producer, consumer, and rule-specific config (expiration...).