### PR TITLE
ft: add lifecycle producer task

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -101,6 +101,12 @@
             "rules": {
                 "expiration": {
                     "enabled": true
+                },
+                "noncurrentVersionExpiration": {
+                    "enabled": true
+                },
+                "abortIncompleteMultipartUpload": {
+                    "enabled": true
                 }
             }
         }

--- a/extensions/lifecycle/LifecycleConfigValidator.js
+++ b/extensions/lifecycle/LifecycleConfigValidator.js
@@ -21,6 +21,12 @@ const joiSchema = {
         expiration: {
             enabled: joi.boolean().default(true),
         },
+        noncurrentVersionExpiration: {
+            enabled: joi.boolean().default(true),
+        },
+        abortIncompleteMultipartUpload: {
+            enabled: joi.boolean().default(true),
+        },
     },
 };
 

--- a/extensions/lifecycle/lifecycleProducer/LifecycleProducer.js
+++ b/extensions/lifecycle/lifecycleProducer/LifecycleProducer.js
@@ -9,10 +9,12 @@ const { errors } = require('arsenal');
 
 const BackbeatProducer = require('../../../lib/BackbeatProducer');
 const BackbeatConsumer = require('../../../lib/BackbeatConsumer');
+const LifecycleTask = require('../tasks/LifecycleTask');
 const VaultClientCache = require('../../../lib/clients/VaultClientCache');
 const safeJsonParse = require('../util/safeJsonParse');
 
 const CONSUMER_FETCH_MAX_BYTES = 5000020;
+const PROCESS_OBJECTS_ACTION = 'processObjects';
 
 /**
  * @class LifecycleProducer
@@ -53,8 +55,8 @@ class LifecycleProducer {
 
         // The task scheduler for processing lifecycle tasks concurrently.
         this._internalTaskScheduler = async.queue((ctx, cb) => {
-            const { task, rules, value } = ctx;
-            return task.processBucketEntry(rules, value, cb);
+            const { task, rules, value, s3target } = ctx;
+            return task.processBucketEntry(rules, value, s3target, cb);
         }, this._lcConfig.producer.concurrency);
 
         // Listen for errors from any task being processed.
@@ -89,14 +91,38 @@ class LifecycleProducer {
         this._bucketProducer.send(entries, cb);
     }
 
+    getQueuedBucketsZkPath() {
+        return `${this._lcConfig.zookeeperPath}/run/queuedBuckets`;
+    }
+
+    sendUnlockBucketEntry(bucketData) {
+        const entry = {
+            action: 'unlockBucket',
+            target: {
+                owner: bucketData.target.owner,
+                bucket: bucketData.target.bucket,
+            },
+            details: {},
+        };
+        this.sendObjectEntry(entry, err => {
+            if (!err) {
+                this._log.debug('sent unlock bucket entry for consumption', {
+                    method: 'LifecycleProducer._sendUnlockBucketEntry',
+                    entry,
+                });
+            }
+        });
+    }
+
     /**
      * Get the state variables of the current instance.
      * @return {Object} Object containing the state variables
      */
     getStateVars() {
         return {
-            sendBucketEntry: this.sendBucketEntry,
-            sendObjectEntry: this.sendObjectEntry,
+            sendBucketEntry: this.sendBucketEntry.bind(this),
+            sendObjectEntry: this.sendObjectEntry.bind(this),
+            sendUnlockBucketEntry: this.sendUnlockBucketEntry.bind(this),
             enabledRules: this._lcConfig.rules,
             log: this._log,
         };
@@ -143,7 +169,7 @@ class LifecycleProducer {
         // Check if backbeat config has a lifecycle rule enabled for processing.
         const enabled = Object.keys(rules).some(rule => rules[rule].enabled);
         if (!enabled) {
-            this.log.debug('no lifecycle rules enabled in backbeat config');
+            this._log.debug('no lifecycle rules enabled in backbeat config');
         }
         return enabled;
     }
@@ -155,25 +181,28 @@ class LifecycleProducer {
      * @param {Object} entry - The kafka entry containing the information for
      * performing a listing of the bucket's objects
      * @param {Object} entry.value - The value of the entry object
-     * @param {String} entry.value.bucket - The bucket which has objects to
-     * perform lifecycle actions on
-     * @param {String} entry.value.owner - The canonical ID of the bucket owner
-     * @param {String} [entry.value.prefix] - An object prefix
-     * @param {String} [entry.value.keyMarker] - KeyMarker to list objects from
-     * @param {String} [entry.value.versionIdMarker] - VersionIdMarker to list
-     * versioned objects from
-     * @param {String} [entry.value.continuationToken] - ContinuationToken
-     * indicating that the list is being continued on this bucket
+     * (see format of messages in lifecycle topic for bucket tasks)
      * @param {Function} cb - The callback to call
      * @return {undefined}
      */
     _processBucketEntry(entry, cb) {
         const { error, result } = safeJsonParse(entry.value);
         if (error) {
-            this._log.error('could not parse bucket entry', { error });
+            this._log.error('could not parse bucket entry',
+                            { value: entry.value, error });
             return process.nextTick(() => cb(error));
         }
-        const { bucket, owner } = result;
+        if (result.action !== PROCESS_OBJECTS_ACTION) {
+            return process.nextTick(cb);
+        }
+        if (typeof result.target !== 'object') {
+            this._log.error('malformed kafka bucket entry', {
+                method: 'LifecycleProducer._processBucketEntry',
+                entry: result,
+            });
+            return process.nextTick(() => cb(errors.InternalError));
+        }
+        const { bucket, owner } = result.target;
         if (!bucket || !owner) {
             this._log.error('kafka bucket entry missing required fields', {
                 method: 'LifecycleProducer._processBucketEntry',
@@ -182,32 +211,47 @@ class LifecycleProducer {
             });
             return process.nextTick(() => cb(errors.InternalError));
         }
+        this._log.debug('processing bucket entry', {
+            method: 'LifecycleProducer._processBucketEntry',
+            bucket,
+            owner,
+        });
         return async.waterfall([
             next => this._getAccountCredentials(owner, next),
             (accountCreds, next) => {
                 const s3 = this._getS3Client(accountCreds);
                 const params = { Bucket: bucket };
-                return s3.getBucketLifecycleConfiguration(params, next);
+                return s3.getBucketLifecycleConfiguration(params,
+                (err, data) => {
+                    next(err, data, s3);
+                });
             },
-        ], (err, config) => {
+        ], (err, config, s3) => {
             if (err) {
                 this._log.error('error getting bucket lifecycle config', {
+                    method: 'LifecycleProducer._processBucketEntry',
+                    bucket,
+                    owner,
                     error: err,
                 });
+                // end the bucket processing chain in case of error
+                this.sendUnlockBucketEntry(result);
                 return cb(err);
             }
             if (!this._shouldProcessConfig(config)) {
+                this.sendUnlockBucketEntry(result);
                 return cb();
             }
             this._log.info('scheduling new task for bucket lifecycle', {
-                bucket,
                 method: 'LifecycleProducer._processBucketEntry',
+                bucket,
+                owner,
             });
             return this._internalTaskScheduler.push({
-                // TODO: Pass new `LifecycleTask(this)` here once implemented.
-                task: { processBucketEntry: (rules, result, done) => done() },
+                task: new LifecycleTask(this),
                 rules: config.Rules,
                 value: result,
+                s3target: s3,
             }, cb);
         });
     }

--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -1,0 +1,769 @@
+'use strict'; // eslint-disable-line
+
+const async = require('async');
+
+const attachReqUids = require('../../replication/utils/attachReqUids');
+const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
+
+const RETRYTIMEOUTS = 300;
+
+// Default max AWS limit is 1000 for both list objects and list object versions
+const MAX_KEYS = 1000;
+// concurrency mainly used in async calls
+const CONCURRENCY_DEFAULT = 10;
+
+class LifecycleTask extends BackbeatTask {
+    /**
+     * Process a list of versioned or non-versioned objects
+     *
+     * @constructor
+     * @param {LifecycleProducer} lp - lifecycle producer instance
+     */
+    constructor(lp) {
+        const lpState = lp.getStateVars();
+        super({ retryTimeoutS: RETRYTIMEOUTS });
+        Object.assign(this, lpState);
+        this._publishedNextListingTask = false;
+    }
+
+    /**
+     * Handles non-versioned objects
+     * @param {object} bucketData - bucket data
+     * @param {object} params - params for AWS S3 `listObjects`
+     * @param {Logger.newRequestLogger} log - logger object
+     * @param {function} done - callback(error, data)
+     * @return {undefined}
+     */
+    _getObjectList(bucketData, params, log, done) {
+        const req = this.s3target.listObjects(params);
+        attachReqUids(req, log);
+        async.waterfall([
+            next => req.send((err, data) => {
+                if (err) {
+                    log.error('error listing bucket objects', {
+                        error: err,
+                        bucket: params.Bucket,
+                    });
+                    return next(err);
+                }
+                return next(null, data);
+            }),
+            (data, next) => {
+                if (data.IsTruncated) {
+                    // re-queue to Kafka topic bucketTasksTopic
+                    // with bucket name and `data.marker`
+                    let marker = data.NextMarker;
+                    if (!marker && data.Contents.length > 0) {
+                        marker = data.Contents[data.Contents.length - 1].Key;
+                    }
+
+                    const entry = Object.assign({}, bucketData, {
+                        details: { marker },
+                    });
+                    return this.sendBucketEntry(entry, err => {
+                        if (!err) {
+                            log.debug(
+                                'sent kafka entry for bucket consumption', {
+                                    method: 'LifecycleTask._getObjectList',
+                                });
+                            this._publishedNextListingTask = true;
+                        }
+                        return next(null, data);
+                    });
+                }
+                return process.nextTick(() => next(null, data));
+            },
+        ], (err, data) => {
+            if (err) {
+                return done(err);
+            }
+            return done(null, { Contents: data.Contents });
+        });
+    }
+
+    /**
+     * Handles versioned objects (both enabled and suspended)
+     * @param {object} bucketData - bucket data
+     * @param {object} params - params for AWS S3 `listObjectVersions`
+     * @param {Logger.newRequestLogger} log - logger object
+     * @param {function} done - callback(error, data)
+     * @return {undefined}
+     */
+    _getObjectVersions(bucketData, params, log, done) {
+        const req = this.s3target.listObjectVersions(params);
+        attachReqUids(req, log);
+        async.waterfall([
+            next => req.send((err, data) => {
+                if (err) {
+                    log.error('error listing versioned bucket objects', {
+                        error: err,
+                        bucket: params.Bucket,
+                    });
+                    return next(err);
+                }
+                return next(null, data);
+            }),
+            (data, next) => {
+                if (data.IsTruncated) {
+                    // NOTE: this might only be needed if a LC rule defines
+                    //   a rule for processing NoncurrentVersion actions
+                    const entry = Object.assign({}, bucketData, {
+                        details: {
+                            keyMarker: data.NextKeyMarker,
+                            versionIdMarker: data.NextVersionIdMarker,
+                        },
+                    });
+                    return this.sendBucketEntry(entry, err => {
+                        if (!err) {
+                            log.debug(
+                                'sent kafka entry for bucket consumption', {
+                                    method: 'LifecycleTask._getObjectVersions',
+                                });
+                            this._publishedNextListingTask = true;
+                        }
+                        return next(null, data);
+                    });
+                }
+                return process.nextTick(() => next(null, data));
+            },
+        ], (err, data) => {
+            if (err) {
+                return done(err);
+            }
+            return done(null, {
+                Versions: data.Versions,
+                DeleteMarkers: data.DeleteMarkers,
+            });
+        });
+    }
+
+    /**
+     * Handles incomplete multipart uploads
+     * @param {object} bucketData - bucket data
+     * @param {array} bucketLCRules - array of bucket lifecycle rules
+     * @param {object} params - params for AWS S3 `listObjectVersions`
+     * @param {Logger.newRequestLogger} log - logger object
+     * @param {function} done - callback(error, data)
+     * @return {undefined}
+     */
+    _getMPUs(bucketData, bucketLCRules, params, log, done) {
+        const req = this.s3target.listMultipartUploads(params);
+        attachReqUids(req, log);
+        async.waterfall([
+            next => req.send((err, data) => {
+                if (err) {
+                    log.error('error checking buckets MPUs', {
+                        method: 'LifecycleTask.processBucketEntry',
+                        error: err,
+                    });
+                    return next(err);
+                }
+                return next(null, data);
+            }),
+            (data, next) => {
+                if (data.IsTruncated) {
+                    // re-queue to kafka with `NextUploadIdMarker` &
+                    // `NextKeyMarker`
+                    const entry = Object.assign({}, bucketData, {
+                        details: {
+                            keyMarker: data.NextKeyMarker,
+                            uploadIdMarker: data.NextUploadIdMarker,
+                        },
+                    });
+                    return this.sendBucketEntry(entry, err => {
+                        if (!err) {
+                            log.debug(
+                                'sent kafka entry for bucket consumption', {
+                                    method: 'LifecycleTask._getMPUs',
+                                });
+                            this._publishedNextListingTask = true;
+                        }
+                        return next(null, data);
+                    });
+                }
+                return process.nextTick(() => next(null, data));
+            },
+        ], (err, data) => {
+            if (err) {
+                return done(err);
+            }
+            this._compareMPUUploads(bucketData, bucketLCRules,
+                data.Uploads, log);
+            return done();
+        });
+    }
+
+    /**
+     * For all incomplete MPU uploads, compare with rules (based only on prefix
+     * because no tags exist for incomplete MPU), and apply
+     * AbortIncompleteMultipartUpload rule (if any) on each upload
+     * @param {object} bucketData - bucket data
+     * @param {array} bucketLCRules - array of bucket lifecycle rules
+     * @param {array} uploads - array of upload objects from
+     *   `listMultipartUploads`
+     * @param {Logger.newRequestLogger} log - logger object
+     * @return {undefined}
+     */
+    _compareMPUUploads(bucketData, bucketLCRules, uploads, log) {
+        uploads.forEach(upload => {
+            const noTags = { TagSet: [] };
+            const filteredRules = this._filterRules(bucketLCRules, upload,
+                noTags);
+            const aRules = this._getApplicableRules(filteredRules);
+
+            const timeDiff = (Date.now() - new Date(upload.Initiated));
+            const daysSinceInitiated = Math.floor(
+                timeDiff / (1000 * 60 * 60 * 24));
+            const abortRule = aRules.AbortIncompleteMultipartUpload;
+
+            if (abortRule && abortRule.DaysAfterInitiation &&
+            daysSinceInitiated >= abortRule.DaysAfterInitiation) {
+                log.debug('send mpu upload for aborting', {
+                    bucket: bucketData.target.bucket,
+                    method: 'LifecycleTask._compareMPUUploads',
+                    uploadId: upload.UploadId,
+                });
+                const entry = {
+                    action: 'deleteMPU',
+                    target: {
+                        owner: bucketData.target.owner,
+                        bucket: bucketData.target.bucket,
+                        key: upload.Key,
+                    },
+                    details: {
+                        UploadId: upload.UploadId,
+                    },
+                };
+                this.sendObjectEntry(entry, err => {
+                    if (!err) {
+                        log.debug('sent object entry for consumption', {
+                            method: 'LifecycleTask._compareMPUUploads',
+                            entry,
+                        });
+                        this._publishedNextListingTask = true;
+                    }
+                });
+            }
+        });
+    }
+
+    /**
+     * Filter out all rules based on `Status` and `Filter` (Prefix and Tags)
+     * @param {array} bucketLCRules - array of bucket lifecycle rules
+     * @param {object} item - represents a single object, version, or upload
+     * @param {object} objTags - all tags for given `item`
+     * @return {array} list of all filtered rules that apply to `item`
+     */
+    _filterRules(bucketLCRules, item, objTags) {
+        function deepCompare(rTags, oTags) {
+            // check key lengths match
+            if (rTags.length !== oTags.length) {
+                return false;
+            }
+            // all key/value tags must match between the 2 sets
+            for (let i = 0; i < rTags.length; i++) {
+                const oTag = oTags.find(pair => pair.Key === rTags[i].Key);
+                if (!oTag || rTags[i].Value !== oTag.Value) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        return bucketLCRules.filter(rule => {
+            if (rule.Status === 'Disabled') {
+                return false;
+            }
+            if (rule.Filter && rule.Filter.And) {
+                // multiple tags or prefix w/ tag(s)
+                const prefix = rule.Filter.And.Prefix;
+                if (prefix && !item.Key.startsWith(prefix)) {
+                    return false;
+                }
+                return deepCompare(rule.Filter.And.Tags, objTags.TagSet);
+            }
+            // only one prefix or one tag to compare in this rule
+            const prefix = rule.Prefix ||
+                (rule.Filter && rule.Filter.Prefix);
+            if (prefix && !item.Key.startsWith(prefix)) {
+                return false;
+            }
+            if (objTags.TagSet.length > 1) {
+                // can only have one tag at this point in time
+                return false;
+            }
+            if (rule.Filter && rule.Filter.Tag && objTags.TagSet[0]) {
+                return deepCompare([rule.Filter.Tag], objTags.TagSet);
+            }
+            return true;
+        });
+    }
+
+    /**
+     * For all filtered rules, get rules that apply the earliest
+     * @param {array} rules - list of filtered rules that apply to a specific
+     *   object, version, or upload
+     * @return {object} all applicable rules with earliest dates of action
+     *  i.e. { Expiration: { Date: <DateObject>, Days: 10 },
+     *         NoncurrentVersionExpiration: { NoncurrentDays: 5 } }
+     */
+    _getApplicableRules(rules) {
+        // NOTE: Ask Team
+        // Assumes if for example a rule defines expiration and transition
+        // and if backbeat disables expiration and enables transition,
+        // we still consider this rules transition to apply
+
+        // these are rules enabled in config.json
+        const enabledRules = Object.keys(this.enabledRules).filter(rule =>
+            this.enabledRules[rule].enabled);
+
+        /* eslint-disable no-param-reassign */
+        return rules.reduce((store, rule) => {
+            // filter and find earliest dates
+            // NOTE: only care about expiration for this feature.
+            //  Add other lifecycle rules here for future features.
+
+            if (rule.Expiration && enabledRules.includes('expiration')) {
+                if (!store.Expiration) {
+                    store.Expiration = {};
+                }
+                if (rule.Expiration.Days) {
+                    if (!store.Expiration.Days || rule.Expiration.Days <
+                    store.Expiration.Days) {
+                        store.Expiration.Days = rule.Expiration.Days;
+                    }
+                }
+                if (rule.Expiration.Date) {
+                    if (!store.Expiration.Date || rule.Expiration.Date <
+                    store.Expiration.Date) {
+                        store.Expiration.Date = rule.Expiration.Date;
+                    }
+                }
+                if (rule.Expiration.ExpiredObjectDeleteMarker) {
+                    store.Expiration.ExpiredObjectDeleteMarker = true;
+                }
+            }
+            if (rule.NoncurrentVersionExpiration &&
+            enabledRules.includes('noncurrentVersionExpiration')) {
+                // Names are long, so obscuring a bit
+                const ncve = 'NoncurrentVersionExpiration';
+                const ncd = 'NoncurrentDays';
+
+                if (!store[ncve]) {
+                    store[ncve] = {};
+                }
+                if (!store[ncve][ncd] || rule[ncve][ncd] < store[ncve][ncd]) {
+                    store[ncve][ncd] = rule[ncve][ncd];
+                }
+            }
+            if (rule.AbortIncompleteMultipartUpload &&
+            enabledRules.includes('abortIncompleteMultipartUpload')) {
+                // Names are long, so obscuring a bit
+                const aimu = 'AbortIncompleteMultipartUpload';
+                const dai = 'DaysAfterInitiation';
+
+                if (!store[aimu]) {
+                    store[aimu] = {};
+                }
+                if (!store[aimu][dai] || rule[aimu][dai] < store[aimu][dai]) {
+                    store[aimu][dai] = rule[aimu][dai];
+                }
+            }
+            return store;
+        }, {});
+        /* eslint-enable no-param-reassign */
+    }
+
+    /**
+     * Compare a non-versioned object to most applicable rules
+     * @param {object} bucketData - bucket data
+     * @param {object} obj - single object from `listObjects`
+     * @param {string} obj.LastModified - last modified date of object
+     * @param {object} rules - most applicable rules from `_getApplicableRules`
+     * @param {Logger.newRequestLogger} log - logger object
+     * @param {function} done - callback(error, data)
+     * @return {undefined}
+     */
+    _compareObject(bucketData, obj, rules, log, done) {
+        const params = {
+            Bucket: bucketData.target.bucket,
+            Key: obj.Key,
+        };
+        if (obj.VersionId) {
+            params.VersionId = obj.VersionId;
+        }
+        const req = this.s3target.headObject(params);
+        attachReqUids(req, log);
+        return req.send((err, data) => {
+            if (err) {
+                log.error('failed to get object', {
+                    method: 'LifecycleTask._compareObject',
+                    error: err,
+                    bucket: bucketData.target.bucket,
+                    objectKey: obj.Key,
+                });
+                return done(err);
+            }
+            // TODO: consider `Date`
+            const objDate = new Date(data.LastModified);
+            const now = Date.now();
+            // time diff in ms
+            const diff = now - objDate;
+            const daysSinceInitiated = Math.floor(diff / (1000 * 60 * 60 * 24));
+
+            /* Example of `rules`
+                {
+                    Expiration: {
+                        Days: 5,
+                        Date: <DateObject>,
+                        ExpiredObjectDeleteMarker: true,
+                    },
+                    NoncurrentVersionExpiration: {
+                        NoncurrentDays: 2,
+                    },
+                    AbortIncompleteMultipartUpload: {
+                        DaysAfterInitiation: 4,
+                    }
+                }
+            */
+            // There is an order of importance in cases of conflicts
+            // Expiration and NoncurrentVersionExpiration should be priority
+            // AbortIncompleteMultipartUpload should run regardless since
+            // it's in its own category
+            // Transitions and NoncurrentVersionTransitions (which we don't
+            // need to worry about this release) should only happen if
+            // no expiration occurred
+            let alreadySent = false;
+
+            if (rules.Expiration) {
+                // TODO: Handle ExpiredObjectDeleteMarker
+                if (rules.Expiration.Date && rules.Expiration.Date < now) {
+                    // expiration date passed for this object
+                    alreadySent = true;
+                    const entry = {
+                        action: 'deleteObject',
+                        target: {
+                            owner: bucketData.target.owner,
+                            bucket: bucketData.target.bucket,
+                            key: obj.Key,
+                        },
+                        details: {
+                            lastModified: data.LastModified,
+                        },
+                    };
+                    this.sendObjectEntry(entry, err => {
+                        if (!err) {
+                            log.debug('sent object entry for consumption', {
+                                method: 'LifecycleTask._compareObject',
+                                entry,
+                            });
+                        }
+                    });
+                }
+                if (!alreadySent && rules.Expiration.Days &&
+                daysSinceInitiated >= rules.Expiration.Days) {
+                    alreadySent = true;
+                    const entry = {
+                        action: 'deleteObject',
+                        target: {
+                            owner: bucketData.target.owner,
+                            bucket: bucketData.target.bucket,
+                            key: obj.Key,
+                        },
+                        details: {
+                            lastModified: data.LastModified,
+                        },
+                    };
+                    this.sendObjectEntry(entry, err => {
+                        if (!err) {
+                            log.debug('sent object entry for consumption', {
+                                method: 'LifecycleTask._compareObject',
+                                entry,
+                            });
+                        }
+                    });
+                }
+            }
+            // if (rules.Transitions && !alreadySent) {}
+
+            return done();
+        });
+    }
+
+    /**
+     * Handles comparing rules for objects
+     * @param {object} bucketData - bucket data
+     * @param {object} bucketData.target - target bucket info
+     * @param {string} bucketData.target.bucket - bucket name
+     * @param {string} bucketData.target.owner - owner id
+     * @param {string} [bucketData.prefix] - prefix
+     * @param {string} [bucketData.details.keyMarker] - next key
+     *   marker for versioned buckets
+     * @param {string} [bucketData.details.versionIdMarker] - next
+     *   version id marker for versioned buckets
+     * @param {string} [bucketData.details.marker] - next
+     *   continuation token marker for non-versioned buckets
+     * @param {array} bucketLCRules - array of bucket lifecycle rules
+     * @param {array} object - object or object version
+     * @param {Logger.newRequestLogger} log - logger object
+     * @param {function} done - callback(error, data)
+     * @return {undefined}
+     */
+    _getRules(bucketData, bucketLCRules, object, log, done) {
+        const tagParams = { Bucket: bucketData.target.bucket, Key: object.Key };
+        if (object.VersionId) {
+            tagParams.VersionId = object.VersionId;
+        }
+
+        const req = this.s3target.getObjectTagging(tagParams);
+        attachReqUids(req, log);
+        return req.send((err, tags) => {
+            if (err) {
+                log.error('failed to get tags', {
+                    method: 'LifecycleTask._getRules',
+                    error: err,
+                    bucket: bucketData.target.bucket,
+                    objectKey: object.Key,
+                    objectVersion: object.VersionId,
+                });
+                return done(err);
+            }
+            // tags.TagSet === [{ Key: '', Value: '' }, ...]
+            const filterRules = this._filterRules(bucketLCRules, object, tags);
+
+            // reduce filteredRules to only get earliest dates
+            return done(null, this._getApplicableRules(filterRules));
+        });
+    }
+
+    _compareContents(bucketData, lcRules, contents, log, done) {
+        if (!contents) {
+            return done();
+        }
+        return async.eachLimit(contents, CONCURRENCY_DEFAULT, (obj, cb) => {
+            async.waterfall([
+                next => this._getRules(bucketData, lcRules, obj, log, next),
+                (applicableRules, next) => this._compareObject(
+                    bucketData, obj, applicableRules, log, next),
+            ], cb);
+        }, done);
+    }
+
+    _compareVersions(bucketData, lcRules, versions, log, done) {
+        if (!versions) {
+            return done();
+        }
+        return async.eachLimit(versions, CONCURRENCY_DEFAULT, (version, cb) => {
+            async.waterfall([
+                next => this._getRules(bucketData, lcRules, version, log, next),
+                (applicableRules, next) => {
+                    // if version is latest, only expiration action applies
+                    if (version.IsLatest) {
+                        return this._compareObject(
+                            bucketData, version, applicableRules, log, next);
+                    }
+                    const req = this.s3target.headObject({
+                        Bucket: bucketData.target.bucket,
+                        Key: version.Key,
+                        VersionId: version.VersionId,
+                    });
+                    attachReqUids(req, log);
+                    return req.send((err, data) => {
+                        if (err) {
+                            log.error('failed to get object', {
+                                method: 'LifecycleTask._compareVersions',
+                                error: err,
+                                bucket: bucketData.target.bucket,
+                                objectKey: version.Key,
+                                versionId: version.VersionId,
+                            });
+                            return next(err);
+                        }
+                        const objDate = new Date(data.LastModified);
+                        const now = Date.now();
+                        // time diff in ms
+                        const diff = now - objDate;
+                        const daysSinceInitiated =
+                            Math.floor(diff / (1000 * 60 * 60 * 24));
+                        const ncve = 'NoncurrentVersionExpiration';
+                        const ncd = 'NoncurrentDays';
+                        if (applicableRules[ncve] &&
+                        applicableRules[ncve][ncd] &&
+                        daysSinceInitiated >= applicableRules[ncve][ncd]) {
+                            const entry = {
+                                action: 'deleteObject',
+                                target: {
+                                    owner: bucketData.target.owner,
+                                    bucket: bucketData.target.bucket,
+                                    key: version.Key,
+                                    version: data.VersionId,
+                                },
+                            };
+                            this.sendObjectEntry(entry, err => {
+                                if (!err) {
+                                    log.debug('sent object entry for ' +
+                                    'consumption', {
+                                        method: 'LifecycleTask.' +
+                                            '_compareVersions',
+                                        entry,
+                                    });
+                                }
+                            });
+                        }
+                        return next();
+                    });
+                },
+            ], cb);
+        }, done);
+    }
+
+    _compareDeleteMarkers(bucketData, lcRules, deleteMarkers, versions,
+        log, done) {
+        // TODO: Issue with rule `Expiration.ExpiredObjectDeleteMarker`
+        // will be completed later
+        return done();
+    }
+
+    _compareWithLCRules(bucketData, bucketLCRules, data, log, cb) {
+        // These could be executed in parallel, but to have better
+        // control on how much parallelism we introduce overall we do
+        // these steps in series for now.
+        async.series([
+            done => this._compareContents(bucketData, bucketLCRules,
+                data.Contents, log, done),
+            done => this._compareVersions(bucketData, bucketLCRules,
+                data.Versions, log, done),
+            done => this._compareDeleteMarkers(bucketData, bucketLCRules,
+                data.DeleteMarkers, data.Versions, log, done),
+        ], cb);
+    }
+
+    /**
+     * Process a single bucket entry with lifecycle configurations enabled
+     * @param {array} bucketLCRules - array of bucket lifecycle rules
+     * @param {object} bucketData - bucket data from zookeeper bucketTasksTopic
+     * @param {object} bucketData.target - target bucket info
+     * @param {string} bucketData.target.bucket - bucket name
+     * @param {string} bucketData.target.owner - owner id
+     * @param {string} [bucketData.details.prefix] - prefix
+     * @param {string} [bucketData.details.keyMarker] - next key
+     *   marker for versioned buckets
+     * @param {string} [bucketData.details.versionIdMarker] - next
+     *   version id marker for versioned buckets
+     * @param {string} [bucketData.details.marker] - next
+     *   continuation token marker for non-versioned buckets
+     * @param {AWS.S3} s3target - s3 instance
+     * @param {function} done - callback(error)
+     * @return {undefined}
+     */
+    processBucketEntry(bucketLCRules, bucketData, s3target, done) {
+        const log = this.log.newRequestLogger();
+        this.s3target = s3target;
+
+        if (!this.s3target) {
+            return process.nextTick(done);
+        }
+        if (typeof bucketData !== 'object' ||
+            typeof bucketData.target !== 'object' ||
+            typeof bucketData.details !== 'object') {
+            log.error('wrong format for bucket entry',
+                      { entry: bucketData });
+            return process.nextTick(done);
+        }
+
+        log.debug('processing bucket entry', {
+            bucket: bucketData.target.bucket,
+            owner: bucketData.target.owner,
+        });
+
+        // NOTE:
+        //  With the addition of mpu's, there was no easy way to handle
+        //  how to process entries w/ markers. Will need to rethink this and
+        //  refactor
+
+        // get all objects whether versioned, non-versioned, or mpu
+        return async.series([
+            cb => {
+                if (bucketData.details.versionIdMarker ||
+                bucketData.details.marker) {
+                    return cb();
+                }
+                const mpuParams = {
+                    Bucket: bucketData.target.bucket,
+                    MaxUploads: MAX_KEYS,
+                    KeyMarker: bucketData.details.uploadIdMarker &&
+                        bucketData.details.keyMarker,
+                    UploadIdMarker: bucketData.details.uploadIdMarker,
+                };
+                return this._getMPUs(bucketData, bucketLCRules,
+                    mpuParams, log, cb);
+            },
+            cb => {
+                if (bucketData.details.uploadIdMarker) {
+                    return cb();
+                }
+
+                const params = {
+                    Bucket: bucketData.target.bucket,
+                    MaxKeys: MAX_KEYS,
+                };
+
+                return async.waterfall([
+                    next => {
+                        const req = this.s3target.getBucketVersioning({
+                            Bucket: bucketData.target.bucket,
+                        });
+                        attachReqUids(req, log);
+                        req.send((err, data) => {
+                            if (err) {
+                                log.error('error checking bucket versioning', {
+                                    method: 'LifecycleTask.processBucketEntry',
+                                    error: err,
+                                });
+                                return next(err);
+                            }
+                            return next(null, data.Status);
+                        });
+                    },
+                    (versioningStatus, next) => {
+                        if (versioningStatus === 'Enabled' ||
+                        versioningStatus === 'Suspended') {
+                            // handle versioned stuff
+                            if (bucketData.details.versionIdMarker &&
+                            bucketData.details.keyMarker) {
+                                params.KeyMarker =
+                                    bucketData.details.keyMarker;
+                                params.VersionIdMarker =
+                                    bucketData.details.versionIdMarker;
+                            }
+                            return this._getObjectVersions(bucketData, params,
+                                log, next);
+                        }
+                        // handle non-versioned stuff
+                        if (bucketData.details.marker) {
+                            params.Marker =
+                                bucketData.details.marker;
+                        }
+                        return this._getObjectList(bucketData, params, log,
+                            next);
+                    },
+                    // Got a list of objects or versions to process now..
+                    (data, next) => this._compareWithLCRules(bucketData,
+                        bucketLCRules, data, log, next),
+                ], cb);
+            },
+        ], err => {
+            this.log.info('finished processing task for bucket lifecycle', {
+                method: 'LifecycleTask.processBucketEntry',
+                bucket: bucketData.target.bucket,
+                owner: bucketData.target.owner,
+            });
+            if (!this._publishedNextListingTask) {
+                this.sendUnlockBucketEntry(bucketData);
+            }
+            return done(err);
+        });
+    }
+}
+
+module.exports = LifecycleTask;

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -92,6 +92,11 @@ class BackbeatConsumer extends EventEmitter {
             this._messagesConsumed++;
             this._consumer.pause();
             q.push(entry, err => {
+                this._log.debug('finished processing of consumed entry', {
+                    method: 'BackbeatConsumer.subscribe',
+                    partition,
+                    offset,
+                });
                 if (err) {
                     this._log.error('error processing an entry', {
                         error: err,

--- a/tests/config.json
+++ b/tests/config.json
@@ -2,6 +2,26 @@
     "zookeeper": {
         "connectionString": "127.0.0.1:2181"
     },
+    "kafka": {
+        "hosts": "127.0.0.1:9092"
+    },
+    "s3": {
+        "host": "127.0.0.1",
+        "port": 8000,
+        "transport": "http",
+        "accessKey": "accessKey1",
+        "secretKey": "verySecretKey1"
+    },
+    "auth": {
+        "type": "account",
+        "account": "bart",
+        "vault": {
+            "host": "127.0.0.1",
+            "port": 8500,
+            "adminPort": 8600,
+            "adminCredentialsFile": "../conf/authdata.json"
+        }
+    },
     "queuePopulator": {
         "cronRule": "*/5 * * * * *",
         "batchMaxRead": 10000,
@@ -13,23 +33,39 @@
             "logName": "s3-recordlog"
         }
     },
-    "kafka": {
-        "hosts": "127.0.0.1:9092"
-    },
-    "s3": {
-        "host": "127.0.0.1",
-        "port": 8000,
-        "transport": "http",
-        "accessKey": "accessKey1",
-        "secretKey": "verySecretKey1"
-    },
     "extensions": {
         "replication": {
             "topic": "backbeat-test-replication",
             "groupId": "backbeat-test-replication-group"
         },
         "lifecycle": {
-            "zookeeperPath": "/backbeat/test/lifecycle"
+            "zookeeperPath": "/lifecycletest",
+            "bucketTasksTopic": "backbeat-test-dummy-bucket-task",
+            "objectTasksTopic": "backbeat-test-dummy-object-task",
+            "conductor": {
+                "cronRule": "0 */5 * * * *"
+            },
+            "producer": {
+                "groupId": "backbeat-lifecycle-producer-test-group",
+                "retryTimeoutS": 300,
+                "concurrency": 10
+            },
+            "consumer": {
+                "groupId": "backbeat-lifecycle-consumer-test-group",
+                "retryTimeoutS": 300,
+                "concurrency": 10
+            },
+            "rules": {
+                "expiration": {
+                    "enabled": true
+                },
+                "noncurrentVersionExpiration": {
+                    "enabled": true
+                },
+                "abortIncompleteMultipartUpload": {
+                    "enabled": true
+                }
+            }
         }
     },
     "log": {

--- a/tests/unit/lifecycle/LifecycleTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleTask.spec.js
@@ -1,0 +1,234 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+
+const LifecycleTask = require(
+    '../../../extensions/lifecycle/tasks/LifecycleTask');
+const Rule = require('../../utils/Rule');
+
+// 5 days prior to CURRENT
+const PAST = new Date(2018, 1, 5);
+const CURRENT = new Date(2018, 1, 10);
+// 5 days after CURRENT
+const FUTURE = new Date(2018, 1, 15);
+
+// get all rule ID's
+function getRuleIDs(rules) {
+    return rules.map(rule => rule.ID).sort();
+}
+
+describe('lifecycle task helper methods', () => {
+    let lct;
+
+    before(() => {
+        const lp = {
+            getStateVars: () => (
+                {
+                    enabledRules: {
+                        expiration: { enabled: true },
+                        transitions: { enabled: true },
+                        noncurrentVersionTransitions: { enabled: true },
+                        noncurrentVersionExpiration: { enabled: true },
+                        abortIncompleteMultipartUpload: { enabled: true },
+                    },
+                }
+            ),
+        };
+        lct = new LifecycleTask(lp);
+    });
+
+    describe('_filterRules for listObjectsV2 contents',
+    () => {
+        it('should filter out Status disabled rules', () => {
+            const mBucketRules = [
+                new Rule().addID('task-1').build(),
+                new Rule().addID('task-2').disable().build(),
+                new Rule().addID('task-3').build(),
+                new Rule().addID('task-4').build(),
+                new Rule().addID('task-2').disable().build(),
+            ];
+            const item = {
+                Key: 'example-item',
+                LastModified: PAST,
+            };
+            const objTags = { TagSet: [] };
+
+            const res = lct._filterRules(mBucketRules, item, objTags);
+            const expected = mBucketRules.filter(rule =>
+                rule.Status === 'Enabled');
+            assert.deepStrictEqual(getRuleIDs(res), getRuleIDs(expected));
+        });
+
+        it('should filter out unmatched prefixes', () => {
+            const mBucketRules = [
+                new Rule().addID('task-1').addPrefix('atask').build(),
+                new Rule().addID('task-2').addPrefix('atasker').build(),
+                new Rule().addID('task-3').addPrefix('cat-').build(),
+                new Rule().addID('task-4').addPrefix('xatask').build(),
+                new Rule().addID('task-5').addPrefix('atasr').build(),
+                new Rule().addID('task-6').addPrefix('Atask').build(),
+                new Rule().addID('task-7').addPrefix('atAsk').build(),
+                new Rule().addID('task-8').build(),
+            ];
+            const item1 = {
+                Key: 'atasker-example-item',
+                LastModified: CURRENT,
+            };
+            const item2 = {
+                Key: 'cat-test',
+                LastModified: CURRENT,
+            };
+            const objTags = { TagSet: [] };
+
+            const res1 = lct._filterRules(mBucketRules, item1, objTags);
+            assert.strictEqual(res1.length, 3);
+            const expRes1 = getRuleIDs(mBucketRules.filter(rule =>
+                (rule.Filter.Prefix && rule.Filter.Prefix.startsWith('atask'))
+                || !rule.Filter.Prefix));
+            assert.deepStrictEqual(expRes1, getRuleIDs(res1));
+
+            const res2 = lct._filterRules(mBucketRules, item2, objTags);
+            assert.strictEqual(res2.length, 2);
+            const expRes2 = getRuleIDs(mBucketRules.filter(rule =>
+                (rule.Filter.Prefix && rule.Filter.Prefix.startsWith('cat-'))
+                || !rule.Filter.Prefix));
+            assert.deepStrictEqual(expRes2, getRuleIDs(res2));
+        });
+
+        it('should filter out unmatched single tags', () => {
+            const mBucketRules = [
+                new Rule().addID('task-1').addTag('tag1', 'val1').build(),
+                new Rule().addID('task-2').addTag('tag3-1', 'val3')
+                    .addTag('tag3-2', 'val3').build(),
+                new Rule().addID('task-3').addTag('tag3-1', 'val3').build(),
+                new Rule().addID('task-4').addTag('tag1', 'val1').build(),
+                new Rule().addID('task-5').addTag('tag3-2', 'val3')
+                    .addTag('tag3-1', 'false').build(),
+                new Rule().addID('task-6').addTag('tag3-2', 'val3')
+                    .addTag('tag3-1', 'val3').build(),
+            ];
+            const item = {
+                Key: 'example-item',
+                LastModified: CURRENT,
+            };
+            const objTags1 = { TagSet: [{ Key: 'tag1', Value: 'val1' }] };
+            const res1 = lct._filterRules(mBucketRules, item, objTags1);
+            assert.strictEqual(res1.length, 2);
+            const expRes1 = getRuleIDs(mBucketRules.filter(rule =>
+                (rule.Filter && rule.Filter.Tag &&
+                rule.Filter.Tag.Key === 'tag1' &&
+                rule.Filter.Tag.Value === 'val1')
+            ));
+            assert.deepStrictEqual(expRes1, getRuleIDs(res1));
+
+            const objTags2 = { TagSet: [{ Key: 'tag3-1', Value: 'val3' }] };
+            const res2 = lct._filterRules(mBucketRules, item, objTags2);
+            assert.strictEqual(res2.length, 1);
+            const expRes2 = getRuleIDs(mBucketRules.filter(rule =>
+                rule.Filter && rule.Filter.Tag &&
+                rule.Filter.Tag.Key === 'tag3-1' &&
+                rule.Filter.Tag.Value === 'val3'
+            ));
+            assert.deepStrictEqual(expRes2, getRuleIDs(res2));
+        });
+
+        it('should filter out unmatched multiple tags', () => {
+            const mBucketRules = [
+                new Rule().addID('task-1').addTag('tag1', 'val1')
+                    .addTag('tag2', 'val1').build(),
+                new Rule().addID('task-2').addTag('tag1', 'val1').build(),
+                new Rule().addID('task-3').addTag('tag2', 'val1').build(),
+                new Rule().addID('task-4').addTag('tag2', 'false').build(),
+                new Rule().addID('task-5').addTag('tag2', 'val1')
+                    .addTag('tag1', 'false').build(),
+                new Rule().addID('task-6').addTag('tag2', 'val1')
+                    .addTag('tag1', 'val1').build(),
+                new Rule().addID('task-7').addTag('tag2', 'val1')
+                    .addTag('tag1', 'val1').addTag('tag3', 'val1').build(),
+                new Rule().addID('task-8').addTag('tag2', 'val1')
+                    .addTag('tag1', 'val1').addTag('tag3', 'val3').build(),
+            ];
+            const item = {
+                Key: 'example-item',
+                LastModified: CURRENT,
+            };
+            const objTags1 = { TagSet: [
+                { Key: 'tag1', Value: 'val1' },
+                { Key: 'tag2', Value: 'val1' },
+            ] };
+            const res1 = lct._filterRules(mBucketRules, item, objTags1);
+            assert.strictEqual(res1.length, 2);
+            assert.deepStrictEqual(getRuleIDs(res1), ['task-1', 'task-6']);
+
+            const objTags2 = { TagSet: [
+                { Key: 'tag2', Value: 'val1' },
+            ] };
+            const res2 = lct._filterRules(mBucketRules, item, objTags2);
+            assert.strictEqual(res2.length, 1);
+            assert.deepStrictEqual(getRuleIDs(res2), ['task-3']);
+
+            const objTags3 = { TagSet: [
+                { Key: 'tag2', Value: 'val1' },
+                { Key: 'tag1', Value: 'val1' },
+                { Key: 'tag3', Value: 'val1' },
+            ] };
+            const res3 = lct._filterRules(mBucketRules, item, objTags3);
+            assert.strictEqual(res3.length, 1);
+            assert.deepStrictEqual(getRuleIDs(res3), ['task-7']);
+        });
+    });
+
+    // describe('_filterRules for listObjectVersions versions',
+    // () => {
+    //     it('should ')
+    // });
+
+    describe('_getApplicableRules', () => {
+        it('should return earliest applicable expirations', () => {
+            const filteredRules = [
+                new Rule().addID('task-1').addExpiration('Date', FUTURE)
+                    .build(),
+                new Rule().addID('task-2').addExpiration('Days', 10).build(),
+                new Rule().addID('task-3').addExpiration('Date', PAST)
+                    .build(),
+                new Rule().addID('task-4').addExpiration('Date', CURRENT)
+                    .build(),
+                new Rule().addID('task-5').addExpiration('Days', 5).build(),
+            ];
+
+            const res1 = lct._getApplicableRules(filteredRules);
+            assert.strictEqual(res1.Expiration.Date, PAST);
+            assert.strictEqual(res1.Expiration.Days, 5);
+
+            // remove `PAST` from rules
+            filteredRules.splice(2, 1);
+            const res2 = lct._getApplicableRules(filteredRules);
+            assert.strictEqual(res2.Expiration.Date, CURRENT);
+        });
+
+        it('should return earliest applicable rules', () => {
+            const filteredRules = [
+                new Rule().addID('task-1').addExpiration('Date', FUTURE)
+                    .build(),
+                new Rule().addID('task-2').addAbortMPU(18).build(),
+                new Rule().addID('task-3').addExpiration('Date', PAST)
+                    .build(),
+                new Rule().addID('task-4').addNCVExpiration(3).build(),
+                new Rule().addID('task-5').addNCVExpiration(12).build(),
+                new Rule().addID('task-6').addExpiration('Date', CURRENT)
+                    .build(),
+                new Rule().addID('task-7').addNCVExpiration(7).build(),
+                new Rule().addID('task-8').addAbortMPU(4).build(),
+                new Rule().addID('task-9').addAbortMPU(22).build(),
+            ];
+
+            const res = lct._getApplicableRules(filteredRules);
+            assert.deepStrictEqual(Object.keys(res.Expiration), ['Date']);
+            assert.deepStrictEqual(res.Expiration, { Date: PAST });
+            assert.strictEqual(
+                res.AbortIncompleteMultipartUpload.DaysAfterInitiation, 4);
+            assert.strictEqual(
+                res.NoncurrentVersionExpiration.NoncurrentDays, 3);
+        });
+    });
+});

--- a/tests/utils/Rule.js
+++ b/tests/utils/Rule.js
@@ -1,0 +1,113 @@
+/**
+ * @class Rule
+ *
+ * @classdesc Simple get/set class to build a single Rule
+ */
+class Rule {
+    constructor() {
+        // defaults
+        this.id = 'test-id';
+        this.status = 'Enabled';
+        this.tags = [];
+    }
+
+    build() {
+        const rule = {};
+
+        rule.ID = this.id;
+        rule.Status = this.status;
+
+        if (this.expiration) {
+            rule.Expiration = this.expiration;
+        }
+        if (this.ncvExpiration) {
+            rule.NoncurrentVersionExpiration = this.ncvExpiration;
+        }
+        if (this.abortMPU) {
+            rule.AbortIncompleteMultipartUpload = this.abortMPU;
+        }
+
+        const filter = {};
+        if ((this.prefix && this.tags.length) || (this.tags.length > 1)) {
+            // And rule
+            const andRule = {};
+
+            if (this.prefix) {
+                andRule.Prefix = this.prefix;
+            }
+            andRule.Tags = this.tags;
+            filter.And = andRule;
+        } else {
+            if (this.prefix) {
+                filter.Prefix = this.prefix;
+            }
+            if (this.tags.length) {
+                filter.Tag = this.tags[0];
+            }
+        }
+        rule.Filter = filter;
+
+        return rule;
+    }
+
+    addID(id) {
+        this.id = id;
+        return this;
+    }
+
+    disable() {
+        this.status = 'Disabled';
+        return this;
+    }
+
+    addPrefix(prefix) {
+        this.prefix = prefix;
+        return this;
+    }
+
+    addTag(key, value) {
+        this.tags.push({
+            Key: key,
+            Value: value,
+        });
+        return this;
+    }
+
+    /**
+    * Expiration
+    * @param {string} prop - Property must be defined in `validProps`
+    * @param {integer|boolean} value - integer for `Date` or `Days`, or
+    *   boolean for `ExpiredObjectDeleteMarker`
+    * @return {undefined}
+    */
+    addExpiration(prop, value) {
+        const validProps = ['Date', 'Days', 'ExpiredObjectDeleteMarker'];
+        if (validProps.indexOf(prop) > -1) {
+            this.expiration = this.expiration || {};
+            this.expiration[prop] = value;
+        }
+        return this;
+    }
+
+    /**
+    * NoncurrentVersionExpiration
+    * @param {integer} days - NoncurrentDays
+    * @return {undefined}
+    */
+    addNCVExpiration(days) {
+        this.ncvExpiration = { NoncurrentDays: days };
+        return this;
+    }
+
+    /**
+    * AbortIncompleteMultipartUpload
+    * @param {integer} days - DaysAfterInitiation
+    * @return {undefined}
+    */
+    addAbortMPU(days) {
+        this.abortMPU = { DaysAfterInitiation: days };
+        return this;
+    }
+}
+
+module.exports = Rule;


### PR DESCRIPTION
Lifecycle Tasks handles the AWS operations for validating and matching rules. These tasks are processed via the Lifecycle Producer. 
Please refer to the Lifecycle design docs to view the LifecycleProducer/LifecycleTask operations.

To be added and in the works are adding functional tests for specifically LifecycleTask class