### PR TITLE
FIX: Update replication setup script

### DIFF
--- a/extensions/replication/utils/SetupReplication.js
+++ b/extensions/replication/utils/SetupReplication.js
@@ -593,7 +593,7 @@ class SetupReplication extends BackbeatTask {
                 return cb(err);
             }
             return cb(null, { sourceRoleArn: sourceRole.Arn,
-                              targetRoleArn: targetRole.Arn,
+                              targetRoleArn: targetRole && targetRole.Arn,
                               sourcePolicyArn, targetPolicyArn });
         });
     }


### PR DESCRIPTION
This bug was reported in the BETA 7.2.0.4-rc2 build. I am assuming the tag is created from the rel/7.4 branch (hence the target here) since this change does not exist in rel/7.2.