### PR TITLE
non-keyed partitioner in BackbeatProducer

### DIFF
--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -16,12 +16,17 @@ const SNAPPY_COMPRESSION = 2; // eslint-disable-line
 
 // time in ms. to wait for acks from Kafka
 const ACK_TIMEOUT = 100;
+// default (dumb) kafka partitioning - always goes to partition 0
+// const DEFAULT_PARTITIONER = 0;
+// decent choice to spread messages across partitions, but not as fair
+// as cyclic partitioner
+// const RANDOM_PARTITIONER = 1;
+// the cyclic partitioner guarantees fair dispersion across partitions
+const CYCLIC_PARTITIONER = 2;
 // use keyed-message mechanism for partitioning by default. This lets Kafka
 // choose a partition based on the key and ensures entries with the same key
 // ends up in the same partition
 const KEYED_PARTITIONER = 3;
-// default kafka partitioning
-const KAFKA_PARTITIONER = 0;
 // waits for an ack for messages
 const REQUIRE_ACKS = 1;
 
@@ -34,6 +39,9 @@ class BackbeatProducer extends EventEmitter {
     * @param {Object} config - config
     * @param {string} config.topic - Kafka topic to write to
     * @param {number} [config.partition] - partition in a topic to write to
+    * @param {boolean} [config.keyedPartitioner=true] - if no
+    * partition is set, tell whether the producer should use keyed
+    * partitioning or the default partitioning of the kafka client
     * @param {Object} [config.zookeeper] - zookeeper endpoint config
     * @param {string} config.zookeeper.connectionString - zookeeper connection
     * string as "host:port[/chroot]"
@@ -48,10 +56,12 @@ class BackbeatProducer extends EventEmitter {
             sslOptions: joi.object(),
             topic: joi.string().required(),
             partition: joi.number(),
+            keyedPartitioner: joi.boolean().default(true),
         };
         const validConfig = joi.attempt(config, configJoi,
                                         'invalid config params');
-        const { zookeeper, sslOptions, topic, partition } = validConfig;
+        const { zookeeper, sslOptions, topic, partition,
+                keyedPartitioner } = validConfig;
 
         this._partition = partition;
         this._zookeeperEndpoint = zookeeper.connectionString;
@@ -69,8 +79,8 @@ class BackbeatProducer extends EventEmitter {
             ackTimeoutMs: ACK_TIMEOUT,
             // uses keyed-message partitioner to ensure messages with the same
             // key end up in one partition
-            partitionerType: partition === undefined ? KEYED_PARTITIONER :
-                KAFKA_PARTITIONER,
+            partitionerType: partition === undefined && keyedPartitioner ?
+                KEYED_PARTITIONER : CYCLIC_PARTITIONER,
             // controls compression of the message
             attributes: NO_COMPRESSION,
         });
@@ -128,17 +138,26 @@ class BackbeatProducer extends EventEmitter {
                 cb(errors.InternalError);
             });
         }
-        const payload = this._partition === undefined ?
-                  entries.map(item => ({
-                      topic: this._topic,
-                      messages: new KeyedMessage(item.key, item.message),
-                      key: item.key,
-                  })) :
-                  entries.map(item => ({
-                      topic: this._topic,
-                      messages: item.message,
-                      partition: this._partition,
-                  }));
+        const payload = entries.map(item => {
+            if (this._partition !== undefined) {
+                return {
+                    topic: this._topic,
+                    messages: item.message,
+                    partition: this._partition,
+                };
+            }
+            if (item.key !== undefined) {
+                return {
+                    topic: this._topic,
+                    messages: new KeyedMessage(item.key, item.message),
+                    key: item.key,
+                };
+            }
+            return {
+                topic: this._topic,
+                messages: item.message,
+            };
+        });
         this._client.refreshMetadata([this._topic], () =>
             this._producer.send(payload, err => {
                 if (err) {


### PR DESCRIPTION
Allow the possibility to use non-keyed partitioning without specifying
a partition number, so that the default partitioning scheme is used
to spread messages across partitions without providing a key.
