### PR TITLE
FIX: Undefined logger in QueueProcessor class

### DIFF
--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -166,7 +166,7 @@ class QueueProcessor extends EventEmitter {
         producer.once('ready', () => {
             producer.removeAllListeners('error');
             producer.on('error', err => {
-                this.log.error('error from backbeat producer', {
+                this.logger.error('error from backbeat producer', {
                     topic: this.repConfig.replicationStatusTopic,
                     error: err,
                 });


### PR DESCRIPTION
Encountered the following crash when using queue processor:

```
/Users/bennettbuchanan/repos/scality/backbeat/extensions/replication/queueProcessor/QueueProcessor.js:169
                this.log.error('error from backbeat producer', {
                        ^

TypeError: Cannot read property 'error' of undefined
    at BackbeatProducer.producer.on.err (/Users/bennettbuchanan/repos/scality/backbeat/extensions/replication/queueProcessor/QueueProcessor.js:169:25)
    at emitOne (events.js:96:13)
    at BackbeatProducer.emit (events.js:188:7)
    at Producer.BackbeatProducer._producer.on.error (/Users/bennettbuchanan/repos/scality/backbeat/lib/BackbeatProducer.js:87:18)
    at emitOne (events.js:96:13)
    at Producer.emit (events.js:188:7)
    at Client.<anonymous> (/Users/bennettbuchanan/repos/scality/backbeat/node_modules/kafka-node/lib/baseProducer.js:100:10)
    at emitOne (events.js:96:13)
    at Client.emit (events.js:188:7)
    at Socket.<anonymous> (/Users/bennettbuchanan/repos/scality/backbeat/node_modules/kafka-node/lib/client.js:706:10)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at emitErrorNT (net.js:1278:8)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickDomainCallback (internal/process/next_tick.js:122:9)
```

This fix avoids that. :shipit: