### PR TITLE
bf: statsmodel intervals

### DIFF
--- a/lib/MetricsConsumer.js
+++ b/lib/MetricsConsumer.js
@@ -1,8 +1,9 @@
 'use strict'; // eslint-disable-line strict
 
 const Logger = require('werelogs').Logger;
-const { RedisClient, StatsClient } = require('arsenal').metrics;
+const { RedisClient } = require('arsenal').metrics;
 
+const StatsModel = require('./models/StatsModel');
 const BackbeatConsumer = require('./BackbeatConsumer');
 const redisKeys = require('../extensions/replication/constants').redisKeys;
 
@@ -33,7 +34,7 @@ class MetricsConsumer {
         this.logger = new Logger('Backbeat:MetricsConsumer');
 
         const redisClient = new RedisClient(rConfig, this.logger);
-        this._statsClient = new StatsClient(redisClient, INTERVAL,
+        this._statsClient = new StatsModel(redisClient, INTERVAL,
             EXPIRY);
     }
 

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -4,8 +4,9 @@ const async = require('async');
 const zookeeper = require('node-zookeeper-client');
 
 const { errors } = require('arsenal');
-const { RedisClient, StatsClient } = require('arsenal').metrics;
+const { RedisClient } = require('arsenal').metrics;
 
+const StatsModel = require('../models/StatsModel');
 const BackbeatProducer = require('../BackbeatProducer');
 const Healthcheck = require('./Healthcheck');
 const routes = require('./routes');
@@ -54,7 +55,7 @@ class BackbeatAPI {
         }
 
         const redisClient = new RedisClient(this._redisConfig, this._logger);
-        this._statsClient = new StatsClient(redisClient, INTERVAL, EXPIRY);
+        this._statsClient = new StatsModel(redisClient, INTERVAL, EXPIRY);
     }
 
     /**

--- a/lib/models/StatsModel.js
+++ b/lib/models/StatsModel.js
@@ -1,0 +1,22 @@
+const { StatsClient } = require('arsenal').metrics;
+
+/**
+ * @class StatsModel
+ *
+ * @classdesc Extend and overwrite how timestamps are normalized by minutes
+ * rather than by seconds
+ */
+class StatsModel extends StatsClient {
+
+    /**
+    * normalize to the nearest interval
+    * @param {object} d - Date instance
+    * @return {number} timestamp - normalized to the nearest interval
+    */
+    _normalizeTimestamp(d) {
+        const m = d.getMinutes();
+        return d.setMinutes(m - m % (Math.floor(this._interval / 60)), 0, 0);
+    }
+}
+
+module.exports = StatsModel;

--- a/tests/functional/api/BackbeatServer.js
+++ b/tests/functional/api/BackbeatServer.js
@@ -3,8 +3,9 @@ const http = require('http');
 const Redis = require('ioredis');
 const { Client, Producer } = require('kafka-node');
 
-const { RedisClient, StatsClient } = require('arsenal').metrics;
+const { RedisClient } = require('arsenal').metrics;
 
+const StatsModel = require('../../../lib/models/StatsModel');
 const config = require('../../config.json');
 const allRoutes = require('../../../lib/api/routes');
 const redisConfig = { host: '127.0.0.1', port: 6379 };
@@ -133,7 +134,7 @@ describe('Backbeat Server', () => {
         before(done => {
             redis = new Redis();
             redisClient = new RedisClient(redisConfig, fakeLogger);
-            statsClient = new StatsClient(redisClient, interval, expiry);
+            statsClient = new StatsModel(redisClient, interval, expiry);
 
             statsClient.reportNewRequest(OPS, 1725);
             statsClient.reportNewRequest(BYTES, 219800);


### PR DESCRIPTION
StatsClient normalized time by seconds. Since we want to use
intervals by a default of 5 minutes (or configurable to be higher),
we want to normalize time by minutes.

Please only review 877feceb10d9f16cd38b1b4454cfa10d288b048b
