### PR TITLE
remove broken design with unlockBucket messages

### DIFF
--- a/extensions/lifecycle/lifecycleProducer/LifecycleProducer.js
+++ b/extensions/lifecycle/lifecycleProducer/LifecycleProducer.js
@@ -95,25 +95,6 @@ class LifecycleProducer {
         return `${this._lcConfig.zookeeperPath}/run/queuedBuckets`;
     }
 
-    sendUnlockBucketEntry(bucketData) {
-        const entry = {
-            action: 'unlockBucket',
-            target: {
-                owner: bucketData.target.owner,
-                bucket: bucketData.target.bucket,
-            },
-            details: {},
-        };
-        this.sendObjectEntry(entry, err => {
-            if (!err) {
-                this._log.debug('sent unlock bucket entry for consumption', {
-                    method: 'LifecycleProducer._sendUnlockBucketEntry',
-                    entry,
-                });
-            }
-        });
-    }
-
     /**
      * Get the state variables of the current instance.
      * @return {Object} Object containing the state variables
@@ -122,7 +103,6 @@ class LifecycleProducer {
         return {
             sendBucketEntry: this.sendBucketEntry.bind(this),
             sendObjectEntry: this.sendObjectEntry.bind(this),
-            sendUnlockBucketEntry: this.sendUnlockBucketEntry.bind(this),
             enabledRules: this._lcConfig.rules,
             log: this._log,
         };
@@ -234,12 +214,9 @@ class LifecycleProducer {
                     owner,
                     error: err,
                 });
-                // end the bucket processing chain in case of error
-                this.sendUnlockBucketEntry(result);
                 return cb(err);
             }
             if (!this._shouldProcessConfig(config)) {
-                this.sendUnlockBucketEntry(result);
                 return cb();
             }
             this._log.info('scheduling new task for bucket lifecycle', {

--- a/extensions/lifecycle/tasks/LifecycleObjectTask.js
+++ b/extensions/lifecycle/tasks/LifecycleObjectTask.js
@@ -76,10 +76,6 @@ class LifecycleObjectTask extends BackbeatTask {
         return done();
     }
 
-    getQueuedBucketsZkPath() {
-        return `${this.lcConfig.zookeeperPath}/run/queuedBuckets`;
-    }
-
     _executeDelete(entry, log, done) {
         const action = entry.action;
         const { bucket, key, version } = entry.target;
@@ -106,22 +102,6 @@ class LifecycleObjectTask extends BackbeatTask {
                         httpStatus: err.statusCode });
                 return done(err);
             }
-            return done();
-        });
-    }
-
-    _executeUnlockBucket(entry, log, done) {
-        const { owner, bucket } = entry.target;
-
-        const zkPath = `${this.getQueuedBucketsZkPath()}/${owner}:${bucket}`;
-        this.zkClient.remove(zkPath, -1, err => {
-            if (err) {
-                log.error('could not remove queued bucket node from zookeeper',
-                          { owner, bucket, zkPath, error: err.message });
-                return done(err);
-            }
-            log.debug('removed queued bucket node from zookeeper',
-                      { owner, bucket, zkPath });
             return done();
         });
     }
@@ -162,9 +142,6 @@ class LifecycleObjectTask extends BackbeatTask {
                 }
                 return done(err);
             });
-        }
-        if (action === 'unlockBucket') {
-            return this._executeUnlockBucket(entry, log, done);
         }
         log.info(`skipped unsupported action ${action}`, { entry });
         return process.nextTick(done);

--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -23,7 +23,6 @@ class LifecycleTask extends BackbeatTask {
         const lpState = lp.getStateVars();
         super({ retryTimeoutS: RETRYTIMEOUTS });
         Object.assign(this, lpState);
-        this._publishedNextListingTask = false;
     }
 
     /**
@@ -66,7 +65,6 @@ class LifecycleTask extends BackbeatTask {
                                 'sent kafka entry for bucket consumption', {
                                     method: 'LifecycleTask._getObjectList',
                                 });
-                            this._publishedNextListingTask = true;
                         }
                         return next(null, data);
                     });
@@ -119,7 +117,6 @@ class LifecycleTask extends BackbeatTask {
                                 'sent kafka entry for bucket consumption', {
                                     method: 'LifecycleTask._getObjectVersions',
                                 });
-                            this._publishedNextListingTask = true;
                         }
                         return next(null, data);
                     });
@@ -176,7 +173,6 @@ class LifecycleTask extends BackbeatTask {
                                 'sent kafka entry for bucket consumption', {
                                     method: 'LifecycleTask._getMPUs',
                                 });
-                            this._publishedNextListingTask = true;
                         }
                         return next(null, data);
                     });
@@ -240,7 +236,6 @@ class LifecycleTask extends BackbeatTask {
                             method: 'LifecycleTask._compareMPUUploads',
                             entry,
                         });
-                        this._publishedNextListingTask = true;
                     }
                 });
             }
@@ -758,9 +753,6 @@ class LifecycleTask extends BackbeatTask {
                 bucket: bucketData.target.bucket,
                 owner: bucketData.target.owner,
             });
-            if (!this._publishedNextListingTask) {
-                this.sendUnlockBucketEntry(bucketData);
-            }
             return done(err);
         });
     }

--- a/tests/functional/lifecycle/LifecycleConductor.spec.js
+++ b/tests/functional/lifecycle/LifecycleConductor.spec.js
@@ -120,9 +120,21 @@ describe('lifecycle conductor', function lifecycleConductor() {
             next),
         next => {
             lcConductor.processBuckets();
-            // bucket1 and bucket2 are not expected because they are
-            // already in the queue
             consumer.expectUnorderedMessages([
+                {
+                    value: {
+                        action: 'processObjects',
+                        target: { bucket: 'bucket1', owner: 'owner1' },
+                        details: {},
+                    },
+                },
+                {
+                    value: {
+                        action: 'processObjects',
+                        target: { bucket: 'bucket2', owner: 'owner2' },
+                        details: {},
+                    },
+                },
                 {
                     value: {
                         action: 'processObjects',


### PR DESCRIPTION
    The issue with the current design is that we only send one
    'unlockBucket' message after the bucket has been listed entirely, but
    nothing guarantees that previous listing tasks executed by other
    producers will not be longer to proceed, effectively voiding the
    purpose of knowing when all objects of this bucket have been
    processed.
    
    One case where this is very likely to happen is when a specific range
    of objects in the bucket have to be expired at once (other than the
    last listed range), because it will take longer to process objects for
    that particular range than it will be to finish listing the bucket and
    processing the expirations for last range. Moreover this is a common
    case in production (e.g. expiring a sub-directory).
    
    An alternative implementation based on monitoring the backlog of kafka
    to apply backpressure will be done instead.