### PR TITLE
bf: set default concurrency of bucket processing to 1

### DIFF
--- a/extensions/lifecycle/LifecycleConfigValidator.js
+++ b/extensions/lifecycle/LifecycleConfigValidator.js
@@ -11,7 +11,10 @@ const joiSchema = {
     producer: {
         groupId: joi.string().required(),
         retryTimeoutS: joi.number().default(300),
-        concurrency: joi.number().greater(0).default(10),
+        // a single producer task is already involving concurrency in
+        // the processing, no need to add more here to avoid
+        // overloading the system
+        concurrency: joi.number().greater(0).default(1),
     },
     consumer: {
         groupId: joi.string().required(),


### PR DESCRIPTION
The producer can be aggressive with 10 concurrent operations, since
each of them can generate in turn 10 HEAD requests to S3 server (and
there can be 5 concurrent producers on the system), this shows high
CPU usage. Reducing the concurrency should make lifecycle processing
less agressive on resources.