### PR TITLE
rf: change metrics route paths

### DIFF
--- a/conf/Config.js
+++ b/conf/Config.js
@@ -53,14 +53,14 @@ class Config {
         healthChecks.allowFrom =
             healthChecks.allowFrom.concat(defaultHealthChecks);
 
-        // config is validated, safe to assign directly to the config object
-        Object.assign(this, parsedConfig);
-
         // default to standalone configuration if sentinel not setup
-        if (parsedConfig.redis && !parsedConfig.redis.sentinels) {
+        if (!parsedConfig.redis || !parsedConfig.redis.sentinels) {
             this.redis = Object.assign({}, parsedConfig.redis,
                 { host: '127.0.0.1', port: 6379 });
         }
+
+        // config is validated, safe to assign directly to the config object
+        Object.assign(this, parsedConfig);
     }
 
     getBasePath() {

--- a/extensions/replication/ReplicationQueuePopulator.js
+++ b/extensions/replication/ReplicationQueuePopulator.js
@@ -52,7 +52,8 @@ class ReplicationQueuePopulator extends QueuePopulatorExtension {
                      `${queueEntry.getBucket()}/${queueEntry.getObjectKey()}`,
                      JSON.stringify(entry));
 
-        this._incrementMetrics(entry.bucket, queueEntry.getBytesMetric());
+        this._incrementMetrics(queueEntry.getSite(),
+            queueEntry.getContentLength());
     }
 }
 

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -259,9 +259,15 @@ class QueueProcessor extends EventEmitter {
                 this._consumer.subscribe();
 
                 this._consumer.on('metrics', data => {
-                    // i.e. data = { my-bucket: { ops: 1, bytes: 124 } }
-                    this._mProducer.publishMetrics(data, metricsTypeProcessed,
-                        metricsExtension, err => {
+                    // i.e. data = { my-site: { ops: 1, bytes: 124 } }
+                    const filteredData = Object.keys(data).filter(key =>
+                        key === this.site).reduce((store, k) => {
+                            // eslint-disable-next-line no-param-reassign
+                            store[k] = data[this.site];
+                            return store;
+                        }, {});
+                    this._mProducer.publishMetrics(filteredData,
+                        metricsTypeProcessed, metricsExtension, err => {
                             this.logger.trace('error occurred in publishing ' +
                             'metrics', {
                                 error: err,

--- a/extensions/replication/utils/ObjectQueueEntry.js
+++ b/extensions/replication/utils/ObjectQueueEntry.js
@@ -81,18 +81,6 @@ class ObjectQueueEntry extends ObjectMD {
         return `${this.getBucket()}/${this.getObjectKey()}`;
     }
 
-    /**
-     * Get total bytes of this object entry
-     * @return {number} total bytes
-     */
-    getBytesMetric() {
-        const locations = this.getReducedLocations();
-        if (locations) {
-            return locations.reduce((sum, item) => sum + item.size, 0);
-        }
-        return 0;
-    }
-
     getObjectKey() {
         return this.objectKey;
     }

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -5,6 +5,8 @@ const async = require('async');
 const joi = require('joi');
 
 const BackbeatProducer = require('./BackbeatProducer');
+const ObjectQueueEntry =
+    require('../extensions/replication/utils/ObjectQueueEntry');
 const Logger = require('werelogs').Logger;
 kafkaLogging.setLoggerProvider(new Logger('Consumer'));
 
@@ -110,20 +112,28 @@ class BackbeatConsumer extends EventEmitter {
                     this.emit('error', err, entry);
                 } else if (entry.topic === CRR_TOPIC) {
                     const qEntry = QueueEntry.createFromKafkaEntry(entry);
-                    if (!qEntry.error && qEntry.getReducedLocations) {
-                        const locations = qEntry.getReducedLocations();
-                        const bytes = locations.reduce((sum, item) =>
-                            sum + item.size, 0);
+                    if (!qEntry.error && qEntry instanceof ObjectQueueEntry) {
+                        const bytes = qEntry.getContentLength();
 
-                        if (!this._metricsStore[qEntry.bucket]) {
-                            this._metricsStore[qEntry.bucket] = {
-                                ops: 1,
-                                bytes,
-                            };
-                        } else {
-                            this._metricsStore[qEntry.bucket].ops++;
-                            this._metricsStore[qEntry.bucket].bytes += bytes;
-                        }
+                        const repSites = qEntry.getReplicationInfo().backends;
+                        const sites = repSites.reduce((store, entry) => {
+                            if (entry.status === 'PENDING') {
+                                store.push(entry.site);
+                            }
+                            return store;
+                        }, []);
+
+                        sites.forEach(site => {
+                            if (!this._metricsStore[site]) {
+                                this._metricsStore[site] = {
+                                    ops: 1,
+                                    bytes,
+                                };
+                            } else {
+                                this._metricsStore[site].ops++;
+                                this._metricsStore[site].bytes += bytes;
+                            }
+                        });
                     }
                 }
             });

--- a/lib/MetricsProducer.js
+++ b/lib/MetricsProducer.js
@@ -38,19 +38,19 @@ class MetricsProducer {
     }
 
     /**
-     * @param {Object} extMetrics - an object where keys are all buckets for a
-     *   given extension and values are the metrics for the bucket
-     *   (i.e. { my-bucket: { ops: 1, bytes: 124 } } )
+     * @param {Object} extMetrics - an object where keys are all sites for a
+     *   given extension and values are the metrics for the site
+     *   (i.e. { my-site: { ops: 1, bytes: 124 } } )
      * @param {String} type - type of metric (queueud or processed)
      * @param {String} ext - extension (i.e. 'crr')
      * @param {function} cb - callback
      * @return {undefined}
      */
     publishMetrics(extMetrics, type, ext, cb) {
-        async.each(Object.keys(extMetrics), (bucketName, done) => {
-            const { ops, bytes } = extMetrics[bucketName];
+        async.each(Object.keys(extMetrics), (siteName, done) => {
+            const { ops, bytes } = extMetrics[siteName];
             const message = new MetricsModel(ops, bytes, ext, type,
-                bucketName).serialize();
+                siteName).serialize();
             this._producer.send([{ message }], err => {
                 if (err) {
                     // Using trace here because errors are already logged in

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -60,11 +60,70 @@ class BackbeatAPI {
 
     /**
      * Check if incoming request is valid
-     * @param {string} route - request route
+     * @param {BackbeatRequest} bbRequest - holds relevant data about request
      * @return {boolean} true/false
      */
-    isValidRoute(route) {
-        return routes.some(r => r.path.includes(route));
+    isValidRoute(bbRequest) {
+        const rDetails = bbRequest.getRouteDetails();
+        if (!rDetails) {
+            return false;
+        }
+        const route = bbRequest.getRoute();
+        // first validate healthcheck routes
+        if (route.substring(3) === 'healthcheck') {
+            return true;
+        }
+
+        /*
+            {
+                category: 'metrics',
+                extension: 'crr',
+                site: 'my-site-name',
+                metric: 'backlog', (optional)
+            }
+        */
+        // check metric routes
+        // Are there any routes with matching extension?
+        const extensions = routes.reduce((store, r) => {
+            if (rDetails.category === 'metrics' && r.extensions) {
+                store.push(Object.keys(r.extensions));
+            }
+            return store;
+        }, []);
+        if (![].concat.apply([], extensions).includes(rDetails.extension)) {
+            return false;
+        }
+
+        let specifiedType;
+        const validRoutes = [];
+        routes.forEach(r => {
+            if (!r.extensions) {
+                return;
+            }
+            if (!Object.keys(r.extensions).includes(rDetails.extension)) {
+                return;
+            }
+            if (!r.extensions[rDetails.extension].includes(rDetails.site)) {
+                return;
+            }
+            if (rDetails.metric && r.type === rDetails.metric) {
+                specifiedType = r.type;
+            }
+            validRoutes.push(r);
+        });
+
+        if (validRoutes.length === 0) {
+            return false;
+        }
+
+        // since this is an optional field, if a metric type was specified
+        // in the route and it didn't match any metric types defined in
+        // `routes.js`
+        if (rDetails.metric && !specifiedType) {
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -119,7 +178,8 @@ class BackbeatAPI {
     _getData(details, data, cb) {
         if (!data) {
             const dataPoints = details.dataPoints;
-            return this._queryStats(dataPoints, cb);
+            const site = details.site;
+            return this._queryStats(dataPoints, site, cb);
         }
         return cb(null, data);
     }
@@ -282,10 +342,13 @@ class BackbeatAPI {
     /**
      * Query StatsClient for all ops given
      * @param {array} ops - array of redis key names to query
+     * @param {string} site - site name
      * @param {function} cb - callback(err, res)
      * @return {undefined}
      */
-    _queryStats(ops, cb) {
+    _queryStats(ops, site, cb) {
+        // TODO: Querying by site level here will change in future
+        //   For now, since only 'all' sites is supported, query all
         return async.map(ops, (op, done) => {
             this._statsClient.getStats(this._logger, op, done);
         }, cb);

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -195,8 +195,8 @@ class BackbeatAPI {
     getBacklog(details, cb, data) {
         this._getData(details, data, (err, res) => {
             if (err || res.length !== details.dataPoints.length) {
-                this._logger.error('error occurred getting backlog', {
-                    method: 'BackbeatAPI.backlog',
+                this._logger.error('error getting metrics: backlog', {
+                    method: 'BackbeatAPI.getBacklog',
                 });
                 return cb(errors.InternalError);
             }
@@ -232,8 +232,8 @@ class BackbeatAPI {
     getCompletions(details, cb, data) {
         this._getData(details, data, (err, res) => {
             if (err || res.length !== details.dataPoints.length) {
-                this._logger.error('error getting replication completions', {
-                    method: 'BackbeatAPI.completions',
+                this._logger.error('error getting metrics: completions', {
+                    method: 'BackbeatAPI.getCompletions',
                 });
                 return cb(errors.InternalError);
             }
@@ -272,8 +272,8 @@ class BackbeatAPI {
     getThroughput(details, cb, data) {
         this._getData(details, data, (err, res) => {
             if (err) {
-                this._logger.error('error getting throughput', {
-                    method: 'BackbeatAPI.throughput',
+                this._logger.error('error getting metrics: throughput', {
+                    method: 'BackbeatAPI.getThroughput',
                 });
                 return cb(errors.InternalError);
             }
@@ -313,7 +313,7 @@ class BackbeatAPI {
     getAllMetrics(details, cb, data) {
         this._getData(details, data, (err, res) => {
             if (err || res.length !== details.dataPoints.length) {
-                this._logger.error('error getting all metrics', {
+                this._logger.error('error getting metrics: all', {
                     method: 'BackbeatAPI.getAllMetrics',
                 });
                 return cb(errors.InternalError);
@@ -328,7 +328,7 @@ class BackbeatAPI {
                     [res[1], res[3]]),
             ], (err, results) => {
                 if (err) {
-                    this._logger.error('error getting all metrics', {
+                    this._logger.error('error getting metrics: all', {
                         method: 'BackbeatAPI.getAllMetrics',
                     });
                     return cb(errors.InternalError);

--- a/lib/api/BackbeatRequest.js
+++ b/lib/api/BackbeatRequest.js
@@ -19,6 +19,44 @@ class BackbeatRequest {
         this._route = req.url;
         this._statusCode = 0;
         this._error = null;
+        this._routeDetails = {};
+
+        this._parseRoute();
+    }
+
+    /**
+     * Parse a route and store to this._routeDetails
+     * A route will have certain a specific structure following:
+     * /_/metrics/<extension>/<site>/<specific-metric>
+     * All parts of the route are required except for <specific-metric>
+     * @return {undefined}
+     */
+    _parseRoute() {
+        // always drop first 3 chars. This is already validated in
+        // BackbeatServer._isValidRequest
+        const route = this._route.substring(3);
+
+        // if healthcheck, just skip this
+
+        const parts = route.split('/');
+        if (parts.length < 3 || parts.length > 4) {
+            // leave this._routeDetails undefined
+            return;
+        }
+        this._routeDetails.category = parts[0];
+        this._routeDetails.extension = parts[1];
+        this._routeDetails.site = parts[2];
+        if (parts.length === 4) {
+            this._routeDetails.metric = parts[3];
+        }
+    }
+
+    /**
+     * Get route details object
+     * @return {object} this._routeDetails
+     */
+    getRouteDetails() {
+        return this._routeDetails;
     }
 
     /**

--- a/lib/api/BackbeatServer.js
+++ b/lib/api/BackbeatServer.js
@@ -61,18 +61,18 @@ class BackbeatServer {
                 backbeatRequest);
         }
 
-        if (!this.backbeatAPI.isValidRoute(backbeatRequest.getRoute())
-            || !backbeatRequest.getRoute().startsWith('/_/')) {
-            return this._errorResponse(errors.RouteNotFound
-                .customizeDescription(`path ${backbeatRequest.getRoute()} does `
-                    + 'not exist'), backbeatRequest);
-        }
-
         if (req.method !== 'GET') {
             // So far the API should only be receiving GET requests
             return this._errorResponse(errors.MethodNotAllowed
                 .customizeDescription('invalid http verb'),
                 backbeatRequest);
+        }
+
+        if (!this.backbeatAPI.isValidRoute(backbeatRequest)
+            || !backbeatRequest.getRoute().startsWith('/_/')) {
+            return this._errorResponse(errors.RouteNotFound
+                .customizeDescription(`path ${backbeatRequest.getRoute()} does `
+                    + 'not exist'), backbeatRequest);
         }
 
         return true;
@@ -119,9 +119,32 @@ class BackbeatServer {
         if (this._isValidRequest(req, bbRequest)
         && this._areConditionsOk(bbRequest)) {
             bbRequest.setStatusCode(200);
+            bbRequest.setRoute(bbRequest.getRoute().substring(3));
 
-            const routeDetails = routes.find(route =>
-                route.path === bbRequest.getRoute());
+            /*
+                {
+                    category: 'metrics',
+                    extension: 'crr',
+                    site: 'my-site-name',
+                    metric: 'backlog', (optional)
+                }
+            */
+            // TODO: when adding deep healthcheck, this logic will change
+            let routeDetails;
+            if (bbRequest.getRoute() === 'healthcheck') {
+                routeDetails = routes.find(r => r.category === 'healthcheck');
+            } else {
+                // metrics route
+                const rDetails = bbRequest.getRouteDetails();
+                if (!rDetails.metric) {
+                    // no metric type is specified, so use all route
+                    routeDetails = routes.find(r => r.type === 'all');
+                } else {
+                    routeDetails = routes.find(r => r.type === rDetails.metric);
+                }
+                routeDetails.site = rDetails.site;
+            }
+
             const requestMethod = routeDetails.method;
 
             this.backbeatAPI[requestMethod](routeDetails, (err, data) => {

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -7,27 +7,36 @@ const redisKeys = require('../../extensions/replication/constants').redisKeys;
 
 module.exports = [
     {
-        path: '/_/healthcheck',
+        category: 'healthcheck',
+        type: 'basic',
         method: 'getHealthcheck',
     },
     {
-        path: '/_/metrics/backlog',
+        category: 'metrics',
+        type: 'backlog',
+        extensions: { crr: ['all'] },
         method: 'getBacklog',
         dataPoints: [redisKeys.ops, redisKeys.opsDone, redisKeys.bytes,
             redisKeys.bytesDone],
     },
     {
-        path: '/_/metrics/completions',
+        category: 'metrics',
+        type: 'completions',
+        extensions: { crr: ['all'] },
         method: 'getCompletions',
         dataPoints: [redisKeys.opsDone, redisKeys.bytesDone],
     },
     {
-        path: '/_/metrics/throughput',
+        category: 'metrics',
+        type: 'throughput',
+        extensions: { crr: ['all'] },
         method: 'getThroughput',
         dataPoints: [redisKeys.opsDone, redisKeys.bytesDone],
     },
     {
-        path: '/_/metrics',
+        category: 'metrics',
+        type: 'all',
+        extensions: { crr: ['all'] },
         method: 'getAllMetrics',
         dataPoints: [redisKeys.ops, redisKeys.opsDone, redisKeys.bytes,
             redisKeys.bytesDone],

--- a/lib/models/MetricsModel.js
+++ b/lib/models/MetricsModel.js
@@ -7,16 +7,16 @@ class MetricsModel {
      * @param {Number} bytes - data size in bytes
      * @param {String} extension - extension
      * @param {String} type - operation indicator (queued or processed)
-     * @param {String} bucket - bucket name
+     * @param {String} site - site name
      */
 
-    constructor(ops, bytes, extension, type, bucket) {
+    constructor(ops, bytes, extension, type, site) {
         this._timestamp = Date.now();
         this._ops = ops;
         this._bytes = bytes;
         this._extension = extension;
         this._type = type;
-        this._bucket = bucket;
+        this._site = site;
     }
 
     serialize() {
@@ -26,7 +26,7 @@ class MetricsModel {
             bytes: this._bytes,
             extension: this._extension,
             type: this._type,
-            bucket: this._bucket,
+            site: this._site,
         });
     }
 }

--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -1,6 +1,8 @@
 const async = require('async');
 
 const BackbeatProducer = require('../BackbeatProducer');
+const ReplicationQueuePopulator =
+    require('../../extensions/replication/ReplicationQueuePopulator');
 
 const { metricsExtension, metricsTypeQueued } =
     require('../../extensions/replication/constants');
@@ -380,14 +382,15 @@ class LogReader {
             if (err) {
                 return done(err);
             }
-            // NOTE: Currently on CRR extension is in `this._extensions`
-            this._extensions.forEach(ext => {
-                const extMetrics = ext.getAndResetMetrics();
-                if (Object.keys(extMetrics).length > 0) {
-                    this._mProducer.publishMetrics(extMetrics,
-                        metricsTypeQueued, metricsExtension, () => {});
-                }
-            });
+            // Find the CRR Class extension
+            const crrExtension = this._extensions.find(ext => (
+                ext instanceof ReplicationQueuePopulator
+            ));
+            const extMetrics = crrExtension.getAndResetMetrics();
+            if (Object.keys(extMetrics).length > 0) {
+                this._mProducer.publishMetrics(extMetrics, metricsTypeQueued,
+                    metricsExtension, () => {});
+            }
             return done();
         });
     }

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -61,11 +61,11 @@ class QueuePopulator {
     open(cb) {
         this._loadExtensions();
         async.series([
+            next => this._setupMetricsClients(next),
             next => this._setupZookeeper(() => {
                 this._setupLogSources();
                 next();
             }),
-            next => this._setupMetricsClients(next),
         ], err => {
             if (err) {
                 this.log.error('error starting up queue populator',

--- a/lib/queuePopulator/QueuePopulatorExtension.js
+++ b/lib/queuePopulator/QueuePopulatorExtension.js
@@ -88,20 +88,20 @@ class QueuePopulatorExtension {
     }
 
     /**
-     * Set or accumulate metrics based on bucket
-     * @param {String} bucket - name of bucket
+     * Set or accumulate metrics based on site
+     * @param {String} site - name of site
      * @param {Number} bytes - total bytes to set or increment by
      * @return {undefined}
      */
-    _incrementMetrics(bucket, bytes) {
-        if (!this._metricsStore[bucket]) {
-            this._metricsStore[bucket] = {
+    _incrementMetrics(site, bytes) {
+        if (!this._metricsStore[site]) {
+            this._metricsStore[site] = {
                 ops: 1,
                 bytes,
             };
         } else {
-            this._metricsStore[bucket].ops++;
-            this._metricsStore[bucket].bytes += bytes;
+            this._metricsStore[site].ops++;
+            this._metricsStore[site].bytes += bytes;
         }
     }
 }


### PR DESCRIPTION
Metric routes have been changed to the following format:

`/_/metrics/<extension>/<site>`

or you can add an optional metric type (i.e. backlog, completions, throughput):

`/_/metrics/<extension>/<site>/<type>`

Where `<site>` === the cloud type (i.e. `aws_s3` or `azure`) OR the cloud site name (i.e. `philz-site`). If using a different backend like AWS or Azure, we always only use the type name specified in Federation.

Example routes:
`/_/metrics/crr/all`                         # Gets all CRR metrics for all sites
`/_/metrics/crr/philz-site`             # Gets all CRR metrics for philz-site
`/_/metrics/crr/all/throughput`     # Gets only throughput metrics for all sites
`/_/metrics/crr/azure/backlog`     # Gets only backlog metrics for azure site

Please refer to the following discussion for reasons on route changes. These changes should allow for easier addition of future routes 👍
https://github.com/scality/backbeat/pull/193#discussion_r173317494

Note: For rel/7.4, only site "all" is allowed, and in a future release, we will allow for specifying a site