### PR TITLE
switch to node-rdkafka

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -165,8 +165,9 @@ hasn't been fully replicated to site B when the failure occurred).
 
 * Kafka and Zookeeper are the only dependencies of Backbeat which are licensed
     under Apache License 2.0.
-* `kafka-node` npm module which will be used for the producer/consumer actions
-    is licensed under MIT license.
+* `node-rdkafka` npm module which is be used for the
+    producer/consumer actions and maintained by Blizzard Entertainment
+    is licensed under the MIT license.
 
 ## STATISTICS FOR SLA, METRICS etc
 

--- a/bin/queuePopulator.js
+++ b/bin/queuePopulator.js
@@ -5,6 +5,7 @@ const werelogs = require('werelogs');
 
 const config = require('../conf/Config');
 const zkConfig = config.zookeeper;
+const kafkaConfig = config.kafka;
 const extConfigs = config.extensions;
 const qpConfig = config.queuePopulator;
 const mConfig = config.metrics;
@@ -43,7 +44,8 @@ function queueBatch(queuePopulator, taskState) {
 }
 /* eslint-enable no-param-reassign */
 
-const queuePopulator = new QueuePopulator(zkConfig, qpConfig, mConfig,
+const queuePopulator = new QueuePopulator(zkConfig, kafkaConfig,
+    qpConfig, mConfig,
     rConfig, extConfigs);
 
 async.waterfall([

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -21,7 +21,7 @@ stages:
           haltOnFailure: True
       - ShellCommand:
           name: Npm install
-          command: npm install
+          command: npm install --unsafe-perm
       - ShellCommand:
           name: run static analysis tools on markdown
           command: npm run --silent lint_md

--- a/eve/workers/unit_and_feature_tests/Dockerfile
+++ b/eve/workers/unit_and_feature_tests/Dockerfile
@@ -9,7 +9,7 @@ RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && cat /tmp/*packages.list | xargs apt-get install -y \
     && pip install pip==9.0.1 \
     && rm -rf /var/lib/apt/lists/* \
-    && rm -f /tmp/packages.list
+    && rm -f /tmp/*packages.list
 
 #
 # Add user eve

--- a/eve/workers/unit_and_feature_tests/buildbot_worker_packages.list
+++ b/eve/workers/unit_and_feature_tests/buildbot_worker_packages.list
@@ -7,4 +7,3 @@ python2.7-dev
 python-pip
 software-properties-common
 sudo
-

--- a/extensions/lifecycle/conductor/service.js
+++ b/extensions/lifecycle/conductor/service.js
@@ -6,9 +6,10 @@ const LifecycleConductor = require('./LifecycleConductor');
 
 const config = require('../../../conf/Config');
 const zkConfig = config.zookeeper;
+const kafkaConfig = config.kafka;
 const lcConfig = config.extensions.lifecycle;
 
-const lcConductor = new LifecycleConductor(zkConfig, lcConfig);
+const lcConductor = new LifecycleConductor(zkConfig, kafkaConfig, lcConfig);
 
 werelogs.configure({ level: config.log.logLevel,
                      dump: config.log.dumpLevel });

--- a/extensions/lifecycle/lifecycleConsumer/task.js
+++ b/extensions/lifecycle/lifecycleConsumer/task.js
@@ -5,13 +5,14 @@ const LifecycleConsumer = require('./LifecycleConsumer');
 
 const config = require('../../../conf/Config');
 const zkConfig = config.zookeeper;
+const kafkaConfig = config.kafka;
 const lcConfig = config.extensions.lifecycle;
 const s3Config = config.s3;
 const authConfig = config.auth;
 const transport = config.transport;
 
 const lifecycleConsumer = new LifecycleConsumer(
-    zkConfig, lcConfig, s3Config, authConfig, transport);
+    zkConfig, kafkaConfig, lcConfig, s3Config, authConfig, transport);
 
 werelogs.configure({ level: config.log.logLevel,
     dump: config.log.dumpLevel });

--- a/extensions/lifecycle/lifecycleProducer/task.js
+++ b/extensions/lifecycle/lifecycleProducer/task.js
@@ -1,13 +1,14 @@
 'use strict'; // eslint-disable-line
 const werelogs = require('werelogs');
 const LifecycleProducer = require('./LifecycleProducer');
-const { zookeeper, extensions, s3, auth, transport, log } =
+const { zookeeper, kafka, extensions, s3, auth, transport, log } =
     require('../../../conf/Config');
 
 werelogs.configure({ level: log.logLevel,
                      dump: log.dumpLevel });
 
 const lifecycleProducer =
-    new LifecycleProducer(zookeeper, extensions.lifecycle, s3, auth, transport);
+    new LifecycleProducer(zookeeper, kafka, extensions.lifecycle,
+                          s3, auth, transport);
 
 lifecycleProducer.start();

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -27,15 +27,6 @@ const {
     metricsTypeProcessed,
 } = require('../constants');
 
-/**
-* Given that the largest object JSON from S3 is about 1.6 MB and adding some
-* padding to it, Backbeat replication topic is currently setup with a config
-* max.message.bytes.limit to 5MB. Consumers need to update their fetchMaxBytes
-* to get atleast 5MB put in the Kafka topic, adding a little extra bytes of
-* padding for approximation.
-*/
-const CONSUMER_FETCH_MAX_BYTES = 5000020;
-
 class QueueProcessor extends EventEmitter {
 
     /**
@@ -44,9 +35,9 @@ class QueueProcessor extends EventEmitter {
      * entries to a target S3 endpoint.
      *
      * @constructor
-     * @param {Object} zkConfig - zookeeper configuration object
-     * @param {String} zkConfig.connectionString - zookeeper connection string
-     *   as "host:port[/chroot]"
+     * @param {Object} kafkaConfig - kafka configuration object
+     * @param {string} kafkaConfig.hosts - list of kafka brokers
+     *   as "host:port[,host:port...]"
      * @param {Object} sourceConfig - source S3 configuration
      * @param {Object} sourceConfig.s3 - s3 endpoint configuration object
      * @param {Object} sourceConfig.auth - authentication info on source
@@ -64,10 +55,10 @@ class QueueProcessor extends EventEmitter {
      * @param {String} site - site name
      * @param {MetricsProducer} mProducer - instance of metrics producer
      */
-    constructor(zkConfig, sourceConfig, destConfig, repConfig, site,
+    constructor(kafkaConfig, sourceConfig, destConfig, repConfig, site,
     mProducer) {
         super();
-        this.zkConfig = zkConfig;
+        this.kafkaConfig = kafkaConfig;
         this.sourceConfig = sourceConfig;
         this.destConfig = destConfig;
         this.repConfig = repConfig;
@@ -167,7 +158,7 @@ class QueueProcessor extends EventEmitter {
 
     _setupProducer(done) {
         const producer = new BackbeatProducer({
-            zookeeper: { connectionString: this.zkConfig.connectionString },
+            kafka: { hosts: this.kafkaConfig.hosts },
             topic: this.repConfig.replicationStatusTopic,
         });
         producer.once('error', done);
@@ -242,37 +233,38 @@ class QueueProcessor extends EventEmitter {
                                  { error: err.message });
                 return undefined;
             }
-            if (!(options && options.disableConsumer)) {
-                const groupId =
-                    `${this.repConfig.queueProcessor.groupId}-${this.site}`;
-                this._consumer = new BackbeatConsumer({
-                    zookeeper: {
-                        connectionString: this.zkConfig.connectionString,
-                    },
-                    topic: this.repConfig.topic,
-                    groupId,
-                    concurrency: this.repConfig.queueProcessor.concurrency,
-                    queueProcessor: this.processKafkaEntry.bind(this),
-                    fetchMaxBytes: CONSUMER_FETCH_MAX_BYTES,
-                });
-                this._consumer.on('error', () => {});
+            if (options && options.disableConsumer) {
+                this.emit('ready');
+                return undefined;
+            }
+            const groupId =
+                `${this.repConfig.queueProcessor.groupId}-${this.site}`;
+            this._consumer = new BackbeatConsumer({
+                kafka: { hosts: this.kafkaConfig.hosts },
+                topic: this.repConfig.topic,
+                groupId,
+                concurrency: this.repConfig.queueProcessor.concurrency,
+                queueProcessor: this.processKafkaEntry.bind(this),
+            });
+            this._consumer.on('error', () => {});
+            this._consumer.on('ready', () => {
                 this._consumer.subscribe();
-
-                this._consumer.on('metrics', data => {
-                    // i.e. data = { my-bucket: { ops: 1, bytes: 124 } }
-                    this._mProducer.publishMetrics(data, metricsTypeProcessed,
-                        metricsExtension, err => {
-                            this.logger.trace('error occurred in publishing ' +
+                this.logger.info('queue processor is ready to consume ' +
+                                 'replication entries');
+                this.emit('ready');
+            });
+            this._consumer.on('metrics', data => {
+                // i.e. data = { my-bucket: { ops: 1, bytes: 124 } }
+                this._mProducer.publishMetrics(data, metricsTypeProcessed,
+                    metricsExtension, err => {
+                        this.logger.trace('error occurred in publishing ' +
                             'metrics', {
                                 error: err,
                                 method: 'QueueProcessor.start',
                             });
-                        });
-                });
-            }
-            this.logger.info('queue processor is ready to consume ' +
-                             'replication entries');
-            return this.emit('ready');
+                    });
+            });
+            return undefined;
         });
     }
 

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -6,7 +6,7 @@ const QueueProcessor = require('./QueueProcessor');
 const MetricsProducer = require('../../../lib/MetricsProducer');
 
 const config = require('../../../conf/Config');
-const zkConfig = config.zookeeper;
+const kafkaConfig = config.kafka;
 const repConfig = config.extensions.replication;
 const sourceConfig = repConfig.source;
 const mConfig = config.metrics;
@@ -26,7 +26,7 @@ const log = new werelogs.Logger('Backbeat:QueueProcessor:task');
 werelogs.configure({ level: config.log.logLevel,
     dump: config.log.dumpLevel });
 
-const metricsProducer = new MetricsProducer(zkConfig, mConfig);
+const metricsProducer = new MetricsProducer(kafkaConfig, mConfig);
 metricsProducer.setupProducer(err => {
     if (err) {
         log.error('error starting metrics producer for queue processor', {
@@ -35,7 +35,7 @@ metricsProducer.setupProducer(err => {
         });
         return undefined;
     }
-    const queueProcessor = new QueueProcessor(zkConfig, sourceConfig,
+    const queueProcessor = new QueueProcessor(kafkaConfig, sourceConfig,
         destConfig, repConfig, site, metricsProducer);
     return queueProcessor.start();
 });

--- a/extensions/replication/replicationStatusProcessor/task.js
+++ b/extensions/replication/replicationStatusProcessor/task.js
@@ -5,12 +5,12 @@ const werelogs = require('werelogs');
 const ReplicationStatusProcessor = require('./ReplicationStatusProcessor');
 
 const config = require('../../../conf/Config');
-const zkConfig = config.zookeeper;
+const kafkaConfig = config.kafka;
 const repConfig = config.extensions.replication;
 const sourceConfig = repConfig.source;
 
 const replicationStatusProcessor =
-          new ReplicationStatusProcessor(zkConfig, sourceConfig, repConfig);
+          new ReplicationStatusProcessor(kafkaConfig, sourceConfig, repConfig);
 
 werelogs.configure({ level: config.log.logLevel,
                      dump: config.log.dumpLevel });

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -1,13 +1,11 @@
 const { EventEmitter } = require('events');
-const { ConsumerGroup } = require('kafka-node');
-const kafkaLogging = require('kafka-node/logging');
+const kafka = require('node-rdkafka');
 const assert = require('assert');
 const async = require('async');
 const joi = require('joi');
 
 const BackbeatProducer = require('./BackbeatProducer');
 const Logger = require('werelogs').Logger;
-kafkaLogging.setLoggerProvider(new Logger('Consumer'));
 
 const QueueEntry = require('./models/QueueEntry');
 
@@ -28,72 +26,108 @@ class BackbeatConsumer extends EventEmitter {
      * @param {string} config.groupId - consumer group id. Messages are
      * distributed among multiple consumers belonging to the same group
      * @param {Object} [config.zookeeper] - zookeeper endpoint config
-     * @param {string} config.zookeeper.connectionString - zookeeper connection
-     * string as "host:port[/chroot]"
-     * @param {boolean} [config.ssl] - ssl enabled if ssl === true
+     * @param {string} [config.zookeeper.connectionString] - zookeeper
+     * connection string as "host:port[/chroot]"
+     * @param {Object} config.kafka - kafka connection config
+     * @param {string} config.kafka.hosts - kafka hosts list
+     * as "host:port[,host:port...]"
      * @param {string} [config.fromOffset] - valid values latest/earliest/none
      * @param {number} [config.concurrency] - represents the number of entries
      * that can be processed in parallel
      * @param {number} [config.fetchMaxBytes] - max. bytes to fetch in a
      * fetch loop
-     * @param {boolean} [config.createConsumer=true] - false to defer
-     * creation of consumer (TEST ONLY, set to false before calling
-     * {@link bootstrap()}, because for reliable behavior the consumer
-     * has to be created after the producer - to ensure the topic is
-     * created)
+     * @param {boolean} [config.bootstrap=false] - TEST ONLY: true to
+     * bootstrap the consumer with test messages until it starts
+     * consuming them
      */
     constructor(config) {
         super();
 
         const configJoi = {
             zookeeper: {
-                connectionString: joi.string().required(),
+                connectionString: joi.string(),
             },
-            ssl: joi.boolean(),
+            kafka: joi.object({
+                hosts: joi.string().required(),
+            }).required(),
             topic: joi.string().required(),
             groupId: joi.string().required(),
             queueProcessor: joi.func(),
             fromOffset: joi.alternatives().try('latest', 'earliest', 'none'),
+            autoCommit: joi.boolean().default(false),
             concurrency: joi.number().greater(0).default(CONCURRENCY_DEFAULT),
             fetchMaxBytes: joi.number(),
-            createConsumer: joi.boolean().default(true),
+            bootstrap: joi.boolean().default(false),
         };
         const validConfig = joi.attempt(config, configJoi,
                                         'invalid config params');
 
-        const { zookeeper, ssl, topic, groupId, queueProcessor,
-                fromOffset, concurrency, fetchMaxBytes,
-                createConsumer } = validConfig;
+        const { zookeeper, kafka, topic, groupId, queueProcessor,
+                fromOffset, autoCommit, concurrency, fetchMaxBytes,
+                bootstrap } = validConfig;
 
-        this._zookeeperEndpoint = zookeeper.connectionString;
-        this._ssl = ssl;
+        this._zookeeperEndpoint = zookeeper && zookeeper.connectionString;
+        this._kafkaHosts = kafka.hosts;
         this._fromOffset = fromOffset;
+        this._autoCommit = autoCommit;
         this._log = new Logger(CLIENT_ID);
         this._topic = topic;
         this._groupId = groupId;
         this._queueProcessor = queueProcessor;
         this._concurrency = concurrency;
         this._fetchMaxBytes = fetchMaxBytes;
+        this._bootstrap = bootstrap;
+        this._processingQueue = null;
         this._messagesConsumed = 0;
         this._consumer = null;
-        if (createConsumer) {
-            this._initConsumer();
-        }
+        this._consumerReady = false;
+        this._bootstrapping = false;
         // metrics - consumption
         this._metricsStore = {};
+        this._init();
         return this;
     }
 
+    _init() {
+        if (this._bootstrap) {
+            this._consumerReady = true;
+            process.nextTick(this._checkIfReady.bind(this));
+        } else {
+            this._initConsumer();
+        }
+    }
+
     _initConsumer() {
-        this._consumer = new ConsumerGroup({
-            host: this._zookeeperEndpoint,
-            ssl: this._ssl,
-            groupId: this._groupId,
-            fromOffset: this._fromOffset,
-            autoCommit: false,
-            fetchMaxBytes: this._fetchMaxBytes,
-        }, this._topic);
-        this._consumer.once('connect', () => this.emit('connect'));
+        const consumerParams = {
+            'metadata.broker.list': this._kafkaHosts,
+            'group.id': this._groupId,
+            'enable.auto.commit': this._autoCommit,
+            'offset_commit_cb': this._onOffsetCommit.bind(this),
+        };
+        if (this._fromOffset !== undefined) {
+            consumerParams['auto.offset.reset'] = this._fromOffset;
+        }
+        if (this._fetchMaxBytes !== undefined) {
+            consumerParams['fetch.message.max.bytes'] = this._fetchMaxBytes;
+        }
+        this._consumer = new kafka.KafkaConsumer(consumerParams);
+        this._consumer.connect();
+        return this._consumer.once('ready', () => {
+            this._consumerReady = true;
+            this._checkIfReady();
+        });
+    }
+
+    _checkIfReady() {
+        if (this._consumerReady) {
+            if (this._bootstrap) {
+                if (!this._bootstrapping) {
+                    this._bootstrapConsumer();
+                }
+            } else {
+                this.emit('ready');
+            }
+        }
     }
 
     /**
@@ -106,134 +140,201 @@ class BackbeatConsumer extends EventEmitter {
     * @return {this} current instance
     */
     subscribe() {
-        const q = async.queue(this._queueProcessor, this._concurrency);
-        let partition = null;
-        let offset = null;
-        // consume a message in the fetch loop
-        this._consumer.on('message', entry => {
-            partition = entry.partition;
-            offset = entry.offset;
-            this._messagesConsumed++;
-            this._consumer.pause();
-            q.push(entry, err => {
-                this._log.debug('finished processing of consumed entry', {
-                    method: 'BackbeatConsumer.subscribe',
-                    partition,
-                    offset,
-                });
-                if (err) {
-                    this._log.error('error processing an entry', {
-                        error: err,
-                        method: 'BackbeatConsumer.subscribe',
-                        partition,
-                        offset,
-                    });
-                    this.emit('error', err, entry);
-                } else if (entry.topic === CRR_TOPIC) {
-                    const qEntry = QueueEntry.createFromKafkaEntry(entry);
-                    if (!qEntry.error && qEntry.getReducedLocations) {
-                        const locations = qEntry.getReducedLocations();
-                        const bytes = locations.reduce((sum, item) =>
-                            sum + item.size, 0);
+        this._consumer.subscribe([this._topic]);
 
-                        if (!this._metricsStore[qEntry.bucket]) {
-                            this._metricsStore[qEntry.bucket] = {
-                                ops: 1,
-                                bytes,
-                            };
-                        } else {
-                            this._metricsStore[qEntry.bucket].ops++;
-                            this._metricsStore[qEntry.bucket].bytes += bytes;
-                        }
-                    }
-                }
-            });
-        });
+        this._processingQueue = async.queue(
+            this._queueProcessor, this._concurrency);
+        // when the task queue is empty, commit offset for all
+        // consumed partitions and try consuming new messages right away
+        this._processingQueue.drain = () => {
+            // when auto-commit is set we don't have to commit
+            // explicitly, so let's not do it for performance reasons
+            if (!this._autoCommit) {
+                this._consumer.commit();
+            }
+            this.emit('consumed', this._messagesConsumed);
+            this._messagesConsumed = 0;
 
-        // commit offset and resume fetch loop when the task queue is empty
-        q.drain = () => {
-            const count = this._messagesConsumed;
-            this._consumer.sendOffsetCommitRequest([{
-                topic: this._topic,
-                partition, // default 0
-                offset,
-                metadata: 'm', //default 'm'
-            }], () => {
-                this.emit('consumed', count);
-                this._messagesConsumed = 0;
+            this.emit('metrics', this._metricsStore);
+            this._metricsStore = {};
 
-                this.emit('metrics', this._metricsStore);
-                this._metricsStore = {};
-
-                this._consumer.resume();
-            });
+            this._tryConsume();
         };
 
-        this._consumer.on('error', error => {
-            this._log.error('error subscribing to topic', {
-                error,
-                method: 'BackbeatConsumer.subscribe',
-                topic: this._topic,
-                partition: this._partition,
-            });
-            this.emit('error', error);
+        this._consumer.on('event.error', error => {
+            // This is a bit hacky: the "broker transport failure"
+            // error occurs when the kafka broker reaps the idle
+            // connections every few minutes, and librdkafka handles
+            // reconnection automatically anyway, so we ignore those
+            // harmless errors (moreover with the current
+            // implementation there's no way to access the original
+            // error code, so we match the message instead).
+            if (!['broker transport failure',
+                  'all broker connections are down']
+                .includes(error.message)) {
+                this._log.error('consumer error', {
+                    error,
+                    topic: this._topic,
+                });
+                this.emit('error', error);
+            }
         });
 
+        // trigger initial consumption
+        this._tryConsume();
         return this;
+    }
+
+    _tryConsume() {
+        // use non-flowing mode of consumption to add some flow
+        // control: explicit consumption of messages is required,
+        // needs explicit polling until new messages become available.
+        this._consumer.consume(this._concurrency, (err, entries) => {
+            if (!err) {
+                entries.forEach(entry => {
+                    this._messagesConsumed++;
+                    this._processingQueue.push(
+                        entry, err => this._onEntryProcessingDone(err, entry));
+                });
+            }
+            if (err || entries.length === 0) {
+                // retry later to fetch new messages in case no one is
+                // available yet in the message queue
+                setTimeout(this._tryConsume.bind(this), 1000);
+            }
+        });
+    }
+
+    _onEntryProcessingDone(err, entry) {
+        const { topic, partition, offset, key, timestamp } = entry;
+        this._log.debug('finished processing of consumed entry', {
+            method: 'BackbeatConsumer.subscribe',
+            partition,
+            offset,
+        });
+        if (err) {
+            this._log.error('error processing an entry', {
+                error: err,
+                entry: { topic, partition, offset, key, timestamp },
+            });
+            this.emit('error', err, entry);
+        } else if (entry.topic === CRR_TOPIC) {
+            const qEntry = QueueEntry.createFromKafkaEntry(entry);
+            if (!qEntry.error && qEntry.getReducedLocations) {
+                const locations = qEntry.getReducedLocations();
+                const bytes = locations.reduce((sum, item) =>
+                                               sum + item.size, 0);
+
+                if (!this._metricsStore[qEntry.bucket]) {
+                    this._metricsStore[qEntry.bucket] = {
+                        ops: 1,
+                        bytes,
+                    };
+                } else {
+                    this._metricsStore[qEntry.bucket].ops++;
+                    this._metricsStore[qEntry.bucket].bytes += bytes;
+                }
+            }
+        }
+    }
+
+
+    _onOffsetCommit(err, topicPartitions) {
+        if (err) {
+            // NO_OFFSET is a "soft error" meaning that the same
+            // offset is already committed, which occurs because of
+            // auto-commit (e.g. if nothing was done by the producer
+            // on this partition since last commit).
+            if (err === kafka.CODES.ERRORS.ERR__NO_OFFSET) {
+                return undefined;
+            }
+            this._log.error('error committing offset to kafka',
+                            { errorCode: err });
+            return undefined;
+        }
+        this._log.debug('commit offsets callback',
+                        { topicPartitions });
+        return undefined;
+    }
+
+    /**
+     * get metadata from kafka topics
+     * @param {object} params - call params
+     * @param {string} params.topic - topic name
+     * @param {number} params.timeout - timeout for the request
+     * @param {function} cb - callback: cb(err, response)
+     * @return {undefined}
+     */
+    getMetadata(params, cb) {
+        this._consumer.getMetadata(params, cb);
     }
 
     /**
      * Bootstrap consumer by periodically sending bootstrap messages
      * and wait until it's receiving newly produced messages in a
-     * timely fashion. The constructor must have been called with
-     * "createConsumer" parameter set to false.
-     *
-     * ONLY USE FOR TESTING PURPOSE
-     *
-     * @param {function} cb - callback when consumer is effectively
-     * receiving newly produced messages
+     * timely fashion.
      * @return {undefined}
      */
-    bootstrap(cb) {
+    _bootstrapConsumer() {
+        const self = this;
         let lastBootstrapId;
         let producer; // eslint-disable-line prefer-const
-        let timer; // eslint-disable-line prefer-const
-        function onBootstrapMessage(message) {
-            const bootstrapId = JSON.parse(message.value).bootstrapId;
-            if (bootstrapId) {
-                this._log.info('bootstraping backbeat consumer: ' +
-                               'received bootstrap message',
-                               { bootstrapId });
-                if (bootstrapId === lastBootstrapId) {
-                    this._log.info('backbeat consumer is bootstrapped');
-                    clearInterval(timer);
-                    this._consumer.removeListener('message',
-                                                  onBootstrapMessage);
-                    producer.close(cb);
-                }
+        let producerTimer; // eslint-disable-line prefer-const
+        let consumerTimer; // eslint-disable-line prefer-const
+        function consumeCb(err, messages) {
+            if (err) {
+                return undefined;
             }
+            messages.forEach(message => {
+                const bootstrapId = JSON.parse(message.value).bootstrapId;
+                if (bootstrapId) {
+                    self._log.info('bootstraping backbeat consumer: ' +
+                                   'received bootstrap message',
+                                   { bootstrapId });
+                    if (bootstrapId === lastBootstrapId) {
+                        self._log.info('backbeat consumer is bootstrapped');
+                        clearInterval(producerTimer);
+                        clearInterval(consumerTimer);
+                        self._consumer.commit();
+                        self._consumer.unsubscribe();
+                        producer.close(() => {
+                            self._bootstrapping = false;
+                            self.emit('ready');
+                        });
+                    }
+                }
+            });
+            return undefined;
         }
         assert.strictEqual(this._consumer, null);
         producer = new BackbeatProducer({
-            zookeeper: { connectionString: 'localhost:2181' },
+            kafka: { hosts: this._kafkaHosts },
             topic: this._topic,
         });
-        timer = setInterval(() => {
-            lastBootstrapId = `${Math.round(Math.random() * 1000000)}`;
-            const contents = `{"bootstrapId":"${lastBootstrapId}"}`;
-            this._log.info('bootstraping backbeat consumer: ' +
-                           'sending bootstrap message',
-                           { contents });
-            producer.send([{ key: 'bootstrap',
-                             message: contents }],
-                          () => {});
-            if (!this._consumer) {
-                setTimeout(() => {
-                    this._initConsumer();
-                    this._consumer.on('message', onBootstrapMessage.bind(this));
-                }, 500);
-            }
-        }, 1000);
+        producer.on('ready', () => {
+            producerTimer = setInterval(() => {
+                lastBootstrapId = `${Math.round(Math.random() * 1000000)}`;
+                const contents = `{"bootstrapId":"${lastBootstrapId}"}`;
+                this._log.info('bootstraping backbeat consumer: ' +
+                               'sending bootstrap message',
+                               { contents });
+                producer.send([{ key: 'bootstrap',
+                                 message: contents }],
+                              () => {});
+                if (!this._consumer) {
+                    setTimeout(() => {
+                        this._bootstrapping = true;
+                        this._initConsumer();
+                        this._consumer.on('ready', () => {
+                            this._consumer.subscribe([this._topic]);
+                            consumerTimer = setInterval(() => {
+                                this._consumer.consume(1, consumeCb);
+                            }, 200);
+                        });
+                    }, 500);
+                }
+            }, 5000);
+        });
     }
 
     /**
@@ -242,7 +343,14 @@ class BackbeatConsumer extends EventEmitter {
     * @return {undefined}
     */
     close(cb) {
-        this._consumer.close(true, cb);
+        if (this._consumer) {
+            this._consumer.commit();
+            this._consumer.unsubscribe();
+            this._consumer.disconnect();
+            this._consumer.on('disconnected', () => cb());
+        } else {
+            process.nextTick(cb);
+        }
     }
 }
 

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -1,34 +1,17 @@
 const { EventEmitter } = require('events');
-const { Client, KeyedMessage, Producer } = require('kafka-node');
+const { Producer } = require('node-rdkafka');
 const joi = require('joi');
 
 const errors = require('arsenal').errors;
+const jsutil = require('arsenal').jsutil;
 const Logger = require('werelogs').Logger;
 
-/**
-* compression params define compression for log compaction in topics. It is
-* not recommended to enable by default as the compression options tend to
-* consume a lot of CPU.
-*/
-const NO_COMPRESSION = 0;
-const GZIP_COMPRESSION = 1; // eslint-disable-line
-const SNAPPY_COMPRESSION = 2; // eslint-disable-line
-
-// time in ms. to wait for acks from Kafka
-const ACK_TIMEOUT = 100;
-// default (dumb) kafka partitioning - always goes to partition 0
-// const DEFAULT_PARTITIONER = 0;
-// decent choice to spread messages across partitions, but not as fair
-// as cyclic partitioner
-// const RANDOM_PARTITIONER = 1;
-// the cyclic partitioner guarantees fair dispersion across partitions
-const CYCLIC_PARTITIONER = 2;
-// use keyed-message mechanism for partitioning by default. This lets Kafka
-// choose a partition based on the key and ensures entries with the same key
-// ends up in the same partition
-const KEYED_PARTITIONER = 3;
 // waits for an ack for messages
 const REQUIRE_ACKS = 1;
+// time in ms. to wait for acks from Kafka
+const ACK_TIMEOUT = 5000;
+// max time in ms. to wait for flush to complete
+const FLUSH_TIMEOUT = 5000;
 
 const CLIENT_ID = 'BackbeatProducer';
 
@@ -38,86 +21,104 @@ class BackbeatProducer extends EventEmitter {
     * constructor
     * @param {Object} config - config
     * @param {string} config.topic - Kafka topic to write to
-    * @param {number} [config.partition] - partition in a topic to write to
     * @param {boolean} [config.keyedPartitioner=true] - if no
     * partition is set, tell whether the producer should use keyed
     * partitioning or the default partitioning of the kafka client
-    * @param {Object} [config.zookeeper] - zookeeper endpoint config
-    * @param {string} config.zookeeper.connectionString - zookeeper connection
-    * string as "host:port[/chroot]"
+    * @param {Object} config.kafka - kafka connection config
+    * @param {string} config.kafka.hosts - kafka hosts list
+    * as "host:port[,host:port...]"
     */
     constructor(config) {
         super();
 
         const configJoi = {
-            zookeeper: {
-                connectionString: joi.string().required(),
-            },
-            sslOptions: joi.object(),
+            kafka: joi.object({
+                hosts: joi.string().required(),
+            }).required(),
             topic: joi.string().required(),
-            partition: joi.number(),
             keyedPartitioner: joi.boolean().default(true),
+            pollIntervalMs: joi.number().default(2000),
         };
         const validConfig = joi.attempt(config, configJoi,
                                         'invalid config params');
-        const { zookeeper, sslOptions, topic, partition,
-                keyedPartitioner } = validConfig;
+        const { kafka, topic, pollIntervalMs } = validConfig;
 
-        this._partition = partition;
-        this._zookeeperEndpoint = zookeeper.connectionString;
+        this._kafkaHosts = kafka.hosts;
         this._log = new Logger(CLIENT_ID);
         this._topic = topic;
         this._ready = false;
-        // create zookeeper client
-        this._client = new Client(this._zookeeperEndpoint, CLIENT_ID,
-            { sslOptions });
+
         // create a new producer instance
-        this._producer = new Producer(this._client, {
-            // configuration for when to consider a message as acknowledged
-            requireAcks: REQUIRE_ACKS,
-            // amount of time in ms. to wait for all acks
-            ackTimeoutMs: ACK_TIMEOUT,
-            // uses keyed-message partitioner to ensure messages with the same
-            // key end up in one partition
-            partitionerType: partition === undefined && keyedPartitioner ?
-                KEYED_PARTITIONER : CYCLIC_PARTITIONER,
-            // controls compression of the message
-            attributes: NO_COMPRESSION,
+        this._producer = new Producer({
+            'metadata.broker.list': this._kafkaHosts,
+            'dr_cb': true,
+        }, {
+            'request.required.acks': REQUIRE_ACKS,
+            'request.timeout.ms': ACK_TIMEOUT,
         });
         this._ready = false;
+        this._producer.connect();
         this._producer.on('ready', () => {
             this._ready = true;
             this.emit('ready');
+            this._producer.setPollInterval(pollIntervalMs);
+            this._producer.on('delivery-report',
+                              this._onDeliveryReport.bind(this));
         });
-        this._producer.on('error', error => {
-            this._log.error('error with producer', {
-                config,
+        this._producer.on('event.error', error => {
+            // This is a bit hacky: the "broker transport failure"
+            // error occurs when the kafka broker reaps the idle
+            // connections every few minutes, and librdkafka handles
+            // reconnection automatically anyway, so we ignore those
+            // harmless errors (moreover with the current
+            // implementation there's no way to access the original
+            // error code, so we match the message instead).
+            if (!['broker transport failure',
+                  'all broker connections are down']
+                .includes(error.message)) {
+                this._log.error('error with producer', {
+                    config,
+                    error: error.message,
+                    method: 'BackbeatProducer.constructor',
+                });
+                this.emit('error', error);
+            }
+        });
+        return this;
+    }
+
+    /**
+     * get metadata from kafka topics
+     * @param {object} params - call params
+     * @param {string} params.topic - topic name
+     * @param {number} params.timeout - timeout for the request
+     * @param {function} cb - callback: cb(err, response)
+     * @return {undefined}
+     */
+    getMetadata(params, cb) {
+        this._producer.getMetadata(params, cb);
+    }
+
+    _onDeliveryReport(error, report) {
+        const sendCtx = report.opaque;
+        const cbOnce = sendCtx.cbOnce;
+        --sendCtx.pendingReportsCount;
+        if (error) {
+            this._log.error('error in delivery report retrieval', {
                 error: error.message,
-                method: 'BackbeatProducer.constructor',
+                method: 'BackbeatProducer._onDeliveryReport',
             });
             this.emit('error', error);
-        });
-        return this;
-    }
-
-    /**
-    * get external modules kafka client
-    * @return {kafka-node.Client} - external kafka client instance
-    */
-    getKafkaClient() {
-        return this._client;
-    }
-
-    /**
-    * create topic - works only when auto.create.topics.enable=true for the
-    * Kafka server. It sends a metadata request to the server which will create
-    * the topic
-    * @param {callback} cb - cb(err, data)
-    * @return {this} - current instance
-    */
-    createTopic(cb) {
-        this._producer.createTopics([this._topic], cb);
-        return this;
+            return cbOnce(error);
+        }
+        this._log.debug('delivery report received', { report });
+        if (sendCtx.pendingReportsCount === 0) {
+            // all delivery reports received (if errors occurred, the
+            // callback will have been called earlier so this will be
+            // a no-op)
+            cbOnce();
+        }
+        return undefined;
     }
 
     /**
@@ -147,39 +148,29 @@ class BackbeatProducer extends EventEmitter {
                 cb(errors.InternalError);
             });
         }
-        const payload = entries.map(item => {
-            if (this._partition !== undefined) {
-                return {
-                    topic: this._topic,
-                    messages: item.message,
-                    partition: this._partition,
-                };
-            }
-            if (item.key !== undefined) {
-                return {
-                    topic: this._topic,
-                    messages: new KeyedMessage(item.key, item.message),
-                    key: item.key,
-                };
-            }
-            return {
-                topic: this._topic,
-                messages: item.message,
-            };
-        });
-        this._client.refreshMetadata([this._topic], () =>
-            this._producer.send(payload, err => {
-                if (err) {
-                    this._log.error('error publishing entries', {
-                        error: err,
-                        method: 'BackbeatProducer.send',
-                    });
-                    return cb(errors.InternalError.
-                        customizeDescription(err.message));
-                }
-                return cb();
-            })
-        );
+        if (entries.length === 0) {
+            return process.nextTick(cb);
+        }
+        const sendCtx = { cbOnce: jsutil.once(cb),
+                          pendingReportsCount: entries.length };
+        try {
+            entries.forEach(item => this._producer.produce(
+                this._topic,
+                null, // partition
+                new Buffer(item.message), // value
+                item.key, // key (for keyed partitioning)
+                Date.now(), // timestamp
+                sendCtx // opaque
+            ));
+        } catch (err) {
+            this._log.error('error publishing entries', {
+                error: err,
+                method: 'BackbeatProducer.send',
+            });
+            return process.nextTick(
+                () => sendCtx.cbOnce(errors.InternalError.
+                                     customizeDescription(err.message)));
+        }
         return this;
     }
 
@@ -189,9 +180,16 @@ class BackbeatProducer extends EventEmitter {
     * @return {object} this - current class instance
     */
     close(cb) {
-        this._producer.close(() => {
+        this._producer.flush(FLUSH_TIMEOUT, err => {
             this._ready = false;
-            cb();
+            if (err) {
+                this._log.error('error flushing entries', {
+                    error: err,
+                    method: 'BackbeatProducer.close',
+                });
+            }
+            this._producer.disconnect();
+            return cb(err);
         });
         return this;
     }

--- a/lib/MetricsConsumer.js
+++ b/lib/MetricsConsumer.js
@@ -22,13 +22,13 @@ class MetricsConsumer {
      * @param {number} rConfig.port - redis port
      * @param {object} mConfig - metrics configurations
      * @param {string} mConfig.topic - metrics topic name
-     * @param {object} zkConfig - zookeeper configurations
-     * @param {string} zkConfig.connectionString - zookeeper connection string
+     * @param {object} kafkaConfig - kafka configurations
+     * @param {string} kafkaConfig.hosts - kafka hosts
      *   as "host:port[/chroot]"
      */
-    constructor(rConfig, mConfig, zkConfig) {
+    constructor(rConfig, mConfig, kafkaConfig) {
         this.mConfig = mConfig;
-        this.zkConfig = zkConfig;
+        this.kafkaConfig = kafkaConfig;
 
         this.logger = new Logger('Backbeat:MetricsConsumer');
 
@@ -39,7 +39,7 @@ class MetricsConsumer {
 
     start() {
         const consumer = new BackbeatConsumer({
-            zookeeper: { connectionString: this.zkConfig.connectionString },
+            kafka: { hosts: this.kafkaConfig.hosts },
             topic: this.mConfig.topic,
             groupId: 'backbeat-metrics-group',
             concurrency: CONCURRENCY,
@@ -47,9 +47,10 @@ class MetricsConsumer {
             fetchMaxBytes: CONSUMER_FETCH_MAX_BYTES,
         });
         consumer.on('error', () => {});
-        consumer.subscribe();
-
-        this.logger.info('metrics processor is ready to consume entries');
+        consumer.on('ready', () => {
+            consumer.subscribe();
+            this.logger.info('metrics processor is ready to consume entries');
+        });
     }
 
     processKafkaEntry(kafkaEntry, done) {

--- a/lib/MetricsProducer.js
+++ b/lib/MetricsProducer.js
@@ -9,11 +9,11 @@ const MetricsModel = require('./models/MetricsModel');
 class MetricsProducer {
     /**
     * @constructor
-    * @param {Object} zkConfig - zookeeper configurations
+     * @param {Object} kafkaConfig - kafka connection config
     * @param {Object} mConfig - metrics configurations
     */
-    constructor(zkConfig, mConfig) {
-        this._zkConfig = zkConfig;
+    constructor(kafkaConfig, mConfig) {
+        this._kafkaConfig = kafkaConfig;
         this._topic = mConfig.topic;
 
         this._producer = null;
@@ -22,7 +22,7 @@ class MetricsProducer {
 
     setupProducer(done) {
         const producer = new BackbeatProducer({
-            zookeeper: { connectionString: this._zkConfig.connectionString },
+            kafka: { hosts: this._kafkaConfig.hosts },
             topic: this._topic,
         });
         producer.once('error', done);

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -29,6 +29,7 @@ class BackbeatAPI {
      */
     constructor(config, logger, optional) {
         this._zkConfig = config.zookeeper;
+        this._kafkaConfig = config.kafka;
         this._repConfig = config.extensions.replication;
         this._crrTopic = this._repConfig.topic;
         this._crrStatusTopic = this._repConfig.replicationStatusTopic;
@@ -334,7 +335,7 @@ class BackbeatAPI {
 
     _setProducer(topic, cb) {
         const producer = new BackbeatProducer({
-            zookeeper: { connectionString: this._zkConfig.connectionString },
+            kafka: { hosts: this._kafkaConfig.hosts },
             topic,
         });
 

--- a/lib/api/Healthcheck.js
+++ b/lib/api/Healthcheck.js
@@ -45,19 +45,18 @@ class Healthcheck {
 
     /**
      * Checks health of in-sync replicas
-     * @param {object} md - topic metadata object
+     * @param {object} topicMd - topic metadata object
      * @return {string} 'ok' if ISR is healthy, else 'error'
      */
-    _checkISRHealth(md) {
-        // eslint-disable-next-line consistent-return
-        const keys = Object.keys(md);
-        for (let i = 0; i < keys.length; i++) {
-            if (md[keys[i]].isr &&
-            md[keys[i]].isr.length !== IN_SYNC_REPLICAS) {
-                return 'error';
+    _checkISRHealth(topicMd) {
+        let status = 'ok';
+        topicMd.partitions.forEach(partition => {
+            if (partition.isrs &&
+                partition.isrs.length !== IN_SYNC_REPLICAS) {
+                status = 'error';
             }
-        }
-        return 'ok';
+        });
+        return status;
     }
 
     /**
@@ -66,10 +65,9 @@ class Healthcheck {
      * @return {undefined}
      */
     getHealthcheck(cb) {
-        const client = this._crrProducer.getKafkaClient();
-
-        // TODO: refactor by calling specific topic
-        client.loadMetadataForTopics([], (err, res) => {
+        const params = { topic: this._repConfig.topic,
+                         timeout: 10000 };
+        this._crrProducer.getMetadata(params, (err, res) => {
             if (err) {
                 const error = {
                     method: 'Healthcheck.getHealthcheck',
@@ -77,35 +75,18 @@ class Healthcheck {
                 };
                 return cb(error);
             }
-            const response = res.map(i => (Object.assign({}, i)));
+            const response = {};
+            const topics = {};
             const connections = {};
-            const topicMD = {};
-            response.forEach((obj, idx) => {
-                if (obj.metadata && obj.metadata[this._repConfig.topic]) {
-                    let copy;
-                    try {
-                        copy = JSON.parse(JSON.stringify(obj.metadata[
-                            this._repConfig.topic]));
-                        topicMD.metadata = copy;
-                        response.splice(idx, 1);
-                    } catch (e) {
-                        this._logger.error('error getting topic metadata', {
-                            error: e.message,
-                        });
-                    }
-                }
-            });
-            response.push(topicMD);
-
-            if (topicMD.metadata) {
-                connections.isrHealth = this._checkISRHealth(topicMD.metadata);
+            const topicMd = res.topics.find(
+                topic => topic.name === this._repConfig.topic);
+            if (topicMd) {
+                topics[this._repConfig.topic] = topicMd;
+                connections.isrHealth = this._checkISRHealth(topicMd);
             }
-
             Object.assign(connections, this._getConnectionDetails());
-            response.push({
-                internalConnections: connections,
-            });
-
+            response.topics = topics;
+            response.internalConnections = connections;
             return cb(null, response);
         });
     }

--- a/lib/queuePopulator/BucketFileLogReader.js
+++ b/lib/queuePopulator/BucketFileLogReader.js
@@ -5,9 +5,9 @@ const LogReader = require('./LogReader');
 
 class BucketFileLogReader extends LogReader {
     constructor(params) {
-        const { zkClient, zkConfig, dmdConfig, logger,
+        const { zkClient, kafkaConfig, dmdConfig, logger,
             extensions, metricsProducer } = params;
-        super({ zkClient, zkConfig, logConsumer: null,
+        super({ zkClient, kafkaConfig, logConsumer: null,
             logId: `bucketFile_${dmdConfig.logName}`, logger, extensions,
             metricsProducer });
 

--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -15,7 +15,7 @@ class LogReader {
      * @constructor
      * @param {Object} params - constructor params
      * @param {Object} params.zkClient - zookeeper client object
-     * @param {Object} params.zkConfig - zookeeper configuration object
+     * @param {Object} params.kafkaConfig - kafka configuration object
      * @param {Object} [params.logConsumer] - log consumer object
      * @param {function} params.logConsumer.readRecords - function
      *   that fetches records from the log, called by LogReader
@@ -28,7 +28,7 @@ class LogReader {
      */
     constructor(params) {
         this.zkClient = params.zkClient;
-        this.zkConfig = params.zkConfig;
+        this.kafkaConfig = params.kafkaConfig;
         this.logConsumer = params.logConsumer;
         this.pathToLogOffset = `${config.queuePopulator.zookeeperPath}/` +
             `logState/${params.logId}/logOffset`;
@@ -328,11 +328,14 @@ class LogReader {
             return process.nextTick(done);
         }
         const producer = new BackbeatProducer({
-            zookeeper: { connectionString: this.zkConfig.connectionString },
+            kafka: { hosts: this.kafkaConfig.hosts },
             topic,
         });
         producer.once('error', done);
         producer.once('ready', () => {
+            this.log.debug('producer is ready',
+                           { kafkaConfig: this.kafkaConfig,
+                             topic });
             producer.removeAllListeners('error');
             producer.on('error', err => {
                 this.log.error('error from backbeat producer',

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -18,6 +18,9 @@ class QueuePopulator {
      * @param {Object} zkConfig - zookeeper configuration object
      * @param {String} zkConfig.connectionString - zookeeper
      *   connection string as "host:port[/chroot]"
+     * @param {Object} kafkaConfig - kafka configuration object
+     * @param {string} kafkaConfig.hosts - kafka hosts list
+     * as "host:port[,host:port...]"
      * @param {Object} qpConfig - queue populator configuration
      * @param {String} qpConfig.zookeeperPath - sub-path to use for
      *   storing populator state in zookeeper
@@ -33,8 +36,10 @@ class QueuePopulator {
      * @param {Object} extConfigs - configuration of extensions: keys
      *   are extension names and values are extension's config object.
      */
-    constructor(zkConfig, qpConfig, mConfig, rConfig, extConfigs) {
+    constructor(zkConfig, kafkaConfig, qpConfig, mConfig, rConfig,
+                extConfigs) {
         this.zkConfig = zkConfig;
+        this.kafkaConfig = kafkaConfig;
         this.qpConfig = qpConfig;
         this.mConfig = mConfig;
         this.rConfig = rConfig;
@@ -93,11 +98,11 @@ class QueuePopulator {
     _setupMetricsClients(cb) {
         // Metrics Consumer
         this._mConsumer = new MetricsConsumer(this.rConfig, this.mConfig,
-            this.zkConfig);
+            this.kafkaConfig);
         this._mConsumer.start();
 
         // Metrics Producer
-        this._mProducer = new MetricsProducer(this.zkConfig, this.mConfig);
+        this._mProducer = new MetricsProducer(this.kafkaConfig, this.mConfig);
         this._mProducer.setupProducer(cb);
     }
 
@@ -121,7 +126,7 @@ class QueuePopulator {
         case 'dmd':
             this.logReadersUpdate = [
                 new BucketFileLogReader({ zkClient: this.zkClient,
-                    zkConfig: this.zkConfig,
+                    kafkaConfig: this.kafkaConfig,
                     dmdConfig: this.qpConfig.dmd,
                     logger: this.log,
                     extensions: this._extensions,
@@ -155,7 +160,7 @@ class QueuePopulator {
             this.logReadersUpdate = items.map(
                 raftId => new RaftLogReader({
                     zkClient: this.zkClient,
-                    zkConfig: this.zkConfig,
+                    kafkaConfig: this.kafkaConfig,
                     bucketdConfig: this.qpConfig.bucketd,
                     raftId,
                     logger: this.log,

--- a/lib/queuePopulator/RaftLogReader.js
+++ b/lib/queuePopulator/RaftLogReader.js
@@ -6,7 +6,7 @@ const LogReader = require('./LogReader');
 
 class RaftLogReader extends LogReader {
     constructor(params) {
-        const { zkClient, zkConfig, bucketdConfig,
+        const { zkClient, kafkaConfig, bucketdConfig,
                 raftId, logger, extensions, metricsProducer } = params;
         const { host, port } = bucketdConfig;
         logger.info('initializing raft log reader',
@@ -16,7 +16,7 @@ class RaftLogReader extends LogReader {
         const logConsumer = new LogConsumer({ bucketClient,
             raftSession: raftId,
             logger });
-        super({ zkClient, zkConfig, logConsumer, logId: `raft_${raftId}`,
+        super({ zkClient, kafkaConfig, logConsumer, logId: `raft_${raftId}`,
                 logger, extensions, metricsProducer });
         this.raftId = raftId;
     }

--- a/package.json
+++ b/package.json
@@ -40,8 +40,9 @@
     "eslint-config-scality": "scality/Guidelines#rel/7.4-beta",
     "eslint-plugin-react": "^4.2.3",
     "joi": "^10.6",
-    "kafka-node": "^2.2.0",
+    "node-rdkafka": "^2.2.0",
     "node-schedule": "^1.2.0",
+    "node-zookeeper-client": "^0.2.2",
     "uuid": "^3.1.0",
     "vaultclient": "github:scality/vaultclient#rel/7.4-beta",
     "werelogs": "scality/werelogs#rel/7.4-beta"

--- a/tests/behavior/queuePopulator.js
+++ b/tests/behavior/queuePopulator.js
@@ -83,6 +83,7 @@ describe('queuePopulator', () => {
             (data, next) => {
                 queuePopulator = new QueuePopulator(
                     testConfig.zookeeper,
+                    testConfig.kafka,
                     testConfig.queuePopulator,
                     testConfig.extensions);
                 queuePopulator.open(next);

--- a/tests/functional/BackbeatConsumer.js
+++ b/tests/functional/BackbeatConsumer.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const BackbeatProducer = require('../../lib/BackbeatProducer');
 const BackbeatConsumer = require('../../lib/BackbeatConsumer');
-const zookeeper = { connectionString: 'localhost:2181' };
+const kafkaConf = { hosts: 'localhost:9092' };
 const topic = 'backbeat-consumer-spec';
 const groupId = `replication-group-${Math.random()}`;
 const messages = [
@@ -9,9 +9,7 @@ const messages = [
     { key: 'bar', message: 'world' },
     { key: 'qux', message: 'hi' },
 ];
-// skipping test suite for now, as tests are failing intermittently. Connect
-// event is not reliable enough to check if consumer is ready
-describe.skip('BackbeatConsumer', () => {
+describe('BackbeatConsumer', () => {
     let producer;
     let consumer;
     const consumedMessages = [];
@@ -19,7 +17,9 @@ describe.skip('BackbeatConsumer', () => {
         consumedMessages.push(message.value);
         process.nextTick(cb);
     }
-    before(done => {
+    before(function before(done) {
+        this.timeout(60000);
+
         let producerReady = false;
         let consumerReady = false;
         function _doneIfReady() {
@@ -27,30 +27,48 @@ describe.skip('BackbeatConsumer', () => {
                 done();
             }
         }
-        producer = new BackbeatProducer({ zookeeper, topic });
-        consumer = new BackbeatConsumer({ zookeeper, groupId, topic,
-            queueProcessor });
+        producer = new BackbeatProducer({ kafka: kafkaConf, topic,
+                                          pollIntervalMs: 100 });
+        consumer = new BackbeatConsumer({ kafka: kafkaConf, groupId, topic,
+                                          queueProcessor,
+                                          bootstrap: true });
         producer.on('ready', () => {
             producerReady = true;
             _doneIfReady();
         });
-        consumer.on('connect', () => {
+        consumer.on('ready', () => {
             consumerReady = true;
             _doneIfReady();
         });
     });
-    after(() => {
-        producer = null;
-        consumer = null;
-    });
-
-    it('should be able to read messages sent to the topic', done => {
-        producer.send(messages, () => {
-            consumer.subscribe().on('consumed', () => {
-                assert.deepStrictEqual(messages.map(e => e.message),
-                    consumedMessages);
+    after(done => {
+        producer.close(() => {
+            consumer.close(() => {
+                producer = null;
+                consumer = null;
                 done();
             });
         });
     });
+
+    it('should be able to read messages sent to the topic', done => {
+        let consumeCb = null;
+        let totalConsumed = 0;
+
+        consumer.subscribe();
+        consumer.on('consumed', messagesConsumed => {
+            totalConsumed += messagesConsumed;
+            assert(totalConsumed <= messages.length);
+            if (totalConsumed === messages.length) {
+                assert.deepStrictEqual(
+                    messages.map(e => e.message),
+                    consumedMessages.map(buffer => buffer.toString()));
+                consumeCb();
+            }
+        });
+        consumeCb = done;
+        producer.send(messages, err => {
+            assert.ifError(err);
+        });
+    }).timeout(30000);
 });

--- a/tests/functional/api/BackbeatServer.js
+++ b/tests/functional/api/BackbeatServer.js
@@ -1,7 +1,8 @@
 const assert = require('assert');
+const async = require('async');
 const http = require('http');
 const Redis = require('ioredis');
-const { Client, Producer } = require('kafka-node');
+const { Producer } = require('node-rdkafka');
 
 const { RedisClient, StatsClient } = require('arsenal').metrics;
 
@@ -60,16 +61,11 @@ function getRequest(path, done) {
 describe('Backbeat Server', () => {
     describe('healthcheck route', () => {
         let data;
+        let healthcheckTimer;
         let resCode;
-        before(done => {
-            const kafkaClient = new Client(config.zookeeper.connectionString,
-                'TestClient');
-            const testProducer = new Producer(kafkaClient);
-            testProducer.createTopics([
-                config.extensions.replication.topic,
-                config.extensions.replication.replicationStatusTopic,
-            ], false, () => {});
+        let testProducer;
 
+        function _doHealthcheckRequest(done) {
             const url = getUrl(defaultOptions, '/_/healthcheck');
 
             http.get(url, res => {
@@ -81,41 +77,80 @@ describe('Backbeat Server', () => {
                 });
                 res.on('end', () => {
                     data = JSON.parse(rawData);
-                    done();
+                    if (done) {
+                        // only set in before() processing
+                        done();
+                    }
                 });
             });
+        }
+
+        before(done => {
+            async.series([
+                next => {
+                    testProducer = new Producer({
+                        'metadata.broker.list': config.kafka.hosts,
+                    });
+                    testProducer.connect();
+                    testProducer.on('ready', () => next());
+                    testProducer.on('event.error', error => {
+                        assert.ifError(error);
+                    });
+                },
+                // create topics by fetching metadata from these topics
+                // (works if auto.create.topics.enabled is true)
+                next => testProducer.getMetadata({
+                    topic: config.extensions.replication.topic,
+                    timeout: 10000,
+                }, next),
+                next => testProducer.getMetadata({
+                    topic: config.extensions.replication.replicationStatusTopic,
+                    timeout: 10000,
+                }, next),
+                next => {
+                    _doHealthcheckRequest(next);
+                    // refresh healthcheck result, as after creating
+                    // topics they take some time to appear in the
+                    // healthcheck results
+                    healthcheckTimer = setInterval(_doHealthcheckRequest,
+                                                   2000);
+                },
+            ], done);
+        });
+
+        after(() => {
+            clearInterval(healthcheckTimer);
         });
 
         it('should get a response with data', done => {
-            assert(Object.keys(data).length > 0);
             assert.equal(resCode, 200);
+            assert(data);
             return done();
         });
 
         it('should have valid keys', done => {
-            const keys = [].concat(...data.map(d => Object.keys(d)));
-
-            assert(keys.includes('metadata'));
-            assert(keys.includes('internalConnections'));
-            return done();
-        });
-
-        it('should be healthy', done => {
-            // NOTE: isrHealth is not checked here because circleci
-            // kafka will have one ISR only. Maybe isrHealth should
-            // be a test for end-to-end
-            let internalConnections;
-            data.forEach(obj => {
-                if (Object.keys(obj).includes('internalConnections')) {
-                    internalConnections = obj.internalConnections;
+            assert(data.topics);
+            let timer = undefined;
+            function _checkValidKeys() {
+                const repTopic =
+                          data.topics[config.extensions.replication.topic];
+                if (!repTopic) {
+                    return undefined;
                 }
-            });
-            Object.keys(internalConnections).forEach(key => {
-                assert.ok(internalConnections[key]);
-            });
-
-            return done();
-        });
+                clearInterval(timer);
+                assert(Array.isArray(repTopic.partitions));
+                assert(data.internalConnections);
+                // NOTE: isrHealth is not checked here because circleci
+                // kafka will have one ISR only. Maybe isrHealth should
+                // be a test for end-to-end
+                assert.strictEqual(
+                    data.internalConnections.zookeeper.status, 'ok');
+                assert.strictEqual(
+                    data.internalConnections.kafkaProducer.status, 'ok');
+                return done();
+            }
+            timer = setInterval(_checkValidKeys, 1000);
+        }).timeout(20000);
     });
 
     describe('metrics routes', () => {

--- a/tests/functional/lifecycle/LifecycleConductor.spec.js
+++ b/tests/functional/lifecycle/LifecycleConductor.spec.js
@@ -16,6 +16,9 @@ const zkConfig = {
         autoCreateNamespace: true,
     },
 };
+const kafkaConfig = {
+    hosts: '127.0.0.1:9092',
+};
 const lcConfig = {
     zookeeperPath: '/test/lifecycle',
     bucketTasksTopic: 'backbeat-lifecycle-bucket-tasks-spec',
@@ -36,9 +39,8 @@ const lcConfig = {
     },
 };
 
-const lcConductor = new LifecycleConductor(
-    { connectionString: zkConfig.zookeeper.connectionString },
-    lcConfig);
+const lcConductor = new LifecycleConductor(zkConfig.zookeeper,
+                                           kafkaConfig, lcConfig);
 
 const TIMEOUT = 120000;
 const CONSUMER_TIMEOUT = 60000;
@@ -64,17 +66,17 @@ describe('lifecycle conductor', function lifecycleConductor() {
             next => lcConductor.initZkPaths(next),
             next => {
                 consumer = new BackbeatTestConsumer({
-                    zookeeper: {
-                        connectionString: zkConfig.zookeeper.connectionString,
-                    },
+                    kafka: { hosts: kafkaConfig.hosts },
                     topic: lcConfig.bucketTasksTopic,
                     groupId: 'test-consumer-group',
                 });
-                consumer.bootstrap(next);
+                consumer.on('ready', next);
             },
             next => {
                 consumer.subscribe();
-                next();
+                // it seems the consumer needs some extra time to
+                // start consuming the first messages
+                setTimeout(next, 2000);
             },
         ], done);
     });

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const async = require('async');
 const crypto = require('crypto');
 const http = require('http');
 const URL = require('url');
@@ -634,7 +635,7 @@ describe('queue processor functional tests with mocking', () => {
                   constants.target.hosts.map(h => `${h.host}:${h.port}`);
 
         queueProcessor = new QueueProcessor(
-            { connectionString: 'localhost:2181' },
+            { hosts: 'localhost:9092' },
             { auth: { type: 'role',
                 vault: { host: constants.source.vault,
                     port: 7777 } },
@@ -661,7 +662,7 @@ describe('queue processor functional tests with mocking', () => {
         // stuck waiting for entries.
         queueProcessor.on('ready', () => {
             replicationStatusProcessor = new ReplicationStatusProcessor(
-                { connectionString: 'localhost:2181' },
+                { hosts: 'localhost:9092' },
                 { auth: { type: 'role',
                           vault: { host: constants.source.vault,
                                    port: 7777 } },
@@ -675,8 +676,7 @@ describe('queue processor functional tests with mocking', () => {
                       groupId: 'backbeat-func-test-group-id',
                   },
               }, 'sf');
-            replicationStatusProcessor.start({ createConsumer: false });
-            replicationStatusProcessor.bootstrapKafkaConsumer(done);
+            replicationStatusProcessor.start({ bootstrap: true }, done);
         });
 
         s3mock = new S3Mock();
@@ -709,15 +709,19 @@ describe('queue processor functional tests with mocking', () => {
                     s3mock.setParam('nbParts', testCase.nbParts);
                 });
                 it('should complete a replication end-to-end', done => {
-                    s3mock.onPutSourceMd = done;
-
-                    queueProcessor.processKafkaEntry(
-                       s3mock.getParam('kafkaEntry'), err => {
-                           assert.ifError(err);
-                           assert.strictEqual(s3mock.hasPutTargetData,
-                                              testCase.nbParts > 0);
-                           assert(s3mock.hasPutTargetMd);
-                       });
+                    async.parallel([
+                        done => {
+                            s3mock.onPutSourceMd = done;
+                        },
+                        done => queueProcessor.processKafkaEntry(
+                            s3mock.getParam('kafkaEntry'), err => {
+                                assert.ifError(err);
+                                assert.strictEqual(s3mock.hasPutTargetData,
+                                                   testCase.nbParts > 0);
+                                assert(s3mock.hasPutTargetMd);
+                                done();
+                            }),
+                    ], done);
                 });
             }));
 
@@ -725,14 +729,18 @@ describe('queue processor functional tests with mocking', () => {
             s3mock.setParam('nbParts', 2);
             s3mock.setParam('source.md.replicationInfo.content',
                             ['METADATA']);
-            s3mock.onPutSourceMd = done;
-
-            queueProcessor.processKafkaEntry(
-                s3mock.getParam('kafkaEntry'), err => {
-                    assert.ifError(err);
-                    assert.strictEqual(s3mock.hasPutTargetData, false);
-                    assert(s3mock.hasPutTargetMd);
-                });
+            async.parallel([
+                done => {
+                    s3mock.onPutSourceMd = done;
+                },
+                done => queueProcessor.processKafkaEntry(
+                    s3mock.getParam('kafkaEntry'), err => {
+                        assert.ifError(err);
+                        assert.strictEqual(s3mock.hasPutTargetData, false);
+                        assert(s3mock.hasPutTargetMd);
+                        done();
+                    }),
+            ], done);
         });
 
         it('should retry with full replication if metadata-only returns ' +
@@ -743,14 +751,18 @@ describe('queue processor functional tests with mocking', () => {
             s3mock.installBackbeatErrorResponder('target.putMetadata',
                                                  errors.ObjNotFound,
                                                  { once: true });
-            s3mock.onPutSourceMd = done;
-
-            queueProcessor.processKafkaEntry(
-                s3mock.getParam('kafkaEntry'), err => {
-                    assert.ifError(err);
-                    assert.strictEqual(s3mock.hasPutTargetData, true);
-                    assert(s3mock.hasPutTargetMd);
-                });
+            async.parallel([
+                done => {
+                    s3mock.onPutSourceMd = done;
+                },
+                done => queueProcessor.processKafkaEntry(
+                    s3mock.getParam('kafkaEntry'), err => {
+                        assert.ifError(err);
+                        assert.strictEqual(s3mock.hasPutTargetData, true);
+                        assert(s3mock.hasPutTargetMd);
+                        done();
+                    }),
+            ], done);
         });
     });
 
@@ -799,14 +811,19 @@ describe('queue processor functional tests with mocking', () => {
             'configuration', done => {
                 s3mock.setParam('replicationEnabled', false);
                 s3mock.setExpectedReplicationStatus('FAILED');
-                s3mock.onPutSourceMd = done;
 
-                queueProcessor.processKafkaEntry(
-                    s3mock.getParam('kafkaEntry'), err => {
-                        assert.ifError(err);
-                        assert(!s3mock.hasPutTargetData);
-                        assert(!s3mock.hasPutTargetMd);
-                    });
+                async.parallel([
+                    done => {
+                        s3mock.onPutSourceMd = done;
+                    },
+                    done => queueProcessor.processKafkaEntry(
+                        s3mock.getParam('kafkaEntry'), err => {
+                            assert.ifError(err);
+                            assert(!s3mock.hasPutTargetData);
+                            assert(!s3mock.hasPutTargetMd);
+                            done();
+                        }),
+                ], done);
             });
 
             it('should fail if object misses dataStoreETag property', done => {
@@ -816,14 +833,19 @@ describe('queue processor functional tests with mocking', () => {
                                    s3mock.getParam('partsContents'),
                                    { doNotIncludeETag: true }));
                 s3mock.setExpectedReplicationStatus('FAILED');
-                s3mock.onPutSourceMd = done;
 
-                queueProcessor.processKafkaEntry(
-                    s3mock.getParam('kafkaEntry'), err => {
-                        assert.ifError(err);
-                        assert(!s3mock.hasPutTargetData);
-                        assert(!s3mock.hasPutTargetMd);
-                    });
+                async.parallel([
+                    done => {
+                        s3mock.onPutSourceMd = done;
+                    },
+                    done => queueProcessor.processKafkaEntry(
+                        s3mock.getParam('kafkaEntry'), err => {
+                            assert.ifError(err);
+                            assert(!s3mock.hasPutTargetData);
+                            assert(!s3mock.hasPutTargetMd);
+                            done();
+                        }),
+                ], done);
             });
 
             ['getBucketReplication', 'getObject'].forEach(action => {
@@ -832,14 +854,19 @@ describe('queue processor functional tests with mocking', () => {
                     `from source S3 on ${action}`, done => {
                         s3mock.installS3ErrorResponder(
                             `source.s3.${action}`, error, { once: true });
-                        s3mock.onPutSourceMd = done;
 
-                        queueProcessor.processKafkaEntry(
-                            s3mock.getParam('kafkaEntry'), err => {
-                                assert.ifError(err);
-                                assert(s3mock.hasPutTargetData);
-                                assert(s3mock.hasPutTargetMd);
-                            });
+                        async.parallel([
+                            done => {
+                                s3mock.onPutSourceMd = done;
+                            },
+                            done => queueProcessor.processKafkaEntry(
+                                s3mock.getParam('kafkaEntry'), err => {
+                                    assert.ifError(err);
+                                    assert(s3mock.hasPutTargetData);
+                                    assert(s3mock.hasPutTargetMd);
+                                    done();
+                                }),
+                        ], done);
                     });
                 });
             });
@@ -854,14 +881,19 @@ describe('queue processor functional tests with mocking', () => {
                             s3mock.installVaultErrorResponder(
                              `target.${action}`, err);
                             s3mock.setExpectedReplicationStatus('FAILED');
-                            s3mock.onPutSourceMd = done;
 
-                            queueProcessor.processKafkaEntry(
-                             s3mock.getParam('kafkaEntry'), error => {
-                                 assert.ifError(error);
-                                 assert(!s3mock.hasPutTargetData);
-                                 assert(!s3mock.hasPutTargetMd);
-                             });
+                            async.parallel([
+                                done => {
+                                    s3mock.onPutSourceMd = done;
+                                },
+                                done => queueProcessor.processKafkaEntry(
+                                    s3mock.getParam('kafkaEntry'), error => {
+                                        assert.ifError(error);
+                                        assert(!s3mock.hasPutTargetData);
+                                        assert(!s3mock.hasPutTargetMd);
+                                        done();
+                                    }),
+                            ], done);
                         });
                     });
                 });
@@ -873,19 +905,24 @@ describe('queue processor functional tests with mocking', () => {
                     `from target Vault on ${action}`, done => {
                         s3mock.installVaultErrorResponder(
                             `target.${action}`, error, { once: true });
-                        s3mock.onPutSourceMd = done;
 
-                        queueProcessor.processKafkaEntry(
-                            s3mock.getParam('kafkaEntry'), err => {
-                                assert.ifError(err);
-                                assert(s3mock.hasPutTargetData);
-                                assert(s3mock.hasPutTargetMd);
-                                // should have retried on other host
-                                assert(s3mock.requestsPerHost['127.0.0.3']
-                                       > 0);
-                                assert(s3mock.requestsPerHost['127.0.0.4']
-                                       > 0);
-                            });
+                        async.parallel([
+                            done => {
+                                s3mock.onPutSourceMd = done;
+                            },
+                            done => queueProcessor.processKafkaEntry(
+                                s3mock.getParam('kafkaEntry'), err => {
+                                    assert.ifError(err);
+                                    assert(s3mock.hasPutTargetData);
+                                    assert(s3mock.hasPutTargetMd);
+                                    // should have retried on other host
+                                    assert(s3mock.requestsPerHost['127.0.0.3']
+                                           > 0);
+                                    assert(s3mock.requestsPerHost['127.0.0.4']
+                                           > 0);
+                                    done();
+                                }),
+                        ], done);
                     });
                 });
             });
@@ -899,13 +936,18 @@ describe('queue processor functional tests with mocking', () => {
                         s3mock.installS3ErrorResponder(`target.${action}`,
                                                        error);
                         s3mock.setExpectedReplicationStatus('FAILED');
-                        s3mock.onPutSourceMd = done;
 
-                        queueProcessor.processKafkaEntry(
-                            s3mock.getParam('kafkaEntry'), err => {
-                                assert.ifError(err);
-                                assert(!s3mock.hasPutTargetMd);
-                            });
+                        async.parallel([
+                            done => {
+                                s3mock.onPutSourceMd = done;
+                            },
+                            done => queueProcessor.processKafkaEntry(
+                                s3mock.getParam('kafkaEntry'), err => {
+                                    assert.ifError(err);
+                                    assert(!s3mock.hasPutTargetMd);
+                                    done();
+                                }),
+                        ], done);
                     });
                 });
             });
@@ -916,19 +958,23 @@ describe('queue processor functional tests with mocking', () => {
                     `from target S3 on ${action}`, done => {
                         s3mock.installS3ErrorResponder(`target.${action}`,
                                                        error, { once: true });
-                        s3mock.onPutSourceMd = done;
-
-                        queueProcessor.processKafkaEntry(
-                            s3mock.getParam('kafkaEntry'), err => {
-                                assert.ifError(err);
-                                assert(s3mock.hasPutTargetData);
-                                assert(s3mock.hasPutTargetMd);
-                                // should have retried on other host
-                                assert(s3mock.requestsPerHost['127.0.0.3']
-                                       > 0);
-                                assert(s3mock.requestsPerHost['127.0.0.4']
-                                       > 0);
-                            });
+                        async.parallel([
+                            done => {
+                                s3mock.onPutSourceMd = done;
+                            },
+                            done => queueProcessor.processKafkaEntry(
+                                s3mock.getParam('kafkaEntry'), err => {
+                                    assert.ifError(err);
+                                    assert(s3mock.hasPutTargetData);
+                                    assert(s3mock.hasPutTargetMd);
+                                    // should have retried on other host
+                                    assert(s3mock.requestsPerHost['127.0.0.3']
+                                           > 0);
+                                    assert(s3mock.requestsPerHost['127.0.0.4']
+                                           > 0);
+                                    done();
+                                }),
+                        ], done);
                     });
                 });
             });
@@ -940,14 +986,19 @@ describe('queue processor functional tests with mocking', () => {
                 s3mock.installS3ErrorResponder('source.s3.getObject',
                                                errors.InternalError);
                 s3mock.setExpectedReplicationStatus('FAILED');
-                s3mock.onPutSourceMd = done;
 
-                queueProcessor.processKafkaEntry(
-                    s3mock.getParam('kafkaEntry'), err => {
-                        assert.ifError(err);
-                        assert(!s3mock.hasPutTargetData);
-                        assert(!s3mock.hasPutTargetMd);
-                    });
+                async.parallel([
+                    done => {
+                        s3mock.onPutSourceMd = done;
+                    },
+                    done => queueProcessor.processKafkaEntry(
+                        s3mock.getParam('kafkaEntry'), err => {
+                            assert.ifError(err);
+                            assert(!s3mock.hasPutTargetData);
+                            assert(!s3mock.hasPutTargetMd);
+                            done();
+                        }),
+                ], done);
             });
         });
     });

--- a/tests/utils/BackbeatTestConsumer.js
+++ b/tests/utils/BackbeatTestConsumer.js
@@ -8,7 +8,7 @@ class BackbeatTestConsumer extends BackbeatConsumer {
     constructor(config) {
         super(Object.assign({}, config,
                             { queueProcessor: function dummy() {},
-                              createConsumer: false }));
+                              bootstrap: true }));
         // hook queue processor function
         this._queueProcessor = this._processMessage.bind(this);
         this._expectVars = null;
@@ -17,14 +17,19 @@ class BackbeatTestConsumer extends BackbeatConsumer {
     _processMessage(message, done) {
         function _matchMessage(expectedMsg) {
             if (expectedMsg.key !== undefined) {
-                assert.deepStrictEqual(message.key, expectedMsg.key,
-                                       'unexpected message key');
+                assert.deepStrictEqual(
+                    message.key.toString(), expectedMsg.key,
+                    `unexpected message key ${message.key}, ` +
+                        `expected ${expectedMsg.key}`);
             }
             if (expectedMsg.value !== undefined) {
                 const parsedMsg = typeof expectedMsg.value === 'object' ?
-                          JSON.parse(message.value) : message.value;
-                assert.deepStrictEqual(parsedMsg, expectedMsg.value,
-                                       'unexpected message value');
+                          JSON.parse(message.value) :
+                          message.value.toString();
+                assert.deepStrictEqual(
+                    parsedMsg, expectedMsg.value,
+                    `unexpected message value ${parsedMsg}, ` +
+                        `expected ${expectedMsg.value}`);
             }
         }
 


### PR DESCRIPTION
    kafka-node has issues dealing with reconnections etc. especially when
    there are concurrent joins of multiple consumers of the same
    group. This often leads to multiple consumers processing the same
    partition, which is not just suboptimal, but breaks lifecycle
    processing.
    
    node-rdkafka is a more maintained and better tested library, relying
    on librdkafka underneath.
