### PR TITLE
Bf/s3 c 1302 rework backpressure

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -85,6 +85,10 @@
             "zookeeperPath": "/lifecycle",
             "bucketTasksTopic": "backbeat-lifecycle-bucket-tasks",
             "objectTasksTopic": "backbeat-lifecycle-object-tasks",
+            "backlogMetrics": {
+                "zkPath": "/lifecycle/run/backlog-metrics",
+                "intervalS": 60
+            },
             "conductor": {
                 "cronRule": "0 */5 * * * *",
                 "concurrency": 10

--- a/extensions/lifecycle/LifecycleConfigValidator.js
+++ b/extensions/lifecycle/LifecycleConfigValidator.js
@@ -4,6 +4,10 @@ const joiSchema = {
     zookeeperPath: joi.string().required(),
     bucketTasksTopic: joi.string().required(),
     objectTasksTopic: joi.string().required(),
+    backlogMetrics: {
+        zkPath: joi.string().default('/lifecycle/run/backlog-metrics'),
+        intervalS: joi.number().default(60),
+    },
     conductor: {
         cronRule: joi.string().required(),
         concurrency: joi.number().greater(0).default(10),

--- a/extensions/lifecycle/lifecycleConsumer/LifecycleConsumer.js
+++ b/extensions/lifecycle/lifecycleConsumer/LifecycleConsumer.js
@@ -29,6 +29,9 @@ class LifecycleConsumer extends EventEmitter {
      *  before giving up retries of an entry lifecycle action
      * @param {Number} lcConfig.consumer.concurrency - number of max allowed
      *  concurrent operations
+     * @param {Object} [lcConfig.backlogMetrics] - param object to
+     * publish backlog metrics to zookeeper (see {@link
+     * BackbeatConsumer} constructor)
      * @param {Object} s3Config - S3 configuration
      * @param {Object} s3Config.host - s3 endpoint host
      * @param {Number} s3Config.port - s3 endpoint port
@@ -71,6 +74,8 @@ class LifecycleConsumer extends EventEmitter {
             groupId: this.lcConfig.consumer.groupId,
             concurrency: this.lcConfig.consumer.concurrency,
             queueProcessor: this.processKafkaEntry.bind(this),
+            autoCommit: true,
+            backlogMetrics: this.lcConfig.backlogMetrics,
         });
         this._consumer.on('error', () => {});
         this._consumer.on('ready', () => {

--- a/extensions/lifecycle/lifecycleProducer/LifecycleProducer.js
+++ b/extensions/lifecycle/lifecycleProducer/LifecycleProducer.js
@@ -33,6 +33,9 @@ class LifecycleProducer {
      * @param {string} kafkaConfig.hosts - list of kafka brokers
      *   as "host:port[,host:port...]"
      * @param {Object} lcConfig - lifecycle config
+     * @param {Object} [lcConfig.backlogMetrics] - param object to
+     * publish backlog metrics to zookeeper (see {@link
+     * BackbeatConsumer} constructor)
      * @param {Object} s3Config - s3 config
      * @param {String} s3Config.host - host ip
      * @param {String} s3Config.port - port
@@ -227,6 +230,7 @@ class LifecycleProducer {
                 method: 'LifecycleProducer._processBucketEntry',
                 bucket,
                 owner,
+                details: result.details,
             });
             return this._internalTaskScheduler.push({
                 task: new LifecycleTask(this),
@@ -275,6 +279,8 @@ class LifecycleProducer {
             groupId: this._lcConfig.producer.groupId,
             concurrency: this._lcConfig.producer.concurrency,
             queueProcessor: this._processBucketEntry.bind(this),
+            autoCommit: true,
+            backlogMetrics: this._lcConfig.backlogMetrics,
         });
         consumer.on('error', () => {});
         consumer.on('ready', () => {

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 const async = require('async');
 const joi = require('joi');
 
+const zookeeperHelper = require('./clients/zookeeper');
 const BackbeatProducer = require('./BackbeatProducer');
 const Logger = require('werelogs').Logger;
 
@@ -26,8 +27,10 @@ class BackbeatConsumer extends EventEmitter {
      * @param {string} config.groupId - consumer group id. Messages are
      * distributed among multiple consumers belonging to the same group
      * @param {Object} [config.zookeeper] - zookeeper endpoint config
-     * @param {string} [config.zookeeper.connectionString] - zookeeper
-     * connection string as "host:port[/chroot]"
+     * (only needed if config.backlogMetrics is set)
+     * @param {string} config.zookeeper.connectionString - zookeeper
+     * connection string as "host:port[/chroot]" (only needed if
+     * config.backlogMetrics is set)
      * @param {Object} config.kafka - kafka connection config
      * @param {string} config.kafka.hosts - kafka hosts list
      * as "host:port[,host:port...]"
@@ -36,6 +39,14 @@ class BackbeatConsumer extends EventEmitter {
      * that can be processed in parallel
      * @param {number} [config.fetchMaxBytes] - max. bytes to fetch in a
      * fetch loop
+     * @param {object} [config.backlogMetrics] - param object to
+     * publish backlog metrics to zookeeper (disabled if param object
+     * is not set)
+     * @param {string} config.backlogMetrics.zkPath - zookeeper base
+     * path to publish metrics to
+     * @param {boolean} [config.backlogMetrics.intervalS=60] -
+     * interval in seconds between iterations of backlog metrics
+     * publishing task
      * @param {boolean} [config.bootstrap=false] - TEST ONLY: true to
      * bootstrap the consumer with test messages until it starts
      * consuming them
@@ -44,9 +55,10 @@ class BackbeatConsumer extends EventEmitter {
         super();
 
         const configJoi = {
-            zookeeper: {
-                connectionString: joi.string(),
-            },
+            zookeeper: joi.object({
+                connectionString: joi.string().required(),
+            }).when('backlogMetrics', { is: joi.exist(),
+                                        then: joi.required() }),
             kafka: joi.object({
                 hosts: joi.string().required(),
             }).required(),
@@ -57,6 +69,10 @@ class BackbeatConsumer extends EventEmitter {
             autoCommit: joi.boolean().default(false),
             concurrency: joi.number().greater(0).default(CONCURRENCY_DEFAULT),
             fetchMaxBytes: joi.number(),
+            backlogMetrics: {
+                zkPath: joi.string().required(),
+                intervalS: joi.number().default(60),
+            },
             bootstrap: joi.boolean().default(false),
         };
         const validConfig = joi.attempt(config, configJoi,
@@ -64,7 +80,7 @@ class BackbeatConsumer extends EventEmitter {
 
         const { zookeeper, kafka, topic, groupId, queueProcessor,
                 fromOffset, autoCommit, concurrency, fetchMaxBytes,
-                bootstrap } = validConfig;
+                backlogMetrics, bootstrap } = validConfig;
 
         this._zookeeperEndpoint = zookeeper && zookeeper.connectionString;
         this._kafkaHosts = kafka.hosts;
@@ -76,14 +92,20 @@ class BackbeatConsumer extends EventEmitter {
         this._queueProcessor = queueProcessor;
         this._concurrency = concurrency;
         this._fetchMaxBytes = fetchMaxBytes;
+        this._backlogMetrics = backlogMetrics;
         this._bootstrap = bootstrap;
+
         this._processingQueue = null;
         this._messagesConsumed = 0;
         this._consumer = null;
         this._consumerReady = false;
         this._bootstrapping = false;
+        this._zookeeper = null;
+        this._zookeeperReady = false;
+        this._publishBacklogMetricsTimer = null;
         // metrics - consumption
         this._metricsStore = {};
+        this._committedOffsets = null;
         this._init();
         return this;
     }
@@ -91,10 +113,15 @@ class BackbeatConsumer extends EventEmitter {
     _init() {
         if (this._bootstrap) {
             this._consumerReady = true;
-            process.nextTick(this._checkIfReady.bind(this));
         } else {
             this._initConsumer();
         }
+        if (this._backlogMetrics) {
+            this._initZookeeperClient();
+        } else {
+            this._zookeeperReady = true;
+        }
+        process.nextTick(this._checkIfReady.bind(this));
     }
 
     _initConsumer() {
@@ -118,15 +145,33 @@ class BackbeatConsumer extends EventEmitter {
         });
     }
 
+    _initZookeeperClient() {
+        this._zookeeper = zookeeperHelper.createClient(this._zookeeperEndpoint);
+        this._zookeeper.connect();
+        this._zookeeper.once('ready', () => {
+            this._zookeeperReady = true;
+            this._checkIfReady();
+        });
+    }
+
     _checkIfReady() {
-        if (this._consumerReady) {
+        if (this._consumerReady && this._zookeeperReady) {
             if (this._bootstrap) {
                 if (!this._bootstrapping) {
                     this._bootstrapConsumer();
                 }
             } else {
-                this.emit('ready');
+                this._onReady();
             }
+        }
+    }
+
+    _onReady() {
+        this.emit('ready');
+        if (this._backlogMetrics) {
+            this._publishBacklogMetricsTimer =
+                setInterval(this._publishOffsetsCron.bind(this),
+                            this._backlogMetrics.intervalS * 1000);
         }
     }
 
@@ -254,7 +299,103 @@ class BackbeatConsumer extends EventEmitter {
         }
         this._log.debug('commit offsets callback',
                         { topicPartitions });
+        // save latest committed offsets for backlog metrics
+        // NOTE: for an unknown reason, in some cases all partitions
+        // are published but only the committed ones have an offset
+        // field, so we pre-filter here.
+        this._committedOffsets =
+            topicPartitions.filter(p => p.offset !== undefined);
         return undefined;
+    }
+
+    _getOffsetZkPath(partition, offsetType) {
+        const basePath = `${this._backlogMetrics.zkPath}/` +
+                  `${this._topic}/${partition}`;
+        return (offsetType === 'topic' ?
+                `${basePath}/topic` :
+                `${basePath}/consumers/${this._groupId}`);
+    }
+
+    _publishOffset(partition, offset, offsetType) {
+        const zkPath = this._getOffsetZkPath(partition, offsetType);
+        const zkData = Buffer.from(offset.toString());
+        this._zookeeper.setOrCreate(zkPath, zkData, err => {
+            if (err) {
+                this._log.error(
+                    'error publishing offset to zookeeper',
+                    { zkPath, offset, offsetType, error: err.message });
+            } else {
+                this._log.debug('published offset to zookeeper', {
+                    topic: this._topic,
+                    partition,
+                    offsetType,
+                    offset,
+                });
+            }
+        });
+    }
+
+    _publishOffsetsCron(cb) {
+        if (!this._committedOffsets) {
+            // skipping, no committed offset yet
+            return undefined;
+        }
+        const consumerOffsets = this._committedOffsets;
+        const topicOffsets = [];
+        return async.each(consumerOffsets, (p, done) => {
+            this._getLatestTopicOffset(p.partition, (err, topicOffset) => {
+                if (err) {
+                    this._log.error('error getting latest topic offset', {
+                        topic: this._topic,
+                        partition: p.partition,
+                        topicOffset,
+                        error: err, // kafka error does not have a
+                        // message field
+                    });
+                    return done(err);
+                }
+                topicOffsets.push({ partition: p.partition,
+                                    offset: topicOffset });
+                return async.parallel([
+                    done => this._publishOffset(p.partition, p.offset,
+                                                'consumer', done),
+                    done => this._publishOffset(p.partition, topicOffset,
+                                                'topic', done),
+                ], done);
+            });
+        }, err => {
+            if (!err) {
+                this._log.info(
+                    'published consumer and topic offsets to zookeeper', {
+                        topic: this._topic,
+                        consumerOffsets,
+                        topicOffsets,
+                    });
+            }
+            if (cb) {
+                // used for shutdown
+                cb(err);
+            }
+        });
+    }
+
+    /**
+     * Fetch latest consumable offset from topic
+     *
+     * @param {number} partition partition number to fetch latest
+     * consumable offset from
+     * @param {function} cb - callback: cb(err, offset)
+     * @return {undefined}
+     */
+    _getLatestTopicOffset(partition, cb) {
+        this._consumer.queryWatermarkOffsets(
+            this._topic, partition, 10000, (err, offsets) => {
+                if (err) {
+                    return cb(err);
+                }
+                // high watermark is last message pushed and consumable
+                return cb(null, offsets.highOffset);
+            });
     }
 
     /**
@@ -299,7 +440,7 @@ class BackbeatConsumer extends EventEmitter {
                         self._consumer.unsubscribe();
                         producer.close(() => {
                             self._bootstrapping = false;
-                            self.emit('ready');
+                            self._onReady();
                         });
                     }
                 }
@@ -343,14 +484,31 @@ class BackbeatConsumer extends EventEmitter {
     * @return {undefined}
     */
     close(cb) {
-        if (this._consumer) {
-            this._consumer.commit();
-            this._consumer.unsubscribe();
-            this._consumer.disconnect();
-            this._consumer.on('disconnected', () => cb());
-        } else {
-            process.nextTick(cb);
+        if (this._zookeeper) {
+            this._zookeeper.close();
         }
+        async.series([
+            next => {
+                if (this._consumer) {
+                    this._consumer.commit();
+                    this._consumer.unsubscribe();
+                    this._consumer.disconnect();
+                    this._consumer.on('disconnected', () => next());
+                } else {
+                    process.nextTick(next);
+                }
+            },
+            next => {
+                if (this._publishBacklogMetricsTimer) {
+                    clearInterval(this._publishBacklogMetricsTimer);
+                    this._publishBacklogMetricsTimer = null;
+                    // publish offsets to zookeeper
+                    this._publishOffsetsCron(() => next());
+                } else {
+                    process.nextTick(next);
+                }
+            },
+        ], () => cb());
     }
 }
 

--- a/lib/clients/zookeeper.js
+++ b/lib/clients/zookeeper.js
@@ -61,6 +61,24 @@ function createClient(connectionString, options) {
             next => zkClient.remove(path, -1, next),
         ], cb);
     };
+
+    zkClient.setOrCreate = function setOrCreate(path, data, cb) {
+        zkClient.setData(path, data, err => {
+            if (err) {
+                if (err.getCode() === zookeeper.Exception.NO_NODE) {
+                    return zkClient.mkdirp(path, err => {
+                        if (err) {
+                            return cb(err);
+                        }
+                        return zkClient.setData(path, data, cb);
+                    });
+                }
+                return cb(err);
+            }
+            return cb();
+        });
+    };
+
     return zkClient;
 }
 

--- a/tests/functional/BackbeatConsumer.js
+++ b/tests/functional/BackbeatConsumer.js
@@ -1,6 +1,9 @@
 const assert = require('assert');
+const async = require('async');
+const zookeeperHelper = require('../../lib/clients/zookeeper');
 const BackbeatProducer = require('../../lib/BackbeatProducer');
 const BackbeatConsumer = require('../../lib/BackbeatConsumer');
+const zookeeperConf = { connectionString: 'localhost:2181' };
 const kafkaConf = { hosts: 'localhost:9092' };
 const topic = 'backbeat-consumer-spec';
 const groupId = `replication-group-${Math.random()}`;
@@ -10,6 +13,7 @@ const messages = [
     { key: 'qux', message: 'hi' },
 ];
 describe('BackbeatConsumer', () => {
+    let zookeeper;
     let producer;
     let consumer;
     const consumedMessages = [];
@@ -20,18 +24,32 @@ describe('BackbeatConsumer', () => {
     before(function before(done) {
         this.timeout(60000);
 
+        let zookeeperReady = false;
         let producerReady = false;
         let consumerReady = false;
         function _doneIfReady() {
-            if (producerReady && consumerReady) {
+            if (zookeeperReady && producerReady && consumerReady) {
                 done();
             }
         }
         producer = new BackbeatProducer({ kafka: kafkaConf, topic,
                                           pollIntervalMs: 100 });
-        consumer = new BackbeatConsumer({ kafka: kafkaConf, groupId, topic,
+        consumer = new BackbeatConsumer({ zookeeper: zookeeperConf,
+                                          kafka: kafkaConf, groupId, topic,
                                           queueProcessor,
-                                          bootstrap: true });
+                                          backlogMetrics: {
+                                              zkPath: '/test/backlog-metrics',
+                                              intervalS: 1,
+                                          },
+                                          bootstrap: true,
+                                        });
+        zookeeper = zookeeperHelper.createClient(
+            zookeeperConf.connectionString);
+        zookeeper.connect();
+        zookeeper.on('ready', () => {
+            zookeeperReady = true;
+            _doneIfReady();
+        });
         producer.on('ready', () => {
             producerReady = true;
             _doneIfReady();
@@ -44,6 +62,8 @@ describe('BackbeatConsumer', () => {
     after(done => {
         producer.close(() => {
             consumer.close(() => {
+                zookeeper.close();
+                zookeeper = null;
                 producer = null;
                 consumer = null;
                 done();
@@ -51,10 +71,28 @@ describe('BackbeatConsumer', () => {
         });
     });
 
-    it('should be able to read messages sent to the topic', done => {
+    it('should be able to read messages sent to the topic and publish ' +
+    'backlog metrics', done => {
         let consumeCb = null;
         let totalConsumed = 0;
-
+        let topicOffset;
+        let consumerOffset;
+        const zkMetricsPath = `/test/backlog-metrics/${topic}/0`;
+        function _checkZkMetrics(done) {
+            async.waterfall([
+                next => zookeeper.getData(`${zkMetricsPath}/topic`, next),
+                (topicOffsetData, stat, next) => {
+                    topicOffset = Number.parseInt(topicOffsetData, 10);
+                    zookeeper.getData(`${zkMetricsPath}/consumers/${groupId}`,
+                                      next);
+                },
+            ], (err, consumerOffsetData) => {
+                assert.ifError(err);
+                consumerOffset = Number.parseInt(consumerOffsetData, 10);
+                assert.strictEqual(topicOffset, consumerOffset);
+                done();
+            });
+        }
         consumer.subscribe();
         consumer.on('consumed', messagesConsumed => {
             totalConsumed += messagesConsumed;
@@ -63,7 +101,17 @@ describe('BackbeatConsumer', () => {
                 assert.deepStrictEqual(
                     messages.map(e => e.message),
                     consumedMessages.map(buffer => buffer.toString()));
-                consumeCb();
+                // metrics are published every second, so they
+                // should be there after 5s
+                setTimeout(() => {
+                    _checkZkMetrics(() => {
+                        consumeCb();
+                        consumer.unsubscribe();
+                    });
+                }, 5000);
+                assert.deepStrictEqual(
+                    messages.map(e => e.message),
+                    consumedMessages.map(buffer => buffer.toString()));
             }
         });
         consumeCb = done;

--- a/tests/functional/lifecycle/LifecycleConductor.spec.js
+++ b/tests/functional/lifecycle/LifecycleConductor.spec.js
@@ -23,6 +23,10 @@ const lcConfig = {
     zookeeperPath: '/test/lifecycle',
     bucketTasksTopic: 'backbeat-lifecycle-bucket-tasks-spec',
     objectTasksTopic: 'backbeat-lifecycle-object-tasks-spec',
+    backlogMetrics: {
+        zkPath: '/test/lifecycle/backlog-metrics',
+        intervalS: 1,
+    },
     conductor: {
         cronRule: '*/5 * * * * *',
     },


### PR DESCRIPTION
Temporary target, will be set to rel/7.4-beta once rdkafka PR is merged

* bf: add backlog metrics to BackbeatConsumer
    
    Now BackbeatConsumer will publish metrics periodically in zookeeper
    about the current backlog: consumer offset and latest topic
    offset. This will be used to check how much is the backlog (or if
    there is any at all) and throttle processing if needed.

* bf: backpressure for lifecycle
    
    In order to avoid accumulating lifecycle tasks and diverging when the
    system cannot process everything in the allocated time, add a
    mechanism to skip processing cycles when the previous cycle has not
    finished yet.
    
    Kafka consumers in LifecycleConsumer and LifecycleProducer now publish
    to zookeeper, for their consumed topic partitions, their current
    committed offset and the latest topic partition offset.
    
    The conductor checks those when he's about to start a new cycle: if
    they are not equal (i.e. if the backlog is non-null), it means there
    are still things being processed, so the conductor does not trigger a
    new cycle and waits for the next one.

