### PR TITLE
bf: disable removal of zookeeper bucket node

### DIFF
--- a/tests/behavior/queuePopulator.js
+++ b/tests/behavior/queuePopulator.js
@@ -281,7 +281,8 @@ describe('queuePopulator', () => {
                             done);
                     }));
 
-            it('should delete lifecycle bucket data path if bucket is deleted',
+            it.skip('should delete lifecycle bucket data path if bucket ' +
+            'is deleted',
             done => async.series([
                 next =>
                     queuePopulator.processAllLogEntries({ maxRead: 10 }, next),
@@ -296,8 +297,8 @@ describe('queuePopulator', () => {
                     doesZkNodeExist(false, zkClient, zkBucketPath, next),
             ], done));
 
-            it('should delete lifecycle bucket data path if lifecycle config ' +
-            'is deleted', done => async.series([
+            it.skip('should delete lifecycle bucket data path if lifecycle ' +
+            'config is deleted', done => async.series([
                 next =>
                     queuePopulator.processAllLogEntries({ maxRead: 10 }, next),
                 next =>


### PR DESCRIPTION
Rationale:

From the raft log, we observe that bucket operations come from
multiple raft sessions (observed bucket metadata for one bucket from
sessions 1, 2 and 3), where the original expectation was that
operations on one bucket came from only one raft session at a time.

This means that we have no guarantee in which order we process
operations on a single bucket, since raft sessions are processed
independently by multiple queue populators. Because of time
constraints on delivery we disable the removal of bucket nodes for
now, but we should consider re-enabling removal with a correct method
later.