### PR TITLE
properly shutdown lifecycle processes

### DIFF
--- a/extensions/lifecycle/lifecycleConsumer/LifecycleConsumer.js
+++ b/extensions/lifecycle/lifecycleConsumer/LifecycleConsumer.js
@@ -80,6 +80,15 @@ class LifecycleConsumer extends EventEmitter {
         });
     }
 
+    /**
+     * Close the lifecycle consumer
+     * @param {function} cb - callback function
+     * @return {undefined}
+     */
+    close(cb) {
+        this.logger.debug('closing object tasks consumer');
+        this._consumer.close(cb);
+    }
 
     /**
      * Proceed to the lifecycle action of an object given a kafka

--- a/extensions/lifecycle/lifecycleConsumer/task.js
+++ b/extensions/lifecycle/lifecycleConsumer/task.js
@@ -11,6 +11,8 @@ const s3Config = config.s3;
 const authConfig = config.auth;
 const transport = config.transport;
 
+const log = new werelogs.Logger('Backbeat:Lifecycle:Consumer');
+
 const lifecycleConsumer = new LifecycleConsumer(
     zkConfig, kafkaConfig, lcConfig, s3Config, authConfig, transport);
 
@@ -18,3 +20,10 @@ werelogs.configure({ level: config.log.logLevel,
     dump: config.log.dumpLevel });
 
 lifecycleConsumer.start();
+
+process.on('SIGTERM', () => {
+    log.info('received SIGTERM, exiting');
+    lifecycleConsumer.close(() => {
+        process.exit(0);
+    });
+});

--- a/extensions/lifecycle/lifecycleProducer/LifecycleProducer.js
+++ b/extensions/lifecycle/lifecycleProducer/LifecycleProducer.js
@@ -365,7 +365,6 @@ class LifecycleProducer {
      */
     start() {
         this._setupVaultClientCache();
-        this._setupConsumer();
         return async.parallel([
             // Set up producer to populate the lifecycle bucket task topic.
             next => this._setupProducer(this._lcConfig.bucketTasksTopic,
@@ -402,6 +401,7 @@ class LifecycleProducer {
                     method: 'LifecycleProducer.start',
                 });
             }
+            this._setupConsumer();
             this._log.info('lifecycle producer successfully started');
             return undefined;
         });

--- a/extensions/lifecycle/lifecycleProducer/LifecycleProducer.js
+++ b/extensions/lifecycle/lifecycleProducer/LifecycleProducer.js
@@ -406,6 +406,28 @@ class LifecycleProducer {
             return undefined;
         });
     }
+
+    /**
+     * Close the lifecycle producer
+     * @param {function} cb - callback function
+     * @return {undefined}
+     */
+    close(cb) {
+        async.parallel([
+            done => {
+                this._log.debug('closing bucket tasks consumer');
+                this._consumer.close(done);
+            },
+            done => {
+                this._log.debug('closing bucket tasks producer');
+                this._bucketProducer.close(done);
+            },
+            done => {
+                this._log.debug('closing object tasks producer');
+                this._objectProducer.close(done);
+            },
+        ], () => cb());
+    }
 }
 
 module.exports = LifecycleProducer;

--- a/extensions/lifecycle/lifecycleProducer/task.js
+++ b/extensions/lifecycle/lifecycleProducer/task.js
@@ -7,8 +7,17 @@ const { zookeeper, kafka, extensions, s3, auth, transport, log } =
 werelogs.configure({ level: log.logLevel,
                      dump: log.dumpLevel });
 
+const logger = new werelogs.Logger('Backbeat:Lifecycle:Producer');
+
 const lifecycleProducer =
     new LifecycleProducer(zookeeper, kafka, extensions.lifecycle,
                           s3, auth, transport);
 
 lifecycleProducer.start();
+
+process.on('SIGTERM', () => {
+    logger.info('received SIGTERM, exiting');
+    lifecycleProducer.close(() => {
+        process.exit(0);
+    });
+});


### PR DESCRIPTION
Catch SIGTERM in producer and consumer processes and call close() functions.
