### PR TITLE
Ft: add lifecycle task expire functional tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,6 +16,9 @@ dependencies:
     override:
         - rm -rf node_modules
         - npm install
+    post:
+        - TEST_SWITCH=1 cd node_modules/s3 && npm run mem_backend: {background: true}
+
 test:
     override:
         - docker run -e AUTO_CREATE_TOPICS=true -d --net=host --name kafka spotify/kafka
@@ -23,4 +26,4 @@ test:
         - npm run --silent lint
         - npm test
         - TEST_SWITCH=1 npm start & bash tests/utils/wait_for_local_port.bash 8900 40 && npm run ft_server_test
-        - cd node_modules/s3 && npm run mem_backend & bash tests/utils/wait_for_local_port.bash 8000 40 && TEST_SWITCH=1 npm run ft_test
+        - TEST_SWITCH=1 npm run ft_test

--- a/circle.yml
+++ b/circle.yml
@@ -23,4 +23,4 @@ test:
         - npm run --silent lint
         - npm test
         - TEST_SWITCH=1 npm start & bash tests/utils/wait_for_local_port.bash 8900 40 && npm run ft_server_test
-        - npm run ft_test
+        - cd node_modules/s3 && npm run mem_backend & bash tests/utils/wait_for_local_port.bash 8000 40 && TEST_SWITCH=1 npm run ft_test

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -32,5 +32,9 @@ stages:
           name: run unit tests
           command: npm test
       - ShellCommand:
+          name: start s3 membackend server
+          command: npm run mem_backend &
+          workdir: node_modules/s3
+      - ShellCommand:
           name: run feature tests
           command: npm run ft_test

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -33,7 +33,7 @@ stages:
           command: npm test
       - ShellCommand:
           name: start s3 membackend server
-          command: npm run run_my_s3
+          command: cd node_modules/s3 && npm run mem_backend
       - ShellCommand:
           name: run feature tests
           command: npm run ft_test

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -33,8 +33,7 @@ stages:
           command: npm test
       - ShellCommand:
           name: start s3 membackend server
-          command: npm run mem_backend &
-          workdir: node_modules/s3
+          command: npm run run_my_s3
       - ShellCommand:
           name: run feature tests
           command: npm run ft_test

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -31,9 +31,13 @@ stages:
       - ShellCommand:
           name: run unit tests
           command: npm test
+      # - ShellCommand:
+      #     name: run server api functional tests
+      #     command: TEST_SWITCH=1 npm start && bash tests/utils/wait_for_local_port.bash 8900 40 && npm run ft_server_test
       - ShellCommand:
-          name: start s3 membackend server
-          command: cd node_modules/s3 && npm run mem_backend
-      - ShellCommand:
-          name: run feature tests
-          command: npm run ft_test
+          name: run s3 server and run feature tests
+          command: bash ./eve/workers/unit_and_feature_tests/run_server_tests.bash
+          workdir: '%(prop:builddir)s/build'
+      # - ShellCommand:
+      #     name: run feature tests
+      #     command: TEST_SWITCH=1 npm run ft_test

--- a/eve/workers/unit_and_feature_tests/Dockerfile
+++ b/eve/workers/unit_and_feature_tests/Dockerfile
@@ -6,7 +6,6 @@ FROM spotify/kafka
 COPY ./backbeat_packages.list ./buildbot_worker_packages.list /tmp/
 
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
-    && apt-get update \
     && cat /tmp/*packages.list | xargs apt-get install -y \
     && pip install pip==9.0.1 \
     && rm -rf /var/lib/apt/lists/* \

--- a/eve/workers/unit_and_feature_tests/Dockerfile
+++ b/eve/workers/unit_and_feature_tests/Dockerfile
@@ -6,6 +6,7 @@ FROM spotify/kafka
 COPY ./backbeat_packages.list ./buildbot_worker_packages.list /tmp/
 
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
+    && apt-get update \
     && cat /tmp/*packages.list | xargs apt-get install -y \
     && pip install pip==9.0.1 \
     && rm -rf /var/lib/apt/lists/* \

--- a/eve/workers/unit_and_feature_tests/backbeat_packages.list
+++ b/eve/workers/unit_and_feature_tests/backbeat_packages.list
@@ -1,2 +1,3 @@
 build-essential
 nodejs
+nc

--- a/eve/workers/unit_and_feature_tests/backbeat_packages.list
+++ b/eve/workers/unit_and_feature_tests/backbeat_packages.list
@@ -1,3 +1,3 @@
 build-essential
 nodejs
-nc
+redis-server

--- a/eve/workers/unit_and_feature_tests/buildbot_worker_packages.list
+++ b/eve/workers/unit_and_feature_tests/buildbot_worker_packages.list
@@ -7,3 +7,5 @@ python2.7-dev
 python-pip
 software-properties-common
 sudo
+lsof
+nc

--- a/eve/workers/unit_and_feature_tests/buildbot_worker_packages.list
+++ b/eve/workers/unit_and_feature_tests/buildbot_worker_packages.list
@@ -8,4 +8,3 @@ python-pip
 software-properties-common
 sudo
 lsof
-nc

--- a/eve/workers/unit_and_feature_tests/run_server_tests.bash
+++ b/eve/workers/unit_and_feature_tests/run_server_tests.bash
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# pwd === eve/workers/unit_and_feature_tests/
+
+# echo $(pwd) === /docker-prod-backbeat-backend-0/build
+
+killandsleep () {
+  kill -9 $(lsof -t -i:$1) || true
+  sleep 10
+}
+
+# run s3 mem_backend
+cd node_modules/s3 && TEST_SWITCH=1 npm run mem_backend & bash tests/utils/wait_for_local_port.bash 8000 40 && npm run ft_test
+
+killandsleep 8000
+
+# run backbeat server
+cd TEST_SWITCH=1 npm start & bash tests/utils/wait_for_local_port.bash 8900 40 && npm run ft_server_test
+
+killandsleep 8900
+
+exit 0

--- a/eve/workers/unit_and_feature_tests/supervisor/buildbot_worker.conf
+++ b/eve/workers/unit_and_feature_tests/supervisor/buildbot_worker.conf
@@ -2,3 +2,8 @@
 command=/bin/sh -c 'buildbot-worker create-worker . "%(ENV_BUILDMASTER)s:%(ENV_BUILDMASTER_PORT)s" "%(ENV_WORKERNAME)s" "%(ENV_WORKERPASS)s"  && buildbot-worker start --nodaemon'
 autostart=true
 autorestart=false
+
+[program:redis]
+command=/usr/bin/redis-server
+autostart=true
+autorestart=false

--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -8,7 +8,7 @@ const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
 const RETRYTIMEOUTS = 300;
 
 // Default max AWS limit is 1000 for both list objects and list object versions
-const MAX_KEYS = 1000;
+const MAX_KEYS = process.env.TEST_SWITCH ? 3 : 1000;
 // concurrency mainly used in async calls
 const CONCURRENCY_DEFAULT = 10;
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "bh_test": "mocha --recursive tests/behavior",
     "lint": "eslint $(git ls-files '*.js')",
     "lint_md": "mdlint $(git ls-files '*.md')",
-    "run_my_s3": "cd node_modules/s3 && npm run mem_backend & bash tests/utils/wait_for_local_port.bash 8000 40",
     "start": "node index.js"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "mocha --recursive tests/unit",
     "ft_test": "mocha --recursive $(find tests/functional -name '*.js' ! -name 'BackbeatServer.js')",
     "ft_server_test": "mocha tests/functional/api/BackbeatServer.js",
+    "test_all_ft_test": "mocha --recursive tests/functional",
     "bh_test": "mocha --recursive tests/behavior",
     "lint": "eslint $(git ls-files '*.js')",
     "lint_md": "mdlint $(git ls-files '*.md')",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "werelogs": "scality/werelogs#rel/7.4-beta"
   },
   "devDependencies": {
-    "mocha": "^3.3.0"
+    "mocha": "^3.3.0",
+    "s3": "scality/S3#rel/7.4-beta"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "bh_test": "mocha --recursive tests/behavior",
     "lint": "eslint $(git ls-files '*.js')",
     "lint_md": "mdlint $(git ls-files '*.md')",
+    "run_my_s3": "cd node_modules/s3 && npm run mem_backend & bash tests/utils/wait_for_local_port.bash 8000 40",
     "start": "node index.js"
   },
   "repository": {

--- a/tests/config.json
+++ b/tests/config.json
@@ -23,6 +23,26 @@
             "adminCredentialsFile": "../conf/authdata.json"
         }
     },
+    "kafka": {
+        "hosts": "127.0.0.1:9092"
+    },
+    "s3": {
+        "host": "127.0.0.1",
+        "port": 8000,
+        "transport": "http",
+        "accessKey": "accessKey1",
+        "secretKey": "verySecretKey1"
+    },
+    "auth": {
+        "type": "account",
+        "account": "bart",
+        "vault": {
+            "host": "127.0.0.1",
+            "port": 8500,
+            "adminPort": 8600,
+            "adminCredentialsFile": "../conf/authdata.json"
+        }
+    },
     "queuePopulator": {
         "cronRule": "*/5 * * * * *",
         "batchMaxRead": 10000,

--- a/tests/functional/lifecycle/LifecycleTask.js
+++ b/tests/functional/lifecycle/LifecycleTask.js
@@ -1,0 +1,770 @@
+const assert = require('assert');
+const uuid = require('uuid/v4');
+const util = require('util');
+
+const { errors } = require('arsenal');
+const Logger = require('werelogs').Logger;
+
+const LifecycleTask = require('../../../extensions/lifecycle' +
+    '/tasks/LifecycleTask');
+const Rule = require('../../utils/Rule');
+
+/*
+    NOTE:
+    When using CURRENT, running the lifecycle tasks will internally use
+    `Date.now` to compare dates. This means that CURRENT date usage will most
+    likely be in the past.
+    To avoid flakiness, I will be setting the day of CURRENT back 2 day to
+    avoid any flakiness.
+    When comparing rules, if I set a rule that says "Days: 1", then any objects
+    using CURRENT as LastModified should pass. To avoid flakiness, set a rule
+    that says "Days: 3" to have any objects using CURRENT as LastModified to
+    not pass.
+*/
+// current date
+const CURRENT = new Date();
+CURRENT.setDate(CURRENT.getDate() - 2);
+// 5 days prior to currentDate
+const PAST = new Date(CURRENT);
+PAST.setDate(PAST.getDate() - 5);
+// 5 days after currentDate
+const FUTURE = new Date(CURRENT);
+FUTURE.setDate(FUTURE.getDate() + 5);
+
+const OWNER = 'testOwner';
+
+// NOTE: Since all S3 calls are only 'GET's, I decided to just go for mock
+//  S3 that defines all buckets and their conditions
+class S3Mock {
+    constructor() {
+        this.overrideMax = undefined;
+
+        this.s3Storage = {
+            'test-expire': {
+                Objects: [
+                    {
+                        Key: 'expire-1',
+                        LastModified: PAST,
+                        StorageClass: 'STANDARD',
+                        Marker: uuid().replace(/-/g, ''),
+                        //
+                        TagSet: [],
+                    },
+                    {
+                        Key: 'expire-2',
+                        LastModified: CURRENT,
+                        StorageClass: 'STANDARD',
+                        Marker: uuid().replace(/-/g, ''),
+                        //
+                        TagSet: [
+                            { Key: 'key1', Value: 'value1' },
+                        ],
+                    },
+                    {
+                        Key: 'expire-3',
+                        LastModified: PAST,
+                        StorageClass: 'STANDARD',
+                        Marker: uuid().replace(/-/g, ''),
+                        //
+                        TagSet: [
+                            { Key: 'key1', Value: 'value1' },
+                            { Key: 'key2', Value: 'value2' },
+                        ],
+                    },
+                    {
+                        Key: 'expire-4',
+                        LastModified: FUTURE,
+                        StorageClass: 'STANDARD',
+                        Marker: uuid().replace(/-/g, ''),
+                        //
+                        TagSet: [
+                            { Key: 'key2', Value: 'value2' },
+                            { Key: 'key1', Value: 'value1' },
+                        ],
+                    },
+                    {
+                        Key: 'expire-5',
+                        LastModified: FUTURE,
+                        StorageClass: 'STANDARD',
+                        Marker: uuid().replace(/-/g, ''),
+                        //
+                        TagSet: [
+                            { Key: 'key2', Value: 'value2' },
+                        ],
+                    },
+                ],
+            },
+            // 'test-versioned-bucket': {
+            //     Versioning: { Status: 'Enabled' },
+            //     Versions: [
+            //         {
+            //             Key: 'a-key',
+            //             LastModified: PAST,
+            //             IsLatest: true,
+            //             StorageClass: 'STANDARD',
+            //             VersionId: uuid().replace(/-/g, ''),
+            //             //
+            //             KeyMarker: uuid().replace(/-/g, ''),
+            //             TagSet: [],
+            //         },
+            //     ],
+            // },
+            // 'test-mpu': {
+            //     Uploads: [
+            //         {
+            //             Initiated: PAST,
+            //             Key: 'first-upload',
+            //             StorageClass: 'STANDARD',
+            //             UploadId: uuid().replace(/-/g, ''),
+            //             //
+            //             KeyMarker: uuid().replace(/-/g, ''),
+            //         },
+            //     ],
+            // },
+        };
+    }
+
+    _noop() {}
+
+    getObjectCount(bucketName) {
+        return this.s3Storage[bucketName].Objects.length;
+    }
+
+    /**
+     * head object operation on either a version or object
+     * @param {Object} params - parameters
+     * @param {string} params.Bucket - bucket name
+     * @param {string} params.Key - key
+     * @param {string} [params.VersionId] - optional version id
+     * @return {Object} wrapper to mock `send`
+     */
+    headObject(params) {
+        assert(params.Bucket);
+        assert(params.Key);
+
+        return {
+            send: this._headObjectHandler.bind(this, params),
+            on: this._noop,
+            httpRequest: { headers: {} },
+        };
+    }
+
+    // Currently only care about returning `data.LastModified`
+    _headObjectHandler(params, cb) {
+        const bucket = this.s3Storage[params.Bucket];
+        if (!bucket) {
+            return cb(errors.NoSuchBucket);
+        }
+        if (params.VersionId) {
+            const version = bucket.Versions.find(v =>
+                v.VersionId === params.VersionId && v.Key === params.Key);
+            if (!version) {
+                return cb(errors.ObjNotFound);
+            }
+
+            const res = Object.assign({}, version);
+            delete res.TagSet;
+            return cb(null, res);
+        }
+        const obj = bucket.Objects.find(o => o.Key === params.Key);
+        if (!obj) {
+            return cb(errors.ObjNotFound);
+        }
+
+        const res = Object.assign({}, obj);
+        delete res.TagSet;
+        return cb(null, res);
+    }
+
+    /**
+     * get bucket versioning
+     * @param {Object} params - parameters
+     * @param {string} params.Bucket - bucket name
+     * @return {Object} wrapper to mock `send`
+     */
+    getBucketVersioning(params) {
+        assert(params.Bucket);
+
+        return {
+            send: this._getBucketVersioningHandler.bind(this, params),
+            on: this._noop,
+            httpRequest: { headers: {} },
+        };
+    }
+
+    _getBucketVersioningHandler(params, cb) {
+        const bucketVersioning = this.s3Storage[params.Bucket].Versioning;
+        return cb(null, bucketVersioning || {});
+    }
+
+    /**
+     * get an object or a versions tags
+     * @param {Object} params - parameters
+     * @param {string} params.Bucket - bucket name
+     * @param {string} params.Key - key
+     * @param {string} [params.VersionId] - optional version id
+     * @return {Object} wrapper to mock `send`
+     */
+    getObjectTagging(params) {
+        assert(params.Bucket);
+        assert(params.Key);
+
+        return {
+            send: this._getObjectTaggingHandler.bind(this, params),
+            on: this._noop,
+            httpRequest: { headers: {} },
+        };
+    }
+
+    _getObjectTaggingHandler(params, cb) {
+        const bucket = this.s3Storage[params.Bucket];
+        if (!bucket) {
+            return cb(errors.NoSuchBucket);
+        }
+        if (params.VersionId) {
+            if (!bucket.Versions) {
+                // TODO: verify this logic. Return empty array? or error?
+                return cb(null, { TagSet: [] });
+            }
+            const version = bucket.Versions.find(v =>
+                v.VersionId === params.VersionId && v.Key === params.Key);
+            if (!version) {
+                return cb(errors.ObjNotFound);
+            }
+
+            const res = { TagSet: version.TagSet };
+            return cb(null, res);
+        }
+        const obj = bucket.Objects.find(o => o.Key === params.Key);
+        if (!obj) {
+            return cb(errors.ObjNotFound);
+        }
+
+        const res = { TagSet: obj.TagSet };
+        return cb(null, res);
+    }
+
+    /**
+     * get all objects from bucket for given key
+     * @param {Object} params - parameters
+     * @param {string} params.Bucket - bucket name
+     * @param {string} params.Key - key
+     * @return {Object} wrapper to mock `send`
+     */
+    listObjects(params) {
+        assert(params.Bucket);
+
+        // Override default MaxKeys from LifecycleTask
+        const newParams = params;
+        if (this.overrideMax) {
+            newParams.MaxKeys = this.overrideMax;
+        }
+
+        return {
+            send: this._listObjectsHandler.bind(this, newParams),
+            on: this._noop,
+            httpRequest: { headers: {} },
+        };
+    }
+
+    _listObjectsHandler(params, cb) {
+        const bucket = this.s3Storage[params.Bucket];
+        if (!bucket) {
+            return cb(errors.NoSuchBucket);
+        }
+
+        const bucketObjs = bucket.Objects;
+        if (!bucketObjs || bucketObjs.length === 0) {
+            const res = { Contents: [] };
+            return cb(null, res);
+        }
+
+        let markerIdx = 0;
+        let maxIdx = params.MaxKeys;
+        if (params.Marker) {
+            markerIdx = bucketObjs.findIndex(o => o.Marker === params.Marker);
+            maxIdx = markerIdx + params.MaxKeys;
+        }
+
+        const IsTruncated = bucketObjs.length > maxIdx;
+        const Contents = bucketObjs.slice(markerIdx, maxIdx).map(o => {
+            const newObj = Object.assign({}, o);
+            delete newObj.TagSet;
+            return newObj;
+        });
+        const res = {
+            Contents,
+            IsTruncated,
+            NextMarker: IsTruncated ? this._findNextMarker(bucketObjs,
+                Contents[Contents.length - 1].Marker, 'Marker') : null,
+        };
+        return cb(null, res);
+    }
+
+    /**
+     * get all versions from bucket
+     * @param {Object} params - parameters
+     * @param {string} params.Bucket - bucket name
+     * @param {string} [params.KeyMarker] - optional key marker
+     * @param {string} [params.VersionIdMarker] - required if key marker exists
+     * @return {Object} wrapper to mock `send`
+     */
+    listObjectVersions(params) {
+        assert(params.Bucket);
+        if (params.VersionIdMarker || params.KeyMarker) {
+            assert(params.VersionIdMarker && params.KeyMarker);
+        }
+
+        // Override default MaxKeys from LifecycleTask
+        const newParams = params;
+        if (this.overrideMax) {
+            newParams.MaxKeys = this.overrideMax;
+        }
+
+        return {
+            send: this._listObjectVersionsHandler.bind(this, newParams),
+            on: this._noop,
+            httpRequest: { headers: {} },
+        };
+    }
+
+    _listObjectVersionsHandler(params, cb) {
+        const bucket = this.s3Storage[params.Bucket];
+        if (!bucket) {
+            return cb(errors.NoSuchBucket);
+        }
+
+        const bucketVersions = bucket.Versions;
+        if (!bucketVersions || bucketVersions.length === 0) {
+            const res = { Versions: [] };
+            return cb(null, res);
+        }
+
+        let markerIdx = 0;
+        let maxIdx = params.MaxKeys;
+        if (params.KeyMarker) {
+            markerIdx = bucketVersions.findIndex(v =>
+                v.KeyMarker === params.KeyMarker &&
+                v.VersionId === params.VersionIdMarker);
+            if (markerIdx === -1) {
+                // wrong keymarker / versionidmarker combo
+                process.stdout.write('ALERT: Error in list object versions');
+                assert(false);
+            }
+            maxIdx = markerIdx + params.MaxKeys;
+        }
+
+        const IsTruncated = bucketVersions.length > maxIdx;
+        const Versions = bucketVersions.slice(markerIdx, maxIdx).map(v => {
+            const newVer = Object.assign({}, v);
+            delete newVer.TagSet;
+            delete newVer.KeyMarker;
+            return newVer;
+        });
+        const res = {
+            Versions,
+            IsTruncated,
+            NextKeyMarker: IsTruncated ? this._findNextMarker(bucketVersions,
+                Versions[Versions.length - 1].KeyMarker, 'KeyMarker') : null,
+            NextVersionIdMarker: IsTruncated ? this._findNextMarker(
+                bucketVersions, Versions[Versions.length - 1].VersionId,
+                'VersionId') : null,
+        };
+        return cb(null, res);
+    }
+
+    /**
+     * get all mpus from bucket
+     * @param {Object} params - parameters
+     * @param {string} params.Bucket - bucket name
+     * @param {string} [params.KeyMarker] - optional key marker
+     * @param {string} [params.UploadIdMarker] - required if key marker exists
+     * @return {Object} wrapper to mock `send`
+     */
+    listMultipartUploads(params) {
+        assert(params.Bucket);
+        if (params.KeyMarker || params.UploadIdMarker) {
+            assert(params.KeyMarker && params.UploadIdMarker);
+        }
+
+        // Override default MaxKeys from LifecycleTask
+        const newParams = params;
+        if (this.overrideMax) {
+            newParams.MaxKeys = this.overrideMax;
+        }
+
+        return {
+            send: this._listMultipartUploadsHandler.bind(this, newParams),
+            on: this._noop,
+            httpRequest: { headers: {} },
+        };
+    }
+
+    _listMultipartUploadsHandler(params, cb) {
+        process.stdout.write(util.inspect(params));
+        const bucket = this.s3Storage[params.Bucket];
+        if (!bucket) {
+            return cb(errors.NoSuchBucket);
+        }
+
+        const bucketUploads = bucket.Uploads;
+        if (!bucketUploads || bucketUploads.length === 0) {
+            const res = { Uploads: [] };
+            return cb(null, res);
+        }
+
+        let markerIdx = 0;
+        let maxIdx = params.MaxUploads;
+        if (params.KeyMarker) {
+            markerIdx = bucketUploads.findIndex(u =>
+                u.KeyMarker === params.KeyMarker &&
+                u.UploadId === params.UploadIdMarker);
+            if (markerIdx === -1) {
+                // wrong keymarker / uploadidmarker combo
+                process.stdout.write('ALERT: Error in list multipart uploads');
+                assert(false);
+            }
+            maxIdx = markerIdx + params.MaxUploads;
+        }
+
+        const IsTruncated = bucketUploads.length > maxIdx;
+        const Uploads = bucketUploads.slice(markerIdx, maxIdx).map(u => {
+            const upload = Object.assign({}, u);
+            delete upload.KeyMarker;
+            return upload;
+        });
+        const res = {
+            Uploads,
+            IsTruncated,
+            NextKeyMarker: IsTruncated ? this._findNextMarker(bucketUploads,
+                Uploads[Uploads.length - 1].KeyMarker, 'KeyMarker') : null,
+            NextUploadIdMarker: IsTruncated ? this._findNextMarker(
+                bucketUploads, Uploads[Uploads.length - 1].UploadId,
+                'UploadId') : null,
+        };
+        return cb(null, res);
+    }
+
+    // helper methods //
+
+    _findNextMarker(objs, marker, id) {
+        const curObjIdx = objs.findIndex(o => o[id] === marker);
+
+        if (curObjIdx === -1 || curObjIdx === objs.length - 1) {
+            // error in test
+            // Either object should not be `IsTruncated` or
+            // `Marker` cannot be found in list of objects
+            process.stdout.write('ALERT: Error in test functionality\n');
+            assert(false);
+        }
+        return objs[curObjIdx + 1][id];
+    }
+
+    /**
+     * set max keys or parts
+     * @param {number} max - max keys or parts in a listing
+     * @return {undefined}
+     */
+    setMax(max) {
+        this.overrideMax = max;
+    }
+
+    resetMax() {
+        this.overrideMax = undefined;
+    }
+}
+
+class LifecycleProducerMock {
+    constructor() {
+        this._log = new Logger('LifecycleProducer:test:LifecycleProducerMock');
+
+        // TODO: only added current working features
+        this._lcConfig = {
+            rules: {
+                expiration: { enabled: true },
+                noncurrentVersionExpiration: { enabled: true },
+                abortIncompleteMultipartUpload: { enabled: true },
+                // below are features not implemented yet
+                transition: { enabled: false },
+                noncurrentVersionTransition: { enabled: false },
+            },
+        };
+
+        this.sendBucketEntry = null;
+        this.sendObjectEntry = null;
+
+        this.sendCount = {
+            bucket: 0,
+            object: 0,
+        };
+        this.entries = {
+            bucket: [],
+            object: [],
+        };
+    }
+
+    setBucketFxn(fxn, cb) {
+        this.sendBucketEntry = fxn;
+        cb();
+    }
+
+    setObjectFxn(fxn, cb) {
+        this.sendObjectEntry = fxn;
+        cb();
+    }
+
+    incrementCount(type) {
+        this.sendCount[type]++;
+    }
+
+    addEntry(type, entry) {
+        this.entries[type].push(entry);
+    }
+
+    getCount() {
+        return this.sendCount;
+    }
+
+    getEntries() {
+        return this.entries;
+    }
+
+    disableRule(rule) {
+        if (this._lcConfig.rules[rule]) {
+            this._lcConfig.rules[rule].enabled = false;
+        }
+    }
+
+    enableRule(rule) {
+        if (this._lcConfig.rules[rule]) {
+            this._lcConfig.rules[rule].enabled = true;
+        }
+    }
+
+    getStateVars() {
+        return {
+            sendBucketEntry: this.sendBucketEntry,
+            sendObjectEntry: this.sendObjectEntry,
+            removeBucketFromQueued: () => {},
+            enabledRules: this._lcConfig.rules,
+            log: this._log,
+        };
+    }
+
+    reset() {
+        this.sendCount = {
+            bucket: 0,
+            object: 0,
+        };
+        this.entries = {
+            bucket: [],
+            object: [],
+        };
+        this.sendBucketEntry = null;
+        this.sendObjectEntry = null;
+    }
+}
+
+
+/*
+    To override MaxKeys or MaxUploads, set `testMaxKeys` or `testMaxUploads`
+    respectively in params.
+*/
+
+describe('lifecycle producer functional tests with mocking', () => {
+    let lcp;
+    let lcTask;
+    let s3mock;
+
+    before(() => {
+        lcp = new LifecycleProducerMock();
+        s3mock = new S3Mock();
+    });
+
+    // Example lifecycle configs
+    // {
+    //     "Filter": {
+    //         "And": {
+    //             "Prefix": "myprefix",
+    //             "Tags": [
+    //                 {
+    //                     "Value": "value1",
+    //                     "Key": "tag1"
+    //                 },
+    //                 {
+    //                     "Value": "value2",
+    //                     "Key": "tag2"
+    //                 }
+    //             ]
+    //         }
+    //     },
+    //     "Status": "Enabled",
+    //     "Expiration": {
+    //         "Days": 5
+    //     },
+    //     "ID": "rule1"
+    // },
+
+    describe('non-versioned bucket tests', () => {
+        before(() => {
+            lcp.setBucketFxn((entry, cb) => {
+                lcp.incrementCount('bucket');
+                lcp.addEntry('bucket', entry);
+
+                return cb(null, true);
+            }, () => {});
+            lcp.setObjectFxn((entry, cb) => {
+                lcp.incrementCount('object');
+                lcp.addEntry('object', entry.target.key);
+
+                // can assert entry stuff
+                return cb(null, true);
+            }, () => {});
+            lcTask = new LifecycleTask(lcp);
+        });
+
+        afterEach(() => {
+            lcp.reset();
+            s3mock.resetMax();
+        });
+
+        [
+            // basic expire with Date rule, no pagination, no tags
+            {
+                message: 'should verify that EXPIRED objects are sent to ' +
+                    'object kafka topic with no pagination, no tags',
+                bucketLCRules: [
+                    new Rule().addID('task-1').addExpiration('Date', PAST)
+                        .build(),
+                ],
+                bucketEntry: {
+                    action: 'testing',
+                    target: {
+                        bucket: 'test-expire',
+                        owner: OWNER,
+                    },
+                    details: {},
+                },
+                expected: {
+                    objects: ['expire-1', 'expire-2', 'expire-3',
+                        'expire-4', 'expire-5'],
+                    bucketCount: 0,
+                    objectCount: 5,
+                },
+            },
+            // basic expire with 1 Day rule, pagination, tagging part 1
+            {
+                message: 'should verify that EXPIRED objects are sent to ' +
+                    'object kafka topic with pagination, with tags: rule 1',
+                bucketLCRules: [
+                    new Rule().addID('task-1').addExpiration('Days', 1)
+                        .addTag('key1', 'value1').build(),
+                ],
+                bucketEntry: {
+                    action: 'testing',
+                    target: {
+                        bucket: 'test-expire',
+                        owner: OWNER,
+                    },
+                    details: {},
+                },
+                setMax: 2,
+                expected: {
+                    objects: ['expire-2', 'expire-3'],
+                    bucketCount: 2,
+                    objectCount: 2,
+                },
+            },
+            // basic expire with 1 Day rule, pagination, tagging part 2
+            {
+                message: 'should verify that EXPIRED objects are sent to ' +
+                    'object kafka topic with pagination, with tags: rule 2',
+                bucketLCRules: [
+                    new Rule().addID('task-1').addExpiration('Days', 1)
+                        .addTag('key2', 'value2').build(),
+                ],
+                bucketEntry: {
+                    action: 'testing',
+                    target: {
+                        bucket: 'test-expire',
+                        owner: OWNER,
+                    },
+                    details: {},
+                },
+                setMax: 3,
+                expected: {
+                    objects: ['expire-3'],
+                    bucketCount: 1,
+                    objectCount: 1,
+                },
+            },
+            // Multiple bucket expiration rules, no pagination, tagging
+            {
+                message: 'should verify that EXPIRED rules are properly ' +
+                    'being handled',
+                bucketLCRules: [
+                    new Rule().addID('task-1').addExpiration('Days', 3)
+                        .addTag('key2', 'value2').build(),
+                    new Rule().addID('task-2').addExpiration('Days', 1)
+                        .addTag('key1', 'value1').addTag('key2', 'value2')
+                        .build(),
+                    new Rule().addID('task-3').addExpiration('Date', FUTURE)
+                        .build(),
+                ],
+                bucketEntry: {
+                    action: 'testing',
+                    target: {
+                        bucket: 'test-expire',
+                        owner: OWNER,
+                    },
+                    details: {},
+                },
+                expected: {
+                    objects: ['expire-3'],
+                    bucketCount: 0,
+                    objectCount: 1,
+                },
+            },
+        ].forEach(item => {
+            it(item.message, done => {
+                if (item.setMax) {
+                    s3mock.setMax(item.setMax);
+                }
+                let counter = 0;
+                function wrapProcessBucketEntry(bucketLCRules, bucketEntry,
+                s3mock, cb) {
+                    lcTask.processBucketEntry(bucketLCRules, bucketEntry,
+                    s3mock, err => {
+                        assert.ifError(err);
+                        counter++;
+
+                        const entries = lcp.getEntries();
+                        // console.log(entries)
+
+                        if (counter === entries.bucket.length) {
+                            return wrapProcessBucketEntry(bucketLCRules,
+                                entries.bucket[entries.bucket.length - 1],
+                                s3mock, cb);
+                        }
+                        return cb(null);
+                    });
+                }
+                wrapProcessBucketEntry(item.bucketLCRules, item.bucketEntry,
+                s3mock, err => {
+                    assert.ifError(err);
+
+                    const count = lcp.getCount();
+                    const entries = lcp.getEntries();
+
+                    const expectedObjects = item.expected.objects;
+
+                    assert.equal(count.bucket, item.expected.bucketCount);
+                    assert.equal(count.object, item.expected.objectCount);
+
+                    assert.deepStrictEqual(entries.object, expectedObjects);
+                    done();
+                });
+            });
+        });
+    });
+});

--- a/tests/functional/lifecycle/LifecycleTask.js
+++ b/tests/functional/lifecycle/LifecycleTask.js
@@ -266,7 +266,7 @@ s3mock, params, cb) {
     });
 }
 
-describe('lifecycle producer functional tests', () => {
+describe('lifecycle producer functional', () => {
     let lcp;
     let lcTask;
     let s3;
@@ -313,7 +313,7 @@ describe('lifecycle producer functional tests', () => {
             });
         });
 
-        it('should verify changes in lifecycle rules will apply to the ' +
+        it.only('should verify changes in lifecycle rules will apply to the ' +
         'correct objects', done => {
             // kafka bucket entry
             const bucketEntry = {


### PR DESCRIPTION
Initial commit for LifecycleTask tests. Only tests expiration rule and will add tests for each
rule separately.

Solely tests the LifecycleTask class by counting the number of times a bucket or object Kafka
entry is made and tracks each object entry name.