### PR TITLE
FT: Add failure retry routes

### DIFF
--- a/extensions/replication/constants.js
+++ b/extensions/replication/constants.js
@@ -14,6 +14,7 @@ const constants = {
         bytes: testIsOn ? 'test:bb:bytes' : 'bb:crr:bytes',
         opsDone: testIsOn ? 'test:bb:opsdone' : 'bb:crr:opsdone',
         bytesDone: testIsOn ? 'test:bb:bytesdone' : 'bb:crr:bytesdone',
+        failedCRR: testIsOn ? 'test:bb:crr:failed' : 'bb:crr:failed',
     },
 };
 

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -10,6 +10,7 @@ const StatsModel = require('../models/StatsModel');
 const BackbeatProducer = require('../BackbeatProducer');
 const Healthcheck = require('./Healthcheck');
 const routes = require('./routes');
+const { redisKeys } = require('../../extensions/replication/constants');
 
 // StatsClient constant defaults
 // TODO: This should be moved to constants file
@@ -90,7 +91,10 @@ class BackbeatAPI {
         // check metric routes
         // Are there any routes with matching extension?
         const extensions = routes.reduce((store, r) => {
-            if (rDetails.category === 'metrics' && r.extensions) {
+            if (r.extensions[rDetails.extension] &&
+                r.extensions[rDetails.extension].includes(rDetails.status)) {
+                store.push(Object.keys(r.extensions));
+            } else if (rDetails.category === 'metrics') {
                 store.push(Object.keys(r.extensions));
             }
             return store;
@@ -102,7 +106,9 @@ class BackbeatAPI {
         let specifiedType;
         const validRoutes = [];
         routes.forEach(r => {
-            if (!r.extensions) {
+            if (r.extensions[rDetails.extension] &&
+                r.extensions[rDetails.extension].includes(rDetails.status)) {
+                validRoutes.push(r);
                 return;
             }
             if (!Object.keys(r.extensions).includes(rDetails.extension)) {
@@ -361,6 +367,144 @@ class BackbeatAPI {
                 return cb(null, store);
             });
         });
+    }
+
+    /**
+     * Find all failed CRR operations that match the bucket, key, and versionID.
+     * @param {Object} details - The route details
+     * @param {Function} cb - The callback to call
+     * @return {undefined}
+     */
+    getFailedCRR(details, cb) {
+        const { bucket, key, versionId } = details;
+        const pattern = `${bucket}:${key}:${versionId}:*`;
+        const cmds = ['hscan', redisKeys.failedCRR, 0, 'MATCH', pattern];
+        this._redisClient.batch([cmds], (err, res) => {
+            if (err) {
+                return cb(err);
+            }
+            const [cmdErr, cursor] = res[0];
+            if (cmdErr) {
+                return cb(cmdErr);
+            }
+            const collection = cursor[1];
+            const response = [];
+            for (let i = 0; i < collection.length; i += 2) {
+                const hashKey = collection[i];
+                const [bucket, key, versionId, site] = hashKey.split(':');
+                response.push({ bucket, key, versionId, site });
+            }
+            return cb(null, response);
+        });
+    }
+
+    /**
+     * Get all CRR operations that have failed.
+     * @param {Object} details - The route details
+     * @param {Function} cb - The callback to call
+     * @return {undefined}
+     */
+    getAllFailedCRR(details, cb) {
+        const cmds = ['hgetall', redisKeys.failedCRR];
+        this._redisClient.batch([cmds], (err, res) => {
+            if (err) {
+                return cb(err);
+            }
+            const [cmdErr, hashes] = res[0];
+            if (cmdErr) {
+                return cb(cmdErr);
+            }
+            const hashKeys = hashes ? Object.keys(hashes) : [];
+            const response = hashKeys.map(hashKey => {
+                const [bucket, key, versionId, site] = hashKey.split(':');
+                return { bucket, key, versionId, site };
+            });
+            return cb(null, response);
+        });
+    }
+
+    /**
+     * Retry all CRR operations that have failed.
+     * @param {Object} details - The route details
+     * @param {String} body - The POST request body string
+     * @param {Function} cb - The callback to call
+     * @return {undefined}
+     */
+    retryFailedCRR(details, body, cb) {
+        const { error, reqBody } = this._parseRetryFailedCRR(body);
+        if (error) {
+            return cb(error);
+        }
+        const fields = reqBody.map(o => {
+            const { bucket, key, versionId, site } = o;
+            return `${bucket}:${key}:${versionId}:${site}`;
+        });
+        const cmds = ['hmget', redisKeys.failedCRR, ...fields];
+        return this._redisClient.batch([cmds], (err, res) => {
+            if (err) {
+                return cb(err);
+            }
+            const [cmdErr, results] = res[0];
+            if (cmdErr) {
+                return cb(cmdErr);
+            }
+            // TODO: For all object metadata in results, push to kafka topics.
+            const response = [];
+            for (let i = 0; i < results.length; i++) {
+                if (results[i]) {
+                    const { bucket, key, versionId, site } = reqBody[i];
+                    const status = 'PENDING';
+                    response.push({ bucket, key, versionId, site, status });
+                }
+            }
+            return cb(null, response);
+        });
+    }
+
+    /**
+     * Validate that the POST request body has the necessary content.
+     * @param {String} body - The POST request body string
+     * @param {Function} cb - The callback to call
+     * @return {Object} - Object containing any error and the request body
+     */
+    _parseRetryFailedCRR(body) {
+        const msg = 'The body of your POST request is not well-formed';
+        let reqBody;
+        try {
+            reqBody = JSON.parse(body);
+        } catch (e) {
+            return {
+                error: errors.MalformedPOSTRequest.customizeDescription(msg),
+            };
+        }
+        if (!Array.isArray(reqBody) || reqBody.length === 0) {
+            return {
+                error: errors.MalformedPOSTRequest.customizeDescription(
+                    `${msg}: body must be a non-empty array`),
+            };
+        }
+        let errMsg;
+        reqBody.find(o => {
+            if (typeof o !== 'object') {
+                errMsg = `${msg}: body must be an array of objects`;
+                return true;
+            }
+            const requiredProperties = ['bucket', 'key', 'versionId', 'site'];
+            requiredProperties.find(prop => {
+                if (typeof o[prop] !== 'string' || o[prop] === '') {
+                    errMsg = `${msg}: ${prop} must be a non-empty string`;
+                    return true;
+                }
+                return false;
+            });
+            return false;
+        });
+        if (errMsg) {
+            return {
+                error: errors.MalformedPOSTRequest.customizeDescription(errMsg),
+            };
+        }
+        return { reqBody };
     }
 
     /**

--- a/lib/api/BackbeatRequest.js
+++ b/lib/api/BackbeatRequest.js
@@ -25,6 +25,19 @@ class BackbeatRequest {
     }
 
     /**
+     * Parse the route details for any of the retry routes.
+     * @param {Array} parts - The route schema split by '/'
+     * @return {undefined}
+     */
+    _parseRetryRoutes(parts) {
+        this._routeDetails.extension = parts[0];
+        this._routeDetails.status = parts[1];
+        this._routeDetails.bucket = parts[2];
+        this._routeDetails.key = parts[3];
+        this._routeDetails.versionId = parts[4];
+    }
+
+    /**
      * Parse a route and store to this._routeDetails
      * A route will have certain a specific structure following:
      * /_/metrics/<extension>/<site>/<specific-metric>
@@ -39,6 +52,10 @@ class BackbeatRequest {
         // if healthcheck, just skip this
 
         const parts = route.split('/');
+        if (parts[0] === 'crr') {
+            this._parseRetryRoutes(parts);
+            return;
+        }
         if (parts.length < 3 || parts.length > 4) {
             // leave this._routeDetails undefined
             return;

--- a/lib/api/BackbeatServer.js
+++ b/lib/api/BackbeatServer.js
@@ -63,8 +63,8 @@ class BackbeatServer {
                 backbeatRequest);
         }
 
-        if (req.method !== 'GET') {
-            // So far the API should only be receiving GET requests
+        const validMethods = ['GET', 'POST'];
+        if (!validMethods.includes(req.method)) {
             return this._errorResponse(errors.MethodNotAllowed
                 .customizeDescription('invalid http verb'),
                 backbeatRequest);
@@ -107,6 +107,52 @@ class BackbeatServer {
     }
 
     /**
+     * Get the body of a POST request and route it accordingly.
+     * @param {ClientRequest} req - The incoming request
+     * @param {BackbeatRequest} bbRequest - The Backbeat API Request
+     * @param {Object} routeDetails - The Backbeat route details
+     * @return {undefined}
+     */
+    _handlePOSTReq(req, bbRequest, routeDetails) {
+        const data = [];
+        req.on('data', chunk => data.push(chunk));
+        req.on('end', () => {
+            const { method } = routeDetails;
+            const body = data.join('');
+            return this.backbeatAPI[method](routeDetails, body, (err, data) => {
+                if (err) {
+                    return this._errorResponse(err, bbRequest);
+                }
+                return this._response(data, bbRequest);
+            });
+        });
+        req.on('error', err => this._errorResponse(err, bbRequest));
+        return;
+    }
+
+    /**
+     *
+     * @param {Object} rDetails - The Backbeat request details
+     * @param {ClientRequest} req - The incoming request
+     * @return {Object} The matching Backbeat route
+     */
+    _getRetryRoute(rDetails, req) {
+        const { extension, status, bucket, key, versionId } = rDetails;
+        const route = routes.find(r => {
+            if (r.extensions[extension] &&
+                r.extensions[extension].includes(status)) {
+                return r.httpMethod === req.method &&
+                    (bucket && key && versionId ?
+                    r.type === 'specific' :
+                    r.type === 'all');
+            }
+            return false;
+        });
+        // Include any granularity in the details for the response method.
+        return Object.assign({}, route, { bucket, key, versionId });
+    }
+
+    /**
      * Server incoming request handler
      * @param {object} req - request object
      * @param {object} res - response object
@@ -136,9 +182,10 @@ class BackbeatServer {
             if (bbRequest.getRoute() === 'healthcheck') {
                 routeDetails = routes.find(r => r.category === 'healthcheck');
             } else {
-                // metrics route
                 const rDetails = bbRequest.getRouteDetails();
-                if (!rDetails.metric) {
+                if (rDetails.status) {
+                    routeDetails = this._getRetryRoute(rDetails, req);
+                } else if (!rDetails.metric) {
                     // no metric type is specified, so use all route
                     routeDetails = routes.find(r => r.type === 'all');
                 } else {
@@ -149,6 +196,9 @@ class BackbeatServer {
 
             const requestMethod = routeDetails.method;
 
+            if (routeDetails.httpMethod === 'POST') {
+                return this._handlePOSTReq(req, bbRequest, routeDetails);
+            }
             this.backbeatAPI[requestMethod](routeDetails, (err, data) => {
                 if (err) {
                     this._errorResponse(err, bbRequest);
@@ -157,6 +207,7 @@ class BackbeatServer {
                 }
             });
         }
+        return undefined;
     }
 
     /**

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -15,11 +15,14 @@ const allSites = boostrapList.map(item => item.site);
 
 module.exports = [
     {
+        httpMethod: 'GET',
         category: 'healthcheck',
         type: 'basic',
         method: 'getHealthcheck',
+        extensions: {},
     },
     {
+        httpMethod: 'GET',
         category: 'metrics',
         type: 'backlog',
         extensions: { crr: [...allSites, 'all'] },
@@ -28,6 +31,7 @@ module.exports = [
             redisKeys.bytesDone],
     },
     {
+        httpMethod: 'GET',
         category: 'metrics',
         type: 'completions',
         extensions: { crr: [...allSites, 'all'] },
@@ -35,6 +39,7 @@ module.exports = [
         dataPoints: [redisKeys.opsDone, redisKeys.bytesDone],
     },
     {
+        httpMethod: 'GET',
         category: 'metrics',
         type: 'throughput',
         extensions: { crr: [...allSites, 'all'] },
@@ -42,11 +47,30 @@ module.exports = [
         dataPoints: [redisKeys.opsDone, redisKeys.bytesDone],
     },
     {
+        httpMethod: 'GET',
         category: 'metrics',
         type: 'all',
         extensions: { crr: [...allSites, 'all'] },
         method: 'getAllMetrics',
         dataPoints: [redisKeys.ops, redisKeys.opsDone, redisKeys.bytes,
             redisKeys.bytesDone],
+    },
+    {
+        httpMethod: 'GET',
+        type: 'all',
+        extensions: { crr: ['failed'] },
+        method: 'getAllFailedCRR',
+    },
+    {
+        httpMethod: 'GET',
+        type: 'specific',
+        extensions: { crr: ['failed'] },
+        method: 'getFailedCRR',
+    },
+    {
+        httpMethod: 'POST',
+        type: 'all',
+        extensions: { crr: ['failed'] },
+        method: 'retryFailedCRR',
     },
 ];

--- a/tests/functional/utils/makePOSTRequest.js
+++ b/tests/functional/utils/makePOSTRequest.js
@@ -1,0 +1,17 @@
+const http = require('http');
+
+function makePOSTRequest(options, body, cb) {
+    const req = http.request(options, res => cb(null, res));
+    req.on('error', err => cb(err));
+    req.end(body);
+}
+
+function getResponseBody(res, cb) {
+    res.setEncoding('utf8');
+    const resBody = [];
+    res.on('data', chunk => resBody.push(chunk));
+    res.on('end', () => cb(null, resBody.join('')));
+    res.on('error', err => cb(err));
+}
+
+module.exports = { makePOSTRequest, getResponseBody };


### PR DESCRIPTION
Add the CRR retry routes. 🙌

This is the first PR of the retry feature. See the corresponding [design doc](https://github.com/scality/backbeat/blob/9dee4ca7b282c0a38bfaeeaa3a9a7ed11f0706e6/docs/replication-retry.md.) for further details.

🔜PR to push object metadata to kafka topics to actually do the retry actions.

Thanks!