### PR TITLE
bf: fix metrics redis key site names

### DIFF
--- a/extensions/replication/ReplicationQueuePopulator.js
+++ b/extensions/replication/ReplicationQueuePopulator.js
@@ -59,9 +59,11 @@ class ReplicationQueuePopulator extends QueuePopulatorExtension {
         const repSites = queueEntry.getReplicationInfo().backends;
 
         // for one-to-many
-        repSites.filter(entry => entry.status === 'PENDING').forEach(site => {
-            this._incrementMetrics(site, queueEntry.getContentLength());
-        });
+        repSites.filter(entry => entry.status === 'PENDING')
+            .forEach(backend => {
+                this._incrementMetrics(backend.site,
+                    queueEntry.getContentLength());
+            });
     }
 }
 

--- a/tests/unit/replication/ReplicationQueuePopulator.spec.js
+++ b/tests/unit/replication/ReplicationQueuePopulator.spec.js
@@ -1,0 +1,166 @@
+const assert = require('assert');
+
+const ReplicationQueuePopulator =
+    require('../../../extensions/replication/ReplicationQueuePopulator');
+
+const fakeLogger = {
+    debug: () => {},
+    error: () => {},
+    info: () => {},
+    trace: () => {},
+};
+
+const TOPIC = 'test-topic';
+const SITE = 'test-site';
+const SITE2 = 'test-site2';
+
+/**
+ * This mock object is to overwrite the `publish` method and add a way of
+ * getting information on published messages.
+ * @class
+ */
+class ReplicationQueuePopulatorMock extends ReplicationQueuePopulator {
+    constructor(params) {
+        super(params);
+
+        this._state = {};
+    }
+
+    publish(topic, key, message) {
+        assert.equal(topic, TOPIC);
+
+        this._state.key = encodeURIComponent(key);
+        this._state.message = message;
+    }
+
+    getState() {
+        return this._state;
+    }
+
+    resetState() {
+        this._state = {};
+    }
+}
+
+function overwriteBackends(obj, backends) {
+    /* eslint-disable no-param-reassign */
+    obj.replicationInfo.backends = backends;
+    return JSON.stringify(obj);
+    /* eslint-enable no-param-reassign */
+}
+
+describe('replication queue populator', () => {
+    let rqp;
+
+    before(() => {
+        const params = {
+            config: {
+                topic: TOPIC,
+            },
+            logger: fakeLogger,
+        };
+        rqp = new ReplicationQueuePopulatorMock(params);
+    });
+
+    afterEach(() => {
+        rqp.resetState();
+    });
+
+    /* eslint-disable */
+    const kafkaValue = {
+        'owner-display-name': 'test_1522198049',
+        'owner-id': 'e166a2080a0c2cf1474dce54654f3f224dd5ae01379f20f338d106b8bc964bb1',
+        'content-length': 128,
+        'content-md5': 'd41d8cd98f00b204e9800118ecf8427e',
+        'x-amz-version-id': 'null',
+        'x-amz-server-version-id': '',
+        'x-amz-storage-class': 'STANDARD',
+        'x-amz-server-side-encryption': '',
+        'x-amz-server-side-encryption-aws-kms-key-id': '',
+        'x-amz-server-side-encryption-customer-algorithm': '',
+        'x-amz-website-redirect-location': '',
+        acl: {
+            Canned: 'private',
+            FULL_CONTROL: [],
+            WRITE_ACP: [],
+            READ: [],
+            READ_ACP: []
+        },
+        key: '',
+        location: null,
+        isDeleteMarker: false,
+        tags: {},
+        replicationInfo: {
+            status: 'PENDING',
+            backends: [{
+                'site': SITE,
+                'status': 'PENDING',
+                'dataStoreVersionId': '',
+            }],
+            content: [ 'METADATA' ],
+            destination: 'arn:aws:s3:::test-bucket-target',
+            storageClass: 'awsbackend',
+            role: 'arn:aws:iam::922268666771:role/bb-replication-1522257577471',
+            storageType: 'aws_s3',
+            dataStoreVersionId: '',
+        },
+        dataStoreName: 'dc-1',
+        'last-modified': '2018-03-28T22:10:00.534Z',
+        'md-model-version': 3,
+        versionId: '98477724999464999999RG001  1.30.12',
+    };
+    /* eslint-enable */
+
+    [
+        {
+            desc: 'object entry, not a master key',
+            entry: Object.assign({}, {
+                type: 'put',
+                bucket: 'test-bucket-source',
+                key: 'a-test-key',
+            }, { value: JSON.stringify(kafkaValue) }),
+            results: {},
+        },
+        {
+            desc: 'object entry, master key',
+            entry: Object.assign({}, {
+                type: 'put',
+                bucket: 'test-bucket-source',
+                key: 'a-test-key\u000098477724999464999999RG001  1.30.12',
+            }, { value: JSON.stringify(kafkaValue) }),
+            results: { [SITE]: { ops: 1, bytes: 128 } },
+        },
+        {
+            desc: 'object entry, master key, multiple backend',
+            entry: Object.assign({}, {
+                type: 'put',
+                bucket: 'test-bucket-source',
+                key: 'a-test-key2\u000098477724999464999999RG001  1.30.12',
+            }, { value:
+                overwriteBackends(kafkaValue, [
+                    { site: SITE, status: 'PENDING' },
+                    { site: SITE2, status: 'PENDING' },
+                ]),
+            }),
+            results: {
+                [SITE]: { ops: 1, bytes: 128 },
+                [SITE2]: { ops: 1, bytes: 128 },
+            },
+        },
+    ].forEach(input => {
+        it(`should filter entries properly: ${input.desc}`, () => {
+            rqp.filter(input.entry);
+
+            const metrics = rqp.getAndResetMetrics();
+
+            assert.deepStrictEqual(input.results, metrics);
+
+            if (Object.keys(input.results).length) {
+                assert.deepStrictEqual(JSON.stringify(input.entry),
+                    rqp.getState().message);
+            } else {
+                assert.deepStrictEqual(rqp.getState(), {});
+            }
+        });
+    });
+});


### PR DESCRIPTION
Metrics redis keys are prepended with site name for
multi-cloud. The site name was not correctly targeted.