### PR TITLE
transient source

### DIFF
--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -514,14 +514,12 @@ class ReplicateObject extends BackbeatTask {
     }
 
     _handleReplicationOutcome(err, sourceEntry, destEntry, log, done) {
-        let status;
         if (!err) {
             log.debug('replication succeeded for object, publishing ' +
                       'replication status as COMPLETED',
                       { entry: sourceEntry.getLogInfo() });
-            status = 'COMPLETED';
-            return this._publishReplicationStatus(sourceEntry, status, { log },
-                done);
+            return this._publishReplicationStatus(sourceEntry, 'COMPLETED',
+                { log }, done);
         }
         if (err.BadRole ||
             (err.origin === 'source' &&
@@ -553,8 +551,7 @@ class ReplicateObject extends BackbeatTask {
             { failMethod: err.method,
                 entry: sourceEntry.getLogInfo(),
                 error: err.description });
-        status = 'FAILED';
-        return this._publishReplicationStatus(sourceEntry, status,
+        return this._publishReplicationStatus(sourceEntry, 'FAILED',
             { log, reason: err.description }, done);
     }
 }

--- a/extensions/replication/tasks/UpdateReplicationStatus.js
+++ b/extensions/replication/tasks/UpdateReplicationStatus.js
@@ -39,11 +39,12 @@ class UpdateReplicationStatus extends BackbeatTask {
         return new RoleCredentials(vaultclient, 'replication', roleArn, log);
     }
 
-    _putMetadata(entry, log, cb) {
+    _putMetadata(entry, log, options, cb) {
         this.retry({
             actionDesc: 'update metadata on source',
             logFields: { entry: entry.getLogInfo() },
-            actionFunc: done => this._putMetadataOnce(entry, log, done),
+            actionFunc: done => this._putMetadataOnce(entry, log, options,
+                                                      done),
             shouldRetryFunc: err => err.retryable,
             log,
         }, cb);
@@ -76,7 +77,7 @@ class UpdateReplicationStatus extends BackbeatTask {
         return null;
     }
 
-    _putMetadataOnce(entry, log, cb) {
+    _putMetadataOnce(entry, log, options, cb) {
         log.debug('putting metadata',
                   { where: 'source', entry: entry.getLogInfo(),
                     replicationStatus: entry.getReplicationStatus() });
@@ -89,6 +90,7 @@ class UpdateReplicationStatus extends BackbeatTask {
             Key: entry.getObjectKey(),
             ContentLength: Buffer.byteLength(mdBlob),
             Body: mdBlob,
+            DeleteOldLocation: options && options.deleteOldLocation,
         });
         attachReqUids(req, log);
         req.send((err, data) => {
@@ -223,7 +225,22 @@ class UpdateReplicationStatus extends BackbeatTask {
             updatedSourceEntry.setSite(site);
             updatedSourceEntry.setReplicationSiteDataStoreVersionId(site,
                 sourceEntry.getReplicationSiteDataStoreVersionId(site));
-            return this._putMetadata(updatedSourceEntry, log, err => {
+            if (Array.isArray(sourceEntry.getNonTransientLocation())) {
+                updatedSourceEntry.setNonTransientLocation(
+                    sourceEntry.getNonTransientLocation());
+            }
+            const options = {};
+            if (updatedSourceEntry.getReplicationStatus() === 'COMPLETED'
+                && Array.isArray(
+                    updatedSourceEntry.getNonTransientLocation())) {
+                // replace location by the non-transient cloud
+                // location on CRR global completion
+                updatedSourceEntry.setLocation(
+                    updatedSourceEntry.getNonTransientLocation());
+                updatedSourceEntry.setNonTransientLocation(undefined);
+                options.deleteOldLocation = true;
+            }
+            return this._putMetadata(updatedSourceEntry, log, options, err => {
                 if (err) {
                     log.error('an error occurred when writing replication ' +
                               'status',

--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -152,6 +152,32 @@
                 "members": {
                     "versionId": {
                         "type": "string"
+                    },
+                    "Location": {
+                        "type": "structure",
+                        "members": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "size": {
+                                "type": "long"
+                            },
+                            "start": {
+                                "type": "long"
+                            },
+                            "dataStoreName": {
+                                "type": "string"
+                            },
+                            "dataStoreETag": {
+                                "type": "string"
+                            },
+                            "dataStoreType": {
+                                "type": "string"
+                            },
+                            "dataStoreVersionId": {
+                                "type": "string"
+                            }
+                        }
                     }
                 }
             }
@@ -401,6 +427,32 @@
                 "members": {
                     "versionId": {
                         "type": "string"
+                    },
+                    "Location": {
+                        "type": "structure",
+                        "members": {
+                            "key": {
+                                "type": "string"
+                            },
+                            "size": {
+                                "type": "long"
+                            },
+                            "start": {
+                                "type": "long"
+                            },
+                            "dataStoreName": {
+                                "type": "string"
+                            },
+                            "dataStoreETag": {
+                                "type": "string"
+                            },
+                            "dataStoreType": {
+                                "type": "string"
+                            },
+                            "dataStoreVersionId": {
+                                "type": "string"
+                            }
+                        }
                     }
                 }
             }
@@ -565,6 +617,11 @@
                         "location": "header",
                         "locationName": "x-scal-replication-content",
                         "type": "string"
+                    },
+                    "DeleteOldLocation": {
+                        "location": "header",
+                        "locationName": "x-scal-delete-old-location",
+                        "type": "boolean"
                     }
                 },
                 "payload": "Body"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/scality/backbeat#readme",
   "dependencies": {
-    "arsenal": "scality/Arsenal",
+    "arsenal": "scality/Arsenal#ft/ZENKO-143-transient-source",
     "async": "^2.3.0",
     "aws-sdk": "2.147.0",
     "backo": "^1.1.0",


### PR DESCRIPTION
transient source support

Mainly two important changes, the rest is cosmetic:

- the queue processor matching the default CRR location replaces the
  `nonTransientLocation` attribute by the actual CRR location array of
  the object. The `nonTransientLocation` attribute is originally set
  by cloud-server for objects on transient locations.

- the replication status processor, at the time it processes the last
  CRR successful completion, replaces the original object location by
  the CRR target one stored in `nonTransientLocation`, and removes the
  latter attribute. This way the object becomes readable natively on
  the default CRR external target, then the transient data can be
  removed (not implemented yet).
