### PR TITLE
Fix mongo replicaset setting

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -32,7 +32,7 @@ if [[ "$MONGODB_HOSTS" ]]; then
 fi
 
 if [[ "$MONGODB_RS" ]]; then
-    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .mongodb.replicaSet=\"$MONGODB_RS\""
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .queuePopulator.mongo.replicaSet=\"$MONGODB_RS\""
 fi
 
 if [[ "$MONGODB_DATABASE" ]]; then


### PR DESCRIPTION
Fixes setting the replicaset through an env variable, otherwise fails with

```
"mongodb" is not allowed
```