### PR TITLE
Fix/sandbox deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,12 @@ FROM node:8
 WORKDIR /usr/src/app
 
 RUN apt-get update \
-    && apt-get install -y jq --no-install-recommends
+    && apt-get install -y jq wget --no-install-recommends
+
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 # Keep the .git directory in order to properly report version
 COPY . /usr/src/app

--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -64,6 +64,8 @@ const joiSchema = {
         port: joi.number().default(8900),
     },
     redis: {
+        host: joi.string().default('localhost'),
+        port: joi.number().default(6379),
         name: joi.string().default('backbeat'),
         password: joi.string().default('').allow(''),
         sentinels: joi.array().items(

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,6 +18,14 @@ if [[ "$KAFKA_HOSTS" ]]; then
     JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .kafka.hosts=\"$KAFKA_HOSTS\""
 fi
 
+if [[ "$REDIS_HOST" ]]; then
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .redis.host=\"$REDIS_HOST\""
+fi
+
+if [[ "$REDIS_PORT" ]]; then
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .redis.port=\"$REDIS_PORT\""
+fi
+
 if [[ "$QUEUE_POPULATOR_DMD_HOST" ]]; then
     JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .queuePopulator.dmd.host=\"$QUEUE_POPULATOR_DMD_HOST\""
 fi

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -75,6 +75,10 @@ if [[ "$EXTENSIONS_REPLICATION_DEST_BOOTSTRAPLIST" ]]; then
     JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .extensions.replication.destination.bootstrapList=[{\"site\": \"zenko\", \"servers\": [\"$EXTENSIONS_REPLICATION_DEST_BOOTSTRAPLIST\"]}]"
 fi
 
+if [[ "$HEALTHCHECKS_ALLOWFROM" ]]; then
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .server.healthChecks.allowFrom=[\"$HEALTHCHECKS_ALLOWFROM\"]"
+fi
+
 if [[ $JQ_FILTERS_CONFIG != "." ]]; then
     jq "$JQ_FILTERS_CONFIG" conf/config.json > conf/config.json.tmp
     mv conf/config.json.tmp conf/config.json


### PR DESCRIPTION
Adds features to ease deployment in orbit sandboxes:

* Add `dockerize` to wait for dependency services and hard-fail if they are unavailable after a timeout
* Make redis host/port configurable
* Allow configuring healthcheck clients