### PR TITLE
ft: add metrics unit tests for route checks

### DIFF
--- a/tests/unit/api/BackbeatAPI.spec.js
+++ b/tests/unit/api/BackbeatAPI.spec.js
@@ -1,0 +1,48 @@
+const assert = require('assert');
+
+const BackbeatAPI = require('../../../lib/api/BackbeatAPI');
+const BackbeatRequest = require('../../../lib/api/BackbeatRequest');
+const config = require('../../config.json');
+
+const fakeLogger = {
+    trace: () => {},
+    error: () => {},
+    info: () => {},
+    debug: () => {},
+};
+
+describe('BackbeatAPI', () => {
+    let bbapi;
+
+    before(() => {
+        bbapi = new BackbeatAPI(config, fakeLogger, { timer: true });
+    });
+
+    it('should validate routes', () => {
+        // valid routes
+        [
+            '/_/metrics/crr/all',
+            '/_/healthcheck',
+            '/_/metrics/crr/all/backlog',
+            '/_/metrics/crr/all/completions',
+            '/_/metrics/crr/all/throughput',
+        ].forEach(path => {
+            const req = new BackbeatRequest({ url: path });
+
+            assert.ok(bbapi.isValidRoute(req));
+        });
+
+        // invalid routes
+        [
+            '/_/invalid/crr/all',
+            '/_/metrics/ext/all',
+            '/_/metrics/crr/test',
+            '/_/metrics/crr/all/backlo',
+            '/_/metrics/crr/all/completionss',
+        ].forEach(path => {
+            const req = new BackbeatRequest({ url: path });
+
+            assert.equal(bbapi.isValidRoute(req), false);
+        });
+    });
+});

--- a/tests/unit/api/BackbeatRequest.spec.js
+++ b/tests/unit/api/BackbeatRequest.spec.js
@@ -1,0 +1,29 @@
+const assert = require('assert');
+
+const BackbeatRequest = require('../../../lib/api/BackbeatRequest');
+
+describe('BackbeatRequest helper class', () => {
+    it('should not store any route details for healthcheck routes', () => {
+        const req = new BackbeatRequest({ url: '/_/healthcheck' });
+        const details = req.getRouteDetails();
+
+        assert.deepStrictEqual(details, {});
+    });
+
+    it('should parse routes and store internally as route details', () => {
+        const req = new BackbeatRequest({ url: '/_/metrics/crr/all' });
+        const details = req.getRouteDetails();
+
+        assert.strictEqual(details.category, 'metrics');
+        assert.strictEqual(details.extension, 'crr');
+        assert.strictEqual(details.site, 'all');
+        assert.strictEqual(details.metric, undefined);
+
+        const req2 = new BackbeatRequest(
+            { url: '/_/metrics/crr/test/backlog' });
+        const details2 = req2.getRouteDetails();
+
+        assert.strictEqual(details2.site, 'test');
+        assert.strictEqual(details2.metric, 'backlog');
+    });
+});


### PR DESCRIPTION
Targeting `rel/7.4`, to be forward ported to beta and updated for the changes there (if any), then to be forward ported to master.