### PR TITLE
Automatically update bootstrap list

### DIFF
--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -39,6 +39,10 @@ metricsProducer.setupProducer(err => {
             const destConfig = Object.assign({}, repConfig.destination);
             destConfig.bootstrapList = bootstrapList;
 
+            config.on('bootstrap-list-update', () => {
+                destConfig.bootstrapList = config.getBootstrapList();
+            });
+
             const queueProcessor = new QueueProcessor(zkConfig, kafkaConfig,
                 sourceConfig, destConfig, repConfig, metricsProducer);
             queueProcessor.start();


### PR DESCRIPTION
Listen to bootstrap list updates so that subsequent replication entries are flagged properly as multiplebackend.