### PR TITLE
bf: fix flaky metrics tests

### DIFF
--- a/tests/functional/api/BackbeatServer.js
+++ b/tests/functional/api/BackbeatServer.js
@@ -118,7 +118,9 @@ describe('Backbeat Server', () => {
         });
     });
 
-    describe('metrics routes', () => {
+    describe('metrics routes', function dF() {
+        this.timeout(10000);
+
         const interval = 300;
         const expiry = 900;
         const OPS = 'test:bb:ops';
@@ -172,8 +174,7 @@ describe('Backbeat Server', () => {
                 });
             });
 
-            it(`should get correct data keys for route: ${path}`,
-            done => {
+            it(`should get correct data keys for route: ${path}`, done => {
                 getRequest(path, (err, res) => {
                     assert.ifError(err);
                     const key = Object.keys(res)[0];
@@ -215,8 +216,7 @@ describe('Backbeat Server', () => {
         ];
 
         allWrongPaths.forEach(path => {
-            it(`should get a 404 response for route: ${path}`,
-            done => {
+            it(`should get a 404 response for route: ${path}`, done => {
                 const url = getUrl(defaultOptions, path);
 
                 http.get(url, res => {


### PR DESCRIPTION
Flakiness seen on this CI build:
https://circleci.com/gh/scality/backbeat/3180

For now, increasing timeouts and will need to observe