### PR TITLE
fix: run metrics api tests in eve

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -32,5 +32,9 @@ stages:
           name: run unit tests
           command: npm test
       - ShellCommand:
+          name: run s3 server tests
+          command: bash ./eve/workers/unit_and_feature_tests/run_server_tests.bash
+          workdir: '%(prop:builddir)s/build'
+      - ShellCommand:
           name: run feature tests
           command: npm run ft_test

--- a/eve/workers/unit_and_feature_tests/backbeat_packages.list
+++ b/eve/workers/unit_and_feature_tests/backbeat_packages.list
@@ -1,2 +1,3 @@
 build-essential
 nodejs
+redis-server

--- a/eve/workers/unit_and_feature_tests/buildbot_worker_packages.list
+++ b/eve/workers/unit_and_feature_tests/buildbot_worker_packages.list
@@ -7,4 +7,5 @@ python2.7-dev
 python-pip
 software-properties-common
 sudo
-
+lsof
+netcat

--- a/eve/workers/unit_and_feature_tests/run_server_tests.bash
+++ b/eve/workers/unit_and_feature_tests/run_server_tests.bash
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -x
+set -e
+
+killandsleep () {
+  kill -9 $(lsof -t -i:$1) || true
+  sleep 10
+}
+
+# run backbeat server
+TEST_SWITCH=1 npm start & bash tests/utils/wait_for_local_port.bash 8900 40 && npm run ft_server_test
+
+killandsleep 8900
+
+exit $?

--- a/eve/workers/unit_and_feature_tests/supervisor/buildbot_worker.conf
+++ b/eve/workers/unit_and_feature_tests/supervisor/buildbot_worker.conf
@@ -2,3 +2,8 @@
 command=/bin/sh -c 'buildbot-worker create-worker . "%(ENV_BUILDMASTER)s:%(ENV_BUILDMASTER_PORT)s" "%(ENV_WORKERNAME)s" "%(ENV_WORKERPASS)s"  && buildbot-worker start --nodaemon'
 autostart=true
 autorestart=false
+
+[program:redis]
+command=/usr/bin/redis-server
+autostart=true
+autorestart=false


### PR DESCRIPTION
The metrics api tests were not being run on eve since they were separated from the functional tests script