### PR TITLE
fix node-rdkafka version to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint-config-scality": "scality/Guidelines#rel/7.4-beta",
     "eslint-plugin-react": "^4.2.3",
     "joi": "^10.6",
-    "node-rdkafka": "^2.2.0",
+    "node-rdkafka": "2.2.0",
     "node-schedule": "^1.2.0",
     "node-zookeeper-client": "^0.2.2",
     "uuid": "^3.1.0",


### PR DESCRIPTION
Same fix done for master branch on rel/7.4-beta.
