### PR TITLE
FT: Use ranged gets for GCP MPUs > 1024 parts

### DIFF
--- a/tests/unit/replication/MultipleBackendTask.js
+++ b/tests/unit/replication/MultipleBackendTask.js
@@ -1,0 +1,77 @@
+const assert = require('assert');
+const MultipleBackendTask =
+    require('../../../extensions/replication/tasks/MultipleBackendTask');
+
+const partSize = 1024 * 1024 * 1024 + 1;
+const MPU_GCP_MAX_PARTS = 1024;
+
+describe('MultipleBackendTask', () => {
+    const task = new MultipleBackendTask({
+        getStateVars: () => ({
+            repConfig: {
+                queueProcessor: {
+                    retryTimeoutS: 0,
+                },
+            },
+        }),
+    });
+
+    describe('::_getRanges', () => {
+        it('should get a list of ranges with content length 1025', () => {
+            const ranges = task._getRanges(1025);
+            assert.strictEqual(513, ranges.length);
+            assert.deepStrictEqual(ranges[0], {
+                start: 0,
+                end: 1,
+            });
+            assert.deepStrictEqual(ranges[1], {
+                start: 2,
+                end: 3,
+            });
+            assert.deepStrictEqual(ranges[ranges.length - 1], {
+                start: 1024,
+                end: 1024,
+            });
+        });
+
+        it('should get a list of ranges with content length 1026', () => {
+            const ranges = task._getRanges(1026);
+            assert.deepStrictEqual(ranges[0], {
+                start: 0,
+                end: 1,
+            });
+            assert.deepStrictEqual(ranges[1], {
+                start: 2,
+                end: 3,
+            });
+            assert.deepStrictEqual(ranges[ranges.length - 1], {
+                start: 1024,
+                end: 1025,
+            });
+        });
+
+        Array.from(Array(10000 - 1024).keys()).forEach(n => {
+            const count = n + 1025;
+            const ranges = task._getRanges(count * partSize);
+            const contentLen = count * partSize;
+            const pow = Math.pow(2,
+                Math.ceil(Math.log(contentLen) / Math.log(2)));
+            const range = pow / MPU_GCP_MAX_PARTS;
+            it(`should get list of 1024 ranges: ${count} parts`, () => {
+                assert.strictEqual(ranges.length <= 1024, true);
+                assert.deepStrictEqual(ranges[0], {
+                    start: 0,
+                    end: range - 1,
+                });
+                assert.deepStrictEqual(ranges[1], {
+                    start: range,
+                    end: range * 2 - 1,
+                });
+                assert.deepStrictEqual(ranges[ranges.length - 1], {
+                    start: range * (ranges.length - 1),
+                    end: contentLen - 1,
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
If the source object is being replicated to GCP and it is composed of more than 1024 parts, use ranged requests to translate the MPU from N > 1024 parts to N <= parts.