### PR TITLE
Add RING/Ceph as aws_s3

### DIFF
--- a/conf/Config.js
+++ b/conf/Config.js
@@ -17,6 +17,8 @@ const locationTypeMatch = {
     'location-aws-s3-v1': 'aws_s3',
     'location-wasabi-v1': 'aws_s3',
     'location-gcp-v1': 'gcp',
+    'location-scality-ring-s3-v1': 'aws_s3',
+    'location-ceph-radosgw-s3-v1': 'aws_s3',
 };
 
 class Config extends EventEmitter {


### PR DESCRIPTION
Adds support for configuring scality RING as aws_s3 locations.