### PR TITLE
bf: ZENKO-252 Use source bucket for multiple backend replication

### DIFF
--- a/extensions/replication/tasks/MultipleBackendTask.js
+++ b/extensions/replication/tasks/MultipleBackendTask.js
@@ -747,7 +747,7 @@ class MultipleBackendTask extends ReplicateObject {
 
     processQueueEntry(sourceEntry, done) {
         const log = this.logger.newRequestLogger();
-        const destEntry = sourceEntry.toReplicaEntry(this.site);
+        const destEntry = sourceEntry.toMultipleBackendReplicaEntry(this.site);
         log.debug('processing entry', { entry: sourceEntry.getLogInfo() });
 
         return async.waterfall([

--- a/extensions/replication/utils/ObjectQueueEntry.js
+++ b/extensions/replication/utils/ObjectQueueEntry.js
@@ -120,6 +120,19 @@ class ObjectQueueEntry extends ObjectMD {
         return newEntry;
     }
 
+    /**
+     * Set the destination entry to have a REPLICA status and the bucket as the
+     * source bucket (used for context in CloudServers's multiple backend).
+     * @param {String} site - The replication site given in the configuration
+     * @return {ObjectQueueEntry} - The replica ObjectQueueEntry
+     */
+    toMultipleBackendReplicaEntry(site) {
+        return this.clone()
+            .setBucket(this.getBucket())
+            .setReplicationSiteStatus(site, 'REPLICA')
+            .setReplicationStatus('REPLICA');
+    }
+
     toCompletedEntry(site) {
         const newEntry = this.clone();
         newEntry.setReplicationSiteStatus(site, 'COMPLETED');

--- a/tests/unit/replication/QueueEntry.spec.js
+++ b/tests/unit/replication/QueueEntry.spec.js
@@ -42,6 +42,20 @@ describe('QueueEntry helper class', () => {
                 'PENDING');
             assert.strictEqual(replica.getReplicationStatus(), 'REPLICA');
 
+            const multipleBackendReplica =
+                entry.toMultipleBackendReplicaEntry('sf');
+            assert.strictEqual(
+                multipleBackendReplica.getReplicationSiteStatus('sf'),
+                'REPLICA');
+            assert.strictEqual(
+                multipleBackendReplica
+                    .getReplicationSiteStatus('replicationaws'),
+                'PENDING');
+            assert.strictEqual(
+                multipleBackendReplica.getReplicationStatus(), 'REPLICA');
+            assert.strictEqual(entry.getBucket(),
+                multipleBackendReplica.getBucket());
+
             // If one site is FAILED, the global status should be FAILED
             const failed = entry.toFailedEntry('sf');
             assert.strictEqual(failed.getReplicationSiteStatus('sf'),


### PR DESCRIPTION
Sets the source bucket (instead of the destination bucket) as the bucket name when replicating to a public cloud. This allows S3's multiple backend to prefix the key properly when a location constraint has `bucketMatch` set to `false`. For example, the bucket name will be passed as context to S3's multiple backend here: https://github.com/scality/S3/blob/master/lib/routes/routeBackbeat.js#L352.