### PR TITLE
bf: ZENKO-271 Set message.max.bytes in producer

### DIFF
--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -13,6 +13,15 @@ const ACK_TIMEOUT = 5000;
 // max time in ms. to wait for flush to complete
 const FLUSH_TIMEOUT = 5000;
 
+/**
+* Given that the largest object JSON from S3 is about 1.6 MB and adding some
+* padding to it, Backbeat replication topic is currently setup with a config
+* max.message.bytes.limit to 5MB. Producers need to update their messageMaxBytes
+* to get at least 5MB put in the Kafka topic, adding a little extra bytes of
+* padding for approximation.
+*/
+const PRODUCER_MESSAGE_MAX_BYTES = 5000020;
+
 const CLIENT_ID = 'BackbeatProducer';
 
 class BackbeatProducer extends EventEmitter {
@@ -38,20 +47,22 @@ class BackbeatProducer extends EventEmitter {
             topic: joi.string().required(),
             keyedPartitioner: joi.boolean().default(true),
             pollIntervalMs: joi.number().default(2000),
+            messageMaxBytes: joi.number(),
         };
         const validConfig = joi.attempt(config, configJoi,
                                         'invalid config params');
-        const { kafka, topic, pollIntervalMs } = validConfig;
-
+        const { kafka, topic, pollIntervalMs, messageMaxBytes } = validConfig;
         this._kafkaHosts = kafka.hosts;
         this._log = new Logger(CLIENT_ID);
         this._topic = topic;
         this._ready = false;
+        this._messageMaxBytes = messageMaxBytes || PRODUCER_MESSAGE_MAX_BYTES;
 
         // create a new producer instance
         this._producer = new Producer({
             'metadata.broker.list': this._kafkaHosts,
             'dr_cb': true,
+            'message.max.bytes': this._messageMaxBytes,
         }, {
             'request.required.acks': REQUIRE_ACKS,
             'request.timeout.ms': ACK_TIMEOUT,

--- a/tests/unit/backbeatProducer.js
+++ b/tests/unit/backbeatProducer.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+
+const BackbeatProducer = require('../../lib/BackbeatProducer');
+
+const { kafka, extensions } = require('../config.json');
+
+const CONSUMER_FETCH_MAX_BYTES = 5000020;
+
+describe('backbeatProducer', () => {
+    it('should have a default max message bytes value', () => {
+        const backbeatProducer = new BackbeatProducer({
+            kafka,
+            topic: extensions.replication.topic,
+        });
+        assert.strictEqual(backbeatProducer._messageMaxBytes,
+            CONSUMER_FETCH_MAX_BYTES);
+    });
+
+    it('should allow setting a custom max message bytes value', () => {
+        const backbeatProducer = new BackbeatProducer({
+            kafka,
+            topic: extensions.replication.topic,
+            messageMaxBytes: 1000,
+        });
+        assert.strictEqual(backbeatProducer._messageMaxBytes, 1000);
+    });
+});


### PR DESCRIPTION
Allow the node-rdkafka producer to push a message when performing a 10,000 part MPU.