### PR TITLE
bf: ZENKO-147 Check site when setting failed hash

### DIFF
--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -143,12 +143,12 @@ class ReplicationStatusProcessor {
         const fields = [];
         backends.forEach(backend => {
             const { status, site } = backend;
-            if (status !== 'FAILED') {
-                return undefined;
+            if (status === 'FAILED' && site === queueEntry.getSite()) {
+                const field = `${bucket}:${key}:${versionId}:${site}`;
+                const value = JSON.parse(kafkaEntry.value);
+                fields.push(field, JSON.stringify(value));
             }
-            const field = `${bucket}:${key}:${versionId}:${site}`;
-            const value = JSON.parse(kafkaEntry.value);
-            return fields.push(field, JSON.stringify(value));
+            return undefined;
         });
         const cmds = ['hmset', redisKeys.failedCRR, ...fields];
         return redisClient.batch([cmds], (err, res) => {


### PR DESCRIPTION
Now that we have a single replication status processor so that operations occur sequentially, the `replicationInfo` backends may contain a 'FAILED' status from a previous operation. This change ensures that the failure hash field is set only once.

I will aim to get https://github.com/scality/Integration/pull/660 merged to avoid this kind of unexpected problem going forward.