### PR TITLE
share helpers for gc

### DIFF
--- a/extensions/lifecycle/tasks/LifecycleObjectTask.js
+++ b/extensions/lifecycle/tasks/LifecycleObjectTask.js
@@ -4,8 +4,7 @@ const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
 const async = require('async');
 const getVaultCredentials =
     require('../../../lib/credentials/getVaultCredentials');
-const attachReqUids =
-    require('../../replication/utils/attachReqUids');
+const { attachReqUids } = require('../../../lib/clients/utils');
 
 
 class LifecycleObjectTask extends BackbeatTask {

--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -3,7 +3,7 @@
 const async = require('async');
 const { errors } = require('arsenal');
 
-const attachReqUids = require('../../replication/utils/attachReqUids');
+const { attachReqUids } = require('../../../lib/clients/utils');
 const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
 
 const RETRYTIMEOUTS = 300;

--- a/extensions/replication/tasks/MultipleBackendTask.js
+++ b/extensions/replication/tasks/MultipleBackendTask.js
@@ -6,7 +6,7 @@ const jsutil = require('arsenal').jsutil;
 const ObjectMDLocation = require('arsenal').models.ObjectMDLocation;
 
 const ReplicateObject = require('./ReplicateObject');
-const attachReqUids = require('../utils/attachReqUids');
+const { attachReqUids } = require('../../../lib/clients/utils');
 
 const MPU_CONC_LIMIT = 10;
 const MPU_GCP_MAX_PARTS = 1024;

--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -7,7 +7,7 @@ const ObjectMDLocation = require('arsenal').models.ObjectMDLocation;
 
 const BackbeatClient = require('../../../lib/clients/BackbeatClient');
 
-const attachReqUids = require('../utils/attachReqUids');
+const { attachReqUids } = require('../../../lib/clients/utils');
 const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
 const {
     StaticFileAccountCredentials,

--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -9,10 +9,8 @@ const BackbeatClient = require('../../../lib/clients/BackbeatClient');
 
 const { attachReqUids } = require('../../../lib/clients/utils');
 const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
-const {
-    StaticFileAccountCredentials,
-    ProvisionedServiceAccountCredentials,
-} = require('../../../lib/credentials/AccountCredentials');
+const { getAccountCredentials } =
+          require('../../../lib/credentials/AccountCredentials');
 const RoleCredentials =
           require('../../../lib/credentials/RoleCredentials');
 
@@ -49,11 +47,9 @@ class ReplicateObject extends BackbeatTask {
     }
 
     _createCredentials(where, authConfig, roleArn, log) {
-        if (authConfig.type === 'account') {
-            return new StaticFileAccountCredentials(authConfig, log);
-        }
-        if (authConfig.type === 'service') {
-            return new ProvisionedServiceAccountCredentials(authConfig, log);
+        const accountCredentials = getAccountCredentials(authConfig, log);
+        if (accountCredentials) {
+            return accountCredentials;
         }
         let vaultclient;
         if (where === 'source') {

--- a/extensions/replication/tasks/UpdateReplicationStatus.js
+++ b/extensions/replication/tasks/UpdateReplicationStatus.js
@@ -5,10 +5,8 @@ const ObjectQueueEntry = require('../../replication/utils/ObjectQueueEntry');
 const BackbeatClient = require('../../../lib/clients/BackbeatClient');
 const { attachReqUids } = require('../../../lib/clients/utils');
 const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
-const {
-    StaticFileAccountCredentials,
-    ProvisionedServiceAccountCredentials,
-} = require('../../../lib/credentials/AccountCredentials');
+const { getAccountCredentials } =
+          require('../../../lib/credentials/AccountCredentials');
 const RoleCredentials =
           require('../../../lib/credentials/RoleCredentials');
 
@@ -34,11 +32,9 @@ class UpdateReplicationStatus extends BackbeatTask {
     }
 
     _createCredentials(authConfig, roleArn, log) {
-        if (authConfig.type === 'account') {
-            return new StaticFileAccountCredentials(authConfig, log);
-        }
-        if (authConfig.type === 'service') {
-            return new ProvisionedServiceAccountCredentials(authConfig, log);
+        const accountCredentials = getAccountCredentials(authConfig, log);
+        if (accountCredentials) {
+            return accountCredentials;
         }
         const vaultclient = this.vaultclientCache.getClient('source:s3');
         return new RoleCredentials(vaultclient, 'replication', roleArn, log);

--- a/extensions/replication/tasks/UpdateReplicationStatus.js
+++ b/extensions/replication/tasks/UpdateReplicationStatus.js
@@ -3,7 +3,7 @@ const jsutil = require('arsenal').jsutil;
 
 const ObjectQueueEntry = require('../../replication/utils/ObjectQueueEntry');
 const BackbeatClient = require('../../../lib/clients/BackbeatClient');
-const attachReqUids = require('../utils/attachReqUids');
+const { attachReqUids } = require('../../../lib/clients/utils');
 const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
 const {
     StaticFileAccountCredentials,

--- a/lib/clients/utils.js
+++ b/lib/clients/utils.js
@@ -6,4 +6,6 @@ function attachReqUids(s3req, log) {
     });
 }
 
-module.exports = attachReqUids;
+module.exports = {
+    attachReqUids,
+};

--- a/lib/credentials/AccountCredentials.js
+++ b/lib/credentials/AccountCredentials.js
@@ -62,7 +62,30 @@ class ProvisionedServiceAccountCredentials extends AccountCredentials {
     }
 }
 
+/**
+ * gather account credentials object and return it
+ *
+ * @param {object} authConfig - authentication config params
+ * @param {string} authConfig.type - type of authentication -
+ * supported are 'account' for static file accounts, and 'service' for
+ * externally provisioned accounts through Orbit
+ * @param {string} authConfig.account - account name
+ * @param {Logger} log - logger object
+ * @return {AWS.Credentials|null} credentials object, or null if
+ * authConfig.type is not 'account' or 'service'
+ */
+function getAccountCredentials(authConfig, log) {
+    if (authConfig.type === 'account') {
+        return new StaticFileAccountCredentials(authConfig, log);
+    }
+    if (authConfig.type === 'service') {
+        return new ProvisionedServiceAccountCredentials(authConfig, log);
+    }
+    return null;
+}
+
 module.exports = {
     StaticFileAccountCredentials,
     ProvisionedServiceAccountCredentials,
+    getAccountCredentials,
 };


### PR DESCRIPTION
Some small refactors to prepare backbeat garbage collector implementation

-   rf: ZENKO-143 move attachReqUids() helper
    
    Move attachReqUids() helper to lib/client/utils.js. This to done to
    share the simple but useful logic across extensions.

-   rf: ZENKO-143 add helper getAccountCredentials()
    
    Move account-credentials gathering in a single getAccountCredentials()
    helper in AccountCredentials.js, instead of having to check the type
    of authentication ('account' or 'service') and create the class
    accordingly.
