### PR TITLE
Zenko-21: FT: CRR Metrics for backbeat

### DIFF
--- a/conf/Config.js
+++ b/conf/Config.js
@@ -8,6 +8,7 @@ const joi = require('joi');
 
 const extensions = require('../extensions');
 const backbeatConfigJoi = require('./config.joi.js');
+const monitoringClient = require('../lib/clients/monitoringHandler');
 
 const locationTypeMatch = {
     'location-mem-v1': 'mem',
@@ -105,6 +106,7 @@ class Config extends EventEmitter {
     }
 
     getBootstrapList() {
+        monitoringClient.crrSiteCount.set(this.bootstrapList.length);
         return this.bootstrapList;
     }
 }

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -11,6 +11,7 @@ const ObjectQueueEntry =
 const Logger = require('werelogs').Logger;
 
 const QueueEntry = require('./models/QueueEntry');
+const monitoringClient = require('./clients/monitoringHandler');
 
 const CRR_TOPIC = require('../conf/Config').extensions.replication.topic;
 
@@ -452,6 +453,8 @@ class BackbeatConsumer extends EventEmitter {
                     this._metricsStore[site].ops++;
                     this._metricsStore[site].bytes += bytes;
                 }
+                monitoringClient.crrOpDone.inc();
+                monitoringClient.crrBytesDone.inc(bytes);
             });
         }
     }

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -12,6 +12,7 @@ const QueueEntry = require('../../lib/models/QueueEntry');
 const Healthcheck = require('./Healthcheck');
 const routes = require('./routes');
 const { redisKeys } = require('../../extensions/replication/constants');
+const monitoringClient = require('../clients/monitoringHandler').client;
 
 // StatsClient constant defaults
 // TODO: This should be moved to constants file
@@ -108,6 +109,9 @@ class BackbeatAPI {
         if (route.substring(3) === 'healthcheck') {
             return true;
         }
+        if (route.substring(3) === 'monitoring/metrics') {
+            return true;
+        }
 
         /*
             {
@@ -194,6 +198,17 @@ class BackbeatAPI {
             }
             return cb(null, data);
         });
+    }
+
+    /**
+     * Collects metrics from Prometheus variables and register for response
+     * @param {Object} details - route details from lib/api/routes.js
+     * @param {Function} cb = callback(error, data)
+     * @returns {undefined}
+     */
+    monitoringHandler(details, cb) {
+        const promMetrics = monitoringClient.register.metrics();
+        return cb(null, promMetrics);
     }
 
     /**

--- a/lib/api/BackbeatServer.js
+++ b/lib/api/BackbeatServer.js
@@ -7,6 +7,7 @@ const { Clustering, errors, ipCheck } = require('arsenal');
 const BackbeatRequest = require('./BackbeatRequest');
 const BackbeatAPI = require('./BackbeatAPI');
 const routes = require('./routes');
+const monitoringClient = require('../clients/monitoringHandler');
 
 const WORKERS = 1;
 
@@ -186,6 +187,8 @@ class BackbeatServer {
             let routeDetails;
             if (bbRequest.getRoute() === 'healthcheck') {
                 routeDetails = routes.find(r => r.category === 'healthcheck');
+            } else if (bbRequest.getRoute() === 'monitoring/metrics') {
+                routeDetails = routes.find(r => r.category === 'monitoring');
             } else {
                 const rDetails = bbRequest.getRouteDetails();
                 if (rDetails.status) {
@@ -301,6 +304,7 @@ function run(config, Logger) {
                 process.on('SIGINT', () => server.stop());
                 server.start();
             });
+            monitoringClient.collectDefaultMetrics({ timeout: 5000 });
         }
     });
 }

--- a/lib/clients/monitoringHandler.js
+++ b/lib/clients/monitoringHandler.js
@@ -1,0 +1,33 @@
+const client = require('prom-client');
+
+const collectDefaultMetrics = client.collectDefaultMetrics;
+const crrOpCount = new client.Counter({
+    name: 'crr_number_of_operations',
+    help: 'CRR number of objects replicated(operations)',
+});
+const crrOpDone = new client.Counter({
+    name: 'crr_number_of_operations_completed',
+    help: 'CRR number of operations completed',
+});
+const crrBytesCount = new client.Counter({
+    name: 'crr_number_of_bytes',
+    help: 'CRR number of bytes',
+});
+const crrBytesDone = new client.Counter({
+    name: 'crr_number_of_bytes_completed',
+    help: 'CRR number of bytes completed',
+});
+const crrSiteCount = new client.Gauge({
+    name: 'crr_number_of_sites',
+    help: 'CRR number of sites',
+});
+
+module.exports = {
+    client,
+    collectDefaultMetrics,
+    crrOpCount,
+    crrOpDone,
+    crrBytesCount,
+    crrBytesDone,
+    crrSiteCount,
+};

--- a/lib/queuePopulator/QueuePopulatorExtension.js
+++ b/lib/queuePopulator/QueuePopulatorExtension.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 
 const zookeeper = require('../clients/zookeeper');
+const monitoringClient = require('../clients/monitoringHandler');
 
 class QueuePopulatorExtension {
     /**
@@ -139,6 +140,8 @@ class QueuePopulatorExtension {
             this._metricsStore[site].ops++;
             this._metricsStore[site].bytes += bytes;
         }
+        monitoringClient.crrOpCount.inc();
+        monitoringClient.crrBytesCount.inc(bytes);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "node-zookeeper-client": "^0.2.2",
     "uuid": "^3.1.0",
     "vaultclient": "github:scality/vaultclient#z/1.0",
-    "werelogs": "scality/werelogs#z/1.0"
+    "werelogs": "scality/werelogs#z/1.0",
+    "prom-client": "^10.2.3"
   },
   "devDependencies": {
     "mocha": "^3.3.0",


### PR DESCRIPTION
## Added metrics for backbeat for Prometheus.
[Corresponding route request in Arsenal](https://github.com/scality/Arsenal/pull/478)

## Metrics List:
- crr_number_of_sites: CRR number of sites
- crr_number_of_bytes: The number of CRR bytes completed by backbeat
- crr_number_of_bytes: The number of CRR bytes requested to be replicated
- crr_number_of_operations_completed: The number of CRR operations completed by backbeat
- crr_number_of_operations: The number of CRR operations requested(queued)
- nodejs_version_info Node.js: version info
- nodejs_heap_space_size_available_bytes: Process heap space size available from node.js in bytes
- nodejs_heap_size_total_bytes: Process heap size from node.js in bytes
- nodejs_heap_size_used_bytes: Process heap size used from node.js in bytes
- nodejs_external_memory_bytes: Nodejs external memory size in bytes
- nodejs_heap_space_size_total_bytes: Process heap space size total from node.js in bytes
- process_cpu_user_seconds_total: Total user CPU time spent in seconds
- process_cpu_system_seconds_total: Total system CPU time spent in seconds
- process_cpu_seconds_total: Total user and system CPU time spent in seconds
- process_start_time_seconds: Start time of the process since unix epoch in seconds
- process_resident_memory_bytes: Resident memory size in bytes
- nodejs_eventloop_lag_seconds: Lag of event loop in seconds
- nodejs_active_handles_total: Number of active handles
- nodejs_active_requests_total: Number of active requests
- nodejs_heap_space_size_used_bytes: Process heap space size used from node.js in bytes.

Signed-off-by: anurag4DSB <anurag.213@gmail.com>