### PR TITLE
ft: S3C-1398 Use retry CRR topic

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -78,6 +78,8 @@
             },
             "topic": "backbeat-replication",
             "replicationStatusTopic": "backbeat-replication-status",
+            "replicationFailedTopic": "backbeat-replication-failed",
+            "monitorReplicationFailures": true,
             "queueProcessor": {
                 "groupId": "backbeat-replication-group",
                 "retryTimeoutS": 300,

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -51,6 +51,7 @@ const joiSchema = {
     topic: joi.string().required(),
     replicationStatusTopic: joi.string().required(),
     monitorReplicationFailures: joi.boolean().default(true),
+    replicationFailedTopic: joi.string().required(),
     queueProcessor: {
         groupId: joi.string().required(),
         retryTimeoutS: joi.number().default(300),

--- a/extensions/replication/failedCRR/FailedCRRConsumer.js
+++ b/extensions/replication/failedCRR/FailedCRRConsumer.js
@@ -1,0 +1,130 @@
+'use strict'; // eslint-disable-line strict
+
+const Logger = require('werelogs').Logger;
+const redisClient = require('../../replication/utils/getRedisClient')();
+
+const FailedCRRProducer = require('./FailedCRRProducer');
+const BackbeatConsumer = require('../../../lib/BackbeatConsumer');
+const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
+const redisKeys = require('../constants').redisKeys;
+const config = require('../../../conf/Config');
+
+// BackbeatConsumer constant defaults
+const CONSUMER_FETCH_MAX_BYTES = 5000020;
+const CONCURRENCY = 10;
+
+class FailedCRRConsumer {
+    /**
+     * Create the retry consumer.
+     */
+    constructor() {
+        this._kafkaConfig = config.kafka;
+        this._topic = config.extensions.replication.replicationFailedTopic;
+        this.logger = new Logger('Backbeat:FailedCRRConsumer');
+        this._failedCRRProducer = new FailedCRRProducer(this.kafkaConfig);
+        this._backbeatTask = new BackbeatTask();
+    }
+
+    /**
+     * Start the retry consumer by subscribing to the retry kafka topic. Setup
+     * the failed CRR producer for pushing any failed redis operations back to
+     * the queue.
+     * @param {Function} cb - The callback function
+     * @return {undefined}
+     */
+    start(cb) {
+        const consumer = new BackbeatConsumer({
+            kafka: { hosts: this._kafkaConfig.hosts },
+            topic: this._topic,
+            groupId: 'backbeat-retry-group',
+            concurrency: CONCURRENCY,
+            queueProcessor: this.processKafkaEntry.bind(this),
+            fetchMaxBytes: CONSUMER_FETCH_MAX_BYTES,
+        });
+        consumer.on('error', () => {});
+        consumer.on('ready', () => {
+            consumer.subscribe();
+            this.logger.info('retry consumer is ready to consume entries');
+        });
+        return this._failedCRRProducer.setupProducer(err => {
+            if (err) {
+                this.logger.error('could not setup producer', {
+                    method: 'FailedCRRConsumer.processKafkaEntry',
+                    error: err,
+                });
+                return cb(err);
+            }
+            return cb();
+        });
+    }
+
+    /**
+     * Process an entry from the retry topic, and set the data in a Redis hash.
+     * @param {Object} kafkaEntry - The entry from the retry topic
+     * @param {function} cb - The callback function
+     * @return {undefined}
+     */
+    processKafkaEntry(kafkaEntry, cb) {
+        const log = this.logger.newRequestLogger();
+        let data;
+        try {
+            data = JSON.parse(kafkaEntry.value);
+        } catch (err) {
+            log.error('error processing retry entry', {
+                method: 'FailedCRRConsumer.processKafkaEntry',
+                error: err,
+            });
+            log.end();
+            return cb();
+        }
+        return this._setRedisHash(data, kafkaEntry, log, cb);
+    }
+
+    /**
+     * Attempt to set the Redis hash, using an exponential backoff should the
+     * key set fail. If the backoff time is exceeded, push the entry back into
+     * the retry entry topic for a later reattempt.
+     * @param {Object} data - The field and value for the Redis hash
+     * @param {Object} kafkaEntry - The entry from the retry topic
+     * @param {Werelogs} log - The werelogs logger
+     * @param {Function} cb - The callback function
+     * @return {undefined}
+     */
+    _setRedisHash(data, kafkaEntry, log, cb) {
+        this._backbeatTask.retry({
+            actionDesc: 'set redis key',
+            logFields: {},
+            actionFunc: done => this._setRedisHashOnce(data, log, done),
+            shouldRetryFunc: err => err.retryable,
+            log,
+        }, err => {
+            if (err && err.retryable === true) {
+                log.info('publishing entry back into the kafka queue');
+                const entry = Buffer.from(kafkaEntry.value).toString();
+                return this._failedCRRProducer.publishFailedCRREntry(entry, cb);
+            }
+            log.info('successfully set redis key');
+            return cb();
+        });
+    }
+
+    /**
+     * Attempt to set the Redis hash.
+     * @param {Object} data - The field and value for the Redis hash
+     * @param {Werelogs} log - The werelogs logger
+     * @param {Function} cb - The callback function
+     * @return {undefined}
+     */
+    _setRedisHashOnce(data, log, cb) {
+        const cmds = ['hmset', redisKeys.failedCRR, [data.field, data.value]];
+        return redisClient.batch([cmds], (err, res) => {
+            if (err) {
+                return cb({ retryable: true });
+            }
+            const [cmdErr] = res[0];
+            return cb({ retryable: cmdErr !== null });
+        });
+    }
+}
+
+module.exports = FailedCRRConsumer;

--- a/extensions/replication/failedCRR/FailedCRRProducer.js
+++ b/extensions/replication/failedCRR/FailedCRRProducer.js
@@ -1,0 +1,61 @@
+'use strict'; // eslint-disable-line strict
+
+const { Logger } = require('werelogs');
+
+const BackbeatProducer = require('../../../lib/BackbeatProducer');
+const config = require('../../../conf/Config');
+
+class FailedCRRProducer {
+    /**
+     * Create the retry producer.
+     */
+    constructor() {
+        this._kafkaConfig = config.kafka;
+        this._topic = config.extensions.replication.replicationFailedTopic;
+        this._producer = null;
+        this._log = new Logger('Backbeat:FailedCRRProducer');
+    }
+
+    /**
+     * Set up the retry producer.
+     * @param {function} [cb] - Optional callback called when startup
+     * is complete
+     * @return {undefined}
+     */
+    setupProducer(cb) {
+        const producer = new BackbeatProducer({
+            kafka: { hosts: this._kafkaConfig.hosts },
+            topic: this._topic,
+        });
+        producer.once('error', () => {});
+        producer.once('ready', () => {
+            producer.removeAllListeners('error');
+            producer.on('error', err =>
+                this._log.error('error from backbeat producer', {
+                    error: err,
+                }));
+            this._producer = producer;
+            if (cb) {
+                return cb();
+            }
+            return undefined;
+        });
+    }
+
+    /**
+     * Publish the given message to the retry Kafka topic.
+     * @param {String} message - The message to publish
+     * @param {Function} cb - The callback function
+     * @return {undefined}
+     */
+    publishFailedCRREntry(message, cb) {
+        this._producer.send([{ message }], err => {
+            if (err) {
+                this._log.trace('error publishing retry entry');
+            }
+            return cb();
+        });
+    }
+}
+
+module.exports = FailedCRRProducer;

--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -1,18 +1,19 @@
 'use strict'; // eslint-disable-line
 
 const http = require('http');
+const async = require('async');
 
 const Logger = require('werelogs').Logger;
 const errors = require('arsenal').errors;
 
 const BackbeatConsumer = require('../../../lib/BackbeatConsumer');
+const FailedCRRProducer =
+    require('../../../extensions/replication/failedCRR/FailedCRRProducer');
 const VaultClientCache = require('../../../lib/clients/VaultClientCache');
 const ReplicationTaskScheduler = require('../utils/ReplicationTaskScheduler');
-const redisClient = require('../utils/getRedisClient')();
 const UpdateReplicationStatus = require('../tasks/UpdateReplicationStatus');
 const QueueEntry = require('../../../lib/models/QueueEntry');
 const ObjectQueueEntry = require('../utils/ObjectQueueEntry');
-const { redisKeys } = require('../constants');
 
 /**
  * @class ReplicationStatusProcessor
@@ -92,6 +93,7 @@ class ReplicationStatusProcessor {
      * @return {undefined}
      */
     start(options, cb) {
+        this._FailedCRRProducer = new FailedCRRProducer(this.kafkaConfig);
         this._consumer = new BackbeatConsumer({
             kafka: { hosts: this.kafkaConfig.hosts },
             topic: this.repConfig.replicationStatusTopic,
@@ -106,9 +108,7 @@ class ReplicationStatusProcessor {
             this.logger.info('replication status processor is ready to ' +
                              'consume replication status entries');
             this._consumer.subscribe();
-            if (cb) {
-                cb();
-            }
+            this._FailedCRRProducer.setupProducer(cb);
         });
     }
 
@@ -126,38 +126,32 @@ class ReplicationStatusProcessor {
     }
 
     /**
-     * Set the Redis hash key for each failed backend.
+     * Push any failed entry to the "failed" topic.
      * @param {QueueEntry} queueEntry - The queue entry with the failed status.
      * @param {Object} kafkaEntry - The kafka entry with the failed status.
-     * @param {Function} cb          [description]
+     * @param {Function} cb - The callback function
      * @return {undefined}
      */
-    _setFailedKeys(queueEntry, kafkaEntry, cb) {
+    _pushFailedEntry(queueEntry, kafkaEntry, cb) {
         const { status, backends } = queueEntry.getReplicationInfo();
         if (status !== 'FAILED') {
             return process.nextTick(cb);
         }
-        const bucket = queueEntry.getBucket();
-        const key = queueEntry.getObjectKey();
-        const versionId = queueEntry.getEncodedVersionId();
-        const fields = [];
-        backends.forEach(backend => {
-            const { status, site } = backend;
-            if (status === 'FAILED' && site === queueEntry.getSite()) {
-                const field = `${bucket}:${key}:${versionId}:${site}`;
-                const value = JSON.parse(kafkaEntry.value);
-                fields.push(field, JSON.stringify(value));
-            }
-            return undefined;
-        });
-        const cmds = ['hmset', redisKeys.failedCRR, ...fields];
-        return redisClient.batch([cmds], (err, res) => {
-            if (err) {
-                return cb(err);
-            }
-            const [cmdErr] = res[0];
-            return cb(cmdErr);
-        });
+        const backend = backends.find(b =>
+            b.status === 'FAILED' && b.site === queueEntry.getSite());
+        if (backend) {
+            const bucket = queueEntry.getBucket();
+            const key = queueEntry.getObjectKey();
+            const versionId = queueEntry.getEncodedVersionId();
+            const { site } = backend;
+            const message = {
+                field: `${bucket}:${key}:${versionId}:${site}`,
+                value: Buffer.from(kafkaEntry.value).toString(),
+            };
+            return this._FailedCRRProducer
+                .publishFailedCRREntry(JSON.stringify(message), cb);
+        }
+        return cb();
     }
 
     /**
@@ -183,15 +177,11 @@ class ReplicationStatusProcessor {
             task = new UpdateReplicationStatus(this);
         }
         if (task && this.repConfig.monitorReplicationFailures) {
-            return this._setFailedKeys(sourceEntry, kafkaEntry, err => {
-                if (err) {
-                    this.logger.error('error setting redis hash key', {
-                        error: err,
-                    });
-                }
-                return this.taskScheduler.push({ task, entry: sourceEntry },
-                    sourceEntry.getCanonicalKey(), done);
-            });
+            return async.parallel([
+                next => this._pushFailedEntry(sourceEntry, kafkaEntry, next),
+                next => this.taskScheduler.push({ task, entry: sourceEntry },
+                    sourceEntry.getCanonicalKey(), next),
+            ], done);
         }
         if (task) {
             return this.taskScheduler.push({ task, entry: sourceEntry },

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -8,6 +8,8 @@ const RaftLogReader = require('./RaftLogReader');
 const BucketFileLogReader = require('./BucketFileLogReader');
 const MetricsProducer = require('../MetricsProducer');
 const MetricsConsumer = require('../MetricsConsumer');
+const FailedCRRConsumer =
+    require('../../extensions/replication/failedCRR/FailedCRRConsumer');
 const MongoLogReader = require('./MongoLogReader');
 
 class QueuePopulator {
@@ -78,6 +80,7 @@ class QueuePopulator {
                 }
                 return next(err);
             }),
+            next => this._setupFailedCRRClients(next),
             next => this._setupExtensions(err => {
                 if (err) {
                     this.log.error(
@@ -115,6 +118,16 @@ class QueuePopulator {
         // Metrics Producer
         this._mProducer = new MetricsProducer(this.kafkaConfig, this.mConfig);
         this._mProducer.setupProducer(cb);
+    }
+
+    /**
+     * Set up and start the consumer for retrying failed CRR operations.
+     * @param {Function} cb - The callback function
+     * @return {undefined}
+     */
+    _setupFailedCRRClients(cb) {
+        this._failedCRRConsumer = new FailedCRRConsumer(this.kafkaConfig);
+        return this._failedCRRConsumer.start(cb);
     }
 
     /**

--- a/tests/config.json
+++ b/tests/config.json
@@ -42,6 +42,7 @@
         "replication": {
             "topic": "backbeat-test-replication",
             "replicationStatusTopic": "backbeat-test-replication-status",
+            "monitorReplicationFailures": true,
             "groupId": "backbeat-test-replication-group",
             "destination": {
                 "bootstrapList": [


### PR DESCRIPTION
Decouple logic around making calls to Redis and updating object metadata. Allows for usage of `ioredis`'s offline queue during cases where the connection to Redis is faulty. To that end, this PR alters the retry feature to do the following:
* Push failed entries to a kafka "retry" topic.
* Set Redis keys during processing of "retry" kafka entry.

Depends on https://github.com/scality/Federation/pull/1514 for creating the topic.