### PR TITLE
bf: zk dispatcher for mongo log

### DIFF
--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -37,6 +37,7 @@ const joiSchema = {
         zookeeperPath: joi.string().required(),
 
         logSource: joi.alternatives().try('bucketd', 'dmd', 'mongo').required(),
+        subscribeToLogSourceDispatcher: joi.boolean().default(false),
         bucketd: hostPortJoi
             .when('logSource', { is: 'bucketd', then: joi.required() }),
         dmd: hostPortJoi.keys({

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -124,7 +124,29 @@ class QueuePopulator {
             // initialization of log source is deferred until the
             // dispatcher notifies us of which raft sessions we're
             // responsible for
-            this._subscribeToRaftSessionDispatcher();
+            this._subscribeToLogSourceDispatcher('raft-id-dispatcher');
+            break;
+        case 'mongo':
+            if (this.qpConfig.subscribeToLogSourceDispatcher) {
+                // initialization of mongo log source is deferred until
+                // the dispatcher notifies us we're the single populator
+                // responsible for it
+                this._subscribeToLogSourceDispatcher('mongo-dispatcher');
+            } else {
+                // always consume from mongo log (good for Kubernetes
+                // deployments)
+                this.logReadersUpdate = [
+                    new MongoLogReader({
+                        zkClient: this.zkClient,
+                        kafkaConfig: this.kafkaConfig,
+                        zkConfig: this.zkConfig,
+                        mongoConfig: this.qpConfig.mongo,
+                        logger: this.log,
+                        extensions: this._extensions,
+                        metricsProducer: this._mProducer,
+                    }),
+                ];
+            }
             break;
         case 'dmd':
             this.logReadersUpdate = [
@@ -137,54 +159,56 @@ class QueuePopulator {
                 }),
             ];
             break;
-        case 'mongo':
-            this.logReadersUpdate = [
-                new MongoLogReader({ zkClient: this.zkClient,
-                    kafkaConfig: this.kafkaConfig,
-                    zkConfig: this.zkConfig,
-                    mongoConfig: this.qpConfig.mongo,
-                    logger: this.log,
-                    extensions: this._extensions,
-                    metricsProducer: this._mProducer,
-                }),
-            ];
-            break;
         default:
             throw new Error("bad 'logSource' config value: expect 'bucketd,'" +
                         ` mongo or 'dmd', got '${this.qpConfig.logSource}'`);
         }
     }
 
-    _subscribeToRaftSessionDispatcher() {
+    _subscribeToLogSourceDispatcher(dispatcherZkNode) {
         const zookeeperUrl =
                   this.zkConfig.connectionString +
                   this.qpConfig.zookeeperPath;
-        const zkEndpoint = `${zookeeperUrl}/raft-id-dispatcher`;
+        const zkEndpoint = `${zookeeperUrl}/${dispatcherZkNode}`;
         this.raftIdDispatcher =
             new ProvisionDispatcher({ connectionString: zkEndpoint });
         this.raftIdDispatcher.subscribe((err, items) => {
             if (err) {
-                this.log.error('error when receiving raft ID provision list',
-                               { zkEndpoint, error: err });
+                this.log.error(
+                    'error when receiving log source provision list',
+                    { zkEndpoint, error: err });
                 return undefined;
             }
             if (items.length === 0) {
-                this.log.info('no raft ID provisioned, idling',
+                this.log.info('no log source provisioned, idling',
                               { zkEndpoint });
             }
             this.logReadersUpdate = items.map(
-                raftId => new RaftLogReader({
-                    zkClient: this.zkClient,
-                    kafkaConfig: this.kafkaConfig,
-                    bucketdConfig: this.qpConfig.bucketd,
-                    raftId,
-                    logger: this.log,
-                    extensions: this._extensions,
-                    metricsProducer: this._mProducer,
-                }));
+                token => {
+                    if (token === 'mongo') {
+                        return new MongoLogReader({
+                            zkClient: this.zkClient,
+                            kafkaConfig: this.kafkaConfig,
+                            zkConfig: this.zkConfig,
+                            mongoConfig: this.qpConfig.mongo,
+                            logger: this.log,
+                            extensions: this._extensions,
+                            metricsProducer: this._mProducer,
+                        });
+                    }
+                    return new RaftLogReader({
+                        zkClient: this.zkClient,
+                        kafkaConfig: this.kafkaConfig,
+                        bucketdConfig: this.qpConfig.bucketd,
+                        raftId: token,
+                        logger: this.log,
+                        extensions: this._extensions,
+                        metricsProducer: this._mProducer,
+                    });
+                });
             return undefined;
         });
-        this.log.info('waiting to be provisioned a raft ID',
+        this.log.info('waiting to be provisioned a log source',
                       { zkEndpoint });
     }
 


### PR DESCRIPTION
We need only and exactly one queue populator processing the mongo log,
but we have 10 running in Federation deployments, so one has to be
picked and failover to another when the active one fails.

This can be implemented the same way we did for raft session log
consumption, with help from zookeeper watchers (ProvisionDispatcher),
but instead of having 8 raft sessions to consume from, we only have
one mongo log.

Kubernetes deployments don't need this, so an option
"subscribeToLogSourceDispatcher" has been added, set to true in
Federation deployments only.
