### PR TITLE
poc: queue processor per site

### DIFF
--- a/conf/Config.js
+++ b/conf/Config.js
@@ -98,10 +98,10 @@ class Config extends EventEmitter {
     }
 
     setBootstrapList(locationConstraints) {
-        this.bootstrapList =
-        Object.keys(locationConstraints)
-        .map(key => ({ site: key, type:
-              locationTypeMatch[locationConstraints[key].locationType] }));
+        this.bootstrapList = Object.keys(locationConstraints).map(key => ({
+            site: key,
+            type: locationTypeMatch[locationConstraints[key].locationType],
+        }));
         this.emit('bootstrap-list-update');
     }
 

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -74,7 +74,8 @@ class QueueProcessor extends EventEmitter {
 
         this.echoMode = false;
 
-        this.logger = new Logger('Backbeat:Replication:QueueProcessor');
+        this.logger = new Logger(
+            `Backbeat:Replication:QueueProcessor:${this.site}`);
 
         // global variables
         // TODO: for SSL support, create HTTPS agents instead

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -1,12 +1,13 @@
 'use strict'; // eslint-disable-line
+
 const werelogs = require('werelogs');
+
 const QueueProcessor = require('./QueueProcessor');
 const config = require('../../../conf/Config');
 const { initManagement } = require('../../../lib/management');
-
-const zkConfig = config.zookeeper;
 const MetricsProducer = require('../../../lib/MetricsProducer');
 
+const zkConfig = config.zookeeper;
 const kafkaConfig = config.kafka;
 const repConfig = config.extensions.replication;
 const sourceConfig = repConfig.source;
@@ -44,9 +45,13 @@ metricsProducer.setupProducer(err => {
                 destConfig.bootstrapList = config.getBootstrapList();
             });
 
-            const queueProcessor = new QueueProcessor(zkConfig, kafkaConfig,
-                sourceConfig, destConfig, repConfig, metricsProducer);
-            queueProcessor.start();
+            // Start QueueProcessor for each site
+            const siteNames = bootstrapList.map(i => i.site);
+            siteNames.forEach(site => {
+                const queueProcessor = new QueueProcessor(zkConfig, kafkaConfig,
+                    sourceConfig, destConfig, repConfig, metricsProducer, site);
+                queueProcessor.start();
+            });
         });
     }
     return initAndStart();

--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -28,15 +28,13 @@ class ReplicateObject extends BackbeatTask {
      *
      * @constructor
      * @param {QueueProcessor} qp - queue processor instance
-     * @param {String} site - site used for replication
      */
-    constructor(qp, site) {
+    constructor(qp) {
         const qpState = qp.getStateVars();
         super({
             retryTimeoutS: qpState.repConfig.queueProcessor.retryTimeoutS,
         });
         Object.assign(this, qpState);
-        this.site = site;
 
         this.sourceRole = null;
         this.targetRole = null;

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -656,7 +656,7 @@ describe('queue processor functional tests with mocking', () => {
                   retryTimeoutS: 5,
                   groupId: 'backbeat-func-test-group-id',
               },
-            }, new MetricsMock());
+          }, new MetricsMock(), 'sf');
         queueProcessor.start({ disableConsumer: true });
         // create the replication status processor only when the queue
         // processor is ready, so that we ensure the replication


### PR DESCRIPTION
This is a POC and opening to test

Differences from previous implementation of a QueueProcessor per site is that instead of taking a site as an argument and calling the npm script per site, instead, based on the config file, instantiate a new QueueProcessor instance per site after waiting for the `initManagement`