### PR TITLE
ft: ZENKO-147 Use Redis keys instead of hash

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -80,6 +80,7 @@
             "replicationStatusTopic": "backbeat-replication-status",
             "replicationFailedTopic": "backbeat-replication-failed",
             "monitorReplicationFailures": true,
+            "monitorReplicationFailureExpiryTimeS": 86400,
             "queueProcessor": {
                 "groupId": "backbeat-replication-group",
                 "retryTimeoutS": 300,

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -6,6 +6,8 @@ const { hostPortJoi, bootstrapListJoi, adminCredsJoi } =
 const transportJoi = joi.alternatives().try('http', 'https')
     .default('http');
 
+const CRR_FAILURE_EXPIRY = 24 * 60 * 60; // Expire Redis keys after 24 hours.
+
 const joiSchema = {
     source: {
         transport: transportJoi,
@@ -52,6 +54,8 @@ const joiSchema = {
     replicationStatusTopic: joi.string().required(),
     monitorReplicationFailures: joi.boolean().default(true),
     replicationFailedTopic: joi.string().required(),
+    monitorReplicationFailureExpiryTimeS:
+        joi.number().default(CRR_FAILURE_EXPIRY),
     queueProcessor: {
         groupId: joi.string().required(),
         retryTimeoutS: joi.number().default(300),

--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -14,6 +14,7 @@ const ReplicationTaskScheduler = require('../utils/ReplicationTaskScheduler');
 const UpdateReplicationStatus = require('../tasks/UpdateReplicationStatus');
 const QueueEntry = require('../../../lib/models/QueueEntry');
 const ObjectQueueEntry = require('../utils/ObjectQueueEntry');
+const { redisKeys } = require('../constants');
 
 /**
  * @class ReplicationStatusProcessor
@@ -145,7 +146,8 @@ class ReplicationStatusProcessor {
             const versionId = queueEntry.getEncodedVersionId();
             const { site } = backend;
             const message = {
-                field: `${bucket}:${key}:${versionId}:${site}`,
+                key: `${redisKeys.failedCRR}:` +
+                    `${bucket}:${key}:${versionId}:${site}`,
                 value: Buffer.from(kafkaEntry.value).toString(),
             };
             return this._FailedCRRProducer

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -12,6 +12,7 @@ const QueueEntry = require('../../lib/models/QueueEntry');
 const Healthcheck = require('./Healthcheck');
 const routes = require('./routes');
 const { redisKeys } = require('../../extensions/replication/constants');
+const getFailedCRRKey = require('../util/getFailedCRRKey');
 const monitoringClient = require('../clients/monitoringHandler').client;
 
 // StatsClient constant defaults
@@ -216,10 +217,11 @@ class BackbeatAPI {
     /**
      * Builds the failed CRR response.
      * @param {String} cursor - The Redis HSCAN cursor
-     * @param {Array} hashes - The collection of Redis hashes for the iteration
-     * @return {Object} - The response object
+     * @param {Array} keys - The collection of Redis keys for the iteration
+     * @param {Function} cb - The callback function
+     * @return {undefined}
      */
-    _getFailedCRRResponse(cursor, hashes) {
+    _getFailedCRRResponse(cursor, keys, cb) {
         const response = {
             IsTruncated: Number.parseInt(cursor, 10) !== 0,
             Versions: [],
@@ -227,20 +229,57 @@ class BackbeatAPI {
         if (response.IsTruncated) {
             response.NextMarker = Number.parseInt(cursor, 10);
         }
-        for (let i = 0; i < hashes.length; i += 2) {
-            const [bucket, key, versionId, site] = hashes[i].split(':');
-            const entry = hashes[i + 1];
-            const value = JSON.parse(JSON.parse(entry).value);
-            response.Versions.push({
-                Bucket: bucket,
-                Key: key,
-                VersionId: versionId,
-                StorageClass: site,
-                Size: value['content-length'],
-                LastModified: value['last-modified'],
-            });
-        }
-        return response;
+        const cmds = keys.map(k => ['get', k]);
+        return this._redisClient.batch(cmds, (err, res) => {
+            if (err) {
+                return cb(err);
+            }
+            for (let i = 0; i < res.length; i++) {
+                const [cmdErr, value] = res[i];
+                if (cmdErr) {
+                    return cb(cmdErr);
+                }
+                const queueEntry = QueueEntry.createFromKafkaEntry({ value });
+                response.Versions.push({
+                    Bucket: queueEntry.getBucket(),
+                    Key: queueEntry.getObjectKey(),
+                    VersionId: queueEntry.getEncodedVersionId(),
+                    StorageClass: queueEntry.getSite(),
+                    Size: queueEntry.getContentLength(),
+                    LastModified: queueEntry.getLastModified(),
+                });
+            }
+            return cb(null, response);
+        });
+    }
+
+    /**
+     * Recursively scan all existing keys with a count of 1000. Call callback if
+     * the response is greater or equal to 1000 keys, or we have scanned all
+     * keys (i.e. when the cursor is 0).
+     * @param {String} pattern - The key pattern to match
+     * @param {Number} marker - The cursor to start scanning from
+     * @param {Array} allKeys - The collection of all matching keys found
+     * @param {Function} cb - The callback function
+     * @return {undefined}
+     */
+    _scanAllKeys(pattern, marker, allKeys, cb) {
+        const cmd = ['scan', marker, 'MATCH', pattern, 'COUNT', 1000];
+        this._redisClient.batch([cmd], (err, res) => {
+            if (err) {
+                return cb(err);
+            }
+            const [cmdErr, collection] = res[0];
+            if (cmdErr) {
+                return cb(cmdErr);
+            }
+            const [cursor, keys] = collection;
+            allKeys.push(...keys);
+            if (allKeys.length >= 1000 || Number.parseInt(cursor, 10) === 0) {
+                return cb(null, cursor, allKeys);
+            }
+            return this._scanAllKeys(pattern, cursor, allKeys, cb);
+        });
     }
 
     /**
@@ -251,20 +290,10 @@ class BackbeatAPI {
      */
     getFailedCRR(details, cb) {
         const { bucket, key, versionId } = details;
-        const pattern = `${bucket}:${key}:${versionId}:*`;
-        const cmds =
-            ['hscan', redisKeys.failedCRR, 0, 'MATCH', pattern, 'COUNT', 1000];
-        this._redisClient.batch([cmds], (err, res) => {
-            if (err) {
-                return cb(err);
-            }
-            const [cmdErr, collection] = res[0];
-            if (cmdErr) {
-                return cb(cmdErr);
-            }
-            const [cursor, hashes] = collection;
-            return cb(null, this._getFailedCRRResponse(cursor, hashes));
-        });
+        const { failedCRR } = redisKeys;
+        const pattern = `${failedCRR}:${bucket}:${key}:${versionId}:*`;
+        return this._scanAllKeys(pattern, 0, [], (err, cursor, keys) =>
+            this._getFailedCRRResponse(cursor, keys, cb));
     }
 
     /**
@@ -275,26 +304,17 @@ class BackbeatAPI {
      */
     getAllFailedCRR(details, cb) {
         const marker = Number.parseInt(details.marker, 10) || 0;
-        const cmds = ['hscan', redisKeys.failedCRR, marker, 'COUNT', 1000];
-        this._redisClient.batch([cmds], (err, res) => {
-            if (err) {
-                return cb(err);
-            }
-            const [cmdErr, collection] = res[0];
-            if (cmdErr) {
-                return cb(cmdErr);
-            }
-            const [cursor, hashes] = collection;
-            return cb(null, this._getFailedCRRResponse(cursor, hashes));
-        });
+        const pattern = `${redisKeys.failedCRR}:*`;
+        return this._scanAllKeys(pattern, marker, [], (err, cursor, keys) =>
+            this._getFailedCRRResponse(cursor, keys, cb));
     }
 
     /**
-     * For the given queue enry's site, send an entry with PENDING status to the
-     * replication status topic, then send an entry to the replication topic so
-     * that the queue processor re-attempts replication.
+     * For the given queue entry's site, send an entry with PENDING status to
+     * the replication status topic, then send an entry to the replication topic
+     * so that the queue processor re-attempts replication.
      * @param {QueueEntry} queueEntry - The queue entry constructed from the
-     * failed kafka entry that was stored as a Redis hash value.
+     * failed kafka entry that was stored as a Redis key value.
      * @param {Function} cb - The callback.
      * @return {undefined}
      */
@@ -312,29 +332,27 @@ class BackbeatAPI {
     }
 
     /**
-     * Delete the failed CRR Redis hash field.
-     * @param {String} field - The field in the hash to delete
+     * Delete the failed CRR Redis key.
+     * @param {String} key - The key to delete
      * @param {Function} cb - The callback function
      * @return {undefined}
      */
-    _deleteFailedCRRField(field, cb) {
-        const cmds = ['hdel', redisKeys.failedCRR, field];
-        return this._redisClient.batch([cmds], (err, res) => {
+    _deleteFailedCRRField(key, cb) {
+        const cmd = ['del', key];
+        return this._redisClient.batch([cmd], (err, res) => {
             if (err) {
-                this._logger.error('error deleting redis hash field', {
+                this._logger.error('error deleting redis key', {
                     method: 'BackbeatAPI._deleteFailedCRRField',
-                    key: redisKeys.failedCRR,
-                    field,
+                    key,
                     error: err,
                 });
                 return cb(err);
             }
             const [cmdErr] = res[0];
             if (cmdErr) {
-                this._logger.error('error deleting redis hash field', {
+                this._logger.error('error deleting redis key', {
                     method: 'BackbeatAPI._deleteFailedCRRField',
-                    key: redisKeys.failedCRR,
-                    field,
+                    key,
                     error: cmdErr,
                 });
                 return cb(cmdErr);
@@ -380,11 +398,12 @@ class BackbeatAPI {
                     LastModified: queueEntry.getLastModified(),
                     ReplicationStatus: 'PENDING',
                 });
-                const field = `${Bucket}:${Key}:${VersionId}:${StorageClass}`;
-                return this._deleteFailedCRRField(field, err => {
+                const key =
+                    getFailedCRRKey(Bucket, Key, VersionId, StorageClass);
+                return this._deleteFailedCRRField(key, err => {
                     if (err) {
-                        this._logger.error('could not delete redis hash key ' +
-                        'after pushing to kafka topics', {
+                        this._logger.error('could not delete redis key after ' +
+                        'pushing to kafka topics', {
                             method: 'BackbeatAPI._processFailedKafkaEntries',
                             error: err,
                         });
@@ -408,20 +427,24 @@ class BackbeatAPI {
         if (error) {
             return cb(error);
         }
-        const fields = reqBody.map(o => {
+        const cmds = reqBody.map(o => {
             const { Bucket, Key, VersionId, StorageClass } = o;
-            return `${Bucket}:${Key}:${VersionId}:${StorageClass}`;
+            const key = getFailedCRRKey(Bucket, Key, VersionId, StorageClass);
+            return ['get', key];
         });
-        const cmds = ['hmget', redisKeys.failedCRR, ...fields];
-        return this._redisClient.batch([cmds], (err, res) => {
+        return this._redisClient.batch(cmds, (err, res) => {
             if (err) {
                 return cb(err);
             }
-            const [cmdErr, results] = res[0];
-            if (cmdErr) {
-                return cb(cmdErr);
+            const entries = [];
+            for (let i = 0; i < res.length; i++) {
+                const [cmdErr, entry] = res[i];
+                if (cmdErr) {
+                    return cb(cmdErr);
+                }
+                entries.push(entry);
             }
-            return this._processFailedKafkaEntries(results, cb);
+            return this._processFailedKafkaEntries(entries, cb);
         });
     }
 

--- a/lib/util/getFailedCRRKey.js
+++ b/lib/util/getFailedCRRKey.js
@@ -1,0 +1,16 @@
+const { redisKeys } = require('../../extensions/replication/constants');
+
+/**
+ * Returns the schema used for failed CRR entry Redis keys.
+ * @param {String} bucket - The name of the bucket
+ * @param {String} key - The name of the key
+ * @param {String} versionId - The encoded version ID
+ * @param {String} storageClass - The storage class of the object
+ * @return {String} - The Redis key used for the failed CRR entry
+ */
+function getFailedCRRKey(bucket, key, versionId, storageClass) {
+    const { failedCRR } = redisKeys;
+    return `${failedCRR}:${bucket}:${key}:${versionId}:${storageClass}`;
+}
+
+module.exports = getFailedCRRKey;

--- a/tests/config.json
+++ b/tests/config.json
@@ -43,6 +43,7 @@
             "topic": "backbeat-test-replication",
             "replicationStatusTopic": "backbeat-test-replication-status",
             "monitorReplicationFailures": true,
+            "monitorReplicationFailureExpiryTimeS": 86400,
             "groupId": "backbeat-test-replication-group",
             "destination": {
                 "bootstrapList": [

--- a/tests/functional/api/BackbeatServer.js
+++ b/tests/functional/api/BackbeatServer.js
@@ -11,7 +11,7 @@ const { makePOSTRequest, getResponseBody } =
     require('../utils/makePOSTRequest');
 const getKafkaEntry = require('../utils/getKafkaEntry');
 const redisConfig = { host: '127.0.0.1', port: 6379 };
-const REDIS_KEY_FAILED_CRR = 'test:bb:crr:failed';
+const TEST_REDIS_KEY_FAILED_CRR = 'test:bb:crr:failed';
 
 const fakeLogger = {
     trace: () => {},
@@ -30,19 +30,23 @@ function getUrl(options, path) {
     return `http://${options.host}:${options.port}${path}`;
 }
 
-function setHash(redisClient, fields, cb) {
-    const cmds = fields.map(field => {
+function setKey(redisClient, keys, cb) {
+    const cmds = keys.map(key => {
         // eslint-disable-next-line no-unused-vars
-        const [bucket, key, versionId, site] = field.split(':');
-        const value = getKafkaEntry(bucket, key, site);
-        return ['hset', REDIS_KEY_FAILED_CRR, field, value];
+        const [bucket, objectKey, versionId, site] = key.split(':');
+        const value = getKafkaEntry(bucket, objectKey, site);
+        return ['set', `${TEST_REDIS_KEY_FAILED_CRR}:${key}`, value];
     });
     redisClient.batch(cmds, cb);
 }
 
-function deleteHash(redisClient, cb) {
-    const cmds = ['del', REDIS_KEY_FAILED_CRR];
-    redisClient.batch([cmds], cb);
+function setDummyKey(redisClient, keys, cb) {
+    const cmds = keys.map(key => ['set', key, 'null']);
+    redisClient.batch(cmds, cb);
+}
+
+function deleteKeys(redisClient, cb) {
+    redisClient.batch([['flushall']], cb);
 }
 
 function makeRetryPOSTRequest(body, cb) {
@@ -402,12 +406,12 @@ describe('Backbeat Server', () => {
             const testVersionId =
                 '393834373735353134343536313039393939393952473030312020313030';
 
-            before(done => deleteHash(redisClient, done));
+            before(done => deleteKeys(redisClient, done));
 
-            afterEach(done => deleteHash(redisClient, done));
+            afterEach(done => deleteKeys(redisClient, done));
 
             it('should get correct data for GET route: /_/crr/failed when no ' +
-            'hash key has been created', done => {
+            'key has been created', done => {
                 getRequest('/_/crr/failed', (err, res) => {
                     assert.ifError(err);
                     assert.deepStrictEqual(res, {
@@ -419,9 +423,9 @@ describe('Backbeat Server', () => {
             });
 
             it('should get correct data for GET route: /_/crr/failed when ' +
-            'the hash has been created and there is one hash key', done => {
-                const key = 'test-bucket-1:test-key:test-versionId:test-site';
-                setHash(redisClient, [key], err => {
+            'the key has been created and there is one key', done => {
+                const key = `test-bucket-1:test-key:${testVersionId}:test-site`;
+                setKey(redisClient, [key], err => {
                     assert.ifError(err);
                     getRequest('/_/crr/failed?marker=0', (err, res) => {
                         assert.ifError(err);
@@ -430,7 +434,7 @@ describe('Backbeat Server', () => {
                             Versions: [{
                                 Bucket: 'test-bucket-1',
                                 Key: 'test-key',
-                                VersionId: 'test-versionId',
+                                VersionId: testVersionId,
                                 StorageClass: 'test-site',
                                 Size: 1,
                                 LastModified: '2018-03-30T22:22:34.384Z',
@@ -442,14 +446,14 @@ describe('Backbeat Server', () => {
             });
 
             it('should get correct data for GET route: /_/crr/failed when ' +
-            'the hash has been created and there are multiple hash keys',
+            'the key has been created and there are multiple key keys',
             done => {
                 const keys = [
                     'test-bucket:test-key:test-versionId:test-site',
                     'test-bucket-1:test-key-1:test-versionId-1:test-site-1',
                     'test-bucket-2:test-key-2:test-versionId-2:test-site-2',
                 ];
-                setHash(redisClient, keys, err => {
+                setKey(redisClient, keys, err => {
                     assert.ifError(err);
                     getRequest('/_/crr/failed', (err, res) => {
                         assert.ifError(err);
@@ -458,11 +462,12 @@ describe('Backbeat Server', () => {
                         // We cannot guarantee order because it depends on how
                         // Redis fetches the keys.
                         keys.forEach(k => {
+                            // eslint-disable-next-line no-unused-vars
                             const [bucket, key, versionId, site] = k.split(':');
                             assert(res.Versions.some(o => (
                                 o.Bucket === bucket &&
                                 o.Key === key &&
-                                o.VersionId === versionId &&
+                                o.VersionId === testVersionId &&
                                 o.StorageClass === site
                             )));
                         });
@@ -474,42 +479,53 @@ describe('Backbeat Server', () => {
             it('should get correct data at scale for GET route: /_/crr/failed',
             function f(done) {
                 this.timeout(30000);
-                async.timesLimit(2000, 10, (i, next) => {
-                    const keys = [
-                        `bucket-${i}:key-${i}:versionId-${i}:site-${i}-a`,
-                        `bucket-${i}:key-${i}:versionId-${i}:site-${i}-b`,
-                        `bucket-${i}:key-${i}:versionId-${i}:site-${i}-c`,
-                        `bucket-${i}:key-${i}:versionId-${i}:site-${i}-d`,
-                        `bucket-${i}:key-${i}:versionId-${i}:site-${i}-e`,
-                    ];
-                    setHash(redisClient, keys, next);
+                // Set non-matching keys so that recursive condition is met.
+                async.timesLimit(500, 10, (i, next) => {
+                    const keys = ['a', 'b', 'c', 'd', 'e'];
+                    setDummyKey(redisClient, keys, next);
                 }, err => {
-                    assert.ifError(err);
-                    const keyCount = 2000 * 5;
-                    const scanCount = 1000;
-                    const set = new Set();
-                    let marker = 0;
-                    async.timesSeries(keyCount / scanCount, (i, next) =>
-                        getRequest(`/_/crr/failed?marker=${marker}`,
-                        (err, res) => {
-                            assert.ifError(err);
-                            res.Versions.forEach(version => {
-                                // Ensure we have no duplicate results.
-                                assert(!set.has(version.StorageClass));
-                                set.add(version.StorageClass);
-                            });
-                            if (i === (keyCount / scanCount) - 1) {
-                                assert.strictEqual(res.IsTruncated, false);
-                                assert.strictEqual(res.NextMarker, undefined);
-                                assert.strictEqual(set.size, keyCount);
+                    if (err) {
+                        return done(err);
+                    }
+                    return async.timesLimit(2000, 10, (i, next) => {
+                        const keys = [
+                            `bucket-${i}:key-${i}:versionId-${i}:site-${i}-a`,
+                            `bucket-${i}:key-${i}:versionId-${i}:site-${i}-b`,
+                            `bucket-${i}:key-${i}:versionId-${i}:site-${i}-c`,
+                            `bucket-${i}:key-${i}:versionId-${i}:site-${i}-d`,
+                            `bucket-${i}:key-${i}:versionId-${i}:site-${i}-e`,
+                        ];
+                        setKey(redisClient, keys, next);
+                    }, err => {
+                        assert.ifError(err);
+                        const dummyKeyCount = 500 * 5;
+                        const keyCount = 2000 * 5;
+                        const scanCount = 1000;
+                        const reqCount = (keyCount + dummyKeyCount) / scanCount;
+                        const set = new Set();
+                        let marker = 0;
+                        async.timesSeries(reqCount, (i, next) =>
+                            getRequest(`/_/crr/failed?marker=${marker}`,
+                            (err, res) => {
+                                assert.ifError(err);
+                                res.Versions.forEach(version => {
+                                    // Ensure we have no duplicate results.
+                                    assert(!set.has(version.StorageClass));
+                                    set.add(version.StorageClass);
+                                });
+                                if (res.IsTruncated === false) {
+                                    assert.strictEqual(res.NextMarker,
+                                        undefined);
+                                    assert.strictEqual(set.size, keyCount);
+                                    return done();
+                                }
+                                assert.strictEqual(res.IsTruncated, true);
+                                assert.strictEqual(
+                                    typeof(res.NextMarker), 'number');
+                                marker = res.NextMarker;
                                 return next();
-                            }
-                            assert.strictEqual(res.IsTruncated, true);
-                            assert.strictEqual(
-                                typeof(res.NextMarker), 'number');
-                            marker = res.NextMarker;
-                            return next();
-                        }), done);
+                            }), done);
+                    });
                 });
             });
 
@@ -534,7 +550,7 @@ describe('Backbeat Server', () => {
                     'test-bucket:test-key:test-versionId:test-site-2',
                     'test-bucket-1:test-key-1:test-versionId-1:test-site',
                 ];
-                setHash(redisClient, keys, err => {
+                setKey(redisClient, keys, err => {
                     assert.ifError(err);
                     const route =
                         '/_/crr/failed/test-bucket/test-key/test-versionId';
@@ -544,11 +560,12 @@ describe('Backbeat Server', () => {
                         assert.strictEqual(res.Versions.length, 2);
                         const matchingkeys = [keys[0], keys[1]];
                         matchingkeys.forEach(k => {
+                            // eslint-disable-next-line no-unused-vars
                             const [bucket, key, versionId, site] = k.split(':');
                             assert(res.Versions.some(o => (
                                 o.Bucket === bucket &&
                                 o.Key === key &&
-                                o.VersionId === versionId &&
+                                o.VersionId === testVersionId &&
                                 o.StorageClass === site
                             )));
                         });
@@ -558,7 +575,7 @@ describe('Backbeat Server', () => {
             });
 
             it('should get correct data for GET route: /_/crr/failed when no ' +
-            'hash key has been matched', done => {
+            'key key has been matched', done => {
                 const body = JSON.stringify([{
                     Bucket: 'bucket',
                     Key: 'key',
@@ -577,14 +594,14 @@ describe('Backbeat Server', () => {
             });
 
             it('should get correct data for POST route: /_/crr/failed ' +
-            'when there are multiple matching hash keys', function f(done) {
+            'when there are multiple matching key keys', function f(done) {
                 this.timeout(10000);
                 const keys = [
                     `test-bucket:test-key:${testVersionId}:test-site-1`,
                     `test-bucket:test-key:${testVersionId}:test-site-2`,
                     `test-bucket:test-key:${testVersionId}:test-site-3`,
                 ];
-                setHash(redisClient, keys, err => {
+                setKey(redisClient, keys, err => {
                     assert.ifError(err);
                     const body = JSON.stringify([{
                         Bucket: 'test-bucket',
@@ -682,7 +699,7 @@ describe('Backbeat Server', () => {
                         `bucket-${i}:key-${i}:${testVersionId}:site-${i}-d`,
                         `bucket-${i}:key-${i}:${testVersionId}:site-${i}-e`,
                     ];
-                    setHash(redisClient, keys, next);
+                    setKey(redisClient, keys, next);
                 }, err => {
                     assert.ifError(err);
                     const body = JSON.stringify(reqBody);

--- a/tests/unit/getFailedCRRKey.js
+++ b/tests/unit/getFailedCRRKey.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+const { redisKeys } = require('../../extensions/replication/constants');
+
+const getFailedCRRKey = require('../../lib/util/getFailedCRRKey');
+
+describe('getFailedCRRKey', () => {
+    it('should return the correct Redis key schema', () => {
+        const key = getFailedCRRKey('a', 'b', 'c', 'd');
+        assert.strictEqual(key, `${redisKeys.failedCRR}:a:b:c:d`);
+    });
+});


### PR DESCRIPTION
We want to be able to expire entries from failed CRR after a configurable amount of time (default is 24 hours). Unfortunately Redis does not support expiry of hash data structure fields, so this PR moves the design to store failed CRR as keys. 

Alternatives considered:
* Setting the hash fields with a timestamp and then retroactively removing hashes at certain time intervals.
* Setting hash keys with a timestamp, one for each expiry time interval, then retroactively deleting old hashes.

I considered this the simplest solution because it leverages Redis' built-in expiry and we obviate the use of a cron job to delete old keys.

This PR also fixes a problem where when >= 1000 keys are stored, the listing of specific version failures does not iterate beyond the first count. The solution is to use a recursive scan listing.