### PR TITLE
bf: allow healthchecks even if clients not ok

### DIFF
--- a/lib/api/BackbeatServer.js
+++ b/lib/api/BackbeatServer.js
@@ -117,7 +117,8 @@ class BackbeatServer {
 
         // check request conditions and all internal conditions here
         if (this._isValidRequest(req, bbRequest)
-        && this._areConditionsOk(bbRequest)) {
+        && (this._areConditionsOk(bbRequest) ||
+        bbRequest.getRoute() === '/_/healthcheck')) {
             bbRequest.setStatusCode(200);
             bbRequest.setRoute(bbRequest.getRoute().substring(3));
 


### PR DESCRIPTION
All routes had preliminary checks made. One of these checks
were to check if conditions were ok. This check defeats the
purpose of a healthcheck, so the check needs to be eased for
healthcheck routes only