### PR TITLE
bf: ZENKO-351 allow healthchecks even if clients not ok

### DIFF
--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -104,12 +104,9 @@ class BackbeatAPI {
         if (!rDetails) {
             return false;
         }
+        // first validate healthcheck routes or prom routes
         const route = bbRequest.getRoute();
-        // first validate healthcheck routes
-        if (route.substring(3) === 'healthcheck') {
-            return true;
-        }
-        if (route.substring(3) === 'monitoring/metrics') {
+        if (route === 'healthcheck' || route === 'monitoring/metrics') {
             return true;
         }
 

--- a/lib/api/BackbeatRequest.js
+++ b/lib/api/BackbeatRequest.js
@@ -18,11 +18,13 @@ class BackbeatRequest {
         this._request = req;
         this._response = res;
         this._log = log;
-        this._route = req.url;
+        this._route = null;
+        this._hasValidPrefix = null;
         this._statusCode = 0;
         this._error = null;
         this._routeDetails = {};
 
+        this._setRoute(req.url);
         this._parseRoute();
     }
 
@@ -49,16 +51,14 @@ class BackbeatRequest {
      * @return {undefined}
      */
     _parseRoute() {
-        // always drop first 3 chars. This is already validated in
-        // BackbeatServer._isValidRequest
-        const route = this._route.substring(3);
-        const { pathname, query } = url.parse(route);
-        // if healthcheck, just skip this
+        const { pathname, query } = url.parse(this._route);
         const parts = pathname ? pathname.split('/') : [];
+        // if retry route
         if (parts[0] === 'crr') {
             this._parseRetryRoutes(parts, query);
             return;
         }
+        // if healthcheck, just skip this
         if (parts.length < 3 || parts.length > 4) {
             // leave this._routeDetails undefined
             return;
@@ -152,6 +152,14 @@ class BackbeatRequest {
     }
 
     /**
+     * Get if the initial route prefix was valid
+     * @return {boolean} true if request.url began with "/_/"
+     */
+    getHasValidPrefix() {
+        return this._hasValidPrefix;
+    }
+
+    /**
      * Get route
      * @return {string} current route
      */
@@ -161,11 +169,12 @@ class BackbeatRequest {
 
     /**
      * Set route
-     * @param {string} route - new route string
+     * @param {string} route - route string
      * @return {BackbeatRequest} itself
      */
-    setRoute(route) {
-        this._route = route;
+    _setRoute(route) {
+        this._hasValidPrefix = route.startsWith('/_/');
+        this._route = route.substring(3);
         return this;
     }
 

--- a/lib/api/BackbeatServer.js
+++ b/lib/api/BackbeatServer.js
@@ -171,7 +171,8 @@ class BackbeatServer {
 
         // check request conditions and all internal conditions here
         if (this._isValidRequest(req, bbRequest)
-        && this._areConditionsOk(bbRequest)) {
+        && (this._areConditionsOk(bbRequest) ||
+        bbRequest.getRoute() === '/_/healthcheck')) {
             bbRequest.setStatusCode(200);
             bbRequest.setRoute(bbRequest.getRoute().substring(3));
 

--- a/lib/api/BackbeatServer.js
+++ b/lib/api/BackbeatServer.js
@@ -72,7 +72,7 @@ class BackbeatServer {
         }
 
         if (!this.backbeatAPI.isValidRoute(backbeatRequest)
-            || !backbeatRequest.getRoute().startsWith('/_/')) {
+            || !backbeatRequest.getHasValidPrefix()) {
             return this._errorResponse(errors.RouteNotFound
                 .customizeDescription(`path ${backbeatRequest.getRoute()} does `
                     + 'not exist'), backbeatRequest);
@@ -172,9 +172,8 @@ class BackbeatServer {
         // check request conditions and all internal conditions here
         if (this._isValidRequest(req, bbRequest)
         && (this._areConditionsOk(bbRequest) ||
-        bbRequest.getRoute() === '/_/healthcheck')) {
+        bbRequest.getRoute().startsWith('healthcheck'))) {
             bbRequest.setStatusCode(200);
-            bbRequest.setRoute(bbRequest.getRoute().substring(3));
 
             /*
                 {


### PR DESCRIPTION
All routes had preliminary checks made. One of these checks
were to check if conditions were ok. This check defeats the
purpose of a healthcheck, so the check needs to be eased for
healthcheck routes only

cherry-picked from rel/7.4: https://github.com/scality/backbeat/pull/289