### PR TITLE
bf: crash when unable to connect with kafka

### DIFF
--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -68,7 +68,14 @@ class BackbeatProducer extends EventEmitter {
             'request.timeout.ms': ACK_TIMEOUT,
         });
         this._ready = false;
-        this._producer.connect();
+        this._producer.connect({ timeout: 30000 }, () => {
+            const opts = { topic: 'backbeat-sanitycheck', timeout: 10000 };
+            this._producer.getMetadata(opts, err => {
+                if (err) {
+                    this.emit('error', err);
+                }
+            });
+        });
         this._producer.on('ready', () => {
             this._ready = true;
             this.emit('ready');

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -69,7 +69,15 @@ class QueuePopulator {
     open(cb) {
         this._loadExtensions();
         async.series([
-            next => this._setupMetricsClients(next),
+            next => this._setupMetricsClients(err => {
+                if (err) {
+                    this.log.error('error setting up metrics client', {
+                        method: 'QueuePopulator.open',
+                        error: err,
+                    });
+                }
+                return next(err);
+            }),
             next => this._setupExtensions(err => {
                 if (err) {
                     this.log.error(


### PR DESCRIPTION
When Kafka is unavailable, the backbeat queue populator will hang and not connect to it even if it becomes available later on. These changes will make the backbeat queue populator throw an exception if it's unable to connect to Kafka after a certain amount of time.

In an orchestrated environment, the orchestration tool can recognize this crash and restart the failed container, thus allowing it to try to connect again to Kafka (which might be available later on).