### PR TITLE
ft: ZENKO-404 service account support for lifecycle

### DIFF
--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -16,21 +16,6 @@ const joiSchema = {
     },
     transport: transportJoi,
     s3: hostPortJoi.required(),
-    auth: joi.object({
-        type: joi.alternatives().try('account', 'vault').required(),
-        account: joi.string()
-            .when('type', { is: 'account', then: joi.required() }),
-        vault: joi.object({
-            host: joi.string().required(),
-            port: joi.number().greater(0).required(),
-            adminPort: joi.number().greater(0)
-                .when('adminCredentialsFile', {
-                    is: joi.exist(),
-                    then: joi.required(),
-                }),
-            adminCredentialsFile: joi.string().optional(),
-        }).when('type', { is: 'vault', then: joi.required() }),
-    }).required(),
     queuePopulator: {
         cronRule: joi.string().required(),
         batchMaxRead: joi.number().default(10000),

--- a/conf/config.json
+++ b/conf/config.json
@@ -10,15 +10,6 @@
         "host": "127.0.0.1",
         "port": 8000
     },
-    "auth": {
-        "type": "account",
-        "account": "bart",
-        "vault": {
-            "host": "127.0.0.1",
-            "port": 8500,
-            "adminPort": 8600
-        }
-    },
     "queuePopulator": {
         "cronRule": "*/5 * * * * *",
         "batchMaxRead": 10000,
@@ -93,6 +84,15 @@
             }
         },
         "lifecycle": {
+            "auth": {
+                "type": "service",
+                "account": "service-lifecycle",
+                "vault": {
+                    "host": "127.0.0.1",
+                    "port": 8500,
+                    "adminPort": 8600
+                }
+            },
             "zookeeperPath": "/lifecycle",
             "bucketTasksTopic": "backbeat-lifecycle-bucket-tasks",
             "objectTasksTopic": "backbeat-lifecycle-object-tasks",

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -6,6 +6,15 @@ set -e
 # modifying config.json
 JQ_FILTERS_CONFIG="."
 
+if [[ "$LOG_LEVEL" ]]; then
+    if [[ "$LOG_LEVEL" == "info" || "$LOG_LEVEL" == "debug" || "$LOG_LEVEL" == "trace" ]]; then
+        JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .log.logLevel=\"$LOG_LEVEL\""
+        echo "Log level has been modified to $LOG_LEVEL"
+    else
+        echo "The log level you provided is incorrect (info/debug/trace)"
+    fi
+fi
+
 if [[ "$ZOOKEEPER_AUTO_CREATE_NAMESPACE" ]]; then
     JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .zookeeper.autoCreateNamespace=true"
 fi
@@ -45,6 +54,14 @@ fi
 
 if [[ "$MONGODB_DATABASE" ]]; then
    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .queuePopulator.mongo.database=\"$MONGODB_DATABASE\""
+fi
+
+if [[ "$S3_HOST" ]]; then
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .s3.host=\"$S3_HOST\""
+fi
+
+if [[ "$S3_PORT" ]]; then
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .s3.port=\"$S3_PORT\""
 fi
 
 if [[ "$EXTENSIONS_REPLICATION_SOURCE_S3_HOST" ]]; then
@@ -123,12 +140,12 @@ if [[ "$EXTENSIONS_LIFECYCLE_RULES_ABORT_INCOMPLETE_MPU_ENABLED" ]]; then
     JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .extensions.lifecycle.rules.abortIncompleteMultipartUpload.enabled=\"$EXTENSIONS_LIFECYCLE_RULES_ABORT_INCOMPLETE_MPU_ENABLED\""
 fi
 
-if [[ "$AUTH_TYPE" ]]; then
-    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .auth.type=\"$AUTH_TYPE\""
+if [[ "$EXTENSIONS_LIFECYCLE_AUTH_TYPE" ]]; then
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .extensions.lifecycle.auth.type=\"$EXTENSIONS_LIFECYCLE_AUTH_TYPE\""
 fi
 
-if [[ "$AUTH_ACCOUNT" ]]; then
-    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .auth.account=\"$AUTH_ACCOUNT\""
+if [[ "$EXTENSIONS_LIFECYCLE_AUTH_ACCOUNT" ]]; then
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .extensions.lifecycle.auth.account=\"$EXTENSIONS_LIFECYCLE_AUTH_ACCOUNT\""
 fi
 
 if [[ $JQ_FILTERS_CONFIG != "." ]]; then

--- a/extensions/lifecycle/LifecycleConfigValidator.js
+++ b/extensions/lifecycle/LifecycleConfigValidator.js
@@ -4,6 +4,23 @@ const joiSchema = {
     zookeeperPath: joi.string().required(),
     bucketTasksTopic: joi.string().required(),
     objectTasksTopic: joi.string().required(),
+    auth: joi.object({
+        type: joi.alternatives().try('account', 'service', 'vault')
+            .required(),
+        account: joi.string()
+            .when('type', { is: 'account', then: joi.required() })
+            .when('type', { is: 'service', then: joi.required() }),
+        vault: joi.object({
+            host: joi.string().required(),
+            port: joi.number().greater(0).required(),
+            adminPort: joi.number().greater(0)
+                .when('adminCredentialsFile', {
+                    is: joi.exist(),
+                    then: joi.required(),
+                }),
+            adminCredentialsFile: joi.string().optional(),
+        }).when('type', { is: 'vault', then: joi.required() }),
+    }).required(),
     backlogMetrics: {
         zkPath: joi.string().default('/lifecycle/run/backlog-metrics'),
         intervalS: joi.number().default(60),

--- a/extensions/lifecycle/lifecycleConsumer/LifecycleConsumer.js
+++ b/extensions/lifecycle/lifecycleConsumer/LifecycleConsumer.js
@@ -22,6 +22,7 @@ class LifecycleConsumer extends EventEmitter {
      * @param {string} kafkaConfig.hosts - list of kafka brokers
      *   as "host:port[,host:port...]"
      * @param {Object} lcConfig - lifecycle configuration object
+     * @param {String} lcConfig.auth - authentication info
      * @param {String} lcConfig.objectTasksTopic - lifecycle object topic name
      * @param {Object} lcConfig.consumer - kafka consumer object
      * @param {String} lcConfig.consumer.groupId - kafka consumer group id
@@ -35,18 +36,17 @@ class LifecycleConsumer extends EventEmitter {
      * @param {Object} s3Config - S3 configuration
      * @param {Object} s3Config.host - s3 endpoint host
      * @param {Number} s3Config.port - s3 endpoint port
-     * @param {Object} authConfig - authentication info on source
      * @param {String} [transport="http"] - transport method ("http"
      *  or "https")
      */
-    constructor(zkConfig, kafkaConfig, lcConfig, s3Config, authConfig,
+    constructor(zkConfig, kafkaConfig, lcConfig, s3Config,
                 transport = 'http') {
         super();
         this.zkConfig = zkConfig;
         this.kafkaConfig = kafkaConfig;
         this.lcConfig = lcConfig;
+        this.authConfig = lcConfig.auth;
         this.s3Config = s3Config;
-        this.authConfig = authConfig;
         this._transport = transport;
         this._consumer = null;
 

--- a/extensions/lifecycle/lifecycleConsumer/task.js
+++ b/extensions/lifecycle/lifecycleConsumer/task.js
@@ -1,6 +1,7 @@
 'use strict'; // eslint-disable-line
 const werelogs = require('werelogs');
 
+const { initManagement } = require('../../../lib/management');
 const LifecycleConsumer = require('./LifecycleConsumer');
 
 const config = require('../../../conf/Config');
@@ -8,18 +9,34 @@ const zkConfig = config.zookeeper;
 const kafkaConfig = config.kafka;
 const lcConfig = config.extensions.lifecycle;
 const s3Config = config.s3;
-const authConfig = config.auth;
 const transport = config.transport;
 
 const log = new werelogs.Logger('Backbeat:Lifecycle:Consumer');
 
 const lifecycleConsumer = new LifecycleConsumer(
-    zkConfig, kafkaConfig, lcConfig, s3Config, authConfig, transport);
+    zkConfig, kafkaConfig, lcConfig, s3Config, transport);
 
 werelogs.configure({ level: config.log.logLevel,
     dump: config.log.dumpLevel });
 
-lifecycleConsumer.start();
+function initAndStart() {
+    initManagement({
+        serviceName: 'lifecycle',
+        serviceAccount: lcConfig.auth.account,
+    }, error => {
+        if (error) {
+            log.error('could not load management db',
+                      { error: error.message });
+            setTimeout(initAndStart, 5000);
+            return;
+        }
+        log.info('management init done');
+
+        lifecycleConsumer.start();
+    });
+}
+
+initAndStart();
 
 process.on('SIGTERM', () => {
     log.info('received SIGTERM, exiting');

--- a/extensions/lifecycle/lifecycleProducer/LifecycleProducer.js
+++ b/extensions/lifecycle/lifecycleProducer/LifecycleProducer.js
@@ -10,6 +10,8 @@ const { errors } = require('arsenal');
 const BackbeatProducer = require('../../../lib/BackbeatProducer');
 const BackbeatConsumer = require('../../../lib/BackbeatConsumer');
 const LifecycleTask = require('../tasks/LifecycleTask');
+const { getAccountCredentials } =
+      require('../../../lib/credentials/AccountCredentials');
 const VaultClientCache = require('../../../lib/clients/VaultClientCache');
 const safeJsonParse = require('../util/safeJsonParse');
 
@@ -33,27 +35,20 @@ class LifecycleProducer {
      * @param {string} kafkaConfig.hosts - list of kafka brokers
      *   as "host:port[,host:port...]"
      * @param {Object} lcConfig - lifecycle config
+     * @param {Object} lcConfig.auth - authentication info
      * @param {Object} [lcConfig.backlogMetrics] - param object to
      * publish backlog metrics to zookeeper (see {@link
      * BackbeatConsumer} constructor)
      * @param {Object} s3Config - s3 config
      * @param {String} s3Config.host - host ip
      * @param {String} s3Config.port - port
-     * @param {Object} authConfig - auth config
-     * @param {String} [authConfig.account] - account name
-     * @param {Object} [authConfig.vault] - vault details
-     * @param {String} authConfig.vault.host - vault host ip
-     * @param {number} authConfig.vault.port - vault port
-     * @param {number} authConfig.vault.adminPort - vault admin port
      * @param {String} transport - http or https
      */
-    constructor(zkConfig, kafkaConfig, lcConfig, s3Config, authConfig,
-                transport) {
+    constructor(zkConfig, kafkaConfig, lcConfig, s3Config, transport) {
         this._log = new Logger('Backbeat:LifecycleProducer');
         this._zkConfig = zkConfig;
         this._kafkaConfig = kafkaConfig;
         this._lcConfig = lcConfig;
-        this._authConfig = authConfig;
         this._s3Endpoint = `${transport}://${s3Config.host}:${s3Config.port}`;
         this._transport = transport;
         this._bucketProducer = null;
@@ -285,11 +280,24 @@ class LifecycleProducer {
     }
 
     /**
+     * Set up the credentials (service account credentials or provided
+     * by vault depending on config)
+     * @return {undefined}
+     */
+    _setupCredentials() {
+        const { type } = this._lcConfig.auth;
+        if (type === 'vault') {
+            return this._setupVaultClientCache();
+        }
+        return undefined;
+    }
+
+    /**
      * Set up the vault client cache for making requests to vault.
      * @return {undefined}
      */
     _setupVaultClientCache() {
-        const { vault } = this._authConfig;
+        const { vault } = this._lcConfig.auth;
         const { host, port, adminPort, adminCredentialsFile } = vault;
         const adminCredsJSON = fs.readFileSync(adminCredentialsFile);
         const adminCredsObj = JSON.parse(adminCredsJSON);
@@ -321,6 +329,21 @@ class LifecycleProducer {
         if (cachedAccountCreds) {
             return process.nextTick(() => cb(null, cachedAccountCreds));
         }
+        const credentials = getAccountCredentials(this._lcConfig.auth,
+                                                  this._log);
+        if (credentials) {
+            this.accountCredsCache[canonicalId] = credentials;
+            return process.nextTick(() => cb(null, credentials));
+        }
+        const { type } = this._lcConfig.auth;
+        if (type === 'vault') {
+            return this._generateVaultAdminCredentials(canonicalId, cb);
+        }
+        return cb(errors.InternalError.customizeDescription(
+            `invalid auth type ${type}`));
+    }
+
+    _generateVaultAdminCredentials(canonicalId, cb) {
         const vaultClient = this._vaultClientCache.getClient('lifecycle:s3');
         const vaultAdmin = this._vaultClientCache.getClient('lifecycle:admin');
         return async.waterfall([
@@ -366,7 +389,7 @@ class LifecycleProducer {
      * @return {undefined}
      */
     start() {
-        this._setupVaultClientCache();
+        this._setupCredentials();
         return async.parallel([
             // Set up producer to populate the lifecycle bucket task topic.
             next => this._setupProducer(this._lcConfig.bucketTasksTopic,

--- a/extensions/lifecycle/lifecycleProducer/task.js
+++ b/extensions/lifecycle/lifecycleProducer/task.js
@@ -1,8 +1,9 @@
 'use strict'; // eslint-disable-line
 const werelogs = require('werelogs');
+const { initManagement } = require('../../../lib/management');
 const LifecycleProducer = require('./LifecycleProducer');
-const { zookeeper, kafka, extensions, s3, auth, transport, log } =
-    require('../../../conf/Config');
+const { zookeeper, kafka, extensions, s3, transport, log } =
+      require('../../../conf/Config');
 
 werelogs.configure({ level: log.logLevel,
                      dump: log.dumpLevel });
@@ -11,9 +12,26 @@ const logger = new werelogs.Logger('Backbeat:Lifecycle:Producer');
 
 const lifecycleProducer =
     new LifecycleProducer(zookeeper, kafka, extensions.lifecycle,
-                          s3, auth, transport);
+                          s3, transport);
 
-lifecycleProducer.start();
+function initAndStart() {
+    initManagement({
+        serviceName: 'lifecycle',
+        serviceAccount: extensions.lifecycle.auth.account,
+    }, error => {
+        if (error) {
+            logger.error('could not load management db',
+                         { error: error.message });
+            setTimeout(initAndStart, 5000);
+            return;
+        }
+        logger.info('management init done');
+
+        lifecycleProducer.start();
+    });
+}
+
+initAndStart();
 
 process.on('SIGTERM', () => {
     logger.info('received SIGTERM, exiting');

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -16,7 +16,8 @@ const joiSchema = {
             type: joi.alternatives().try('account', 'role', 'service').
                 required(),
             account: joi.string()
-                .when('type', { is: 'account', then: joi.required() }),
+                .when('type', { is: 'account', then: joi.required() })
+                .when('type', { is: 'service', then: joi.required() }),
             vault: joi.object({
                 host: joi.string().required(),
                 port: joi.number().greater(0).required(),

--- a/extensions/replication/management.js
+++ b/extensions/replication/management.js
@@ -1,0 +1,231 @@
+const async = require('async');
+const AWS = require('aws-sdk');
+const werelogs = require('werelogs');
+
+const config = require('../../conf/Config');
+const management = require('../../lib/management');
+
+const logger = new werelogs.Logger('mdManagement:replication');
+
+function getS3Client(endpoint) {
+    const serviceCredentials =
+          management.getLatestServiceAccountCredentials();
+    // FIXME
+    const keys = serviceCredentials.accounts[0].keys;
+    const credentials = new AWS.Credentials(keys.access, keys.secret);
+    const s3Client = new AWS.S3({
+        endpoint,
+        sslEnabled: false,
+        credentials,
+        s3ForcePathStyle: true,
+        signatureVersion: 'v4',
+        httpOptions: { timeout: 0 },
+        maxRetries: 3,
+    });
+    return s3Client;
+}
+
+function ensureBucketExists(stream, end, endpoint, cb) {
+    logger.debug('Checking that bucket exists', { end, endpoint });
+    if (!stream.enabled) {
+        logger.debug('stream is not enabled');
+        return process.nextTick(cb);
+    }
+    const params = {
+        Bucket: end.bucketName,
+    };
+    return getS3Client(endpoint).createBucket(params, err => {
+        if (err && err.code === 'BucketAlreadyOwnedByYou') {
+            return cb();
+        }
+        return cb(err);
+    });
+}
+
+function putVersioning(stream, bucketName, endpoint, cb) {
+    if (!stream.enabled) {
+        return process.nextTick(cb);
+    }
+    const params = {
+        Bucket: bucketName,
+        VersioningConfiguration: {
+            Status: 'Enabled',
+        },
+    };
+    return getS3Client(endpoint).putBucketVersioning(params, err => cb(err));
+}
+
+function installReplicationPolicy(stream, endpoint, cb) {
+    const destinationLocations = stream.destination.locations
+        .map(location => location.name)
+        .join(',');
+    const roleName = 'arn:aws:iam::root:role/s3-replication-role';
+    const params = {
+        Bucket: stream.source.bucketName,
+        ReplicationConfiguration: {
+            Role: `${roleName}`,
+            Rules: [{
+                Destination: {
+                    Bucket: `arn:aws:s3:::${stream.source.bucketName}`,
+                    StorageClass: destinationLocations,
+                },
+                Prefix: stream.source.prefix || '',
+                Status: stream.enabled ? 'Enabled' : 'Disabled',
+            }],
+        },
+    };
+
+    getS3Client(endpoint).putBucketReplication(params, err => {
+        logger.debug('replication applied', {
+            sourceBucket: stream.source.bucketName,
+            destinationLocations, error: err });
+        if (err && err.code === 'NoSuchBucket' && !stream.enabled) {
+            return cb();
+        }
+        return cb(err);
+    });
+}
+
+function putReplication(stream, cb) {
+    logger.debug('Changing replication for stream to stream.enabled',
+        { streamId: stream.streamId });
+    const cfg = config.extensions.replication.source.s3;
+    const endpoint = `${cfg.host}:${cfg.port}`;
+
+    async.waterfall([
+        done => ensureBucketExists(stream, stream.source, endpoint, done),
+        done => putVersioning(stream, stream.source.bucketName, endpoint, done),
+        // TODO add service account in source & target bucket ACLs
+        done => installReplicationPolicy(stream, endpoint, done),
+    ], cb);
+}
+
+/* eslint-disable no-unused-vars */
+function disableReplication(stream, cb) {
+    logger.debug('disabling replication for stream',
+        { streamId: stream.streamId });
+    return cb(null, stream);
+}
+/* eslint-enable no-unused-vars */
+
+function applyReplicationState(conf, currentStateSerialized, cb) {
+    if (!conf.replicationStreams) {
+        return process.nextTick(cb);
+    }
+
+    const currentState = currentStateSerialized ?
+        JSON.parse(currentStateSerialized) : {
+            streams: {},
+            overlayVersion: 0,
+        };
+
+    if (currentState.overlayVersion >= conf.version) {
+        return process.nextTick(cb);
+    }
+
+    function streamConfigured(stream, cb) {
+        currentState.streams[stream.streamId] = stream;
+        management.saveExtensionState(currentState, cb);
+    }
+
+    function deleteStream(streamId, cb) {
+        logger.debug('deleting obsolete stream`', { streamId });
+        const stream = currentState.streams[streamId];
+        stream.enabled = false;
+        putReplication(stream, err => {
+            if (err) {
+                return cb(err);
+            }
+            delete currentState.streams[streamId];
+            return management.saveExtensionState(currentState, cb);
+        });
+    }
+
+    function arraysEqual(arr1, arr2) {
+        if (arr1.length !== arr2.length) {
+            return false;
+        }
+        for (let i = arr1.length; i--;) {
+            if (arr1[i] !== arr2[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    function putReplicationAndStreamConfigured(stream, cb) {
+        putReplication(stream, err => {
+            if (err) {
+                return cb(err);
+            }
+            return streamConfigured(stream, cb);
+        });
+    }
+
+    function configureStream(stream, cb) {
+        if (currentState.streams[stream.streamId]) {
+            if (!currentState.streams[stream.streamId].enabled
+                && stream.enabled) {
+                logger.debug('enabling existing stream', {
+                    streamId: stream.streamId });
+                putReplicationAndStreamConfigured(stream, cb);
+            } else if (currentState.streams[stream.streamId].enabled
+                && !stream.enabled) {
+                logger.debug('disabling existing stream',
+                    { streamId: stream.streamId });
+                putReplicationAndStreamConfigured(stream, cb);
+            } else if (currentState.streams[stream.streamId].source.prefix
+                !== stream.source.prefix) {
+                logger.debug('changing stream source prefix',
+                    { streamId: stream.streamId });
+                putReplicationAndStreamConfigured(stream, cb);
+            } else if (!arraysEqual(currentState.streams[stream.streamId]
+                .destination.locations, stream.destination.locations)) {
+                logger.debug('changing stream destination locations',
+                    { streamId: stream.streamId });
+                putReplicationAndStreamConfigured(stream, cb);
+            } else {
+                logger.debug('stream has expected state, doing nothing',
+                { streamId: stream.streamId, streamEnabled: stream.enabled });
+                return cb();
+            }
+        } else {
+            if (stream.enabled) {
+                logger.debug('enabling new stream',
+                    { streamId: stream.streamId });
+                putReplicationAndStreamConfigured(stream, cb);
+            } else {
+                logger.debug('new disabled stream, doing nothing',
+                    { streamId: stream.streamId });
+                return cb();
+            }
+        }
+        return undefined;
+    }
+
+    const existingStreamIds = Object.keys(currentState.streams);
+    const incomingConfigStreamIds =
+        conf.replicationStreams.map(s => s.streamId);
+    const deletedStreamIds =
+        existingStreamIds.filter(s => !incomingConfigStreamIds.includes(s));
+
+    // TODO group streams per source bucket
+    async.eachSeries(conf.replicationStreams, configureStream, err => {
+        if (err) {
+            return cb(err);
+        }
+        currentState.overlayVersion = conf.version;
+        async.eachSeries(deletedStreamIds, deleteStream, err => {
+            if (err) {
+                return cb(err);
+            }
+            return management.saveExtensionState(currentState, cb);
+        });
+        return undefined;
+    });
+    return undefined;
+}
+
+module.exports = {
+    applyReplicationState,
+};

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -3,6 +3,7 @@ const werelogs = require('werelogs');
 const QueueProcessor = require('./QueueProcessor');
 const config = require('../../../conf/Config');
 const { initManagement } = require('../../../lib/management');
+const { applyReplicationState } = require('../management');
 
 const zkConfig = config.zookeeper;
 const MetricsProducer = require('../../../lib/MetricsProducer');
@@ -26,7 +27,11 @@ metricsProducer.setupProducer(err => {
         return undefined;
     }
     function initAndStart() {
-        initManagement(error => {
+        initManagement({
+            serviceName: 'replication',
+            serviceAccount: sourceConfig.auth.account,
+            applyState: applyReplicationState,
+        }, error => {
             if (error) {
                 log.error('could not load management db',
                   { error: error.message });

--- a/extensions/replication/replicationStatusProcessor/task.js
+++ b/extensions/replication/replicationStatusProcessor/task.js
@@ -18,7 +18,10 @@ werelogs.configure({ level: config.log.logLevel,
 
 const logger = new werelogs.Logger('backbeat:ReplicationStatusProcessor:Init');
 function initAndStart() {
-    initManagement(error => {
+    initManagement({
+        serviceName: 'replication',
+        serviceAccount: sourceConfig.auth.account,
+    }, error => {
         if (error) {
             logger.error('could not load management db', error);
             setTimeout(initAndStart, 5000);

--- a/lib/management.js
+++ b/lib/management.js
@@ -2,7 +2,6 @@ const async = require('async');
 const forge = require('node-forge');
 const arsenal = require('arsenal');
 const config = require('../conf/Config');
-const AWS = require('aws-sdk');
 const werelogs = require('werelogs');
 const bucketclient = require('bucketclient');
 
@@ -18,6 +17,7 @@ const refreshInterval = 5000;
 const Metadata = arsenal.storage.metadata.MetadataWrapper;
 let metadata;
 
+let serviceName;
 let overlayVersion;
 
 // let initialized = false;
@@ -26,7 +26,6 @@ let serviceCredentials = {
 };
 
 const tokenKey = 'auth/zenko/remote-management-token';
-const replicationStateKey = 'configuration/state/replication';
 
 // XXX copy-pasted from S3
 function decryptSecret(instanceCredentials, secret) {
@@ -39,255 +38,21 @@ function decryptSecret(instanceCredentials, secret) {
     });
 }
 
-function saveCurrentReplicationState(db, currentState, cb) {
-    logger.debug('saving replication state', { currentState });
-    metadata.putObjectMD(serviceBucket, replicationStateKey,
-        JSON.stringify(currentState), {}, logger, cb);
-}
-
-function getS3Client(endpoint) {
-    const keys = serviceCredentials.accounts[0].keys;
-    const credentials = new AWS.Credentials(keys.access, keys.secret);
-    const s3Client = new AWS.S3({
-        endpoint,
-        sslEnabled: false,
-        credentials,
-        s3ForcePathStyle: true,
-        signatureVersion: 'v4',
-        httpOptions: { timeout: 0 },
-        maxRetries: 3,
-    });
-    return s3Client;
-}
-
-function ensureBucketExists(stream, end, endpoint, cb) {
-    logger.debug('Checking that bucket exists', { end, endpoint });
-    if (!stream.enabled) {
-        logger.debug('stream is not enabled');
-        return process.nextTick(cb);
-    }
-    const params = {
-        Bucket: end.bucketName,
-    };
-    return getS3Client(endpoint).createBucket(params, err => {
-        if (err && err.code === 'BucketAlreadyOwnedByYou') {
-            return cb();
-        }
-        return cb(err);
-    });
-}
-
-function putVersioning(stream, bucketName, endpoint, cb) {
-    if (!stream.enabled) {
-        return process.nextTick(cb);
-    }
-    const params = {
-        Bucket: bucketName,
-        VersioningConfiguration: {
-            Status: 'Enabled',
-        },
-    };
-    return getS3Client(endpoint).putBucketVersioning(params, err => cb(err));
-}
-
-function installReplicationPolicy(stream, endpoint, cb) {
-    const destinationLocations = stream.destination.locations
-        .map(location => location.name)
-        .join(',');
-    const roleName = 'arn:aws:iam::root:role/s3-replication-role';
-    const params = {
-        Bucket: stream.source.bucketName,
-        ReplicationConfiguration: {
-            Role: `${roleName}`,
-            Rules: [{
-                Destination: {
-                    Bucket: `arn:aws:s3:::${stream.source.bucketName}`,
-                    StorageClass: destinationLocations,
-                },
-                Prefix: stream.source.prefix || '',
-                Status: stream.enabled ? 'Enabled' : 'Disabled',
-            }],
-        },
-    };
-
-    getS3Client(endpoint).putBucketReplication(params, err => {
-        logger.debug('replication applied', {
-            sourceBucket: stream.source.bucketName,
-            destinationLocations, error: err });
-        if (err && err.code === 'NoSuchBucket' && !stream.enabled) {
-            return cb();
-        }
-        return cb(err);
-    });
-}
-
-function putReplication(stream, cb) {
-    logger.debug('Changing replication for stream to stream.enabled',
-        { streamId: stream.streamId });
-    const cfg = config.extensions.replication.source.s3;
-    const endpoint = `${cfg.host}:${cfg.port}`;
-
-    async.waterfall([
-        done => ensureBucketExists(stream, stream.source, endpoint, done),
-        done => putVersioning(stream, stream.source.bucketName, endpoint, done),
-        // TODO add service account in source & target bucket ACLs
-        done => installReplicationPolicy(stream, endpoint, done),
-    ], cb);
-}
-
-/* eslint-disable no-unused-vars */
-function disableReplication(stream, cb) {
-    logger.debug('disabling replication for stream',
-        { streamId: stream.streamId });
-    return cb(null, stream);
-}
-/* eslint-enable no-unused-vars */
-
-function applyReplicationState(conf, currentStateSerialized, db, cb) {
-    if (!conf.replicationStreams) {
-        return process.nextTick(cb);
-    }
-
-    const currentState = currentStateSerialized ?
-        JSON.parse(currentStateSerialized) : {
-            streams: {},
-            overlayVersion: 0,
-        };
-
-    if (currentState.overlayVersion >= conf.version) {
-        return process.nextTick(cb);
-    }
-
-    function streamConfigured(stream, cb) {
-        currentState.streams[stream.streamId] = stream;
-        saveCurrentReplicationState(db, currentState, cb);
-    }
-
-    function deleteStream(streamId, cb) {
-        logger.debug('deleting obsolete stream`', { streamId });
-        const stream = currentState.streams[streamId];
-        stream.enabled = false;
-        putReplication(stream, err => {
-            if (err) {
-                return cb(err);
-            }
-            delete currentState.streams[streamId];
-            return saveCurrentReplicationState(db, currentState, cb);
-        });
-    }
-
-    function arraysEqual(arr1, arr2) {
-        if (arr1.length !== arr2.length) {
-            return false;
-        }
-        for (let i = arr1.length; i--;) {
-            if (arr1[i] !== arr2[i]) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    function putReplicationAndStreamConfigured(stream, cb) {
-        putReplication(stream, err => {
-            if (err) {
-                return cb(err);
-            }
-            return streamConfigured(stream, cb);
-        });
-    }
-
-    function configureStream(stream, cb) {
-        if (currentState.streams[stream.streamId]) {
-            if (!currentState.streams[stream.streamId].enabled
-                && stream.enabled) {
-                logger.debug('enabling existing stream', {
-                    streamId: stream.streamId });
-                putReplicationAndStreamConfigured(stream, cb);
-            } else if (currentState.streams[stream.streamId].enabled
-                && !stream.enabled) {
-                logger.debug('disabling existing stream',
-                    { streamId: stream.streamId });
-                putReplicationAndStreamConfigured(stream, cb);
-            } else if (currentState.streams[stream.streamId].source.prefix
-                !== stream.source.prefix) {
-                logger.debug('changing stream source prefix',
-                    { streamId: stream.streamId });
-                putReplicationAndStreamConfigured(stream, cb);
-            } else if (!arraysEqual(currentState.streams[stream.streamId]
-                .destination.locations, stream.destination.locations)) {
-                logger.debug('changing stream destination locations',
-                    { streamId: stream.streamId });
-                putReplicationAndStreamConfigured(stream, cb);
-            } else {
-                logger.debug('stream has expected state, doing nothing',
-                { streamId: stream.streamId, streamEnabled: stream.enabled });
-                return cb();
-            }
-        } else {
-            if (stream.enabled) {
-                logger.debug('enabling new stream',
-                    { streamId: stream.streamId });
-                putReplicationAndStreamConfigured(stream, cb);
-            } else {
-                logger.debug('new disabled stream, doing nothing',
-                    { streamId: stream.streamId });
-                return cb();
-            }
-        }
-        return undefined;
-    }
-
-    const existingStreamIds = Object.keys(currentState.streams);
-    const incomingConfigStreamIds =
-        conf.replicationStreams.map(s => s.streamId);
-    const deletedStreamIds =
-        existingStreamIds.filter(s => !incomingConfigStreamIds.includes(s));
-
-    // TODO group streams per source bucket
-    async.eachSeries(conf.replicationStreams, configureStream, err => {
-        if (err) {
-            return cb(err);
-        }
-        currentState.overlayVersion = conf.version;
-        async.eachSeries(deletedStreamIds, deleteStream, err => {
-            if (err) {
-                return cb(err);
-            }
-            return saveCurrentReplicationState(db, currentState, cb);
-        });
-        return undefined;
-    });
-    return undefined;
-}
-
-function saveServiceCredentials(conf, auth) {
-    // const instanceAuth = JSON.parse(auth);
-    const instanceAuth = auth;
-    const serviceAccount = (conf.users || []).find(
-        u => u.accountType === 'service-replication');
-    if (!serviceAccount) {
-        return;
-    }
-
-    // TODO generate a proper canonicalID during the service account /
-    // instance provisioning
+function saveServiceCredentials(conf, params, instanceAuth) {
     // TODO use a proper account id in arn
-
-    const secretKey = decryptSecret(instanceAuth, serviceAccount.secretKey);
     serviceCredentials = {
-        accounts: [{
-            name: 'service-replication',
-            arn: 'aws::iam:234456789012:root',
-            // canonicalID:
-// '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be',
-            canonicalID: '12349df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d52',
-            displayName: serviceAccount.userName,
-            keys: {
-                access: serviceAccount.accessKey,
-                secret: secretKey,
-            },
-        }],
+        accounts: (conf.users || [])
+            .filter(u => u.accountType === params.serviceAccount)
+            .map(u => ({
+                name: u.accountType,
+                arn: 'aws::iam:234456789012:root',
+                canonicalID: u.canonicalId,
+                displayName: u.userName,
+                keys: {
+                    access: u.accessKey,
+                    secret: decryptSecret(instanceAuth, u.secretKey),
+                },
+            })),
     };
     // initialized = true;
 }
@@ -332,13 +97,57 @@ function patchConfiguration(conf, cb) {
     return process.nextTick(cb, null, conf);
 }
 
-function initManagement(done) {
+function _getExtensionStateKey() {
+    return `configuration/state/${serviceName}`;
+}
+
+function _loadExtensionState(cb) {
+    logger.debug(`loading ${serviceName} state`);
+    metadata.getObjectMD(
+        serviceBucket, _getExtensionStateKey(),
+        {}, logger, (err, currentState) => {
+            if (err && err.NoSuchKey) {
+                /* eslint-disable no-param-reassign */
+                return cb(null, null);
+            }
+            if (err) {
+                return cb(err);
+            }
+            return cb(null, currentState);
+        });
+}
+
+function _refreshExtensionState(conf, params, done) {
+    if (!params.applyState) {
+        return process.nextTick(done);
+    }
+    return async.waterfall([
+        cb => _loadExtensionState(cb),
+        (currentState, cb) => params.applyState(conf, currentState, cb),
+    ], done);
+}
+
+/**
+ * Initialize Orbit management layer
+ *
+ * @param {object} params - params object
+ * @param {string} params.serviceName - name of service to manage
+ * @param {string} [params.serviceAccount] - name of managed service
+ *   account, if any
+ * @param {function} [params.applyState] - callback function to
+ *   apply extension-specific state set from management layer
+ * @param {function} done - callback function when init is complete
+ * @return {undefined}
+ */
+function initManagement(params, done) {
     if (process.env.REMOTE_MANAGEMENT_DISABLE &&
         process.env.REMOTE_MANAGEMENT_DISABLE !== '0') {
         logger.info('remote management disabled');
         return process.nextTick(done);
     }
-    const params = {
+    serviceName = params.serviceName;
+
+    const mdParams = {
         bucketdBootstrap: ['localhost'],
         bucketdLog: null,
         https: null,
@@ -371,7 +180,7 @@ function initManagement(done) {
             cb => {
                 if (!setup) {
                     setup = true;
-                    metadata = new Metadata('mongodb', params, bucketclient,
+                    metadata = new Metadata('mongodb', mdParams, bucketclient,
                         logger);
                     return metadata.setup(() => cb());
                 }
@@ -389,20 +198,10 @@ function initManagement(done) {
                 if (err) {
                     return cb(err);
                 }
-                saveServiceCredentials(conf, instanceAuth);
+                saveServiceCredentials(conf, params, instanceAuth);
                 return cb(null, conf);
             }),
-            (conf, cb) => metadata.getObjectMD(serviceBucket,
-            replicationStateKey, {}, logger, (err, currentReplicationState) => {
-                if (err && err.NoSuchKey) {
-                    /* eslint-disable no-param-reassign */
-                    currentReplicationState = null;
-                } else if (err) {
-                    return cb(err);
-                }
-                return applyReplicationState(conf, currentReplicationState,
-                    metadata, cb);
-            }),
+            (conf, cb) => _refreshExtensionState(conf, params, cb),
         ], done);
     }
 
@@ -424,7 +223,16 @@ function getLatestServiceAccountCredentials() {
     return serviceCredentials;
 }
 
+function saveExtensionState(currentState, cb) {
+    logger.debug(`saving ${serviceName} state`, { currentState });
+    metadata.putObjectMD(
+        serviceBucket, _getExtensionStateKey(),
+        JSON.stringify(currentState), {}, logger, cb);
+}
+
+
 module.exports = {
     initManagement,
     getLatestServiceAccountCredentials,
+    saveExtensionState,
 };


### PR DESCRIPTION
Support a service account 'service-lifecycle' for lifecycle feature
    
* move code related to replication management from lib/management.js
  to extensions/replication/management.js

* add optional callback function 'applyState' that modules can use to
  periodically apply and save their state to management db

* change authentication support for lifecycle to use configuration in
  extensions.lifecycle.auth config, to be able to configure the service
  account name

* update docker-entrypoint.sh with missing S3_HOST and S3_PORT env var
  check

* update docker-entrypoint.sh to add log level support (LOG_LEVEL)
