### PR TITLE
bf: ZENKO-359 instantiate a QueueProcessor per site

### DIFF
--- a/conf/Config.js
+++ b/conf/Config.js
@@ -98,10 +98,10 @@ class Config extends EventEmitter {
     }
 
     setBootstrapList(locationConstraints) {
-        this.bootstrapList =
-        Object.keys(locationConstraints)
-        .map(key => ({ site: key, type:
-              locationTypeMatch[locationConstraints[key].locationType] }));
+        this.bootstrapList = Object.keys(locationConstraints).map(key => ({
+            site: key,
+            type: locationTypeMatch[locationConstraints[key].locationType],
+        }));
         this.emit('bootstrap-list-update');
     }
 

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -1,7 +1,6 @@
 'use strict'; // eslint-disable-line
 
 const http = require('http');
-const async = require('async');
 const { EventEmitter } = require('events');
 
 const Logger = require('werelogs').Logger;
@@ -56,9 +55,10 @@ class QueueProcessor extends EventEmitter {
      *   number of seconds before giving up retries of an entry
      *   replication
      * @param {MetricsProducer} mProducer - instance of metrics producer
+     * @param {String} site - site name
      */
     constructor(zkConfig, kafkaConfig, sourceConfig, destConfig, repConfig,
-        mProducer) {
+        mProducer, site) {
         super();
         this.kafkaConfig = kafkaConfig;
         this.sourceConfig = sourceConfig;
@@ -70,10 +70,12 @@ class QueueProcessor extends EventEmitter {
         this.replicationStatusProducer = null;
         this._consumer = null;
         this._mProducer = mProducer;
+        this.site = site;
 
         this.echoMode = false;
 
-        this.logger = new Logger('Backbeat:Replication:QueueProcessor');
+        this.logger = new Logger(
+            `Backbeat:Replication:QueueProcessor:${this.site}`);
 
         // global variables
         // TODO: for SSL support, create HTTPS agents instead
@@ -210,6 +212,7 @@ class QueueProcessor extends EventEmitter {
             accountCredsCache: this.accountCredsCache,
             replicationStatusProducer: this.replicationStatusProducer,
             logger: this.logger,
+            site: this.site,
         };
     }
 
@@ -238,7 +241,7 @@ class QueueProcessor extends EventEmitter {
                 return undefined;
             }
             const groupId =
-                `${this.repConfig.queueProcessor.groupId}`;
+                `${this.repConfig.queueProcessor.groupId}-${this.site}`;
             this._consumer = new BackbeatConsumer({
                 kafka: { hosts: this.kafkaConfig.hosts },
                 topic: this.repConfig.topic,
@@ -255,7 +258,9 @@ class QueueProcessor extends EventEmitter {
             });
             this._consumer.on('metrics', data => {
                 // i.e. data = { my-site: { ops: 1, bytes: 124 } }
-                this._mProducer.publishMetrics(data,
+                const filteredData = {};
+                filteredData[this.site] = data[this.site];
+                this._mProducer.publishMetrics(filteredData,
                     metricsTypeProcessed, metricsExtension, err => {
                         this.logger.trace('error occurred in publishing ' +
                             'metrics', {
@@ -315,21 +320,17 @@ class QueueProcessor extends EventEmitter {
             const replicationStorageClass =
                 sourceEntry.getReplicationStorageClass();
             const sites = replicationStorageClass.split(',');
-            return async.each(sites, (site, cb) => {
+
+            if (sites.includes(this.site)) {
                 const replicationEndpoint = this.destConfig.bootstrapList
-                    .find(endpoint => endpoint.site === site);
-                if (replicationEndpoint
-                    && replicationBackends.includes(replicationEndpoint.type)) {
-                    task = new MultipleBackendTask(this, site);
+                    .find(endpoint => endpoint.site === this.site);
+                if (replicationEndpoint &&
+                replicationBackends.includes(replicationEndpoint.type)) {
+                    task = new MultipleBackendTask(this);
                 } else {
-                    task = new ReplicateObject(this, site);
+                    task = new ReplicateObject(this);
                 }
-                this.logger.debug('source entry is being pushed',
-                  { entry: sourceEntry.getLogInfo() });
-                return this.taskScheduler.push({ task, entry: sourceEntry },
-                                               sourceEntry.getCanonicalKey(),
-                                               cb);
-            }, err => done(err));
+            }
         }
         if (task) {
             this.logger.debug('source entry is being pushed',

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -1,5 +1,7 @@
 'use strict'; // eslint-disable-line
+
 const werelogs = require('werelogs');
+
 const QueueProcessor = require('./QueueProcessor');
 const config = require('../../../conf/Config');
 const { initManagement } = require('../../../lib/management');
@@ -49,9 +51,13 @@ metricsProducer.setupProducer(err => {
                 destConfig.bootstrapList = config.getBootstrapList();
             });
 
-            const queueProcessor = new QueueProcessor(zkConfig, kafkaConfig,
-                sourceConfig, destConfig, repConfig, metricsProducer);
-            queueProcessor.start();
+            // Start QueueProcessor for each site
+            const siteNames = bootstrapList.map(i => i.site);
+            siteNames.forEach(site => {
+                const queueProcessor = new QueueProcessor(zkConfig, kafkaConfig,
+                    sourceConfig, destConfig, repConfig, metricsProducer, site);
+                queueProcessor.start();
+            });
         });
     }
     return initAndStart();

--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -26,15 +26,13 @@ class ReplicateObject extends BackbeatTask {
      *
      * @constructor
      * @param {QueueProcessor} qp - queue processor instance
-     * @param {String} site - site used for replication
      */
-    constructor(qp, site) {
+    constructor(qp) {
         const qpState = qp.getStateVars();
         super({
             retryTimeoutS: qpState.repConfig.queueProcessor.retryTimeoutS,
         });
         Object.assign(this, qpState);
-        this.site = site;
 
         this.sourceRole = null;
         this.targetRole = null;

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -656,7 +656,7 @@ describe('queue processor functional tests with mocking', () => {
                   retryTimeoutS: 5,
                   groupId: 'backbeat-func-test-group-id',
               },
-            }, new MetricsMock());
+          }, new MetricsMock(), 'sf');
         queueProcessor.start({ disableConsumer: true });
         // create the replication status processor only when the queue
         // processor is ready, so that we ensure the replication


### PR DESCRIPTION
We originally intended to revert to having a queue processor per site.
This way, we can process entries much quicker for every site we are
replicating to rather than queueing all entries to a single queue
processor.

By switching to queue processors per site, the status bug behavior
no longer remains (at least for the few tests done manually). 

In a one-to-many replication setup, if a failed status occurs on a destination
site (i.e. destination bucket doesn't exist), and if the failed destination bucket
is created, the original entry can be re-processed. When processing an entry,
and an error occurs, the replication operation will be retried for a certain
period of time before putting a FAILED status on the entry destination site.
Using a single queue processor meant that the entry could be read again for
the next site within the storage class, and again be retried. This lead to a retry
on the FAILED site and overwriting any COMPLETED sites version id.
