### PR TITLE
backport: S3C-1473 metrics changes from z/1.0

### DIFF
--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -188,7 +188,7 @@ class BackbeatAPI {
     }
 
     /**
-     * Get replication backlog in ops count and size in MB
+     * Get replication backlog in ops count and size in bytes
      * @param {object} details - route details from lib/api/routes.js
      * @param {function} cb - callback(error, data)
      * @param {array} data - optional field providing already fetched data
@@ -214,11 +214,11 @@ class BackbeatAPI {
             const response = {
                 backlog: {
                     description: 'Number of incomplete replication ' +
-                        'operations (count) and number of incomplete MB ' +
+                        'operations (count) and number of incomplete bytes ' +
                         'transferred (size)',
                     results: {
                         count: opsBacklog,
-                        size: (bytesBacklog / 1000).toFixed(2),
+                        size: bytesBacklog,
                     },
                 },
             };
@@ -227,7 +227,7 @@ class BackbeatAPI {
     }
 
     /**
-     * Get completed replicated stats by ops count and size in MB
+     * Get completed replicated stats by ops count and size in bytes
      * @param {object} details - route details from lib/api/routes.js
      * @param {function} cb - callback(error, data)
      * @param {array} data - optional field providing already fetched data
@@ -243,24 +243,26 @@ class BackbeatAPI {
                 return cb(errors.InternalError);
             }
 
-            const d = res.map(r => (
-                r.requests.slice(0, 3).reduce((acc, i) => acc + i)
-            ));
-
             // Find if time since start is less than EXPIRY time
             const timeSinceStart = (Date.now() - this._internalStart) / 1000;
-            // if timeSinceStart, then round the number to nearest 10's
+            // Seconds up to a max of EXPIRY seconds
             const timeDisplay = timeSinceStart < EXPIRY ?
-                (Math.ceil(timeSinceStart / 10) * 10) : EXPIRY;
+                (timeSinceStart || 1) : EXPIRY;
+            const numOfIntervals = Math.ceil(timeDisplay / INTERVAL);
+
+            const d = res.map(r => (
+                r.requests.slice(0, numOfIntervals).reduce((acc, i) =>
+                    acc + i, 0)
+            ));
 
             const response = {
                 completions: {
                     description: 'Number of completed replication operations ' +
-                        '(count) and number of MB transferred (size) in the ' +
-                        `last ${timeDisplay} seconds`,
+                        '(count) and number of bytes transferred (size) in ' +
+                        `the last ${Math.floor(timeDisplay)} seconds`,
                     results: {
                         count: d[0],
-                        size: (d[1] / 1000).toFixed(2),
+                        size: d[1],
                     },
                 },
             };
@@ -288,32 +290,42 @@ class BackbeatAPI {
 
             const now = new Date();
             const timeSinceStart = (now - this._internalStart) / 1000;
+            // Seconds up to a max of EXPIRY seconds
+            const timeDisplay = timeSinceStart < EXPIRY ?
+                (timeSinceStart || 1) : EXPIRY;
+            const numOfIntervals = Math.ceil(timeDisplay / INTERVAL);
 
             const [opsThroughput, bytesThroughput] = res.map(r => {
-                let total = r.requests.slice(0, 3).reduce((acc, i) => acc + i);
+                let total = r.requests.slice(0, numOfIntervals).reduce(
+                    (acc, i) => acc + i, 0);
 
-                // last interval timestamp
-                const lastInterval =
-                    this._statsClient._normalizeTimestamp(new Date(now));
-                // in seconds
-                const diff = Math.floor((now - lastInterval) / 1000);
+                // if timeDisplay !== EXPIRY, use interval timer and do not
+                // include the extra 4th interval
+                if (timeDisplay === EXPIRY) {
+                    // all intervals apply, including 4th interval
+                    const lastInterval =
+                        this._statsClient._normalizeTimestamp(new Date(now));
+                    // in seconds
+                    const diff = (now - lastInterval) / 1000;
 
-                if (timeSinceStart >= EXPIRY) {
-                    // Get average for last interval depending on time surpassed
-                    // so far for newest interval
-                    total += ((INTERVAL - diff) / INTERVAL) * r.requests[3];
+                    // Get average for last interval depending on time
+                    // surpassed so far for newest interval
+                    total += ((INTERVAL - diff) / INTERVAL) *
+                        r.requests[numOfIntervals];
                 }
-                // Divide total by EXPIRY to determine data per second
-                return (total / EXPIRY).toFixed(2);
+
+                // Divide total by timeDisplay to determine data per second
+                return (total / timeDisplay);
             });
 
             const response = {
                 throughput: {
                     description: 'Current throughput for replication ' +
-                        'operations in ops/sec (count) and MB/sec (size)',
+                        'operations in ops/sec (count) and MB/sec (size) ' +
+                        `in the last ${Math.floor(timeDisplay)} seconds`,
                     results: {
-                        count: opsThroughput,
-                        size: (bytesThroughput / 1000).toFixed(2),
+                        count: opsThroughput.toFixed(2),
+                        size: bytesThroughput.toFixed(2),
                     },
                 },
             };

--- a/tests/functional/api/BackbeatServer.js
+++ b/tests/functional/api/BackbeatServer.js
@@ -138,9 +138,9 @@ describe('Backbeat Server', () => {
             statsClient = new StatsModel(redisClient, interval, expiry);
 
             statsClient.reportNewRequest(OPS, 1725);
-            statsClient.reportNewRequest(BYTES, 219800);
+            statsClient.reportNewRequest(BYTES, 2198);
             statsClient.reportNewRequest(OPS_DONE, 450);
-            statsClient.reportNewRequest(BYTES_DONE, 102700);
+            statsClient.reportNewRequest(BYTES_DONE, 1027);
 
             done();
         });
@@ -242,8 +242,8 @@ describe('Backbeat Server', () => {
                 const key = Object.keys(res)[0];
                 // Backlog count = OPS - OPS_DONE
                 assert.equal(res[key].results.count, 1275);
-                // Backlog size = (BYTES - BYTES_DONE) / 1000
-                assert.equal(res[key].results.size, 117.1);
+                // Backlog size = BYTES - BYTES_DONE
+                assert.equal(res[key].results.size, 1171);
                 done();
             });
         });
@@ -255,8 +255,8 @@ describe('Backbeat Server', () => {
                 const key = Object.keys(res)[0];
                 // Completions count = OPS_DONE
                 assert.equal(res[key].results.count, 450);
-                // Completions bytes = BYTES_DONE / 1000
-                assert.equal(res[key].results.size, 102.7);
+                // Completions bytes = BYTES_DONE
+                assert.equal(res[key].results.size, 1027);
                 done();
             });
         });
@@ -268,8 +268,8 @@ describe('Backbeat Server', () => {
                 const key = Object.keys(res)[0];
                 // Throughput count = OPS_DONE / EXPIRY
                 assert.equal(res[key].results.count, 0.5);
-                // Throughput bytes = (BYTES_DONE / 1000) / EXPIRY
-                assert.equal(res[key].results.size, 0.11);
+                // Throughput bytes = BYTES_DONE / EXPIRY
+                assert.equal(res[key].results.size, 1.14);
                 done();
             });
         });
@@ -286,20 +286,20 @@ describe('Backbeat Server', () => {
                 assert(res.backlog.description);
                 // Backlog count = OPS - OPS_DONE
                 assert.equal(res.backlog.results.count, 1275);
-                // Backlog size = (BYTES - BYTES_DONE) / 1000
-                assert.equal(res.backlog.results.size, 117.1);
+                // Backlog size = BYTES - BYTES_DONE
+                assert.equal(res.backlog.results.size, 1171);
 
                 assert(res.completions.description);
                 // Completions count = OPS_DONE
                 assert.equal(res.completions.results.count, 450);
-                // Completions bytes = BYTES_DONE / 1000
-                assert.equal(res.completions.results.size, 102.7);
+                // Completions bytes = BYTES_DONE
+                assert.equal(res.completions.results.size, 1027);
 
                 assert(res.throughput.description);
                 // Throughput count = OPS_DONE / EXPIRY
                 assert.equal(res.throughput.results.count, 0.5);
-                // Throughput bytes = (BYTES_DONE / 1000) / EXPIRY
-                assert.equal(res.throughput.results.size, 0.11);
+                // Throughput bytes = BYTES_DONE / EXPIRY
+                assert.equal(res.throughput.results.size, 1.14);
 
                 done();
             });

--- a/tests/unit/api/BackbeatAPI.spec.js
+++ b/tests/unit/api/BackbeatAPI.spec.js
@@ -57,7 +57,7 @@ describe('BackbeatAPI', () => {
                 },
                 // bytes
                 {
-                    requests: [100000, 0, 0, 100000],
+                    requests: [1024, 0, 0, 1024],
                     errors: [0, 0, 0, 0],
                 },
             ]);
@@ -77,7 +77,7 @@ describe('BackbeatAPI', () => {
             // over double its size. This can only happen when interval time has
             // just reset and the just-expired interval data fully applies
             assert(count >= 0.03 && count <= 0.06);
-            assert(size >= 0.11 && size <= 0.22);
+            assert(size >= 1.14 && size <= 2.28);
         });
     });
 });


### PR DESCRIPTION
Metric sizes were converted down to bytes in z/1.0. Backporting the changes.
Also, changes also reflect interval data is only represented based on the api uptime.

Cherry-picked: https://github.com/scality/backbeat/commit/e100487bace4ffcb64e282132334f7dac1cb90d4
Added changes (from arsenal): https://github.com/scality/backbeat/commit/bc1e32bab942af4886cc2556bd764606b82cbe81