### PR TITLE
chore: add '--max-warnings 0' option to eslint

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -23,8 +23,8 @@ dependencies:
 test:
     override:
         - docker run -e AUTO_CREATE_TOPICS=true -d --net=host --name kafka spotify/kafka
-        - npm run --silent lint_md
-        - npm run --silent lint
+        - npm run --silent lint_md -- --max-warnings 0
+        - npm run --silent lint -- --max-warnings 0
         - npm test
         - TEST_SWITCH=1 npm start & bash tests/utils/wait_for_local_port.bash 8900 40 && npm run ft_server_test
         - TEST_SWITCH=1 npm run ft_test

--- a/tests/unit/replication/MultipleBackendTask.js
+++ b/tests/unit/replication/MultipleBackendTask.js
@@ -50,7 +50,7 @@ describe('MultipleBackendTask', () => {
             });
         });
 
-        it(`should get <= 1024 ranges for part count 1025-10000`, () => {
+        it('should get <= 1024 ranges for part count 1025-10000', () => {
             Array.from(Array(10000 - 1024).keys()).forEach(n => {
                 const count = n + 1025;
                 const ranges = task._getRanges(count * partSize);


### PR DESCRIPTION
Test run was not accounting for linter warnings, fix this.