### PR TITLE
ft: garbage collector service for data locations

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -125,6 +125,18 @@
                     "enabled": true
                 }
             }
+        },
+        "gc": {
+            "topic": "backbeat-gc",
+            "auth": {
+                "type": "service",
+                "account": "service-gc"
+            },
+            "consumer": {
+                "groupId": "backbeat-gc-consumer-group",
+                "retryTimeoutS": 300,
+                "concurrency": 10
+            }
         }
     },
     "log": {

--- a/extensions/gc/GarbageCollector.js
+++ b/extensions/gc/GarbageCollector.js
@@ -1,0 +1,120 @@
+'use strict'; // eslint-disable-line
+
+const http = require('http');
+const { EventEmitter } = require('events');
+
+const errors = require('arsenal').errors;
+const Logger = require('werelogs').Logger;
+
+const BackbeatConsumer = require('../../lib/BackbeatConsumer');
+const GarbageCollectorTask = require('./tasks/GarbageCollectorTask');
+
+/**
+ * @class GarbageCollector
+ *
+ * @classdesc Background task that deletes unused data blobs to
+ * reclaim storage space
+ */
+class GarbageCollector extends EventEmitter {
+
+    /**
+     * @constructor
+     * @param {Object} params - constructor params
+     * @param {Object} params.kafkaConfig - kafka configuration object
+     * @param {string} params.kafkaConfig.hosts - list of kafka
+     *   brokers as "host:port[,host:port...]"
+     * @param {Object} params.s3Config - S3 configuration
+     * @param {Object} params.s3Config.host - s3 endpoint host
+     * @param {Number} params.s3Config.port - s3 endpoint port
+     * @param {Object} params.gcConfig - garbage collector
+     * configuration object
+     * @param {String} params.gcConfig.topic - garbage collector kafka
+     * topic
+     * @param {Object} params.gcConfig.auth - garbage collector
+     *   authentication object
+     * @param {Object} params.gcConfig.consumer - kafka consumer
+     * object
+     * @param {String} params.gcConfig.consumer.groupId - kafka
+     * consumer group id
+     * @param {Number} [params.gcConfig.consumer.retryTimeoutS] -
+     *  number of seconds before giving up retries of an entry
+     *  lifecycle action
+     * @param {Number} [params.gcConfig.consumer.concurrency] - number
+     *  of max allowed concurrent operations
+     * @param {String} [params.transport='http'] - transport
+     */
+    constructor(params) {
+        super();
+
+        this._kafkaConfig = params.kafkaConfig;
+        this._s3Config = params.s3Config;
+        this._gcConfig = params.gcConfig;
+        this._transport = params.transport || 'http';
+        this._consumer = null;
+        this._started = false;
+        this._isActive = false;
+
+        this._httpAgent = new http.Agent({ keepAlive: true });
+        this._logger = new Logger('Backbeat:GC');
+    }
+
+    /**
+     * Start kafka consumer. Emits a 'ready' event when
+     * consumer is ready.
+     *
+     * @return {undefined}
+     */
+    start() {
+        this._consumer = new BackbeatConsumer({
+            kafka: { hosts: this._kafkaConfig.hosts },
+            topic: this._gcConfig.topic,
+            groupId: this._gcConfig.consumer.groupId,
+            concurrency: this._gcConfig.consumer.concurrency,
+            queueProcessor: this.processKafkaEntry.bind(this),
+        });
+        this._consumer.on('error', () => {});
+        this._consumer.on('ready', () => {
+            this._consumer.subscribe();
+            this._logger.info('garbage collector service successfully started');
+            return this.emit('ready');
+        });
+    }
+
+    /**
+     * Close the lifecycle consumer
+     * @param {function} cb - callback function
+     * @return {undefined}
+     */
+    close(cb) {
+        this._logger.debug('closing garbage collector consumer');
+        this._consumer.close(cb);
+    }
+
+    processKafkaEntry(kafkaEntry, done) {
+        this._logger.debug('processing kafka entry');
+
+        let entryData;
+        try {
+            entryData = JSON.parse(kafkaEntry.value);
+        } catch (err) {
+            this._logger.error(
+                'malformed kafka entry from garbage collector topic',
+                { error: err.message });
+            return process.nextTick(() => done(errors.InternalError));
+        }
+        const task = new GarbageCollectorTask(this);
+        return task.processQueueEntry(entryData, done);
+    }
+
+    getStateVars() {
+        return {
+            s3Config: this._s3Config,
+            gcConfig: this._gcConfig,
+            transport: this._transport,
+            httpAgent: this._httpAgent,
+            logger: this._logger,
+        };
+    }
+}
+
+module.exports = GarbageCollector;

--- a/extensions/gc/GarbageCollectorConfigValidator.js
+++ b/extensions/gc/GarbageCollectorConfigValidator.js
@@ -1,0 +1,19 @@
+const joi = require('joi');
+const { zenkoAuthJoi } = require('../../lib/config/configItems.joi.js');
+
+const joiSchema = joi.object({
+    topic: joi.string().required(),
+    auth: zenkoAuthJoi.required(),
+    consumer: {
+        groupId: joi.string().required(),
+        retryTimeoutS: joi.number().default(300),
+        concurrency: joi.number().greater(0).default(10),
+    },
+});
+
+function configValidator(backbeatConfig, extConfig) {
+    const validatedConfig = joi.attempt(extConfig, joiSchema);
+    return validatedConfig;
+}
+
+module.exports = configValidator;

--- a/extensions/gc/index.js
+++ b/extensions/gc/index.js
@@ -1,0 +1,8 @@
+const GarbageCollectorConfigValidator =
+          require('./GarbageCollectorConfigValidator');
+
+module.exports = {
+    name: 'gc',
+    version: '1.0.0',
+    configValidator: GarbageCollectorConfigValidator,
+};

--- a/extensions/gc/service.js
+++ b/extensions/gc/service.js
@@ -1,0 +1,54 @@
+'use strict'; // eslint-disable-line
+
+const werelogs = require('werelogs');
+
+const GarbageCollector = require('./GarbageCollector');
+
+const config = require('../../conf/Config');
+const kafkaConfig = config.kafka;
+const s3Config = config.s3;
+const gcConfig = config.extensions.gc;
+const transport = config.transport;
+
+const { initManagement } = require('../../lib/management');
+const garbageCollector = new GarbageCollector({
+    kafkaConfig,
+    s3Config,
+    gcConfig,
+    transport,
+});
+
+werelogs.configure({ level: config.log.logLevel,
+                     dump: config.log.dumpLevel });
+const logger = new werelogs.Logger('Backbeat:GC:service');
+
+function initAndStart() {
+    initManagement({
+        serviceName: 'gc',
+        serviceAccount: gcConfig.auth.account,
+    }, error => {
+        if (error) {
+            logger.error('could not load management db', error);
+            setTimeout(initAndStart, 5000);
+            return;
+        }
+        logger.info('management init done');
+        garbageCollector.start(err => {
+            if (err) {
+                logger.error('error during garbage collector initialization',
+                             { error: err.message });
+            } else {
+                logger.info('garbage collector is running');
+            }
+        });
+    });
+}
+
+initAndStart();
+
+process.on('SIGTERM', () => {
+    logger.info('received SIGTERM, exiting');
+    garbageCollector.stop(() => {
+        process.exit(0);
+    });
+});

--- a/extensions/gc/tasks/GarbageCollectorTask.js
+++ b/extensions/gc/tasks/GarbageCollectorTask.js
@@ -1,0 +1,83 @@
+const BackbeatClient = require('../../../lib/clients/BackbeatClient');
+const { attachReqUids } = require('../../../lib/clients/utils');
+const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
+const { getAccountCredentials } =
+          require('../../../lib/credentials/AccountCredentials');
+
+class GarbageCollectorTask extends BackbeatTask {
+    /**
+     * Process a lifecycle object entry
+     *
+     * @constructor
+     * @param {GarbageCollector} gc - garbage collector instance
+     */
+    constructor(gc) {
+        super();
+        const gcState = gc.getStateVars();
+        Object.assign(this, gcState);
+
+        this._setup();
+    }
+
+    _setup() {
+        const accountCreds = getAccountCredentials(
+            this.gcConfig.auth, this.logger);
+        const s3 = this.s3Config;
+        const transport = this.transport;
+        this.logger.debug('creating backbeat client', { transport, s3 });
+        this._backbeatClient = new BackbeatClient({
+            endpoint: `${transport}://${s3.host}:${s3.port}`,
+            credentials: accountCreds,
+            sslEnabled: transport === 'https',
+            httpOptions: { agent: this.httpAgent, timeout: 0 },
+            maxRetries: 0,
+        });
+    }
+
+    _executeDeleteData(entry, log, done) {
+        const { locations } = entry.target;
+        const req = this._backbeatClient.batchDelete({
+            Locations: locations,
+        });
+        attachReqUids(req, log);
+        return req.send(err => {
+            if (err) {
+                log.error('an error occurred on deleteData method to ' +
+                          'backbeat route',
+                          { method: 'LifecycleObjectTask._executeDeleteData',
+                            error: err.message,
+                            httpStatus: err.statusCode });
+                return done(err);
+            }
+            return done();
+        });
+    }
+
+    /**
+     * Execute the action specified in kafka queue entry
+     *
+     * @param {Object} entry - kafka queue entry object
+     * @param {String} entry.action - entry action name (e.g. 'deleteData')
+     * @param {Object} entry.target - entry action target object
+     * @param {Function} done - callback funtion
+     * @return {undefined}
+     */
+
+    processQueueEntry(entry, done) {
+        const log = this.logger.newRequestLogger();
+
+        const { action, target } = entry;
+        log.debug('processing garbage collector entry', { action, target });
+        if (!target) {
+            log.error('missing "target" in object queue entry', { entry });
+            return process.nextTick(done);
+        }
+        if (action === 'deleteData') {
+            return this._executeDeleteData(entry, log, done);
+        }
+        log.info('skipped unsupported action', { action, target });
+        return process.nextTick(done);
+    }
+}
+
+module.exports = GarbageCollectorTask;

--- a/extensions/lifecycle/lifecycleConsumer/LifecycleConsumer.js
+++ b/extensions/lifecycle/lifecycleConsumer/LifecycleConsumer.js
@@ -26,9 +26,9 @@ class LifecycleConsumer extends EventEmitter {
      * @param {String} lcConfig.objectTasksTopic - lifecycle object topic name
      * @param {Object} lcConfig.consumer - kafka consumer object
      * @param {String} lcConfig.consumer.groupId - kafka consumer group id
-     * @param {Number} lcConfig.consumer.retryTimeoutS - number of seconds
+     * @param {Number} [lcConfig.consumer.retryTimeoutS] - number of seconds
      *  before giving up retries of an entry lifecycle action
-     * @param {Number} lcConfig.consumer.concurrency - number of max allowed
+     * @param {Number} [lcConfig.consumer.concurrency] - number of max allowed
      *  concurrent operations
      * @param {Object} [lcConfig.backlogMetrics] - param object to
      * publish backlog metrics to zookeeper (see {@link

--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -615,6 +615,46 @@
                     }
                 }
             }
+        },
+        "BatchDelete": {
+            "http": {
+                "method": "POST",
+                "requestUri": "/_/backbeat/batchdelete"
+            },
+            "input": {
+                "type": "structure",
+                "required": [
+                ],
+                "members": {
+                    "ContentType": {
+                        "location": "header",
+                        "locationName": "X-Scal-Content-Type"
+                    },
+                    "Locations": {
+                        "type": "list",
+                        "member": {
+                            "type": "structure",
+                            "required": [
+                                "key",
+                                "dataStoreName"
+                            ],
+                            "members": {
+                                "dataStoreName": {
+                                    "type": "string"
+                                },
+                                "key": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "output": {
+                "type": "structure",
+                "members": {
+                }
+            }
         }
     }
 }

--- a/lib/config/configItems.joi.js
+++ b/lib/config/configItems.joi.js
@@ -46,9 +46,15 @@ const adminCredsJoi = joi.object()
           .min(1)
           .pattern(/^[A-Za-z0-9]{20}$/, joi.string());
 
+const zenkoAuthJoi = joi.object({
+    type: joi.alternatives().try('account', 'service').required(),
+    account: joi.string().required(),
+});
+
 module.exports = {
     hostPortJoi,
     bootstrapListJoi,
     logJoi,
     adminCredsJoi,
+    zenkoAuthJoi,
 };

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lifecycle_conductor": "node extensions/lifecycle/conductor/service.js",
     "lifecycle_producer": "node extensions/lifecycle/lifecycleProducer/task.js",
     "lifecycle_consumer": "node extensions/lifecycle/lifecycleConsumer/task.js",
+    "garbage_collector": "node extensions/gc/service.js",
     "test": "mocha --recursive tests/unit",
     "ft_test": "mocha --recursive $(find tests/functional -name '*.js' ! -name 'BackbeatServer.js')",
     "ft_server_test": "mocha tests/functional/api/BackbeatServer.js",

--- a/tests/unit/gc/GarbageCollector.spec.js
+++ b/tests/unit/gc/GarbageCollector.spec.js
@@ -1,0 +1,80 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+const http = require('http');
+
+const GarbageCollector = require('../../../extensions/gc/GarbageCollector');
+const GarbageCollectorTask =
+      require('../../../extensions/gc/tasks/GarbageCollectorTask');
+
+describe('garbage collector', () => {
+    let gc;
+    let gcTask;
+    let httpServer;
+    let expectBatchDeleteLocations;
+
+    before(() => {
+        gc = new GarbageCollector({
+            kafkaConfig: {},
+            s3Config: {
+                host: 'localhost',
+                port: 7777,
+            },
+            gcConfig: {
+                topic: 'backbeat-gc',
+                auth: {
+                    type: 'account',
+                    account: 'bart',
+                },
+                consumer: {
+                    groupId: 'backbeat-gc-consumer-group',
+                },
+            },
+        });
+        gcTask = new GarbageCollectorTask(gc);
+
+        httpServer = http.createServer(
+            (req, res) => {
+                if (expectBatchDeleteLocations === null) {
+                    assert.fail('did not expect a batch delete request');
+                }
+                assert.strictEqual(req.url, '/_/backbeat/batchdelete');
+                const buffers = [];
+                req.on('data', data => {
+                    buffers.push(data);
+                });
+                req.on('end', () => {
+                    const reqObj = JSON.parse(
+                        Buffer.concat(buffers).toString());
+                    assert.deepStrictEqual(expectBatchDeleteLocations,
+                                           reqObj.Locations);
+                    res.end();
+                });
+            });
+        httpServer.listen(7777);
+    });
+    after(() => {
+        httpServer.close();
+    });
+    it('should skip unsupported action type', done => {
+        expectBatchDeleteLocations = null;
+        gcTask.processQueueEntry({
+            action: 'foo',
+            target: {
+                locations: [],
+            },
+        }, done);
+    });
+    it('should send batch delete request with locations array', done => {
+        expectBatchDeleteLocations = [{
+            key: 'foo',
+            dataStoreName: 'ds',
+        }];
+        gcTask.processQueueEntry({
+            action: 'deleteData',
+            target: {
+                locations: expectBatchDeleteLocations,
+            },
+        }, done);
+    });
+});


### PR DESCRIPTION
Implement a new garbage collector service in backbeat, to remove data
locations asynchronously.

Introduce a new kafka queue 'backbeat-gc' to push removal requests to.

Linked PR: https://github.com/scality/S3/pull/1267