### PR TITLE
bf: crash backbeat consumer when unable to connect with kafka

### DIFF
--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -142,7 +142,14 @@ class BackbeatConsumer extends EventEmitter {
             consumerParams['fetch.message.max.bytes'] = this._fetchMaxBytes;
         }
         this._consumer = new kafka.KafkaConsumer(consumerParams);
-        this._consumer.connect();
+        this._consumer.connect({ timeout: 10000 }, () => {
+            const opts = { topic: 'backbeat-sanitycheck', timeout: 10000 };
+            this._consumer.getMetadata(opts, err => {
+                if (err) {
+                    this.emit('error', err);
+                }
+            });
+        });
         return this._consumer.once('ready', () => {
             this._consumerReady = true;
             this._checkIfReady();


### PR DESCRIPTION
When Kafka is unavailable, the backbeat replication status processor will hang and not connect to it even if it becomes available later on. These changes will make the process exit if it's unable to connect to Kafka after a certain amount of time.

In an orchestrated environment, the orchestration tool can recognize this crash and restart the failed container, thus allowing it to try to connect again to Kafka (which might be available later on).

This PR is very similar to #296. However, this fix is on the backbeat consumer code (and one of its extensions). Consequently, any extension/program that the instanciates a Backbeat Consumer object should have this behavior (not only the replication status processor).