### PR TITLE
ft: ZENKO-235 manual crr pause resume

### DIFF
--- a/docs/crr-pause-resume.md
+++ b/docs/crr-pause-resume.md
@@ -1,0 +1,76 @@
+# Cross-Region Replication (CRR) Manual Pause and Resume
+
+## Description
+
+This feature offers a way for users to manually pause and resume cross-region
+replication (CRR) operations by storage locations.
+
+## Design
+
+A RESTful API will expose methods for users to pause and resume cross-region
+replication operations.
+
+Redis offers a pub/sub function. We will utilize this function to propagate
+requests to all active CRR Kafka Consumers on all nodes with backbeat
+containers setup for replication.
+
+We want to pause and resume the CRR service at the lowest level (in our case,
+pause and resume all Kafka Consumers subscribed to the CRR topic). We want to
+perform these actions at the lowest level in order to stop processing any
+replication entries that might have already been populated by Kafka but have yet
+to be consumed and queued for replication. Any entries that have already been
+consumed by the Kafka Consumer and are being processed for replication will
+continue to finish replication and will not be paused.
+
+The API will have a Redis instance publishing messages to a specific channel.
+All CRR Kafka Consumers will subscribe to this channel and complete any given
+valid requests.
+
+When a Kafka Consumer pauses, the Consumer is still kept alive and maintains
+any internal state, including offset. The Consumer will no longer be
+subscribed to the CRR topic, so will no longer try consuming any entries.
+When the paused Consumer is resumed, it will again resume consuming entries
+from its last offset.
+
+## Definition of API
+
+* POST `/_/crr/pause`
+
+    This POST request is to manually pause the cross-region replication service
+    for all locations configured as destination replication endpoints.
+
+    Response:
+    ```sh
+    {}
+    ```
+
+* POST `/_/crr/pause/<location-name>`
+
+    This POST request is to manually pause the cross-region replication service
+    for a specified location configured as a destination replication endpoint.
+
+    Response:
+    ```sh
+    {}
+    ```
+
+* POST `/_/crr/resume`
+
+    This POST request is to manually resume the cross-region replication
+    service for all locations configured as destination replication endpoints.
+
+    Response:
+    ```sh
+    {}
+    ```
+
+* POST `/_/crr/resume/<location-name>`
+
+    This POST request is to manually resume the cross-region replication
+    service for a specified location configured as a destination replication
+    endpoint.
+
+    Response:
+    ```sh
+    {}
+    ```

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -14,6 +14,7 @@ const kafkaConfig = config.kafka;
 const repConfig = config.extensions.replication;
 const sourceConfig = repConfig.source;
 const mConfig = config.metrics;
+const redisConfig = config.redis;
 
 const log = new werelogs.Logger('Backbeat:QueueProcessor:task');
 werelogs.configure({ level: config.log.logLevel,
@@ -61,7 +62,7 @@ metricsProducer.setupProducer(err => {
                         if (!activeSites.includes(site)) {
                             activeQProcessors[site] = new QueueProcessor(
                                 zkConfig, kafkaConfig, sourceConfig, destConfig,
-                                repConfig, metricsProducer, site);
+                                repConfig, redisConfig, metricsProducer, site);
                             activeQProcessors[site].start();
                         }
                     } else {
@@ -77,7 +78,7 @@ metricsProducer.setupProducer(err => {
             siteNames.forEach(site => {
                 activeQProcessors[site] = new QueueProcessor(zkConfig,
                     kafkaConfig, sourceConfig, destConfig, repConfig,
-                    metricsProducer, site);
+                    redisConfig, metricsProducer, site);
                 activeQProcessors[site].start();
             });
         });

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 const async = require('async');
 const joi = require('joi');
 
+const Config = require('../conf/Config');
 const zookeeperHelper = require('./clients/zookeeper');
 const BackbeatProducer = require('./BackbeatProducer');
 const ObjectQueueEntry =
@@ -13,7 +14,7 @@ const Logger = require('werelogs').Logger;
 const QueueEntry = require('./models/QueueEntry');
 const monitoringClient = require('./clients/monitoringHandler');
 
-const CRR_TOPIC = require('../conf/Config').extensions.replication.topic;
+const CRR_TOPIC = Config.extensions.replication.topic;
 
 // controls the number of messages to process in parallel
 const CONCURRENCY_DEFAULT = 1;
@@ -107,9 +108,11 @@ class BackbeatConsumer extends EventEmitter {
         this._zookeeperReady = false;
         this._publishOffsetsCronTimer = null;
         this._publishOffsetsCronActive = false;
+
         // metrics - consumption
         this._metricsStore = {};
         this._committedOffsets = null;
+
         this._init();
         return this;
     }
@@ -511,10 +514,39 @@ class BackbeatConsumer extends EventEmitter {
     }
 
     /**
-    * force commit the current offset and close the client connection
-    * @param {callback} cb - callback to invoke
-    * @return {undefined}
-    */
+     * pause the kafka consumer
+     * @param {string} site - name of site
+     * @return {undefined}
+     */
+    pause(site) {
+        // Use of KafkaConsumer#pause did not work. Using alternative
+        // of unsubscribe/subscribe
+        this._consumer.unsubscribe();
+        this._log.debug(`paused consumer for location: ${site}`, {
+            method: 'BackbeatConsumer.pause',
+        });
+    }
+
+    /**
+     * resume the kafka consumer
+     * @param {string} site - name of site
+     * @return {undefined}
+     */
+    resume(site) {
+        // if not subscribed, then subscribe
+        if (this._consumer.subscription().length === 0) {
+            this._consumer.subscribe([this._topic]);
+            this._log.debug(`resumed consumer for location: ${site}`, {
+                method: 'BackbeatConsumer.resume',
+            });
+        }
+    }
+
+    /**
+     * force commit the current offset and close the client connection
+     * @param {callback} cb - callback to invoke
+     * @return {undefined}
+     */
     close(cb) {
         if (this._publishOffsetsCronTimer) {
             clearInterval(this._publishOffsetsCronTimer);

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -1,6 +1,7 @@
 'use strict'; // eslint-disable-line strict
 
 const async = require('async');
+const Redis = require('ioredis');
 const zookeeper = require('node-zookeeper-client');
 
 const { errors } = require('arsenal');
@@ -62,6 +63,10 @@ class BackbeatAPI {
             this._internalStart = Date.now();
         }
 
+        // Redis instance for publishing messages to BackbeatConsumers
+        this._redisPublisher = new Redis(this._redisConfig);
+
+        // Redis instance is used for getting/setting keys
         this._redisClient = new RedisClient(this._redisConfig, this._logger);
         // Redis expiry increased by an additional interval so we can reference
         // the immediate older data for average throughput calculation
@@ -167,11 +172,14 @@ class BackbeatAPI {
                     addKeys.key = key;
                     addKeys.versionId = versionId;
                 }
-                if (bbRequest.getHTTPMethod() === 'GET' && type === 'all' &&
-                marker) {
+                if (marker) {
                     // this is optional, so doesn't matter if set or not
                     addKeys.marker = marker;
                 }
+            } else {
+                // currently only pause/resume
+                filteredRoutes = filteredRoutes.filter(r =>
+                    rDetails.status === r.type);
             }
         }
         // if rDetails has a type property
@@ -525,6 +533,52 @@ class BackbeatAPI {
             };
         }
         return { reqBody };
+    }
+
+    /**
+     * Pause CRR operations for given site(s)
+     * @param {Object} details - The route details
+     * @param {String} body - The POST request body string
+     * @param {Function} cb - The callback to call
+     * @return {undefined}
+     */
+    pauseCRRService(details, body, cb) {
+        let sites;
+        if (details.site === 'all') {
+            sites = details.extensions.crr.filter(s => s !== 'all');
+        } else {
+            sites = [details.site];
+        }
+        sites.forEach(site => {
+            const channel = `${this._crrTopic}-${site}`;
+            const message = JSON.stringify({ action: 'pauseService' });
+            this._redisPublisher.publish(channel, message);
+        });
+        this._logger.info(`replication service paused for locations: ${sites}`);
+        return cb(null, {});
+    }
+
+    /**
+     * Resume CRR operations for given site(s)
+     * @param {Object} details - The route details
+     * @param {String} body - The POST request body string
+     * @param {Function} cb - The callback to call
+     * @return {undefined}
+     */
+    resumeCRRService(details, body, cb) {
+        let sites;
+        if (details.site === 'all') {
+            sites = details.extensions.crr.filter(s => s !== 'all');
+        } else {
+            sites = [details.site];
+        }
+        sites.forEach(site => {
+            const channel = `${this._crrTopic}-${site}`;
+            const message = JSON.stringify({ action: 'resumeService' });
+            this._redisPublisher.publish(channel, message);
+        });
+        this._logger.info(`replication service resumed for locations ${sites}`);
+        return cb(null, {});
     }
 
     /**

--- a/lib/api/BackbeatRequest.js
+++ b/lib/api/BackbeatRequest.js
@@ -33,18 +33,25 @@ class BackbeatRequest {
     }
 
     /**
-     * Parse the route details for any of the retry routes.
+     * Parse the route details for any of the crr routes (retry, pause, resume).
      * @param {Array} parts - The route schema split by '/'
      * @param {String} query - The query string.
      * @return {undefined}
      */
-    _parseRetryRoutes(parts, query) {
-        this._routeDetails.extension = parts[0];
-        this._routeDetails.status = parts[1];
-        this._routeDetails.bucket = parts[2];
-        this._routeDetails.key = parts[3];
-        this._routeDetails.versionId = parts[4];
-        this._routeDetails.marker = querystring.parse(query).marker;
+    _parseCRRRoutes(parts, query) {
+        if (parts[1] && parts[1] === 'failed') {
+            this._routeDetails.extension = parts[0];
+            this._routeDetails.status = parts[1];
+            this._routeDetails.bucket = parts[2];
+            this._routeDetails.key = parts[3];
+            this._routeDetails.versionId = parts[4];
+            this._routeDetails.marker = querystring.parse(query).marker;
+        } else {
+            // for now: pause/resume
+            this._routeDetails.extension = parts[0];
+            this._routeDetails.status = parts[1];
+            this._routeDetails.site = parts[2] || 'all';
+        }
     }
 
     /**
@@ -81,8 +88,9 @@ class BackbeatRequest {
         const { pathname, query } = url.parse(this._route);
         const parts = pathname ? pathname.split('/') : [];
 
+        // crr retry/pause/resume routes
         if (parts[0] === 'crr') {
-            this._parseRetryRoutes(parts, query);
+            this._parseCRRRoutes(parts, query);
         } else if (parts[0] === 'metrics') {
             this._parseMetricsRoutes(parts);
         } else if (parts[0] === 'monitoring') {

--- a/package.json
+++ b/package.json
@@ -39,15 +39,16 @@
     "eslint-config-airbnb": "^6.0.0",
     "eslint-config-scality": "scality/Guidelines#development/8.0",
     "eslint-plugin-react": "^4.2.3",
+    "ioredis": "^3.2.2",
     "joi": "^10.6",
     "node-forge": "^0.7.1",
     "node-rdkafka": "2.2.0",
     "node-schedule": "^1.2.0",
     "node-zookeeper-client": "^0.2.2",
+    "prom-client": "^10.2.3",
     "uuid": "^3.1.0",
     "vaultclient": "github:scality/vaultclient#development/8.0",
-    "werelogs": "scality/werelogs#development/8.0",
-    "prom-client": "^10.2.3"
+    "werelogs": "scality/werelogs#development/8.0"
   },
   "devDependencies": {
     "mocha": "^3.3.0",

--- a/tests/functional/api/BackbeatServer.js
+++ b/tests/functional/api/BackbeatServer.js
@@ -240,13 +240,13 @@ describe('Backbeat Server', () => {
             done();
         });
 
-        after(() => {
+        after(done => {
             redis.keys('*:test:bb:*').then(keys => {
                 const pipeline = redis.pipeline();
                 keys.forEach(key => {
                     pipeline.del(key);
                 });
-                return pipeline.exec();
+                pipeline.exec(done);
             });
         });
 
@@ -467,13 +467,13 @@ describe('Backbeat Server', () => {
         });
 
         describe('No metrics data in Redis', () => {
-            before(() => {
+            before(done => {
                 redis.keys('*:test:bb:*').then(keys => {
                     const pipeline = redis.pipeline();
                     keys.forEach(key => {
                         pipeline.del(key);
                     });
-                    return pipeline.exec();
+                    pipeline.exec(done);
                 });
             });
 
@@ -914,6 +914,135 @@ describe('Backbeat Server', () => {
                         });
                     });
                 });
+            });
+        });
+    });
+
+    describe('CRR Pause/Resume service routes', () => {
+        let redis1;
+        let redis2;
+        let cache1 = [];
+        let cache2 = [];
+        let channel1;
+        let channel2;
+
+        const emptyBody = '';
+        const crrConfigs = config.extensions.replication;
+        const crrTopic = crrConfigs.topic;
+        const crrSites = crrConfigs.destination.bootstrapList.map(i =>
+            i.site);
+
+        before(() => {
+            redis1 = new Redis();
+            redis2 = new Redis();
+
+            channel1 = `${crrTopic}-${crrSites[0]}`;
+            redis1.subscribe(channel1, err => assert.ifError(err));
+            redis1.on('message', (channel, message) => {
+                cache1.push({ channel, message });
+            });
+
+            channel2 = `${crrTopic}-${crrSites[1]}`;
+            redis2.subscribe(channel2, err => assert.ifError(err));
+            redis2.on('message', (channel, message) => {
+                cache2.push({ channel, message });
+            });
+        });
+
+        afterEach(() => {
+            cache1 = [];
+            cache2 = [];
+        });
+
+        const validRequests = [
+            { path: '/_/crr/pause', method: 'POST' },
+            { path: '/_/crr/resume', method: 'POST' },
+            { path: `/_/crr/resume/${crrSites[0]}`, method: 'POST' },
+        ];
+        validRequests.forEach(entry => {
+            it(`should get a 200 response for route: ${entry.path}`, done => {
+                const options = Object.assign({}, defaultOptions, {
+                    method: entry.method,
+                    path: entry.path,
+                });
+                const req = http.request(options, res => {
+                    assert.equal(res.statusCode, 200);
+                    done();
+                });
+                req.end();
+            });
+        });
+
+        const invalidRequests = [
+            { path: '/_/crr/pause/invalid-site', method: 'POST' },
+            { path: '/_/crr/resume/invalid-site', method: 'POST' },
+            { path: '/_/crr/resume/all', method: 'GET' },
+        ];
+        invalidRequests.forEach(entry => {
+            it(`should get a 404 response for route: ${entry.path}`, done => {
+                const options = Object.assign({}, defaultOptions, {
+                    method: entry.method,
+                    path: entry.path,
+                });
+                const req = http.request(options, res => {
+                    assert.equal(res.statusCode, 404);
+                    assert.equal(res.statusMessage, 'Not Found');
+                    assert.equal(cache1.length, 0);
+                    assert.equal(cache2.length, 0);
+                    done();
+                });
+                req.end();
+            });
+        });
+
+        it('should receive a pause request on all site channels from route ' +
+        '/_/crr/pause', done => {
+            const options = Object.assign({}, defaultOptions, {
+                method: 'POST',
+                path: '/_/crr/pause',
+            });
+            makePOSTRequest(options, emptyBody, err => {
+                assert.ifError(err);
+
+                setTimeout(() => {
+                    assert.strictEqual(cache1.length, 1);
+                    assert.strictEqual(cache2.length, 1);
+
+                    assert.deepStrictEqual(cache1[0].channel, channel1);
+                    assert.deepStrictEqual(cache2[0].channel, channel2);
+
+                    const message1 = JSON.parse(cache1[0].message);
+                    const message2 = JSON.parse(cache2[0].message);
+                    const expected = { action: 'pauseService' };
+                    assert.deepStrictEqual(message1, expected);
+                    assert.deepStrictEqual(message2, expected);
+                    done();
+                }, 1000);
+            });
+        });
+
+        it('should receive a resume request on all site channels from route ' +
+        '/_/crr/resume', done => {
+            const options = Object.assign({}, defaultOptions, {
+                method: 'POST',
+                path: '/_/crr/resume',
+            });
+            makePOSTRequest(options, emptyBody, err => {
+                assert.ifError(err);
+
+                setTimeout(() => {
+                    assert.strictEqual(cache1.length, 1);
+                    assert.strictEqual(cache2.length, 1);
+                    assert.deepStrictEqual(cache1[0].channel, channel1);
+                    assert.deepStrictEqual(cache2[0].channel, channel2);
+
+                    const message1 = JSON.parse(cache1[0].message);
+                    const message2 = JSON.parse(cache2[0].message);
+                    const expected = { action: 'resumeService' };
+                    assert.deepStrictEqual(message1, expected);
+                    assert.deepStrictEqual(message2, expected);
+                    done();
+                }, 1000);
             });
         });
     });

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -656,7 +656,10 @@ describe('queue processor functional tests with mocking', () => {
                   retryTimeoutS: 5,
                   groupId: 'backbeat-func-test-group-id',
               },
-          }, new MetricsMock(), 'sf');
+            },
+            { host: '127.0.0.1',
+              port: 6379 },
+            new MetricsMock(), 'sf');
         queueProcessor.start({ disableConsumer: true });
         // create the replication status processor only when the queue
         // processor is ready, so that we ensure the replication

--- a/tests/unit/api/BackbeatAPI.spec.js
+++ b/tests/unit/api/BackbeatAPI.spec.js
@@ -32,6 +32,8 @@ describe('BackbeatAPI', () => {
             // invalid params but will default to getting all buckets
             { url: '/_/crr/failed/mybucket', method: 'GET' },
             { url: '/_/crr/failed', method: 'POST' },
+            { url: '/_/crr/pause', method: 'POST' },
+            { url: '/_/crr/resume', method: 'POST' },
         ].forEach(request => {
             const req = new BackbeatRequest(request);
             const routeError = bbapi.findValidRoute(req);
@@ -47,9 +49,12 @@ describe('BackbeatAPI', () => {
             { url: '/_/metrics/crr/all/backlo', method: 'GET' },
             { url: '/_/metrics/crr/all/completionss', method: 'GET' },
             { url: '/_/invalid/crr/all', method: 'GET' },
+            { url: '/_/metrics/pause/all', method: 'GET' },
             // // invalid http verb
             { url: '/_/healthcheck', method: 'POST' },
             { url: '/_/monitoring/metrics', method: 'POST' },
+            { url: '/_/crr/pause', method: 'GET' },
+            { url: '/_/crr/resume', method: 'GET' },
         ].forEach(request => {
             const req = new BackbeatRequest(request);
             const routeError = bbapi.findValidRoute(req);

--- a/tests/unit/api/BackbeatRequest.spec.js
+++ b/tests/unit/api/BackbeatRequest.spec.js
@@ -74,12 +74,33 @@ describe('BackbeatRequest helper class', () => {
         'details', () => {
             const req = new BackbeatRequest({
                 url: '/_/monitoring/metrics',
-                method: 'GET',
+                method: 'POST',
             });
             const details = req.getRouteDetails();
 
             assert.strictEqual(details.category, 'monitoring');
             assert.strictEqual(details.type, 'metrics');
+        });
+
+        it('should parse crr pause/resume routes and store internally as ' +
+        'route details', () => {
+            const req = new BackbeatRequest({
+                url: '/_/crr/pause/mysite',
+                method: 'POST',
+            });
+            const details = req.getRouteDetails();
+
+            assert.strictEqual(details.extension, 'crr');
+            assert.strictEqual(details.status, 'pause');
+            assert.strictEqual(details.site, 'mysite');
+
+            const req2 = new BackbeatRequest({
+                url: '/_/crr/pause',
+                method: 'POST',
+            });
+            const details2 = req2.getRouteDetails();
+            // should default to 'all' if none specified
+            assert.strictEqual(details2.site, 'all');
         });
     });
 


### PR DESCRIPTION
Pause/Resume CRR by pausing all CRR subscribed consumers

Please note that producers are never stopped. This means the user can
still add CRR requests, but they won't be processed if the consumers
have been paused.
Consumers are kept alive. If a crr consumer was paused and it is resumed,
it will start to replicate everything from its last consumed offset.
