### PR TITLE
ft/ZENKO-476: Add build image step to pre-merge

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -4,16 +4,29 @@ version: 0.2
 branches:
   feature/*, improvement/*, bugfix/*, w/*, q/*, hotfix/*, ft/*, bf/*, chore/*, docs/*:
     stage: "pre-merge"
+  development/*:
+    stage: "post-merge"
+
 
 stages:
   pre-merge:
-    worker:
+    worker: &pod
+      type: kube_pod
+      path: eve/workers/pod.yml
+    steps:
+    - TriggerStages:
+        name: trigger all the tests
+        stage_names:
+        - run-tests
+        - docker-build
+  run-tests:
+    worker: &workspace
       type: docker
       path: eve/workers/unit_and_feature_tests
       volumes:
         - '/home/eve/workspace'
     steps:
-      - Git:
+      - Git: &git
           name: fetch source
           repourl: '%(prop:git_reference)s'
           shallow: True
@@ -35,3 +48,22 @@ stages:
           name: run s3 server and run feature tests
           command: bash ./eve/workers/unit_and_feature_tests/run_server_tests.bash
           workdir: '%(prop:builddir)s/build'
+
+  docker-build:
+    worker:
+      type: kube_pod
+      path: eve/workers/pod.yml
+    steps:
+      - Git: *git
+      - ShellCommand: &docker_build
+          name: Docker build
+          command: docker build -t zenko/backbeat:nightly .
+
+  post-merge:
+    worker:
+      type: kube_pod
+      path: eve/workers/pod.yml
+    steps:
+      - Git: *git
+      - ShellCommand: *docker_build
+      # - ShellCommand: &docker_push Waiting for RELENG

--- a/eve/workers/pod.yml
+++ b/eve/workers/pod.yml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "zenko-test-pod"
+spec:
+  activeDeadlineSeconds: 3600
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 10
+  containers:
+  - name: zenko-releng
+    image: zenko/zenko-releng:0.0.6
+    imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 500m
+        memory: 1Gi
+      limits:
+        cpu: "1"
+        memory: 2Gi
+    command: ["/bin/sh", "-c", "buildbot-worker create-worker . ${BUILDMASTER}:${BUILDMASTER_PORT} ${WORKERNAME} ${WORKERPASS} && buildbot-worker start --nodaemon"]
+    volumeMounts:
+    - mountPath: /var/run/docker.sock
+      name: docker-socket
+  volumes:
+  - name: docker-socket
+    hostPath:
+      path: /var/run/docker.sock
+      type: Socket


### PR DESCRIPTION
Changes:

- Add a docker build step in premerge to check if the images are build properly
- Created a new step called post-merge. This step will only be triggered when there a pull requests is perged into development/* branches. 

EVE: tests passed - https://eve.devsca.com/github/scality/backbeat/#/builders/5/builds/2650

TODO: Once we get the credentials from the Bert-e team we need to update the post merge step.