### PR TITLE
ZENKO-470 lifecycle management

### DIFF
--- a/extensions/lifecycle/lifecycleConsumer/task.js
+++ b/extensions/lifecycle/lifecycleConsumer/task.js
@@ -1,7 +1,7 @@
 'use strict'; // eslint-disable-line
 const werelogs = require('werelogs');
 
-const { initManagement } = require('../../../lib/management');
+const { initManagement } = require('../../../lib/management/index');
 const LifecycleConsumer = require('./LifecycleConsumer');
 
 const config = require('../../../conf/Config');

--- a/extensions/lifecycle/lifecycleProducer/task.js
+++ b/extensions/lifecycle/lifecycleProducer/task.js
@@ -1,6 +1,6 @@
 'use strict'; // eslint-disable-line
 const werelogs = require('werelogs');
-const { initManagement } = require('../../../lib/management');
+const { initManagement } = require('../../../lib/management/index');
 const LifecycleProducer = require('./LifecycleProducer');
 const { zookeeper, kafka, extensions, s3, transport, log } =
       require('../../../conf/Config');

--- a/extensions/lifecycle/lifecycleProducer/task.js
+++ b/extensions/lifecycle/lifecycleProducer/task.js
@@ -2,6 +2,7 @@
 const werelogs = require('werelogs');
 const { initManagement } = require('../../../lib/management/index');
 const LifecycleProducer = require('./LifecycleProducer');
+const { applyBucketLifecycleWorkflows } = require('../management');
 const { zookeeper, kafka, extensions, s3, transport, log } =
       require('../../../conf/Config');
 
@@ -18,6 +19,7 @@ function initAndStart() {
     initManagement({
         serviceName: 'lifecycle',
         serviceAccount: extensions.lifecycle.auth.account,
+        applyBucketWorkflows: applyBucketLifecycleWorkflows,
     }, error => {
         if (error) {
             logger.error('could not load management db',

--- a/extensions/lifecycle/management.js
+++ b/extensions/lifecycle/management.js
@@ -1,0 +1,79 @@
+const AWS = require('aws-sdk');
+const werelogs = require('werelogs');
+
+const config = require('../../conf/Config');
+const management = require('../../lib/management/index');
+
+const logger = new werelogs.Logger('mdManagement:lifecycle');
+
+function getS3Client(endpoint) {
+    const serviceCredentials =
+          management.getLatestServiceAccountCredentials();
+    // FIXME
+    const keys = serviceCredentials.accounts[0].keys;
+    const credentials = new AWS.Credentials(keys.access, keys.secret);
+    const s3Client = new AWS.S3({
+        endpoint,
+        sslEnabled: false,
+        credentials,
+        s3ForcePathStyle: true,
+        signatureVersion: 'v4',
+        httpOptions: { timeout: 0 },
+        maxRetries: 3,
+    });
+    return s3Client;
+}
+
+function putLifecycleConfiguration(bucketName, workflows, cb) {
+    logger.debug('updating lifecycle configuration');
+    const cfg = config.s3;
+    const endpoint = `${cfg.host}:${cfg.port}`;
+
+    const params = {
+        Bucket: bucketName,
+        LifecycleConfiguration: {
+            // TODO this is where the translation from Orbit config
+            // to lifecycle config shall occur
+            Rules: workflows.map(wf => wf),
+        },
+    };
+    getS3Client(endpoint).putBucketLifecycleConfiguration(params, err => {
+        logger.debug('lifecycle configuration apply done', {
+            bucket: bucketName, error: err });
+        if (err && err.code === 'NoSuchBucket') {
+            return cb();
+        }
+        return cb(err);
+    });
+}
+
+function deleteLifecycleConfiguration(bucketName, cb) {
+    logger.debug('deleting lifecycle configuration');
+    const cfg = config.extensions.lifecycle.source.s3;
+    const endpoint = `${cfg.host}:${cfg.port}`;
+
+    const params = {
+        Bucket: bucketName,
+    };
+    getS3Client(endpoint).deleteBucketLifecycle(params, err => {
+        logger.debug('lifecycle configuration deleted', {
+            bucket: bucketName, error: err });
+        if (err && err.code === 'NoSuchBucket') {
+            return cb();
+        }
+        return cb(err);
+    });
+}
+
+function applyBucketLifecycleWorkflows(bucketName, bucketWorkflows,
+                                       workflowUpdates, cb) {
+    if (bucketWorkflows.length > 0) {
+        putLifecycleConfiguration(bucketName, bucketWorkflows, cb);
+    } else {
+        deleteLifecycleConfiguration(bucketName, cb);
+    }
+}
+
+module.exports = {
+    applyBucketLifecycleWorkflows,
+};

--- a/extensions/replication/management.js
+++ b/extensions/replication/management.js
@@ -3,7 +3,7 @@ const AWS = require('aws-sdk');
 const werelogs = require('werelogs');
 
 const config = require('../../conf/Config');
-const management = require('../../lib/management');
+const management = require('../../lib/management/index');
 
 const logger = new werelogs.Logger('mdManagement:replication');
 
@@ -25,207 +25,92 @@ function getS3Client(endpoint) {
     return s3Client;
 }
 
-function ensureBucketExists(stream, end, endpoint, cb) {
-    logger.debug('Checking that bucket exists', { end, endpoint });
-    if (!stream.enabled) {
-        logger.debug('stream is not enabled');
-        return process.nextTick(cb);
-    }
-    const params = {
-        Bucket: end.bucketName,
-    };
-    return getS3Client(endpoint).createBucket(params, err => {
-        if (err && err.code === 'BucketAlreadyOwnedByYou') {
-            return cb();
-        }
-        return cb(err);
-    });
-}
-
-function putVersioning(stream, bucketName, endpoint, cb) {
-    if (!stream.enabled) {
-        return process.nextTick(cb);
-    }
+function putVersioning(bucketName, endpoint, cb) {
     const params = {
         Bucket: bucketName,
         VersioningConfiguration: {
             Status: 'Enabled',
         },
     };
-    return getS3Client(endpoint).putBucketVersioning(params, err => cb(err));
-}
-
-function installReplicationPolicy(stream, endpoint, cb) {
-    const destinationLocations = stream.destination.locations
-        .map(location => location.name)
-        .join(',');
-    const roleName = 'arn:aws:iam::root:role/s3-replication-role';
-    const params = {
-        Bucket: stream.source.bucketName,
-        ReplicationConfiguration: {
-            Role: `${roleName}`,
-            Rules: [{
-                Destination: {
-                    Bucket: `arn:aws:s3:::${stream.source.bucketName}`,
-                    StorageClass: destinationLocations,
-                },
-                Prefix: stream.source.prefix || '',
-                Status: stream.enabled ? 'Enabled' : 'Disabled',
-            }],
-        },
-    };
-
-    getS3Client(endpoint).putBucketReplication(params, err => {
-        logger.debug('replication applied', {
-            sourceBucket: stream.source.bucketName,
-            destinationLocations, error: err });
-        if (err && err.code === 'NoSuchBucket' && !stream.enabled) {
+    return getS3Client(endpoint).putBucketVersioning(params, err => {
+        if (err && err.code === 'NoSuchBucket') {
+            logger.info('cannot apply replication configuration: bucket ' +
+                        'does not exist',
+                        { sourceBucket: bucketName });
             return cb();
         }
         return cb(err);
     });
 }
 
-function putReplication(stream, cb) {
-    logger.debug('Changing replication for stream to stream.enabled',
-        { streamId: stream.streamId });
+function installReplicationConfiguration(bucketName, endpoint, workflows, cb) {
+    const params = {
+        Bucket: bucketName,
+        ReplicationConfiguration: {
+            Role: 'arn:aws:iam::root:role/s3-replication-role',
+            Rules: workflows.map(wf => ({
+                Destination: {
+                    Bucket: `arn:aws:s3:::${wf.source.bucketName}`,
+                    StorageClass: wf.destination.locations
+                        .map(location => location.name)
+                        .join(','),
+                },
+                Prefix: wf.source.prefix || '',
+                Status: wf.enabled ? 'Enabled' : 'Disabled',
+            })),
+        },
+    };
+
+    getS3Client(endpoint).putBucketReplication(params, err => {
+        logger.debug('replication configuration apply done', {
+            sourceBucket: bucketName, error: err });
+        return cb(err);
+    });
+}
+
+function putReplication(bucketName, workflows, cb) {
+    logger.debug('updating replication configuration');
     const cfg = config.extensions.replication.source.s3;
     const endpoint = `${cfg.host}:${cfg.port}`;
 
-    async.waterfall([
-        done => ensureBucketExists(stream, stream.source, endpoint, done),
-        done => putVersioning(stream, stream.source.bucketName, endpoint, done),
+    async.series([
+        done => putVersioning(bucketName, endpoint, done),
         // TODO add service account in source & target bucket ACLs
-        done => installReplicationPolicy(stream, endpoint, done),
+        done => installReplicationConfiguration(bucketName, endpoint,
+                                                workflows, done),
     ], cb);
 }
 
-/* eslint-disable no-unused-vars */
-function disableReplication(stream, cb) {
-    logger.debug('disabling replication for stream',
-        { streamId: stream.streamId });
-    return cb(null, stream);
-}
-/* eslint-enable no-unused-vars */
+function deleteReplication(bucketName, cb) {
+    logger.debug('deleting replication configuration');
+    const cfg = config.extensions.replication.source.s3;
+    const endpoint = `${cfg.host}:${cfg.port}`;
 
-function applyReplicationState(conf, currentStateSerialized, cb) {
-    if (!conf.replicationStreams) {
-        return process.nextTick(cb);
-    }
-
-    const currentState = currentStateSerialized ?
-        JSON.parse(currentStateSerialized) : {
-            streams: {},
-            overlayVersion: 0,
-        };
-
-    if (currentState.overlayVersion >= conf.version) {
-        return process.nextTick(cb);
-    }
-
-    function streamConfigured(stream, cb) {
-        currentState.streams[stream.streamId] = stream;
-        management.saveExtensionState(currentState, cb);
-    }
-
-    function deleteStream(streamId, cb) {
-        logger.debug('deleting obsolete stream`', { streamId });
-        const stream = currentState.streams[streamId];
-        stream.enabled = false;
-        putReplication(stream, err => {
-            if (err) {
-                return cb(err);
-            }
-            delete currentState.streams[streamId];
-            return management.saveExtensionState(currentState, cb);
-        });
-    }
-
-    function arraysEqual(arr1, arr2) {
-        if (arr1.length !== arr2.length) {
-            return false;
+    const params = {
+        Bucket: bucketName,
+    };
+    getS3Client(endpoint).deleteBucketReplication(params, err => {
+        logger.debug('replication configuration deleted', {
+            sourceBucket: bucketName, error: err });
+        if (err && err.code === 'NoSuchBucket') {
+            logger.info('cannot delete replication configuration: bucket ' +
+                        'does not exist',
+                        { sourceBucket: bucketName });
+            return cb();
         }
-        for (let i = arr1.length; i--;) {
-            if (arr1[i] !== arr2[i]) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    function putReplicationAndStreamConfigured(stream, cb) {
-        putReplication(stream, err => {
-            if (err) {
-                return cb(err);
-            }
-            return streamConfigured(stream, cb);
-        });
-    }
-
-    function configureStream(stream, cb) {
-        if (currentState.streams[stream.streamId]) {
-            if (!currentState.streams[stream.streamId].enabled
-                && stream.enabled) {
-                logger.debug('enabling existing stream', {
-                    streamId: stream.streamId });
-                putReplicationAndStreamConfigured(stream, cb);
-            } else if (currentState.streams[stream.streamId].enabled
-                && !stream.enabled) {
-                logger.debug('disabling existing stream',
-                    { streamId: stream.streamId });
-                putReplicationAndStreamConfigured(stream, cb);
-            } else if (currentState.streams[stream.streamId].source.prefix
-                !== stream.source.prefix) {
-                logger.debug('changing stream source prefix',
-                    { streamId: stream.streamId });
-                putReplicationAndStreamConfigured(stream, cb);
-            } else if (!arraysEqual(currentState.streams[stream.streamId]
-                .destination.locations, stream.destination.locations)) {
-                logger.debug('changing stream destination locations',
-                    { streamId: stream.streamId });
-                putReplicationAndStreamConfigured(stream, cb);
-            } else {
-                logger.debug('stream has expected state, doing nothing',
-                { streamId: stream.streamId, streamEnabled: stream.enabled });
-                return cb();
-            }
-        } else {
-            if (stream.enabled) {
-                logger.debug('enabling new stream',
-                    { streamId: stream.streamId });
-                putReplicationAndStreamConfigured(stream, cb);
-            } else {
-                logger.debug('new disabled stream, doing nothing',
-                    { streamId: stream.streamId });
-                return cb();
-            }
-        }
-        return undefined;
-    }
-
-    const existingStreamIds = Object.keys(currentState.streams);
-    const incomingConfigStreamIds =
-        conf.replicationStreams.map(s => s.streamId);
-    const deletedStreamIds =
-        existingStreamIds.filter(s => !incomingConfigStreamIds.includes(s));
-
-    // TODO group streams per source bucket
-    async.eachSeries(conf.replicationStreams, configureStream, err => {
-        if (err) {
-            return cb(err);
-        }
-        currentState.overlayVersion = conf.version;
-        async.eachSeries(deletedStreamIds, deleteStream, err => {
-            if (err) {
-                return cb(err);
-            }
-            return management.saveExtensionState(currentState, cb);
-        });
-        return undefined;
+        return cb(err);
     });
-    return undefined;
+}
+
+function applyBucketReplicationWorkflows(bucketName, bucketWorkflows,
+                                         workflowUpdates, cb) {
+    if (bucketWorkflows.length > 0) {
+        putReplication(bucketName, bucketWorkflows, cb);
+    } else {
+        deleteReplication(bucketName, cb);
+    }
 }
 
 module.exports = {
-    applyReplicationState,
+    applyBucketReplicationWorkflows,
 };

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -4,8 +4,8 @@ const werelogs = require('werelogs');
 
 const QueueProcessor = require('./QueueProcessor');
 const config = require('../../../conf/Config');
-const { initManagement } = require('../../../lib/management');
-const { applyReplicationState } = require('../management');
+const { initManagement } = require('../../../lib/management/index');
+const { applyBucketReplicationWorkflows } = require('../management');
 
 const zkConfig = config.zookeeper;
 const MetricsProducer = require('../../../lib/MetricsProducer');
@@ -34,7 +34,7 @@ metricsProducer.setupProducer(err => {
         initManagement({
             serviceName: 'replication',
             serviceAccount: sourceConfig.auth.account,
-            applyState: applyReplicationState,
+            applyBucketWorkflows: applyBucketReplicationWorkflows,
         }, error => {
             if (error) {
                 log.error('could not load management db',

--- a/extensions/replication/replicationStatusProcessor/task.js
+++ b/extensions/replication/replicationStatusProcessor/task.js
@@ -9,7 +9,7 @@ const kafkaConfig = config.kafka;
 const repConfig = config.extensions.replication;
 const sourceConfig = repConfig.source;
 
-const { initManagement } = require('../../../lib/management');
+const { initManagement } = require('../../../lib/management/index');
 const replicationStatusProcessor =
           new ReplicationStatusProcessor(kafkaConfig, sourceConfig, repConfig);
 

--- a/lib/credentials/AccountCredentials.js
+++ b/lib/credentials/AccountCredentials.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const AWS = require('aws-sdk');
 
 const errors = require('arsenal').errors;
-const management = require('../../lib/management');
+const management = require('../../lib/management/index');
 
 class AccountCredentials extends AWS.Credentials {
     constructor(authConfig, getAuthDataCb, log) {

--- a/lib/management/applyWorkflowUpdates.js
+++ b/lib/management/applyWorkflowUpdates.js
@@ -1,0 +1,63 @@
+const async = require('async');
+
+/* eslint-disable no-param-reassign */
+function applyWorkflowUpdates(params, conf, currentState,
+                              workflowUpdates, logger, cb) {
+    if (currentState.overlayVersion >= conf.version) {
+        return process.nextTick(() => cb(null, null));
+    }
+    if (Object.keys(workflowUpdates).length === 0) {
+        return process.nextTick(() => cb(null, null));
+    }
+    let changed = false;
+    const errors = [];
+    return async.each(Object.keys(workflowUpdates), (bucketName, next) => {
+        // if there's a key in workflowUpdates array (returned by
+        // getWorkflowUpdates() helper) it means the bucket workflows
+        // have been updated, so apply the new workflows and updates
+        // to the service
+
+        const newBucketWorkflows =
+              (conf.workflows &&
+               conf.workflows[params.serviceName] &&
+               conf.workflows[params.serviceName][bucketName]) || [];
+        params.applyBucketWorkflows(
+            bucketName, newBucketWorkflows,
+            workflowUpdates[bucketName], err => {
+                if (err) {
+                    errors.push({ bucketName, message: err.message });
+                } else {
+                    const bucketWorkflowsState = {};
+                    newBucketWorkflows.forEach(wf => {
+                        bucketWorkflowsState[wf.workflowId] = wf;
+                    });
+                    if (Object.keys(bucketWorkflowsState).length > 0) {
+                        currentState.workflows[bucketName] =
+                            bucketWorkflowsState;
+                    } else {
+                        delete currentState.workflows[bucketName];
+                    }
+                    changed = true;
+                }
+                next();
+            });
+    }, () => {
+        errors.forEach(error => {
+            logger.error('an error occurred applying bucket workflows',
+                         { bucketName: error.bucketName,
+                           error: error.message });
+        });
+        // if any change has been applied even though errors may have
+        // occurred, update version and return the new state to commit
+        // it
+        if (changed) {
+            currentState.overlayVersion = conf.version;
+            return cb(errors[0] || null, currentState);
+        }
+        return cb(errors[0] || null, null);
+    });
+}
+/* eslint-enable no-param-reassign */
+
+module.exports = applyWorkflowUpdates;
+

--- a/lib/management/convertOverlayFormat.js
+++ b/lib/management/convertOverlayFormat.js
@@ -1,0 +1,34 @@
+/**
+ * convert legacy configuration format into new format (for legacy
+ * replication config)
+ *
+ * @param {object} conf - overlay config object
+ * @return {object} - converted overlay config object
+ *
+ * @note this function should be removed once the new format is
+ * adopted for replication
+ */
+function convertOverlayFormat(conf) {
+    if (!conf.replicationStreams) {
+        return conf;
+    }
+    const convConf = Object.assign({}, conf);
+    const replicationWorkflows = {};
+    conf.replicationStreams.forEach(stream => {
+        const workflow = Object.assign({}, stream);
+        workflow.workflowId = stream.streamId;
+        delete workflow.streamId;
+        if (!replicationWorkflows[stream.source.bucketName]) {
+            replicationWorkflows[stream.source.bucketName] = [];
+        }
+        replicationWorkflows[stream.source.bucketName].push(workflow);
+    });
+    if (!convConf.workflows) {
+        convConf.workflows = {};
+    }
+    convConf.workflows.replication = replicationWorkflows;
+    delete convConf.replicationStreams;
+    return convConf;
+}
+
+module.exports = convertOverlayFormat;

--- a/lib/management/convertServiceStateFormat.js
+++ b/lib/management/convertServiceStateFormat.js
@@ -1,0 +1,32 @@
+/**
+ * convert legacy service state format into new format (for legacy
+ * replication state)
+ *
+ * @param {object} state - service state object
+ * @return {object} - converted service state object
+ *
+ * @note this function should be removed once the new format is
+ * adopted for replication
+ */
+function convertServiceStateFormat(state) {
+    if (!state.streams) {
+        return state;
+    }
+    const convState = Object.assign({}, state);
+    const workflows = {};
+    Object.keys(state.streams).forEach(streamId => {
+        const stream = Object.assign({}, state.streams[streamId]);
+        stream.workflowId = stream.streamId;
+        delete stream.streamId;
+        const bucketName = stream.source.bucketName;
+        if (!workflows[bucketName]) {
+            workflows[bucketName] = {};
+        }
+        workflows[bucketName][streamId] = stream;
+    });
+    convState.workflows = workflows;
+    delete convState.streams;
+    return convState;
+}
+
+module.exports = convertServiceStateFormat;

--- a/lib/management/getWorkflowUpdates.js
+++ b/lib/management/getWorkflowUpdates.js
@@ -1,0 +1,126 @@
+const assert = require('assert');
+
+/**
+ * Get a representation of workflow updates as a JS object
+ *
+ * Any new, modified or deleted workflow for each modified bucket will
+ * have its workflow appended to a list respectively in the new,
+ * modified or deleted key under the bucket key.
+ *
+ * - for new workflows, the workflow object is appended as-is to the
+ *   'new' array
+ *
+ * - for deleted workflows, the previous workflow object is appended
+ *   as-is to the 'deleted' array
+ *
+ * - for modified workflows, the previous and current workflows are
+ *   set in an enclosing object as properties 'previous' and 'current'
+ *   which is pushed to the 'modified' array.
+ *
+ * @example
+ * getWorkflowUpdates({ bucket1: [{ workflowId: 'wf1' }] },
+ *                    {})
+ *    -> { bucket1: { new: [{ workflowId: 'wf1' }],
+ *                    modified: [],
+ *                    deleted: [] } }
+ *
+ * @example
+ * getWorkflowUpdates({ bucket1: [{ workflowId: 'wf1',
+ *                                  someProp: 2 }] },
+ *                    { bucket1: { wf1: { workflowId: 'wf1',
+ *                                        someProp: 1 } } })
+ *    -> { bucket1: { new: [],
+ *                    modified: [{ previous: {
+ *                                     workflowId: 'wf1',
+ *                                     someProp: 1
+ *                                 },
+ *                                 current: {
+ *                                     workflowId: 'wf1',
+ *                                     someProp: 2
+ *                                 } }],
+ *                    deleted: [] } }
+ *
+ * @param {object} [configuredWorkflows] - object containing the
+ *   currently configured workflows, containing arrays of workflow
+ *   objects grouped by target bucket. May be null or undefined.
+ * @param {object} currentWorkflows - current workflow state extracted
+ *   from the service state (under 'workflows' key). May be null or
+ *   undefined.
+ * @return {object} - a representation of workflow updates (see
+ *   examples in description)
+ */
+function getWorkflowUpdates(configuredWorkflows, currentWorkflows) {
+    const workflowUpdates = {};
+    if (!configuredWorkflows) {
+        // eslint-disable-next-line no-param-reassign
+        configuredWorkflows = {};
+    }
+    if (!currentWorkflows) {
+        // eslint-disable-next-line no-param-reassign
+        currentWorkflows = {};
+    }
+    Object.keys(configuredWorkflows).forEach(bucketName => {
+        const currentBucketWorkflows = currentWorkflows[bucketName];
+        const configuredBucketWorkflows = configuredWorkflows[bucketName];
+        if (!currentBucketWorkflows) {
+            if (configuredBucketWorkflows.length > 0) {
+                workflowUpdates[bucketName] = {
+                    new: configuredBucketWorkflows,
+                    modified: [],
+                    deleted: [],
+                };
+            }
+            return undefined;
+        }
+        const currentBucketWorkflowsArray =
+              Object.keys(currentBucketWorkflows)
+              .map(workflowId => currentBucketWorkflows[workflowId]);
+        const updates = {
+            new: configuredBucketWorkflows.filter(
+                wf => !currentBucketWorkflows[wf.workflowId]),
+            modified: configuredBucketWorkflows.filter(
+                wf => {
+                    if (!currentBucketWorkflows[wf.workflowId]) {
+                        return false;
+                    }
+                    try {
+                        assert.deepStrictEqual(
+                            wf, currentBucketWorkflows[wf.workflowId]);
+                        return false;
+                    } catch (err) {
+                        return true;
+                    }
+                }).map(wf => ({
+                    previous: currentBucketWorkflows[wf.workflowId],
+                    current: wf,
+                })),
+            deleted: currentBucketWorkflowsArray
+                .filter(wf => configuredBucketWorkflows.find(
+                    cwf => wf.workflowId === cwf.workflowId) === undefined),
+        };
+        if (updates.new.length > 0 ||
+            updates.modified.length > 0 ||
+            updates.deleted.length > 0) {
+            workflowUpdates[bucketName] = updates;
+        }
+        return undefined;
+    });
+    Object.keys(currentWorkflows).forEach(bucketName => {
+        if (!configuredWorkflows[bucketName]) {
+            const currentBucketWorkflows = currentWorkflows[bucketName];
+            const currentBucketWorkflowsArray =
+                  Object.keys(currentBucketWorkflows)
+                  .map(workflowId => currentBucketWorkflows[workflowId]);
+            if (currentBucketWorkflowsArray.length > 0) {
+                workflowUpdates[bucketName] = {
+                    new: [],
+                    modified: [],
+                    deleted: currentBucketWorkflowsArray,
+                };
+            }
+        }
+    });
+    return workflowUpdates;
+}
+
+module.exports = getWorkflowUpdates;

--- a/lib/management/index.js
+++ b/lib/management/index.js
@@ -1,9 +1,14 @@
 const async = require('async');
 const forge = require('node-forge');
 const arsenal = require('arsenal');
-const config = require('../conf/Config');
+const config = require('../../conf/Config');
 const werelogs = require('werelogs');
 const bucketclient = require('bucketclient');
+
+const convertOverlayFormat = require('./convertOverlayFormat');
+const convertServiceStateFormat = require('./convertServiceStateFormat');
+const getWorkflowUpdates = require('./getWorkflowUpdates');
+const applyWorkflowUpdates = require('./applyWorkflowUpdates');
 
 werelogs.configure({
     level: config.log.logLevel,
@@ -63,7 +68,9 @@ function loadOverlayVersion(metadata, version, cb) {
         if (err) {
             return cb(err);
         }
-        return cb(null, val);
+        const convConf = convertOverlayFormat(val);
+        logger.debug('converted config', { convConf });
+        return cb(null, convConf);
     });
 }
 
@@ -97,34 +104,60 @@ function patchConfiguration(conf, cb) {
     return process.nextTick(cb, null, conf);
 }
 
-function _getExtensionStateKey() {
+function _getServiceStateKey() {
     return `configuration/state/${serviceName}`;
 }
 
-function _loadExtensionState(cb) {
+function _loadServiceState(cb) {
     logger.debug(`loading ${serviceName} state`);
     metadata.getObjectMD(
-        serviceBucket, _getExtensionStateKey(),
-        {}, logger, (err, currentState) => {
+        serviceBucket, _getServiceStateKey(),
+        {}, logger, (err, currentStateSerialized) => {
             if (err && err.NoSuchKey) {
-                /* eslint-disable no-param-reassign */
-                return cb(null, null);
+                return cb(null, {
+                    workflows: {},
+                    overlayVersion: 0,
+                });
             }
             if (err) {
                 return cb(err);
             }
-            return cb(null, currentState);
+            const currentState = JSON.parse(currentStateSerialized);
+            const convState = convertServiceStateFormat(currentState);
+            logger.debug(`converted ${serviceName} state`,
+                         { convState });
+            return cb(null, convState);
         });
 }
 
-function _refreshExtensionState(conf, params, done) {
-    if (!params.applyState) {
+function _saveServiceState(newState, cb) {
+    logger.debug(`saving ${serviceName} state`, { newState });
+    return metadata.putObjectMD(serviceBucket, _getServiceStateKey(),
+                                JSON.stringify(newState), {}, logger, cb);
+}
+
+function _refreshServiceState(conf, params, done) {
+    if (!params.applyBucketWorkflows) {
         return process.nextTick(done);
     }
     return async.waterfall([
-        cb => _loadExtensionState(cb),
-        (currentState, cb) => params.applyState(conf, currentState, cb),
-    ], done);
+        cb => _loadServiceState(cb),
+        (currentState, cb) => {
+            const workflowUpdates = getWorkflowUpdates(
+                conf.workflows && conf.workflows[params.serviceName],
+                currentState && currentState.workflows);
+            logger.debug('applying workflow updates', { workflowUpdates });
+            applyWorkflowUpdates(params, conf, currentState,
+                                 workflowUpdates, logger, cb);
+        },
+    ], (err, newState) => {
+        if (newState) {
+            return _saveServiceState(newState, done);
+        }
+        logger.debug('workflows did not change, skip saving ' +
+                     `${serviceName} state`, { newState });
+        return done(err);
+    });
 }
 
 /**
@@ -134,8 +167,10 @@ function _refreshExtensionState(conf, params, done) {
  * @param {string} params.serviceName - name of service to manage
  * @param {string} [params.serviceAccount] - name of managed service
  *   account, if any
- * @param {function} [params.applyState] - callback function to
- *   apply extension-specific state set from management layer
+ * @param {function} [params.applyBucketWorkflows] - called when a
+ *   bucket has a changed set of workflows that needs to be applied by
+ *   the service: applyBucketWorkflows(bucketName, bucketWorkflows,
+ *   workflowUpdates, cb)
  * @param {function} done - callback function when init is complete
  * @return {undefined}
  */
@@ -201,7 +236,7 @@ function initManagement(params, done) {
                 saveServiceCredentials(conf, params, instanceAuth);
                 return cb(null, conf);
             }),
-            (conf, cb) => _refreshExtensionState(conf, params, cb),
+            (conf, cb) => _refreshServiceState(conf, params, cb),
         ], done);
     }
 
@@ -223,16 +258,7 @@ function getLatestServiceAccountCredentials() {
     return serviceCredentials;
 }
 
-function saveExtensionState(currentState, cb) {
-    logger.debug(`saving ${serviceName} state`, { currentState });
-    metadata.putObjectMD(
-        serviceBucket, _getExtensionStateKey(),
-        JSON.stringify(currentState), {}, logger, cb);
-}
-
-
 module.exports = {
     initManagement,
     getLatestServiceAccountCredentials,
-    saveExtensionState,
 };

--- a/tests/unit/management/applyWorkflowUpdates.spec.js
+++ b/tests/unit/management/applyWorkflowUpdates.spec.js
@@ -1,0 +1,212 @@
+const assert = require('assert');
+
+const werelogs = require('werelogs');
+
+const getWorkflowUpdates =
+      require('../../../lib/management/getWorkflowUpdates');
+const applyWorkflowUpdates =
+      require('../../../lib/management/applyWorkflowUpdates');
+
+const logger = new werelogs.Logger('mdManagement:test');
+
+class DummyWorkflowManager {
+
+    constructor(config, currentState) {
+        this.params = {
+            serviceName: 'dummyService',
+            applyBucketWorkflows: this.applyBucketDummyWorkflows.bind(this),
+        };
+        this.conf = config;
+        this.currentState = currentState;
+        this.notifiedWorkflows = undefined;
+        this.notifiedWorkflowUpdates = undefined;
+    }
+
+    applyBucketDummyWorkflows(bucketName, workflows, workflowUpdates, cb) {
+        assert.strictEqual(bucketName, 'test-bucket');
+        assert.strictEqual(this.notifiedWorkflows, undefined);
+        assert.strictEqual(this.notifiedWorkflowUpdates, undefined);
+        this.notifiedWorkflows = workflows;
+        this.notifiedWorkflowUpdates = workflowUpdates;
+        return process.nextTick(cb);
+    }
+
+    apply(cb) {
+        const workflowUpdates = getWorkflowUpdates(
+            this.conf.workflows.dummyService,
+            this.currentState.workflows);
+        applyWorkflowUpdates(this.params, this.conf, this.currentState,
+                             workflowUpdates, logger, cb);
+    }
+
+    checkNotifiedEqual(expectWorkflows, expectWorkflowUpdates) {
+        assert.deepStrictEqual(this.notifiedWorkflows, expectWorkflows);
+        assert.deepStrictEqual(this.notifiedWorkflowUpdates,
+                               expectWorkflowUpdates);
+    }
+}
+
+
+const workflow1 = {
+    workflowId: 'w1',
+    prefix: '/foo',
+    destination: {
+        locations: ['a', 'b', 'c'],
+    },
+};
+
+const workflow2 = {
+    workflowId: 'w2',
+    prefix: '/bar',
+    destination: {
+        locations: ['d', 'e'],
+    },
+};
+
+const workflow2Mod = {
+    workflowId: 'w2',
+    prefix: '/another_prefix',
+    destination: {
+        locations: ['d', 'e'],
+    },
+};
+
+const workflow3 = {
+    workflowId: 'w3',
+    prefix: '/qux',
+    destination: {
+        locations: ['f', 'g'],
+    },
+};
+
+const workflow4 = {
+    workflowId: 'w4',
+    prefix: '/quz',
+    destination: {
+        locations: ['h', 'i'],
+    },
+};
+
+describe('applyWorkflowUpdates', () => {
+    it('should apply a set of workflow updates to new config', done => {
+        const mgr = new DummyWorkflowManager({
+            version: 2,
+            workflows: {
+                dummyService: {
+                    'test-bucket': [workflow1, workflow2],
+                },
+            },
+        }, {
+            overlayVersion: 1,
+            workflows: {},
+        });
+        mgr.apply((err, newState) => {
+            assert.ifError(err);
+            mgr.checkNotifiedEqual([workflow1, workflow2], {
+                new: [workflow1, workflow2],
+                modified: [],
+                deleted: [],
+            });
+            assert.deepStrictEqual(newState, {
+                overlayVersion: 2,
+                workflows: { 'test-bucket': {
+                    w1: workflow1,
+                    w2: workflow2,
+                } },
+            });
+            done();
+        });
+    });
+
+    it('should apply a set of workflow updates to existing bucket', done => {
+        const mgr = new DummyWorkflowManager({
+            version: 2,
+            workflows: {
+                dummyService: {
+                    'test-bucket': [workflow2Mod, workflow4, workflow3],
+                },
+            },
+        }, {
+            overlayVersion: 1,
+            workflows: {
+                'test-bucket': {
+                    w1: workflow1,
+                    w2: workflow2,
+                    w3: workflow3,
+                },
+            },
+        });
+        mgr.apply((err, newState) => {
+            assert.ifError(err);
+            mgr.checkNotifiedEqual([workflow2Mod, workflow4, workflow3], {
+                new: [workflow4],
+                modified: [{ previous: workflow2,
+                             current: workflow2Mod }],
+                deleted: [workflow1],
+            });
+            assert.deepStrictEqual(newState, {
+                overlayVersion: 2,
+                workflows: { 'test-bucket': {
+                    w2: workflow2Mod,
+                    w3: workflow3,
+                    w4: workflow4,
+                } },
+            });
+            done();
+        });
+    });
+
+    it('should remove bucket from state when last workflow is ' +
+    'deleted', done => {
+        const mgr = new DummyWorkflowManager({
+            version: 2,
+            workflows: {
+                dummyService: {},
+            },
+        }, {
+            overlayVersion: 1,
+            workflows: {
+                'test-bucket': {
+                    w1: workflow1,
+                    w2: workflow2,
+                },
+            },
+        });
+        mgr.apply((err, newState) => {
+            assert.ifError(err);
+            mgr.checkNotifiedEqual([], {
+                new: [],
+                modified: [],
+                deleted: [workflow1, workflow2],
+            });
+            assert.deepStrictEqual(newState, {
+                overlayVersion: 2,
+                workflows: {},
+            });
+            done();
+        });
+    });
+
+    it('should not notify if overlay version has not changed', done => {
+        const mgr = new DummyWorkflowManager({
+            version: 2,
+            workflows: {
+                dummyService: [workflow2Mod, workflow3],
+            },
+        }, {
+            overlayVersion: 2,
+            workflows: {
+                'test-bucket': {
+                    w1: workflow1,
+                    w2: workflow2,
+                },
+            },
+        });
+        mgr.apply((err, newState) => {
+            assert.ifError(err);
+            mgr.checkNotifiedEqual(undefined, undefined);
+            assert.deepStrictEqual(newState, null);
+            done();
+        });
+    });
+});

--- a/tests/unit/management/convertOverlayFormat.spec.js
+++ b/tests/unit/management/convertOverlayFormat.spec.js
@@ -1,0 +1,156 @@
+const assert = require('assert');
+
+const convertOverlayFormat =
+      require('../../../lib/management/convertOverlayFormat');
+
+describe('convertOverlayFormat', () => {
+    it('should convert a legacy conf format into the new format', () => {
+        const legacyConf = {
+            version: 42,
+            locations: ['a', 'b'],
+            replicationStreams: [{
+                streamId: 's1', source: {
+                    bucketName: 'b1',
+                },
+            }, {
+                streamId: 's2', source: {
+                    bucketName: 'b2',
+                },
+            }, {
+                streamId: 's3', source: {
+                    bucketName: 'b1',
+                },
+            }],
+        };
+        const expectedConvConf = {
+            version: 42,
+            locations: ['a', 'b'],
+            workflows: {
+                replication: {
+                    b1: [{
+                        workflowId: 's1',
+                        source: {
+                            bucketName: 'b1',
+                        },
+                    }, {
+                        workflowId: 's3',
+                        source: {
+                            bucketName: 'b1',
+                        },
+                    }],
+                    b2: [{
+                        workflowId: 's2',
+                        source: {
+                            bucketName: 'b2',
+                        },
+                    }],
+                },
+            },
+        };
+
+        const convConf = convertOverlayFormat(legacyConf);
+        assert.deepStrictEqual(convConf, expectedConvConf);
+    });
+
+    it('should convert a mix of legacy conf and new conf format into the ' +
+    'new format', () => {
+        const legacyConf = {
+            version: 42,
+            locations: ['a', 'b'],
+            replicationStreams: [{
+                streamId: 's1', source: {
+                    bucketName: 'b1',
+                },
+            }, {
+                streamId: 's2', source: {
+                    bucketName: 'b2',
+                },
+            }, {
+                streamId: 's3', source: {
+                    bucketName: 'b1',
+                },
+            }],
+            workflows: {
+                lifecycle: {
+                    b1: [{
+                        workflowId: 's1',
+                        expiration: {},
+                    }, {
+                        workflowId: 's2',
+                        noncurrentVersionExpiration: {},
+                    }],
+                    b2: [{
+                        workflowId: 's3',
+                        transition: {},
+                    }],
+                },
+            },
+        };
+        const expectedConvConf = {
+            version: 42,
+            locations: ['a', 'b'],
+            workflows: {
+                replication: {
+                    b1: [{
+                        workflowId: 's1',
+                        source: {
+                            bucketName: 'b1',
+                        },
+                    }, {
+                        workflowId: 's3',
+                        source: {
+                            bucketName: 'b1',
+                        },
+                    }],
+                    b2: [{
+                        workflowId: 's2',
+                        source: {
+                            bucketName: 'b2',
+                        },
+                    }],
+                },
+                lifecycle: {
+                    b1: [{
+                        workflowId: 's1',
+                        expiration: {},
+                    }, {
+                        workflowId: 's2',
+                        noncurrentVersionExpiration: {},
+                    }],
+                    b2: [{
+                        workflowId: 's3',
+                        transition: {},
+                    }],
+                },
+            },
+        };
+
+        const convConf = convertOverlayFormat(legacyConf);
+        assert.deepStrictEqual(convConf, expectedConvConf);
+    });
+
+    it('should keep the new conf format as-is if nothing to convert', () => {
+        const okConf = {
+            version: 42,
+            locations: ['a', 'b'],
+            workflows: {
+                lifecycle: {
+                    b1: [{
+                        workflowId: 's1',
+                        expiration: {},
+                    }, {
+                        workflowId: 's2',
+                        noncurrentVersionExpiration: {},
+                    }],
+                    b2: [{
+                        workflowId: 's3',
+                        transition: {},
+                    }],
+                },
+            },
+        };
+
+        const convConf = convertOverlayFormat(okConf);
+        assert.deepStrictEqual(convConf, okConf);
+    });
+});

--- a/tests/unit/management/convertServiceStateFormat.spec.js
+++ b/tests/unit/management/convertServiceStateFormat.spec.js
@@ -1,0 +1,94 @@
+const assert = require('assert');
+
+const convertServiceStateFormat =
+      require('../../../lib/management/convertServiceStateFormat');
+
+describe('convertServiceStateFormat', () => {
+    it('should convert a legacy state format into the new format', () => {
+        const legacyState = {
+            overlayVersion: 42,
+            streams: {
+                s1: {
+                    streamId: 's1',
+                    source: {
+                        bucketName: 'b1',
+                    },
+                },
+                s2: {
+                    streamId: 's2',
+                    source: {
+                        bucketName: 'b2',
+                    },
+                },
+                s3: {
+                    streamId: 's3',
+                    source: {
+                        bucketName: 'b1',
+                    },
+                },
+            },
+        };
+        const expectedConvState = {
+            overlayVersion: 42,
+            workflows: {
+                b1: {
+                    s1: {
+                        workflowId: 's1',
+                        source: {
+                            bucketName: 'b1',
+                        },
+                    },
+                    s3: {
+                        workflowId: 's3',
+                        source: {
+                            bucketName: 'b1',
+                        },
+                    },
+                },
+                b2: {
+                    s2: {
+                        workflowId: 's2',
+                        source: {
+                            bucketName: 'b2',
+                        },
+                    },
+                },
+            },
+        };
+
+        const convState = convertServiceStateFormat(legacyState);
+        assert.deepStrictEqual(convState, expectedConvState);
+    });
+
+    it('should keep the new state format as-is if nothing to convert', () => {
+        const okState = {
+            overlayVersion: 42,
+            workflows: {
+                b1: {
+                    s1: {
+                        workflowId: 's1',
+                        source: {
+                            bucketName: 'b1',
+                        },
+                    },
+                    s3: {
+                        workflowId: 's3',
+                        source: {
+                            bucketName: 'b1',
+                        },
+                    },
+                },
+                b2: {
+                    s2: {
+                        workflowId: 's2',
+                        source: {
+                            bucketName: 'b2',
+                        },
+                    },
+                },
+            },
+        };
+        const convState = convertServiceStateFormat(okState);
+        assert.deepStrictEqual(convState, okState);
+    });
+});

--- a/tests/unit/management/getWorkflowUpdates.spec.js
+++ b/tests/unit/management/getWorkflowUpdates.spec.js
@@ -1,0 +1,219 @@
+const assert = require('assert');
+
+const getWorkflowUpdates =
+      require('../../../lib/management/getWorkflowUpdates');
+
+const workflow1 = {
+    workflowId: 'w1',
+    prefix: '/foo',
+    destination: {
+        locations: ['a', 'b', 'c'],
+    },
+};
+
+const workflow1Mod = {
+    workflowId: 'w1',
+    prefix: '/foo',
+    destination: {
+        locations: ['a', 'b', 'd'],
+    },
+};
+
+const workflow2 = {
+    workflowId: 'w2',
+    prefix: '/bar',
+    destination: {
+        locations: ['d', 'e'],
+    },
+};
+
+const workflow2Mod = {
+    workflowId: 'w2',
+    prefix: '/another_prefix',
+    destination: {
+        locations: ['d', 'e'],
+    },
+};
+
+const workflow3 = {
+    workflowId: 'w3',
+    prefix: '/qux',
+    destination: {
+        locations: ['f', 'g'],
+    },
+};
+
+const workflow4 = {
+    workflowId: 'w4',
+    prefix: '/quz',
+    destination: {
+        locations: ['h', 'i'],
+    },
+};
+
+describe('getWorkflowUpdates', () => {
+    it('should detect a new workflow on new config', () => {
+        assert.deepStrictEqual(
+            getWorkflowUpdates(
+                {
+                    bucket1: [workflow1],
+                },
+                undefined
+            ),
+            {
+                bucket1: {
+                    new: [workflow1],
+                    modified: [],
+                    deleted: [],
+                },
+            });
+    });
+    it('should detect a new workflow on new bucket', () => {
+        assert.deepStrictEqual(
+            getWorkflowUpdates(
+                {
+                    bucket1: [workflow1],
+                },
+                {
+                }
+            ),
+            {
+                bucket1: {
+                    new: [workflow1],
+                    modified: [],
+                    deleted: [],
+                },
+            });
+    });
+    it('should detect a new workflow on existing bucket with workflows',
+    () => {
+        assert.deepStrictEqual(
+            getWorkflowUpdates(
+                {
+                    bucket1: [workflow1, workflow2],
+                },
+                {
+                    bucket1: { w1: workflow1 },
+                }
+            ),
+            {
+                bucket1: {
+                    new: [workflow2],
+                    modified: [],
+                    deleted: [],
+                },
+            });
+    });
+    it('should detect a modified workflow', () => {
+        assert.deepStrictEqual(
+            getWorkflowUpdates(
+                {
+                    bucket1: [workflow1Mod, workflow2],
+                },
+                {
+                    bucket1: { w1: workflow1, w2: workflow2 },
+                }
+            ),
+            {
+                bucket1: {
+                    new: [],
+                    modified: [{ previous: workflow1,
+                                 current: workflow1Mod }],
+                    deleted: [],
+                },
+            });
+    });
+    it('should ignore an existing but unmodified workflow', () => {
+        assert.deepStrictEqual(
+            getWorkflowUpdates(
+                {
+                    bucket1: [workflow1, workflow2],
+                },
+                {
+                    bucket1: { w1: workflow1, w2: workflow2 },
+                }
+            ),
+            {
+            });
+    });
+    it('should detect a deleted workflow on existing bucket', () => {
+        assert.deepStrictEqual(
+            getWorkflowUpdates(
+                {
+                    bucket1: [workflow2],
+                },
+                {
+                    bucket1: { w1: workflow1, w2: workflow2 },
+                }
+            ),
+            {
+                bucket1: {
+                    new: [],
+                    modified: [],
+                    deleted: [workflow1],
+                },
+            });
+    });
+    it('should detect deleted workflows on deleted bucket', () => {
+        assert.deepStrictEqual(
+            getWorkflowUpdates(
+                {
+                },
+                {
+                    bucket1: { w1: workflow1, w2: workflow2 },
+                }
+            ),
+            {
+                bucket1: {
+                    new: [],
+                    modified: [],
+                    deleted: [workflow1, workflow2],
+                },
+            });
+    });
+    it('should be fine with no configured workflow at all', () => {
+        assert.deepStrictEqual(
+            getWorkflowUpdates(
+                undefined,
+                {
+                    bucket1: { w1: workflow1, w2: workflow2 },
+                }
+            ),
+            {
+                bucket1: {
+                    new: [],
+                    modified: [],
+                    deleted: [workflow1, workflow2],
+                },
+            });
+    });
+    it('should detect a set of new, modified and deleted workflows', () => {
+        assert.deepStrictEqual(
+            getWorkflowUpdates(
+                {
+                    bucket1: [workflow1Mod],
+                    bucket2: [workflow2Mod, workflow4, workflow3],
+                    bucket4: [],
+                },
+                {
+                    bucket1: { w1: workflow1 },
+                    bucket2: { w1: workflow1, w2: workflow2, w3: workflow3 },
+                    bucket3: {},
+                }
+            ),
+            {
+                bucket1: {
+                    new: [],
+                    modified: [{ previous: workflow1,
+                                 current: workflow1Mod }],
+                    deleted: [],
+                },
+                bucket2: {
+                    new: [workflow4],
+                    modified: [{ previous: workflow2,
+                                 current: workflow2Mod }],
+                    deleted: [workflow1],
+                },
+            });
+    });
+});


### PR DESCRIPTION
  * rf: Orbit workflow management rework
    
    Rework workflow management in the following ways:
    
    - support the new config format that groups workflows per bucket,
      provide conversion functions to handle the legacy (replication)
      format for config and state
    
    - let services provide (optionally) a callback function that gets
      called to apply a change in a bucket workflow (only effective
      changes are notified, so the service can blindly apply the new
      workflows).
    
    - in replication workflow management: do not treat a deleted workflow
      as a special case that disables the rule, apply the whole new
      workflow as a whole
    
    - delete replication configuration when the replication workflow is
      empty

  * ft: implement lifecycle management layer
    
    Set or delete lifecycle configuration from Orbit config changes.
    
    TODO: needs to adapt to the actual config values (see comment in
    putLifecycleConfiguration() in extensions/lifecycle/management.js)
