### PR TITLE
bf: crash backbeat components when unable to connect to kafka

### DIFF
--- a/lib/MetricsConsumer.js
+++ b/lib/MetricsConsumer.js
@@ -38,6 +38,7 @@ class MetricsConsumer {
     }
 
     start() {
+        let consumerReady = false;
         const consumer = new BackbeatConsumer({
             kafka: { hosts: this.kafkaConfig.hosts },
             topic: this.mConfig.topic,
@@ -46,8 +47,14 @@ class MetricsConsumer {
             queueProcessor: this.processKafkaEntry.bind(this),
             fetchMaxBytes: CONSUMER_FETCH_MAX_BYTES,
         });
-        consumer.on('error', () => {});
+        consumer.on('error', () => {
+            if (!consumerReady) {
+                this.logger.fatal('error starting metrics consumer');
+                process.exit(1);
+            }
+        });
         consumer.on('ready', () => {
+            consumerReady = true;
             consumer.subscribe();
             this.logger.info('metrics processor is ready to consume entries');
         });


### PR DESCRIPTION
Similar to #314, #309, and #296. This time the behavior was seen in the backbeat lifecycle producer, which will hang when Kafka is unavailable. These changes fix that issue by making the process exit, but it also adds error handling for other backbeat components the instantiate backbeat consumers, so that the hanging behavior is less likely to appear in the future.