### PR TITLE
ZENKO-476 setting up private registry

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -8,6 +8,18 @@ branches:
     stage: "post-merge"
 
 
+models:
+  - SetProperty: &docker_image_name
+      name: Set docker image name property
+      property: docker_image_name
+      value:
+        "%(secret:private_registry_url)s/zenko/backbeat:\
+        %(prop:commit_short_revision)s"
+  - ShellCommand: &docker_build
+      name: Build docker image
+      command: >-
+        docker build -t %(prop:docker_image_name)s .
+
 stages:
   pre-merge:
     worker: &pod
@@ -55,9 +67,8 @@ stages:
       path: eve/workers/pod.yml
     steps:
       - Git: *git
-      - ShellCommand: &docker_build
-          name: Docker build
-          command: docker build -t zenko/backbeat:nightly .
+      - SetProperty: *docker_image_name
+      - ShellCommand: *docker_build
 
   post-merge:
     worker:
@@ -65,6 +76,15 @@ stages:
       path: eve/workers/pod.yml
     steps:
       - Git: *git
+      - ShellCommand: &docker_login
+          name: Private Registry Login
+          command: >
+            docker login
+            -u '%(secret:private_registry_username)s'
+            -p '%(secret:private_registry_password)s'
+            '%(secret:private_registry_url)s'
+      - SetProperty: *docker_image_name
       - ShellCommand: *docker_build
-      # - ShellCommand: &docker_login waiting for RELENG
-      # - ShellCommand: &docker_push Waiting for RELENG
+      - ShellCommand: &docker_push
+          name: Push image
+          command: docker push %(prop:docker_image_name)s


### PR DESCRIPTION
Oh yeah, It's happening!

Made a simple push to a registry, this part of the pipeline will only run on development/* branches (AKA post-merge) but you can force it on the ui here's a build link to one that succeeded https://eve.devsca.com/github/scality/backbeat/#/builders/5/builds/2751.

This is a simple code, I'll happily change some details if you guys want! 