### PR TITLE
ft: ZENKO-143 transient source

### DIFF
--- a/conf/Config.js
+++ b/conf/Config.js
@@ -87,6 +87,8 @@ class Config extends EventEmitter {
 
         // config is validated, safe to assign directly to the config object
         Object.assign(this, parsedConfig);
+
+        this.transientLocations = {};
     }
 
     getBasePath() {
@@ -108,6 +110,14 @@ class Config extends EventEmitter {
     getBootstrapList() {
         monitoringClient.crrSiteCount.set(this.bootstrapList.length);
         return this.bootstrapList;
+    }
+
+    setIsTransientLocation(locationName, isTransient) {
+        this.transientLocations[locationName] = isTransient;
+    }
+
+    getIsTransientLocation(locationName) {
+        return this.transientLocations[locationName] || false;
     }
 }
 

--- a/extensions/replication/tasks/MultipleBackendTask.js
+++ b/extensions/replication/tasks/MultipleBackendTask.js
@@ -152,11 +152,12 @@ class MultipleBackendTask extends ReplicateObject {
             range,
         });
         const doneOnce = jsutil.once(done);
-        const sourceReq = this.S3source.getObject({
+        const sourceReq = this.backbeatSource.getObject({
             Bucket: sourceEntry.getBucket(),
             Key: sourceEntry.getObjectKey(),
             VersionId: sourceEntry.getEncodedVersionId(),
             Range: `bytes=${range.start}-${range.end}`,
+            LocationConstraint: sourceEntry.getDataStoreName(),
         });
         // Range is inclusive, hence + 1.
         const size = range.end - range.start + 1;
@@ -302,11 +303,12 @@ class MultipleBackendTask extends ReplicateObject {
         log.debug('getting object part', { entry: sourceEntry.getLogInfo() });
         const doneOnce = jsutil.once(done);
         const partObj = new ObjectMDLocation(part);
-        const sourceReq = this.S3source.getObject({
+        const sourceReq = this.backbeatSource.getObject({
             Bucket: sourceEntry.getBucket(),
             Key: sourceEntry.getObjectKey(),
             VersionId: sourceEntry.getEncodedVersionId(),
             PartNumber: partObj.getPartNumber(),
+            LocationConstraint: sourceEntry.getDataStoreName(),
         });
         const size = partObj.getPartSize();
         const partNumber = partObj.getPartNumber();
@@ -496,11 +498,12 @@ class MultipleBackendTask extends ReplicateObject {
         log.debug('getting object part', { entry: sourceEntry.getLogInfo() });
         const doneOnce = jsutil.once(done);
         const partObj = part ? new ObjectMDLocation(part) : undefined;
-        const sourceReq = this.S3source.getObject({
+        const sourceReq = this.backbeatSource.getObject({
             Bucket: sourceEntry.getBucket(),
             Key: sourceEntry.getObjectKey(),
             VersionId: sourceEntry.getEncodedVersionId(),
             PartNumber: part ? partObj.getPartNumber() : undefined,
+            LocationConstraint: sourceEntry.getDataStoreName(),
         });
         attachReqUids(sourceReq, log);
         sourceReq.on('error', err => {

--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -516,14 +516,12 @@ class ReplicateObject extends BackbeatTask {
     }
 
     _handleReplicationOutcome(err, sourceEntry, destEntry, log, done) {
-        let status;
         if (!err) {
             log.debug('replication succeeded for object, publishing ' +
                       'replication status as COMPLETED',
                       { entry: sourceEntry.getLogInfo() });
-            status = 'COMPLETED';
-            return this._publishReplicationStatus(sourceEntry, status, { log },
-                done);
+            return this._publishReplicationStatus(sourceEntry, 'COMPLETED',
+                { log }, done);
         }
         if (err.BadRole ||
             (err.origin === 'source' &&
@@ -555,8 +553,7 @@ class ReplicateObject extends BackbeatTask {
             { failMethod: err.method,
                 entry: sourceEntry.getLogInfo(),
                 error: err.description });
-        status = 'FAILED';
-        return this._publishReplicationStatus(sourceEntry, status,
+        return this._publishReplicationStatus(sourceEntry, 'FAILED',
             { log, reason: err.description }, done);
     }
 }

--- a/extensions/replication/utils/ObjectQueueEntry.js
+++ b/extensions/replication/utils/ObjectQueueEntry.js
@@ -9,22 +9,6 @@ function _extractVersionedBaseKey(key) {
     return '';
 }
 
-function _getGlobalReplicationStatus(data) {
-    // Check the global status relative to the other backends
-    if (Array.isArray(data.replicationInfo.backends)) {
-        const statuses = data.replicationInfo.backends.map(backend =>
-            backend.status);
-        // If any site replication failed, set the global status to FAILED.
-        if (statuses.includes('FAILED')) {
-            return 'FAILED';
-        }
-        if (statuses.includes('PENDING')) {
-            return 'PROCESSING';
-        }
-    }
-    return 'COMPLETED';
-}
-
 class ObjectQueueEntry extends ObjectMD {
 
     /**
@@ -112,11 +96,30 @@ class ObjectQueueEntry extends ObjectMD {
         };
     }
 
+    _getGlobalReplicationStatus() {
+        const data = this.getValue();
+        // Check the global status relative to the other backends
+        if (Array.isArray(data.replicationInfo.backends)) {
+            const statuses = data.replicationInfo.backends.map(
+                backend => backend.status);
+            // If any site replication failed, set the global status
+            // to FAILED.
+            if (statuses.includes('FAILED')) {
+                return 'FAILED';
+            }
+            if (statuses.includes('PENDING')) {
+                return 'PROCESSING';
+            }
+        }
+        return 'COMPLETED';
+    }
+
     toReplicaEntry(site) {
         const newEntry = this.clone();
-        newEntry.setBucket(this.getReplicationTargetBucket());
-        newEntry.setReplicationSiteStatus(site, 'REPLICA');
-        newEntry.setReplicationStatus('REPLICA');
+        newEntry
+            .setBucket(this.getReplicationTargetBucket())
+            .setReplicationSiteStatus(site, 'REPLICA')
+            .setReplicationStatus('REPLICA');
         return newEntry;
     }
 
@@ -134,24 +137,21 @@ class ObjectQueueEntry extends ObjectMD {
     }
 
     toCompletedEntry(site) {
-        const newEntry = this.clone();
-        newEntry.setReplicationSiteStatus(site, 'COMPLETED');
-        const status = _getGlobalReplicationStatus(this.getValue());
-        newEntry.setReplicationStatus(status);
-        return newEntry;
+        return this.clone()
+            .setReplicationSiteStatus(site, 'COMPLETED')
+            .setReplicationStatus(this._getGlobalReplicationStatus());
     }
 
     toFailedEntry(site) {
-        const newEntry = this.clone();
-        newEntry.setReplicationSiteStatus(site, 'FAILED');
-        newEntry.setReplicationStatus('FAILED');
-        return newEntry;
+        return this.clone()
+            .setReplicationSiteStatus(site, 'FAILED')
+            .setReplicationStatus('FAILED');
     }
 
     toPendingEntry(site) {
         return this.clone()
             .setReplicationSiteStatus(site, 'PENDING')
-            .setReplicationStatus(_getGlobalReplicationStatus(this.getValue()));
+            .setReplicationStatus(this._getGlobalReplicationStatus());
     }
 
     toRetryEntry(site) {

--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -615,6 +615,233 @@
                 }
             }
         },
+        "GetObject": {
+            "http": {
+                "method": "GET",
+                "requestUri": "/{Bucket}/{Key+}"
+            },
+            "input": {
+                "type": "structure",
+                "required": [
+                    "Bucket",
+                    "Key"
+                ],
+                "members": {
+                    "Bucket": {
+                        "location": "uri",
+                        "locationName": "Bucket"
+                    },
+                    "IfMatch": {
+                        "location": "header",
+                        "locationName": "If-Match"
+                    },
+                    "IfModifiedSince": {
+                        "location": "header",
+                        "locationName": "If-Modified-Since",
+                        "type": "timestamp"
+                    },
+                    "IfNoneMatch": {
+                        "location": "header",
+                        "locationName": "If-None-Match"
+                    },
+                    "IfUnmodifiedSince": {
+                        "location": "header",
+                        "locationName": "If-Unmodified-Since",
+                        "type": "timestamp"
+                    },
+                    "Key": {
+                        "location": "uri",
+                        "locationName": "Key"
+                    },
+                    "Range": {
+                        "location": "header",
+                        "locationName": "Range"
+                    },
+                    "ResponseCacheControl": {
+                        "location": "querystring",
+                        "locationName": "response-cache-control"
+                    },
+                    "ResponseContentDisposition": {
+                        "location": "querystring",
+                        "locationName": "response-content-disposition"
+                    },
+                    "ResponseContentEncoding": {
+                        "location": "querystring",
+                        "locationName": "response-content-encoding"
+                    },
+                    "ResponseContentLanguage": {
+                        "location": "querystring",
+                        "locationName": "response-content-language"
+                    },
+                    "ResponseContentType": {
+                        "location": "querystring",
+                        "locationName": "response-content-type"
+                    },
+                    "ResponseExpires": {
+                        "location": "querystring",
+                        "locationName": "response-expires",
+                        "type": "timestamp"
+                    },
+                    "VersionId": {
+                        "location": "querystring",
+                        "locationName": "versionId"
+                    },
+                    "SSECustomerAlgorithm": {
+                        "location": "header",
+                        "locationName": "x-amz-server-side-encryption-customer-algorithm"
+                    },
+                    "SSECustomerKey": {
+                        "shape": "S19",
+                        "location": "header",
+                        "locationName": "x-amz-server-side-encryption-customer-key"
+                    },
+                    "SSECustomerKeyMD5": {
+                        "location": "header",
+                        "locationName": "x-amz-server-side-encryption-customer-key-MD5"
+                    },
+                    "RequestPayer": {
+                        "location": "header",
+                        "locationName": "x-amz-request-payer"
+                    },
+                    "PartNumber": {
+                        "location": "querystring",
+                        "locationName": "partNumber",
+                        "type": "integer"
+                    },
+                    "LocationConstraint": {
+                        "location": "header",
+                        "locationName": "x-amz-location-constraint"
+                    }
+                }
+            },
+            "output": {
+                "type": "structure",
+                "members": {
+                    "Body": {
+                        "streaming": true,
+                        "type": "blob"
+                    },
+                    "DeleteMarker": {
+                        "location": "header",
+                        "locationName": "x-amz-delete-marker",
+                        "type": "boolean"
+                    },
+                    "AcceptRanges": {
+                        "location": "header",
+                        "locationName": "accept-ranges"
+                    },
+                    "Expiration": {
+                        "location": "header",
+                        "locationName": "x-amz-expiration"
+                    },
+                    "Restore": {
+                        "location": "header",
+                        "locationName": "x-amz-restore"
+                    },
+                    "LastModified": {
+                        "location": "header",
+                        "locationName": "Last-Modified",
+                        "type": "timestamp"
+                    },
+                    "ContentLength": {
+                        "location": "header",
+                        "locationName": "Content-Length",
+                        "type": "long"
+                    },
+                    "ETag": {
+                        "location": "header",
+                        "locationName": "ETag"
+                    },
+                    "MissingMeta": {
+                        "location": "header",
+                        "locationName": "x-amz-missing-meta",
+                        "type": "integer"
+                    },
+                    "VersionId": {
+                        "location": "header",
+                        "locationName": "x-amz-version-id"
+                    },
+                    "CacheControl": {
+                        "location": "header",
+                        "locationName": "Cache-Control"
+                    },
+                    "ContentDisposition": {
+                        "location": "header",
+                        "locationName": "Content-Disposition"
+                    },
+                    "ContentEncoding": {
+                        "location": "header",
+                        "locationName": "Content-Encoding"
+                    },
+                    "ContentLanguage": {
+                        "location": "header",
+                        "locationName": "Content-Language"
+                    },
+                    "ContentRange": {
+                        "location": "header",
+                        "locationName": "Content-Range"
+                    },
+                    "ContentType": {
+                        "location": "header",
+                        "locationName": "Content-Type"
+                    },
+                    "Expires": {
+                        "location": "header",
+                        "locationName": "Expires",
+                        "type": "timestamp"
+                    },
+                    "WebsiteRedirectLocation": {
+                        "location": "header",
+                        "locationName": "x-amz-website-redirect-location"
+                    },
+                    "ServerSideEncryption": {
+                        "location": "header",
+                        "locationName": "x-amz-server-side-encryption"
+                    },
+                    "Metadata": {
+                        "shape": "S11",
+                        "location": "headers",
+                        "locationName": "x-amz-meta-"
+                    },
+                    "SSECustomerAlgorithm": {
+                        "location": "header",
+                        "locationName": "x-amz-server-side-encryption-customer-algorithm"
+                    },
+                    "SSECustomerKeyMD5": {
+                        "location": "header",
+                        "locationName": "x-amz-server-side-encryption-customer-key-MD5"
+                    },
+                    "SSEKMSKeyId": {
+                        "shape": "Sj",
+                        "location": "header",
+                        "locationName": "x-amz-server-side-encryption-aws-kms-key-id"
+                    },
+                    "StorageClass": {
+                        "location": "header",
+                        "locationName": "x-amz-storage-class"
+                    },
+                    "RequestCharged": {
+                        "location": "header",
+                        "locationName": "x-amz-request-charged"
+                    },
+                    "ReplicationStatus": {
+                        "location": "header",
+                        "locationName": "x-amz-replication-status"
+                    },
+                    "PartsCount": {
+                        "location": "header",
+                        "locationName": "x-amz-mp-parts-count",
+                        "type": "integer"
+                    },
+                    "TagCount": {
+                        "location": "header",
+                        "locationName": "x-amz-tagging-count",
+                        "type": "integer"
+                    }
+                },
+                "payload": "Body"
+            }
+        },
         "BatchDelete": {
             "http": {
                 "method": "POST",
@@ -751,6 +978,19 @@
         }
     },
     "shapes": {
+        "Sj": {
+            "type": "string",
+            "sensitive": true
+        },
+        "S11": {
+            "type": "map",
+            "key": {},
+            "value": {}
+        },
+        "S19": {
+            "type": "blob",
+            "sensitive": true
+        },
         "ObjectMDListResponse": {
             "type": "structure",
             "members": {

--- a/lib/management/index.js
+++ b/lib/management/index.js
@@ -96,6 +96,11 @@ function patchConfiguration(conf, cb) {
                 return obj;
             }, {});
             config.setBootstrapList(locationsWithReplicationBackend);
+
+            Object.keys(locations).forEach(locName => {
+                config.setIsTransientLocation(
+                    locName, locations[locName].isTransient);
+            });
         } catch (error) {
             return cb(error);
         }


### PR DESCRIPTION
  * cleanup: ZENKO-143 code cleanups
    
    * in ReplicateObject._handleReplicationOutcome(), don't use temporary
      variable 'status'
    
    * make _getGlobalReplicationStatus() a member of ObjectQueueEntry
      class
    
    * cleanups in ObjectQueueEntry.toXxxEntry() helpers

  * ft: ZENKO-143 force read on local source
    
    Make use of x-amz-location-constraint header to force a read from the
    local source, in case a cloud target is the preferred read location
    e.g. w/ transient source.
    
    - If the cloud target replication is PENDING it avoid failing the read
    
    - If it's in COMPLETED status it enforces a local read for transient
    source to be effective.
    
    For this to work, we have to go through a custom backbeat route that
    maps to AWS SDK getObject() with support for non-standard
    x-amz-location-constraint header.

 *  ft: ZENKO-143 garbage-collect transient data locations
    
    After CRR status becomes COMPLETED for an object on a transient source
    location, publish a message to garbage-collect the original data
    locations of the object.
