### PR TITLE
rf: ZENKO-584 metrics completion on status update

### DIFF
--- a/extensions/replication/ReplicationQueuePopulator.js
+++ b/extensions/replication/ReplicationQueuePopulator.js
@@ -59,7 +59,7 @@ class ReplicationQueuePopulator extends QueuePopulatorExtension {
 
         const repSites = queueEntry.getReplicationInfo().backends;
 
-        // for one-to-many
+        // record replication metrics by site
         repSites.filter(entry => entry.status === 'PENDING')
             .forEach(backend => {
                 this._incrementMetrics(backend.site,

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -8,10 +8,7 @@ const config = require('../../../conf/Config');
 const { initManagement } = require('../../../lib/management/index');
 const { applyBucketReplicationWorkflows } = require('../management');
 const { HealthProbeServer } = require('arsenal').network.probe;
-
-const MetricsProducer = require('../../../lib/MetricsProducer');
 const zookeeper = require('../../../lib/clients/zookeeper');
-
 const { zookeeperReplicationNamespace } = require('../constants');
 const ZK_CRR_STATE_PATH = '/state';
 
@@ -19,8 +16,8 @@ const zkConfig = config.zookeeper;
 const kafkaConfig = config.kafka;
 const repConfig = config.extensions.replication;
 const sourceConfig = repConfig.source;
-const mConfig = config.metrics;
 const redisConfig = config.redis;
+const { connectionString, autoCreateNamespace } = zkConfig;
 
 const log = new werelogs.Logger('Backbeat:QueueProcessor:task');
 werelogs.configure({
@@ -32,6 +29,8 @@ const healthServer = new HealthProbeServer({
     bindAddress: config.healthcheckServer.bindAddress,
     port: config.healthcheckServer.port,
 });
+
+const activeQProcessors = {};
 
 function getCRRStateZkPath() {
     return `${zookeeperReplicationNamespace}${ZK_CRR_STATE_PATH}`;
@@ -84,141 +83,120 @@ function setupZkSiteNode(zkClient, site, done) {
     });
 }
 
-const metricsProducer = new MetricsProducer(kafkaConfig, mConfig);
-let zkClient;
-async.series([
-    done => metricsProducer.setupProducer(err => {
-        if (err) {
-            log.fatal('error starting metrics producer for queue ' +
-            'processor', {
-                error: err,
-                method: 'MetricsProducer::setupProducer',
-            });
+
+function initAndStart(zkClient) {
+    initManagement({
+        serviceName: 'replication',
+        serviceAccount: sourceConfig.auth.account,
+        applyBucketWorkflows: applyBucketReplicationWorkflows,
+    }, error => {
+        if (error) {
+            log.error('could not load management db',
+                { error: error.message });
+            setTimeout(initAndStart, 5000);
+            return;
         }
-        return done(err);
-    }),
-    done => {
-        const { connectionString, autoCreateNamespace } = zkConfig;
-        log.info('opening zookeeper connection for replication processors');
-        zkClient = zookeeper.createClient(connectionString, {
-            autoCreateNamespace,
-        });
-        zkClient.connect();
-        zkClient.once('error', err => {
-            log.fatal('error connecting to zookeeper', {
-                error: err.message,
-            });
-            return done(err);
-        });
-        zkClient.once('ready', () => {
-            zkClient.removeAllListeners('error');
-            const path = getCRRStateZkPath();
-            zkClient.mkdirp(path, err => {
-                if (err) {
-                    log.fatal('could not create path in zookeeper', {
-                        method: 'QueueProcessor:task',
-                        zookeeperPath: path,
-                        error: err.message,
-                    });
-                    return done(err);
+        log.info('management init done');
+
+        const bootstrapList = config.getBootstrapList();
+
+        const destConfig = Object.assign({}, repConfig.destination);
+        destConfig.bootstrapList = bootstrapList;
+
+        config.on('bootstrap-list-update', () => {
+            destConfig.bootstrapList = config.getBootstrapList();
+
+            const activeSites = Object.keys(activeQProcessors);
+            const updatedSites = destConfig.bootstrapList.map(i => i.site);
+            const allSites = [...new Set(activeSites.concat(updatedSites))];
+
+            async.each(allSites, (site, next) => {
+                if (updatedSites.includes(site)) {
+                    if (!activeSites.includes(site)) {
+                        activeQProcessors[site] = new QueueProcessor(
+                            zkClient, kafkaConfig, sourceConfig, destConfig,
+                            repConfig, redisConfig, site);
+                        setupZkSiteNode(zkClient, site, (err, paused) => {
+                            if (err) {
+                                return next(err);
+                            }
+                            activeQProcessors[site].start({ paused });
+                            return next();
+                        });
+                    }
+                } else {
+                    // this site is no longer in bootstrapList
+                    activeQProcessors[site].stop(() => {});
+                    delete activeQProcessors[site];
+                    next();
                 }
-                return done();
-            });
-        });
-    },
-], err => {
-    if (err) {
-        // error occurred at startup trying to start internal clients,
-        // fail immediately
-        process.exit(1);
-    }
-    const activeQProcessors = {};
-
-    function initAndStart() {
-        initManagement({
-            serviceName: 'replication',
-            serviceAccount: sourceConfig.auth.account,
-            applyBucketWorkflows: applyBucketReplicationWorkflows,
-        }, error => {
-            if (error) {
-                log.error('could not load management db',
-                    { error: error.message });
-                setTimeout(initAndStart, 5000);
-                return;
-            }
-            log.info('management init done');
-
-            const bootstrapList = config.getBootstrapList();
-
-            const destConfig = Object.assign({}, repConfig.destination);
-            destConfig.bootstrapList = bootstrapList;
-
-            config.on('bootstrap-list-update', () => {
-                destConfig.bootstrapList = config.getBootstrapList();
-
-                const activeSites = Object.keys(activeQProcessors);
-                const updatedSites = destConfig.bootstrapList.map(i => i.site);
-                const allSites = [...new Set(activeSites.concat(updatedSites))];
-
-                async.each(allSites, (site, next) => {
-                    if (updatedSites.includes(site)) {
-                        if (!activeSites.includes(site)) {
-                            activeQProcessors[site] = new QueueProcessor(
-                                zkClient, kafkaConfig, sourceConfig, destConfig,
-                                repConfig, redisConfig, metricsProducer, site);
-                            setupZkSiteNode(zkClient, site, (err, paused) => {
-                                if (err) {
-                                    return next(err);
-                                }
-                                activeQProcessors[site].start({ paused });
-                                return next();
-                            });
-                        }
-                    } else {
-                        // this site is no longer in bootstrapList
-                        activeQProcessors[site].stop(() => {});
-                        delete activeQProcessors[site];
-                        next();
-                    }
-                }, err => {
-                    if (err) {
-                        process.exit(1);
-                    }
-                });
-            });
-
-            // Start QueueProcessor for each site
-            const siteNames = bootstrapList.map(i => i.site);
-            async.each(siteNames, (site, next) => {
-                activeQProcessors[site] = new QueueProcessor(zkClient,
-                    kafkaConfig, sourceConfig, destConfig, repConfig,
-                    redisConfig, metricsProducer, site);
-                return setupZkSiteNode(zkClient, site, (err, paused) => {
-                    if (err) {
-                        return next(err);
-                    }
-                    activeQProcessors[site].start({ paused });
-                    return next();
-                });
             }, err => {
                 if (err) {
-                    // already logged error in prior function calls
                     process.exit(1);
                 }
             });
-            healthServer.onReadyCheck(() => {
-                let passed = true;
-                Object.keys(activeQProcessors).forEach(site => {
-                    if (!activeQProcessors[site].isReady()) {
-                        passed = false;
-                        log.error(`QueueProcessor for ${site} is not ready!`);
-                    }
-                });
-                return passed;
-            });
-            log.info('Starting HealthProbe server');
-            healthServer.start();
         });
-    }
-    return initAndStart();
+
+        // Start QueueProcessor for each site
+        const siteNames = bootstrapList.map(i => i.site);
+        async.each(siteNames, (site, next) => {
+            activeQProcessors[site] = new QueueProcessor(zkClient,
+                kafkaConfig, sourceConfig, destConfig, repConfig,
+                redisConfig, site);
+            return setupZkSiteNode(zkClient, site, (err, paused) => {
+                if (err) {
+                    return next(err);
+                }
+                activeQProcessors[site].start({ paused });
+                return next();
+            });
+        }, err => {
+            if (err) {
+                // already logged error in prior function calls
+                process.exit(1);
+            }
+        });
+        healthServer.onReadyCheck(() => {
+            let passed = true;
+            Object.keys(activeQProcessors).forEach(site => {
+                if (!activeQProcessors[site].isReady()) {
+                    passed = false;
+                    log.error(`QueueProcessor for ${site} is not ready!`);
+                }
+            });
+            return passed;
+        });
+        log.info('Starting HealthProbe server');
+        healthServer.start();
+    });
+}
+
+const zkClient = zookeeper.createClient(connectionString, {
+    autoCreateNamespace,
+});
+zkClient.connect();
+zkClient.once('error', err => {
+    log.fatal('error connecting to zookeeper', {
+        error: err.message,
+    });
+    // error occurred at startup trying to start internal clients,
+    // fail immediately
+    process.exit(1);
+});
+zkClient.once('ready', () => {
+    zkClient.removeAllListeners('error');
+    const path = getCRRStateZkPath();
+    zkClient.mkdirp(path, err => {
+        if (err) {
+            log.fatal('could not create path in zookeeper', {
+                method: 'QueueProcessor:task',
+                zookeeperPath: path,
+                error: err.message,
+            });
+            // error occurred at startup trying to start internal clients,
+            // fail immediately
+            process.exit(1);
+        }
+        return initAndStart(zkClient);
+    });
 });

--- a/extensions/replication/replicationStatusProcessor/task.js
+++ b/extensions/replication/replicationStatusProcessor/task.js
@@ -8,12 +8,13 @@ const config = require('../../../conf/Config');
 const kafkaConfig = config.kafka;
 const repConfig = config.extensions.replication;
 const sourceConfig = repConfig.source;
+const mConfig = config.metrics;
 
 const { initManagement } = require('../../../lib/management/index');
 const { HealthProbeServer } = require('arsenal').network.probe;
 
-const replicationStatusProcessor =
-          new ReplicationStatusProcessor(kafkaConfig, sourceConfig, repConfig);
+const replicationStatusProcessor = new ReplicationStatusProcessor(kafkaConfig,
+    sourceConfig, repConfig, mConfig);
 
 const healthServer = new HealthProbeServer({
     bindAddress: config.healthcheckServer.bindAddress,

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -4,17 +4,9 @@ const assert = require('assert');
 const async = require('async');
 const joi = require('joi');
 
-const Logger = require('werelogs').Logger;
-
-const Config = require('../conf/Config');
 const zookeeperHelper = require('./clients/zookeeper');
 const BackbeatProducer = require('./BackbeatProducer');
-const ObjectQueueEntry =
-    require('../extensions/replication/utils/ObjectQueueEntry');
-const QueueEntry = require('./models/QueueEntry');
-const monitoringClient = require('./clients/monitoringHandler');
-
-const CRR_TOPIC = Config.extensions.replication.topic;
+const Logger = require('werelogs').Logger;
 
 // controls the number of messages to process in parallel
 const CONCURRENCY_DEFAULT = 1;
@@ -108,8 +100,7 @@ class BackbeatConsumer extends EventEmitter {
         this._zookeeperReady = false;
         this._publishOffsetsCronTimer = null;
         this._publishOffsetsCronActive = false;
-        // metrics - consumption
-        this._metricsStore = {};
+
         this._committedOffsets = null;
 
         this._init();
@@ -223,9 +214,6 @@ class BackbeatConsumer extends EventEmitter {
             this.emit('consumed', this._messagesConsumed);
             this._messagesConsumed = 0;
 
-            this.emit('metrics', this._metricsStore);
-            this._metricsStore = {};
-
             this._tryConsume();
         };
 
@@ -286,8 +274,6 @@ class BackbeatConsumer extends EventEmitter {
                 entry: { topic, partition, offset, key, timestamp },
             });
             this.emit('error', err, entry);
-        } else if (entry.topic === CRR_TOPIC && this._topic === CRR_TOPIC) {
-            this._incrementMetrics(entry);
         }
     }
 
@@ -422,36 +408,6 @@ class BackbeatConsumer extends EventEmitter {
      */
     getMetadata(params, cb) {
         this._consumer.getMetadata(params, cb);
-    }
-
-    _incrementMetrics(entry) {
-        const qEntry = QueueEntry.createFromKafkaEntry(entry);
-        if (!qEntry.error && qEntry instanceof ObjectQueueEntry) {
-            const bytes = qEntry.getContentLength();
-
-            const repSites = qEntry.getReplicationInfo().backends;
-            const sites = repSites.reduce((store, entry) => {
-                if (entry.status === 'PENDING') {
-                    store.push(entry.site);
-                }
-                return store;
-            }, []);
-
-            // for one-to-many
-            sites.forEach(site => {
-                if (!this._metricsStore[site]) {
-                    this._metricsStore[site] = {
-                        ops: 1,
-                        bytes,
-                    };
-                } else {
-                    this._metricsStore[site].ops++;
-                    this._metricsStore[site].bytes += bytes;
-                }
-                monitoringClient.crrOpDone.inc();
-                monitoringClient.crrBytesDone.inc(bytes);
-            });
-        }
     }
 
     /**

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -617,10 +617,6 @@ class S3Mock extends TestConfigurator {
     }
 }
 
-class MetricsMock {
-    publishMetrics() {}
-}
-
 /* eslint-enable max-len */
 
 describe('queue processor functional tests with mocking', () => {
@@ -659,7 +655,7 @@ describe('queue processor functional tests with mocking', () => {
             },
             { host: '127.0.0.1',
               port: 6379 },
-            new MetricsMock(), 'sf');
+            'sf');
         queueProcessor.start({ disableConsumer: true });
         // create the replication status processor only when the queue
         // processor is ready, so that we ensure the replication
@@ -680,7 +676,8 @@ describe('queue processor functional tests with mocking', () => {
                       retryTimeoutS: 5,
                       groupId: 'backbeat-func-test-group-id',
                   },
-              });
+                },
+                { topic: 'metrics-test-topic' });
             replicationStatusProcessor.start({ bootstrap: true }, done);
         });
 


### PR DESCRIPTION
Move metrics producer from QueueProcessor to
ReplicationStatusProcessor.

Instead of collecting completion metrics when entries are
read from Kafka by a consumer, we want to collect metrics
on actual replication completion (whether it be failed or
not). Future features can use this change to collect
other metrics like failed metrics.