### PR TITLE
bugfix: ZENKO-638 Use query params for API route

### DIFF
--- a/lib/api/BackbeatRequest.js
+++ b/lib/api/BackbeatRequest.js
@@ -40,12 +40,13 @@ class BackbeatRequest {
      */
     _parseCRRRoutes(parts, query) {
         if (parts[1] && parts[1] === 'failed') {
+            const { versionId, marker } = querystring.parse(query);
             this._routeDetails.extension = parts[0];
             this._routeDetails.status = parts[1];
             this._routeDetails.bucket = parts[2];
-            this._routeDetails.key = parts[3];
-            this._routeDetails.versionId = parts[4];
-            this._routeDetails.marker = querystring.parse(query).marker;
+            this._routeDetails.key = parts.slice(3).join('/');
+            this._routeDetails.versionId = versionId;
+            this._routeDetails.marker = marker;
         } else {
             // for now: pause/resume/status
             this._routeDetails.extension = parts[0];

--- a/tests/functional/api/BackbeatServer.js
+++ b/tests/functional/api/BackbeatServer.js
@@ -557,7 +557,7 @@ describe('Backbeat Server', () => {
 
         const retryPaths = [
             '/_/crr/failed',
-            '/_/crr/failed/test-bucket/test-key/test-versionId',
+            '/_/crr/failed/test-bucket/test-key?versionId=test-versionId',
         ];
         retryPaths.forEach(path => {
             it(`should get a 200 response for route: ${path}`, done => {
@@ -772,9 +772,11 @@ describe('Backbeat Server', () => {
             });
 
             it('should get correct data for GET route: ' +
-            '/_/crr/failed/<bucket>/<key>/<versionId> when there is no key',
+            '/_/crr/failed/<bucket>/<key>?versionId=<versionId> when there ' +
+            'is no key',
             done => {
-                getRequest('/_/crr/failed/test-bucket/test-key/test-versionId',
+                getRequest('/_/crr/failed/test-bucket/test-key?' +
+                    'versionId=test-versionId',
                 (err, res) => {
                     assert.ifError(err);
                     assert.deepStrictEqual(res, {
@@ -786,16 +788,16 @@ describe('Backbeat Server', () => {
             });
 
             it('should get correct data for GET route: ' +
-            '/_/crr/failed/<bucket>/<key>/<versionId>', done => {
+            '/_/crr/failed/<bucket>/<key>?versionId=<versionId>', done => {
                 const keys = [
-                    'test-bucket:test-key:test-versionId:test-site',
-                    'test-bucket:test-key:test-versionId:test-site-2',
-                    'test-bucket-1:test-key-1:test-versionId-1:test-site',
+                    'test-bucket:test-key/a:test-versionId:test-site',
+                    'test-bucket:test-key/a:test-versionId:test-site-2',
+                    'test-bucket-1:test-key-1/a:test-versionId-1:test-site',
                 ];
                 setKey(redisClient, keys, err => {
                     assert.ifError(err);
-                    const route =
-                        '/_/crr/failed/test-bucket/test-key/test-versionId';
+                    const route = '/_/crr/failed/test-bucket/test-key/a?' +
+                        'versionId=test-versionId';
                     return getRequest(route, (err, res) => {
                         assert.ifError(err);
                         assert.strictEqual(res.IsTruncated, false);

--- a/tests/unit/api/BackbeatAPI.spec.js
+++ b/tests/unit/api/BackbeatAPI.spec.js
@@ -28,7 +28,8 @@ describe('BackbeatAPI', () => {
             { url: '/_/metrics/crr/all/failures', method: 'GET' },
             { url: '/_/metrics/crr/all/throughput', method: 'GET' },
             { url: '/_/monitoring/metrics', method: 'GET' },
-            { url: '/_/crr/failed/mybucket/mykey/vId', method: 'GET' },
+            { url: '/_/crr/failed/mybucket/mykey?versionId=test-myvId',
+                method: 'GET' },
             { url: '/_/crr/failed?mymarker', method: 'GET' },
             // invalid params but will default to getting all buckets
             { url: '/_/crr/failed/mybucket', method: 'GET' },

--- a/tests/unit/api/BackbeatRequest.spec.js
+++ b/tests/unit/api/BackbeatRequest.spec.js
@@ -58,7 +58,7 @@ describe('BackbeatRequest helper class', () => {
             assert.strictEqual(req2.getHTTPMethod(), 'POST');
 
             const req3 = new BackbeatRequest({
-                url: '/_/crr/failed/mybucket/mykey/myvId',
+                url: '/_/crr/failed/mybucket/mykey?versionId=myvId',
                 method: 'GET',
             });
             const details3 = req3.getRouteDetails();


### PR DESCRIPTION
For the GET failed CRR API route `/_/crr/failed/<bucket>/<key>/<versionId>` use query params instead to properly handle key names with `/` character.

Route is thus updated to `/_/crr/failed/<bucket>/<key>?versionId=<version-id>`.