### PR TITLE
Bugfix: ZENKO-621 Failed CRR metrics retry

### DIFF
--- a/extensions/replication/utils/ObjectFailureEntry.js
+++ b/extensions/replication/utils/ObjectFailureEntry.js
@@ -16,7 +16,7 @@ class ObjectFailureEntry {
             schema.shift(); // Test keys are prefixed with 'test:'.
         }
         const [service, extension, status, bucket, objectKey, encodedVersionId,
-            site] = schema;
+            site, timestamp] = schema;
         this.service = service;
         this.extension = extension;
         this.status = status;
@@ -24,7 +24,12 @@ class ObjectFailureEntry {
         this.objectKey = objectKey;
         this.encodedVersionId = encodedVersionId;
         this.site = site;
+        this.timestamp = timestamp;
         this.sourceRole = role;
+    }
+
+    getTimestamp() {
+        return this.timestamp;
     }
 
     getRedisKey() {

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -502,6 +502,69 @@ class BackbeatAPI {
     }
 
     /**
+     * Find the matching metric timestamp key and decrement it accordingly.
+     * @param {Array} keys - Array of keys that matched the query string
+     * @param {Number} timestamp - The normalized timestamp of the failed key
+     * @param {Number} decrement - The value to decrement the matching key by
+     * @param {Function} cb - Callback to call
+     * @return {undefined}
+     */
+    _decrementIntervalKey(keys, timestamp, decrement, cb) {
+        if (keys.length === 0) {
+            return process.nextTick(cb);
+        }
+        const intervalKey = keys.find(key => {
+            const schema = key.split(':');
+            return timestamp === schema[schema.length - 1];
+        });
+        // Edge case in which the key was created immediately before the
+        // normalized interval has elapsed (e.g. 11:59:59).
+        if (!intervalKey) {
+            return process.nextTick(cb);
+        }
+        const cmds = [['decrby', intervalKey, decrement]];
+        return this._redis.batch(cmds, (err, res) => {
+            if (err) {
+                return cb(err);
+            }
+            const [cmdErr] = res[0];
+            return cb(cmdErr);
+        });
+    }
+
+    /**
+     * Decrement any existing failed metrics to account for the retry.
+     * @param {Number} timestamp - The normalized timestamp of the failed key
+     * @param {String} site - The site of the object
+     * @param {Number} contentLength - The size of the object
+     * @param {Function} cb - The callback to call
+     * @return {undefined}
+     */
+    _decrementFailedMetrics(timestamp, site, contentLength, cb) {
+        const opsFailQuerystring = `${site}:${redisKeys.opsFail}:*`;
+        const bytesFailQuerystring = `${site}:${redisKeys.bytesFail}:*`;
+        async.parallel([
+            // Decrement ops failed count by one
+            next => this._redis.scan(opsFailQuerystring, undefined,
+                (err, keys) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    return this._decrementIntervalKey(keys, timestamp, 1, next);
+                }),
+            // Decrement bytes failed by the size of the object which had failed
+            next => this._redis.scan(bytesFailQuerystring, undefined,
+                (err, keys) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    return this._decrementIntervalKey(keys, timestamp,
+                        contentLength, next);
+                }),
+        ], cb);
+    }
+
+    /**
      * Process the stringified kafka entries that were stored in Redis, passing
      * each to `_pushToCRRRetryKafkaTopics`. For each kafka entry, construct the
      * expected HTTP response, passed as the second argument to the callback.
@@ -520,7 +583,12 @@ class BackbeatAPI {
                     // key used to monitor the failure.
                     return this._deleteFailedCRRKey(entry.getRedisKey(), next);
                 }
-                return async.waterfall([
+                const timestamp = entry.getTimestamp();
+                const site = entry.getSite();
+                const contentLength = queueEntry.getContentLength();
+                return async.series([
+                    done => this._decrementFailedMetrics(timestamp, site,
+                        contentLength, done),
                     // Push Kafka entries to respective topics to initiate retry
                     done => this._pushToCRRRetryKafkaTopics(queueEntry, err => {
                         if (err) {
@@ -530,8 +598,8 @@ class BackbeatAPI {
                             Bucket: queueEntry.getBucket(),
                             Key: queueEntry.getObjectKey(),
                             VersionId: queueEntry.getEncodedVersionId(),
-                            StorageClass: entry.getSite(),
-                            Size: queueEntry.getContentLength(),
+                            StorageClass: site,
+                            Size: contentLength,
                             LastModified: queueEntry.getLastModified(),
                             ReplicationStatus: 'PENDING',
                         });
@@ -560,17 +628,24 @@ class BackbeatAPI {
         return async.eachLimit(reqBody, 10, (o, next) => {
             const { Bucket, Key, VersionId, StorageClass } = o;
             const key = getFailedCRRKey(Bucket, Key, VersionId, StorageClass);
-            const cmd = ['get', key];
-            return this._redis.batch([cmd], (err, res) => {
+            return this._redis.scan(`${key}:*`, undefined, (err, keys) => {
                 if (err) {
                     return next(err);
                 }
-                const [cmdErr, sourceRole] = res[0];
-                // If the key did not exist, value is `null`.
-                if (sourceRole !== null) {
-                    entries.push(new ObjectFailureEntry(key, sourceRole));
-                }
-                return next(cmdErr);
+                // There can only be one failed key. We are only using the glob
+                // because we do not know the original timestamp.
+                const [key] = keys;
+                return this._redis.batch([['get', key]], (err, res) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    const [cmdErr, sourceRole] = res[0];
+                    // If the key did not exist, value is `null`.
+                    if (sourceRole !== null) {
+                        entries.push(new ObjectFailureEntry(key, sourceRole));
+                    }
+                    return next(cmdErr);
+                });
             });
         }, err => {
             if (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -160,7 +160,7 @@
       "dev": true
     },
     "arsenal": {
-      "version": "github:scality/Arsenal#1a2ea2f3531e683e24ab533ac4b399a7a4f2d57e",
+      "version": "github:scality/Arsenal#0426f44deee43904a010c4bea472bdda8ae8bbcd",
       "requires": {
         "ajv": "4.10.0",
         "async": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/scality/backbeat#readme",
   "dependencies": {
-    "arsenal": "scality/Arsenal#1a2ea2f",
+    "arsenal": "scality/Arsenal#0426f44",
     "async": "^2.3.0",
     "aws-sdk": "2.147.0",
     "backo": "^1.1.0",

--- a/tests/functional/api/BackbeatServer.js
+++ b/tests/functional/api/BackbeatServer.js
@@ -743,6 +743,7 @@ describe('Backbeat Server', () => {
             // Version ID calculated from the mock object MD.
             const testVersionId =
                 '39383530303038363133343437313939393939395247303031202030';
+            const testTimestamp = '0123456789';
 
             before(done => deleteKeys(redisClient, done));
 
@@ -762,7 +763,8 @@ describe('Backbeat Server', () => {
 
             it('should get correct data for GET route: /_/crr/failed when ' +
             'the key has been created and there is one key', done => {
-                const key = `test-bucket-1:test-key:${testVersionId}:test-site`;
+                const key = `test-bucket-1:test-key:${testVersionId}:` +
+                    `test-site:${testTimestamp}`;
                 setKey(redisClient, [key], err => {
                     assert.ifError(err);
                     getRequest('/_/crr/failed?marker=0', (err, res) => {
@@ -784,12 +786,15 @@ describe('Backbeat Server', () => {
             });
 
             it('should get correct data for GET route: /_/crr/failed when ' +
-            'the key has been created and there are multiple key keys',
+            'the key has been created and there are multiple keys',
             done => {
                 const keys = [
-                    'test-bucket:test-key:test-versionId:test-site',
-                    'test-bucket-1:test-key-1:test-versionId-1:test-site-1',
-                    'test-bucket-2:test-key-2:test-versionId-2:test-site-2',
+                    'test-bucket:test-key:test-versionId:test-site:' +
+                        `${testTimestamp}`,
+                    'test-bucket-1:test-key-1:test-versionId-1:test-site-1:' +
+                        `${testTimestamp}`,
+                    'test-bucket-2:test-key-2:test-versionId-2:test-site-2:' +
+                        `${testTimestamp}`,
                 ];
                 setKey(redisClient, keys, err => {
                     assert.ifError(err);
@@ -827,11 +832,16 @@ describe('Backbeat Server', () => {
                     }
                     return async.timesLimit(2000, 10, (i, next) => {
                         const keys = [
-                            `bucket-${i}:key-${i}:versionId-${i}:site-${i}-a`,
-                            `bucket-${i}:key-${i}:versionId-${i}:site-${i}-b`,
-                            `bucket-${i}:key-${i}:versionId-${i}:site-${i}-c`,
-                            `bucket-${i}:key-${i}:versionId-${i}:site-${i}-d`,
-                            `bucket-${i}:key-${i}:versionId-${i}:site-${i}-e`,
+                            `bucket-${i}:key-${i}:versionId-${i}:site-${i}-a:` +
+                                `${testTimestamp}`,
+                            `bucket-${i}:key-${i}:versionId-${i}:site-${i}-b:` +
+                                `${testTimestamp}`,
+                            `bucket-${i}:key-${i}:versionId-${i}:site-${i}-c:` +
+                                `${testTimestamp}`,
+                            `bucket-${i}:key-${i}:versionId-${i}:site-${i}-d:` +
+                                `${testTimestamp}`,
+                            `bucket-${i}:key-${i}:versionId-${i}:site-${i}-e:` +
+                                `${testTimestamp}`,
                         ];
                         setKey(redisClient, keys, next);
                     }, err => {
@@ -886,9 +896,12 @@ describe('Backbeat Server', () => {
             it('should get correct data for GET route: ' +
             '/_/crr/failed/<bucket>/<key>?versionId=<versionId>', done => {
                 const keys = [
-                    'test-bucket:test-key/a:test-versionId:test-site',
-                    'test-bucket:test-key/a:test-versionId:test-site-2',
-                    'test-bucket-1:test-key-1/a:test-versionId-1:test-site',
+                    'test-bucket:test-key/a:test-versionId:test-site:' +
+                        `${testTimestamp}`,
+                    'test-bucket:test-key/a:test-versionId:test-site-2:' +
+                        `${testTimestamp}`,
+                    'test-bucket-1:test-key-1/a:test-versionId-1:test-site:' +
+                        `${testTimestamp}`,
                 ];
                 setKey(redisClient, keys, err => {
                     assert.ifError(err);
@@ -934,11 +947,14 @@ describe('Backbeat Server', () => {
             });
 
             it('should get correct data for POST route: /_/crr/failed ' +
-            'when there are multiple matching key keys', done => {
+            'when there are multiple matching keys', done => {
                 const keys = [
-                    `test-bucket:test-key:${testVersionId}:test-site-1`,
-                    `test-bucket:test-key:${testVersionId}:test-site-2`,
-                    `test-bucket:test-key:${testVersionId}:test-site-3`,
+                    `test-bucket:test-key:${testVersionId}:test-site-1:` +
+                        `${testTimestamp}`,
+                    `test-bucket:test-key:${testVersionId}:test-site-2:` +
+                        `${testTimestamp}`,
+                    `test-bucket:test-key:${testVersionId}:test-site-3:` +
+                        `${testTimestamp}`,
                 ];
                 setKey(redisClient, keys, err => {
                     assert.ifError(err);
@@ -1032,11 +1048,16 @@ describe('Backbeat Server', () => {
                         StorageClass: `site-${i}-e`,
                     });
                     const keys = [
-                        `bucket-${i}:key-${i}:${testVersionId}:site-${i}-a`,
-                        `bucket-${i}:key-${i}:${testVersionId}:site-${i}-b`,
-                        `bucket-${i}:key-${i}:${testVersionId}:site-${i}-c`,
-                        `bucket-${i}:key-${i}:${testVersionId}:site-${i}-d`,
-                        `bucket-${i}:key-${i}:${testVersionId}:site-${i}-e`,
+                        `bucket-${i}:key-${i}:${testVersionId}:site-${i}-a:` +
+                            `${testTimestamp}`,
+                        `bucket-${i}:key-${i}:${testVersionId}:site-${i}-b:` +
+                            `${testTimestamp}`,
+                        `bucket-${i}:key-${i}:${testVersionId}:site-${i}-c:` +
+                            `${testTimestamp}`,
+                        `bucket-${i}:key-${i}:${testVersionId}:site-${i}-d:` +
+                            `${testTimestamp}`,
+                        `bucket-${i}:key-${i}:${testVersionId}:site-${i}-e:` +
+                            `${testTimestamp}`,
                     ];
                     setKey(redisClient, keys, next);
                 }, err => {

--- a/tests/unit/replication/ObjectFailureEntry.spec.js
+++ b/tests/unit/replication/ObjectFailureEntry.spec.js
@@ -4,7 +4,8 @@ const ObjectFailureEntry =
     require('../../../extensions/replication/utils/ObjectFailureEntry');
 
 describe('ObjectFailureEntry helper class', () => {
-    const key = 'bb:crr:failed:test-bucket:test-key:test-versionId:test-site';
+    const key = 'bb:crr:failed:test-bucket:test-key:test-versionId:test-site:' +
+        '0123456789';
     const role = 'arn:aws:iam::604563867484:test-role';
     const entry = new ObjectFailureEntry(key, role);
 
@@ -32,7 +33,10 @@ describe('ObjectFailureEntry helper class', () => {
     it('should get the site', () =>
         assert.strictEqual(entry.getSite(), 'test-site'));
 
-    it('should get the replicationr oles', () =>
+    it('should get the timestamp', () =>
+        assert.strictEqual(entry.getTimestamp(), '0123456789'));
+
+    it('should get the replication roles', () =>
         assert.strictEqual(entry.getReplicationRoles(), role));
 
     it('should get the log info', () =>


### PR DESCRIPTION
Depends on https://github.com/scality/Arsenal/pull/531.

If a failed CRR object is being retried, find any keys tracking failed metrics for the site and decrement the bytes failed and ops failed of the latest key. Failed metrics thus accounts for any retried objects.