### PR TITLE
bf: ZENKO-688 exit backbeat processes when start() fails

### DIFF
--- a/extensions/lifecycle/conductor/service.js
+++ b/extensions/lifecycle/conductor/service.js
@@ -24,7 +24,7 @@ lcConductor.start(err => {
     if (err) {
         logger.error('error during lifecycle conductor initialization',
                      { error: err.message });
-        return undefined;
+        process.exit(1);
     }
     healthServer.onReadyCheck(log => {
         if (lcConductor.isReady()) {

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -426,14 +426,14 @@ class QueueProcessor extends EventEmitter {
             if (err) {
                 this.logger.info('error setting up metrics producer',
                                  { error: err.message });
-                return undefined;
+                process.exit(1);
             }
             return this._setupProducer(err => {
                 let consumerReady = false;
                 if (err) {
                     this.logger.info('error setting up kafka producer',
                                      { error: err.message });
-                    return undefined;
+                    process.exit(1);
                 }
                 if (options && options.disableConsumer) {
                     this.emit('ready');


### PR DESCRIPTION
Add process.exit(1) calls where backbeat components cannot initialize
correctly (typically due to other dependent services not being ready
yet), so k8s can restart them with back-off.

This was done in a couple places already but some other places were
missing leading to processing being stuck in "not ready" state.