### PR TITLE
bugfix: ZENKO-621 Check redis command error

### DIFF
--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -640,11 +640,14 @@ class BackbeatAPI {
                         return next(err);
                     }
                     const [cmdErr, sourceRole] = res[0];
+                    if (cmdErr) {
+                        return next(cmdErr);
+                    }
                     // If the key did not exist, value is `null`.
-                    if (sourceRole !== null) {
+                    if (sourceRole) {
                         entries.push(new ObjectFailureEntry(key, sourceRole));
                     }
-                    return next(cmdErr);
+                    return next();
                 });
             });
         }, err => {


### PR DESCRIPTION
If Redis' command error is a truthy value, `sourceRole` will be `undefined` so we need to first check for the error.