### PR TITLE
FIX: ZENKO-701 CRR stats error ":preferred_read" issue

### DIFF
--- a/lib/MetricsConsumer.js
+++ b/lib/MetricsConsumer.js
@@ -61,6 +61,10 @@ class MetricsConsumer {
             this.logger.info('metrics processor is ready to consume entries');
         });
     }
+    _removePreferredRead(site) {
+        return site.endsWith(':preferred_read') ?
+            site.split(':')[0] : site;
+    }
 
     _sendSiteLevelRequests(data) {
         const { type, site, ops, bytes } = data;
@@ -123,6 +127,9 @@ class MetricsConsumer {
             });
             log.end();
             return done();
+        }
+        if (data.site) {
+            data.site = this._removePreferredRead(data.site);
         }
         if (data.bucketName && data.objectKey && data.versionId) {
             this._sendObjectLevelRequests(data);


### PR DESCRIPTION
Remove ":preferred_read" suffix from Kafka metrics entry site