### PR TITLE
bugfix: ZENKO-623 Use a ranged GET for MPU replication

### DIFF
--- a/tests/unit/replication/MultipleBackendTask.js
+++ b/tests/unit/replication/MultipleBackendTask.js
@@ -2,8 +2,10 @@ const assert = require('assert');
 const MultipleBackendTask =
     require('../../../extensions/replication/tasks/MultipleBackendTask');
 
-const partSize = 1024 * 1024 * 1024 + 1;
 const MPU_GCP_MAX_PARTS = 1024;
+const MIN_AWS_PART_SIZE = (1024 * 1024) * 5; // 5MB
+const MAX_AWS_PART_SIZE = (1024 * 1024 * 1024) * 5; // 5GB
+const MAX_AWS_OBJECT_SIZE = (1024 * 1024 * 1024 * 1024) * 5; // 5TB
 
 describe('MultipleBackendTask', () => {
     const task = new MultipleBackendTask({
@@ -16,44 +18,173 @@ describe('MultipleBackendTask', () => {
         }),
     });
 
+    function checkPartLength(contentLength, expectedPartSize) {
+        const partSize = task._getRangeSize(contentLength);
+        assert.strictEqual(partSize, expectedPartSize);
+    }
+
+    describe('::_getRangeSize', () => {
+        it('should get correct part sizes', () => {
+            checkPartLength(0, 0);
+            checkPartLength(1, 1);
+            checkPartLength((1024 * 1024) * 16, (1024 * 1024) * 16);
+            checkPartLength(((1024 * 1024) * 16) + 1, (1024 * 1024) * 16);
+            for (let size = (1024 * 1024) * 16;
+                size <= (1024 * 1024) * 512;
+                size *= 2) {
+                checkPartLength((size * 1000), size);
+                // 512MB part sizes should allow for up to 10K parts.
+                if (size === (1024 * 1024) * 512) {
+                    checkPartLength((size * 1000) + 1, size);
+                } else {
+                    checkPartLength((size * 1000) + 1, size * 2);
+                }
+            }
+            checkPartLength(MAX_AWS_OBJECT_SIZE, 1024 * 1024 * 1024);
+        });
+    });
+
     describe('::_getRanges', () => {
-        it('should get a list of ranges with content length 1025', () => {
-            const ranges = task._getRanges(1025);
-            assert.strictEqual(513, ranges.length);
-            assert.deepStrictEqual(ranges[0], {
-                start: 0,
-                end: 1,
-            });
-            assert.deepStrictEqual(ranges[1], {
-                start: 2,
-                end: 3,
-            });
-            assert.deepStrictEqual(ranges[ranges.length - 1], {
-                start: 1024,
-                end: 1024,
-            });
+        it('should get a list of ranges with content length 0B', () => {
+            const ranges = task._getRanges(0, false);
+            assert.strictEqual(ranges.length, 1);
+            assert.strictEqual(ranges[0], null);
         });
 
-        it('should get a list of ranges with content length 1026', () => {
-            const ranges = task._getRanges(1026);
-            assert.deepStrictEqual(ranges[0], {
-                start: 0,
-                end: 1,
+        it('should get a list of ranges with content length 1B', () => {
+            const ranges = task._getRanges(1, false);
+            assert.strictEqual(ranges.length, 1);
+            const expected = { start: 0, end: 0 };
+            assert.deepStrictEqual(ranges[0], expected);
+        });
+
+        it('should get a list of ranges with content length 5MB + 1B', () => {
+            const ranges = task._getRanges(MIN_AWS_PART_SIZE, false);
+            assert.strictEqual(ranges.length, 1);
+            const expected = { start: 0, end: MIN_AWS_PART_SIZE - 1 };
+            assert.deepStrictEqual(ranges[0], expected);
+        });
+
+        it('should get a list of ranges with content length 16MB', () => {
+            const contentLength = (1024 * 1024) * 16; // 16MB
+            const ranges = task._getRanges(contentLength, false);
+            assert.strictEqual(ranges.length, 1);
+            const expected = { start: 0, end: (1024 * 1024) * 16 - 1 };
+            assert.deepStrictEqual(ranges[0], expected);
+        });
+
+        it('should get a list of ranges with content length 16MB + 1B', () => {
+            const contentLength = ((1024 * 1024) * 16) + 1;
+            const ranges = task._getRanges(contentLength, false);
+            assert.strictEqual(ranges.length, 2);
+            let expected = { start: 0, end: ((1024 * 1024) * 16) - 1 };
+            assert.deepStrictEqual(ranges[0], expected);
+            expected = { start: contentLength - 1, end: contentLength - 1 };
+            assert.deepStrictEqual(ranges[ranges.length - 1], expected);
+        });
+
+        it('should get a list of ranges with content length of 16000MB', () => {
+            const sixteenMB = (1024 * 1024) * 16;
+            const contentLength = ((1024 * 1024) * 16) * 1000;
+            const ranges = task._getRanges(contentLength, false);
+            assert.strictEqual(ranges.length, 1000);
+            let expected = { start: 0, end: sixteenMB - 1 };
+            assert.deepStrictEqual(ranges[0], expected);
+            expected = { start: sixteenMB, end: (sixteenMB * 2) - 1 };
+            assert.deepStrictEqual(ranges[1], expected);
+            expected = {
+                start: sixteenMB * (ranges.length - 1),
+                end: contentLength - 1,
+            };
+            assert.deepStrictEqual(ranges[ranges.length - 1], expected);
+        });
+
+        it('should get a list of ranges with content length 16000MB + 1B',
+        () => {
+            const contentLength = (((1024 * 1024) * 16) * 1000) + 1;
+            const ranges = task._getRanges(contentLength, false);
+            assert.strictEqual(ranges.length, 501);
+            const thirtyTwoMB = (1024 * 1024) * 32;
+            let expected = { start: 0, end: thirtyTwoMB - 1 };
+            assert.deepStrictEqual(ranges[0], expected);
+            expected = { start: thirtyTwoMB, end: (thirtyTwoMB * 2) - 1 };
+            assert.deepStrictEqual(ranges[1], expected);
+            expected = { start: contentLength - 1, end: contentLength - 1 };
+            assert.deepStrictEqual(ranges[ranges.length - 1], expected);
+        });
+
+        it('should get a list of 10K ranges', () => {
+            const fiveHundredTwelveMB = (1024 * 1024) * 512;
+            const contentLength = fiveHundredTwelveMB * 10000;
+            const ranges = task._getRanges(contentLength, false);
+            assert.strictEqual(ranges.length, 10000);
+            let expected = { start: 0, end: fiveHundredTwelveMB - 1 };
+            assert.deepStrictEqual(ranges[0], expected);
+            expected = {
+                start: contentLength - fiveHundredTwelveMB,
+                end: contentLength - 1,
+            };
+            assert.deepStrictEqual(ranges[ranges.length - 1], expected);
+        });
+
+        it('should not exceed a list of 10K ranges', () => {
+            const oneGB = 1024 * 1024 * 1024;
+            const contentLength = (((1024 * 1024) * 512) * 10000) + 1;
+            const ranges = task._getRanges(contentLength, false);
+            assert.strictEqual(ranges.length, 5001);
+            let expected = { start: 0, end: oneGB - 1 };
+            assert.deepStrictEqual(ranges[0], expected);
+            expected = { start: contentLength - 1, end: contentLength - 1 };
+            assert.deepStrictEqual(ranges[ranges.length - 1], expected);
+        });
+
+        it('should get a list of ranges with content length 5TB', () => {
+            const contentLength = MAX_AWS_OBJECT_SIZE;
+            const oneGB = 1024 * 1024 * 1024;
+            const ranges = task._getRanges(contentLength, false);
+            assert.strictEqual(ranges.length, 5120);
+            let expected = { start: 0, end: oneGB - 1 };
+            assert.deepStrictEqual(ranges[0], expected);
+            expected = { start: contentLength - oneGB, end: contentLength - 1 };
+            assert.deepStrictEqual(ranges[ranges.length - 1], expected);
+        });
+
+        it('should ensure all parts of the original object are intact',
+        function test() {
+            this.timeout(10000);
+            const minMPUObjectSize = MIN_AWS_PART_SIZE + 1;
+            const contentLengths = [MAX_AWS_OBJECT_SIZE];
+            Array.from(Array(1024).keys()).forEach(n => {
+                for (let i = minMPUObjectSize + n;
+                    i <= MAX_AWS_OBJECT_SIZE;
+                    i *= 2) {
+                    contentLengths.push(i);
+                }
             });
-            assert.deepStrictEqual(ranges[1], {
-                start: 2,
-                end: 3,
-            });
-            assert.deepStrictEqual(ranges[ranges.length - 1], {
-                start: 1024,
-                end: 1025,
+            contentLengths.forEach(contentLength => {
+                const ranges = task._getRanges(contentLength, false);
+                assert(ranges.length <= 10000);
+                let sum = 0;
+                for (let i = 0; i < ranges.length; i++) {
+                    const { start, end } = ranges[i];
+                    const rangeSize = end - start + 1; // Range is inclusive.
+                    const isLastPart = i + 1 === ranges.length;
+                    assert(rangeSize >= isLastPart ? 1 : MIN_AWS_PART_SIZE);
+                    assert(rangeSize <= MAX_AWS_PART_SIZE);
+                    if (!isLastPart) {
+                        assert(rangeSize % 1024 === 0);
+                    }
+                    sum += rangeSize;
+                }
+                assert(sum === contentLength);
             });
         });
 
         it('should get <= 1024 ranges for part count 1025-10000', () => {
+            const partSize = 1024 * 1024 * 1024 + 1;
             Array.from(Array(10000 - 1024).keys()).forEach(n => {
                 const count = n + 1025;
-                const ranges = task._getRanges(count * partSize);
+                const ranges = task._getRanges(count * partSize, true);
                 const contentLen = count * partSize;
                 const pow = Math.pow(2,
                     Math.ceil(Math.log(contentLen) / Math.log(2)));


### PR DESCRIPTION
Use ranged gets for the source object instead of using a part number. A similar change needs to be applied for CRR to a zenko destination in a separate, refactor PR to follow.

Rationale:

When the source object is stored in an external backend the location array does not include all the part information. Instead it stores the parts as a single element in the array (for example, [here](https://github.com/scality/S3/blob/development/8.0/lib/api/completeMultipartUpload.js#L211)):

```
[ { key: 'source-key',
    start: 0,
    size: 10485782,
    dataStoreName: 'source-location',
    dataStoreETag: 'dbff4c86d9f3daa594119662fb8e94b1-2' } ]
```

When this occurs, the multiple backend task attempts to retrieve the part number from the `dataStoreETag` value [here](https://github.com/scality/Arsenal/blob/development/8.0/lib/models/ObjectMDLocation.js#L46), but since the part numbers were never stored with the splitter `:`, we unintentionally send `NaN` as the part number resulting in the following logs:

```
{"name":"Backbeat:Replication:QueueProcessor","method":"MultipleBackendTask._putMPUPart","entry":{"bucket":"mehmeh","objectKey":"Transmit 5.0.5.zip","versionId":"98469702552383999999RG001 23.1","isDeleteMarker":""},"origin":"source","peer":{"host":"zenko-cloudserver-replicator","port":8000},"error":"Part number must be a number.","httpStatus":400,"time":1530297452207,"req_id":"ccdf12d7104ba92bdb98","level":"error","message":"an error occurred on getObject from S3","hostname":"backbeat-consumer-5f768fd94c-n9jv9","pid":27}
```

While the object is replicated properly, this change has the affect that the destination ETag will differ from the source because the MPU parts are composed of different ranges.

This change means that we create MPUs with part counts between 2 and 10,000. The sizes target a part count between 500-1000 parts for larger objects, starting with 16MB part sizes and increasing exponentially from there up to 1GB part sizes.