### PR TITLE
bugfix: ZENKO-793 GCP MPU range calculation

### DIFF
--- a/extensions/replication/tasks/MultipleBackendTask.js
+++ b/extensions/replication/tasks/MultipleBackendTask.js
@@ -341,8 +341,12 @@ class MultipleBackendTask extends ReplicateObject {
      * @return {Number} The range size to use
      */
     _getGCPRangeSize(contentLen) {
-        const pow = Math.pow(2, Math.ceil(Math.log(contentLen) / Math.log(2)));
-        const rangeSize = Math.ceil(pow / MPU_GCP_MAX_PARTS);
+        let rangeSize = this._getRangeSize(contentLen);
+        if (contentLen / rangeSize > MPU_GCP_MAX_PARTS) {
+            const pow =
+                Math.pow(2, Math.ceil(Math.log(contentLen) / Math.log(2)));
+            rangeSize = Math.ceil(pow / MPU_GCP_MAX_PARTS);
+        }
         return rangeSize;
     }
 

--- a/tests/unit/replication/MultipleBackendTask.js
+++ b/tests/unit/replication/MultipleBackendTask.js
@@ -180,6 +180,21 @@ describe('MultipleBackendTask', () => {
             });
         });
 
+        it('should get single part count for GCP', () => {
+            const contentLength = (1024 * 1024) * 5;
+            const ranges = task._getRanges(contentLength, true);
+            assert(ranges.length === 1);
+        });
+
+        it('should use GCP calculation for ranges exceeding 512MB * 1024',
+        () => {
+            const contentLength = ((1024 * 1024) * 512) * 1024;
+            let ranges = task._getRanges(contentLength, true);
+            assert(ranges.length === 1024);
+            ranges = task._getRanges(contentLength + 1, true);
+            assert(ranges.length === 513);
+        });
+
         it('should get <= 1024 ranges for part count 1025-10000', () => {
             const partSize = 1024 * 1024 * 1024 + 1;
             Array.from(Array(10000 - 1024).keys()).forEach(n => {


### PR DESCRIPTION
When uploading a small object to GCP, the `_getGCPRangeSize` was being used outright and could potentially calculate a high number of small parts. This is inefficient and potentially results in an invalid part size upon completion of the MPU. Instead, we want to first use `_getRangeSize` to ensure the minimum part size is met and then only use `_getGCPRangeSize` when the part count exceeds `MPU_GCP_MAX_PARTS` (i.e. 1024 parts).