### PR TITLE
bf: ZENKO-812 fix LifecycleTask tags matching

### DIFF
--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -385,22 +385,22 @@ class LifecycleTask extends BackbeatTask {
             if (rule.Status === 'Disabled') {
                 return false;
             }
-            if (rule.Filter && rule.Filter.And) {
-                // multiple tags or prefix w/ tag(s)
-                const prefix = rule.Filter.And.Prefix;
-                if (prefix && !item.Key.startsWith(prefix)) {
-                    return false;
-                }
-                return deepCompare(rule.Filter.And.Tags, objTags.TagSet);
-            }
-            // only one prefix or one tag to compare in this rule
+            // check all locations where prefix could possibly be
             const prefix = rule.Prefix ||
-                (rule.Filter && rule.Filter.Prefix);
+                  (rule.Filter && (rule.Filter.And ?
+                                   rule.Filter.And.Prefix :
+                                   rule.Filter.Prefix));
             if (prefix && !item.Key.startsWith(prefix)) {
                 return false;
             }
-            if (rule.Filter && rule.Filter.Tag && objTags.TagSet) {
-                return deepCompare([rule.Filter.Tag], objTags.TagSet);
+            if (!rule.Filter) {
+                return true;
+            }
+            const tags = rule.Filter.And ?
+                  rule.Filter.And.Tags :
+                  (rule.Filter.Tag && [rule.Filter.Tag]);
+            if (tags && !deepCompare(tags, objTags.TagSet || [])) {
+                return false;
             }
             return true;
         });

--- a/tests/unit/lifecycle/LifecycleTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleTask.spec.js
@@ -217,37 +217,13 @@ describe('lifecycle task helper methods', () => {
                 LastModified: CURRENT,
             };
             const objTags = { TagSet: [] };
-            const res = lct._filterRules(mBucketRules, item, objTags);
-            assert.strictEqual(res.length, 1);
-            assert.deepStrictEqual(getRuleIDs(res), ['task-9']);
+            const objNoTagSet = {};
+            [objTags, objNoTagSet].forEach(obj => {
+                const res = lct._filterRules(mBucketRules, item, obj);
+                assert.strictEqual(res.length, 1);
+                assert.deepStrictEqual(getRuleIDs(res), ['task-9']);
+            });
         });
-    });
-
-    it('should filter correctly for an object with no tags', () => {
-        const mBucketRules = [
-            new Rule().addID('task-1').addTag('tag1', 'val1')
-                .addTag('tag2', 'val1').build(),
-            new Rule().addID('task-2').addTag('tag1', 'val1').build(),
-            new Rule().addID('task-3').addTag('tag2', 'val1').build(),
-            new Rule().addID('task-4').addTag('tag2', 'false').build(),
-            new Rule().addID('task-5').addTag('tag2', 'val1')
-                .addTag('tag1', 'false').build(),
-            new Rule().addID('task-6').addTag('tag2', 'val1')
-                .addTag('tag1', 'val1').build(),
-            new Rule().addID('task-7').addTag('tag2', 'val1')
-                .addTag('tag1', 'val1').addTag('tag3', 'val1').build(),
-            new Rule().addID('task-8').addTag('tag2', 'val1')
-                .addTag('tag1', 'val1').addTag('tag3', 'false').build(),
-            new Rule().addID('task-9').build(),
-        ];
-        const item = {
-            Key: 'example-item',
-            LastModified: CURRENT,
-        };
-        const objTags = { TagSet: [] };
-        const res = lct._filterRules(mBucketRules, item, objTags);
-        assert.strictEqual(res.length, 1);
-        assert.deepStrictEqual(getRuleIDs(res), ['task-9']);
     });
 
     describe('_getApplicableRules', () => {


### PR DESCRIPTION
Two important fixes in tags matching:

- do not crash when object has a no TagSet at all and a tag matching
  rule nesting tags with 'And'

- fix matching for objects with no TagSet at all (was selecting all
  such objects before when a tag-matching rule was present)

Side improvements:

- remove duplicate unit test

- rework code flow of LifecycleTask_filterRules() to avoid duplicating
  check logic