### PR TITLE
bugfix: ZENKO-818 sensitive config in debug log

### DIFF
--- a/lib/management/index.js
+++ b/lib/management/index.js
@@ -69,7 +69,7 @@ function loadOverlayVersion(metadata, version, cb) {
             return cb(err);
         }
         const convConf = convertOverlayFormat(val);
-        logger.debug('converted config', { convConf });
+        logger.debug('converted overlay config to newest format');
         return cb(null, convConf);
     });
 }


### PR DESCRIPTION
Do not display sensitive config containing secrets in debug logs from
management layer