### PR TITLE
bf: ZENKO-763 update mongo log consumer

### DIFF
--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -279,7 +279,7 @@ class LogReader {
             this.log.debug(
                 'readRecords callback',
                 { method: 'LogReader._processReadRecords',
-                    params, info: res.info });
+                    params });
             batchState.logRes = res;
             return done();
         });
@@ -300,14 +300,13 @@ class LogReader {
     _processPrepareEntries(batchState, done) {
         const { entriesToPublish, logRes, logStats } = batchState;
 
-        if (logRes.info.start === null) {
+        // for raft log only
+        if (logRes.info && logRes.info.start === null) {
             return done(null);
         }
-
         logRes.log.on('data', record => {
             this.log.debug('received log data',
-                           { nbEntries: record.entries.length,
-                             info: logRes.info });
+                           { nbEntries: record.entries.length });
             logStats.nbLogRecordsRead += 1;
 
             this._setEntryBatch(entriesToPublish);
@@ -325,11 +324,12 @@ class LogReader {
             return done(err);
         });
         logRes.log.on('end', () => {
-            this.log.debug('ending record stream', { info: logRes.info });
+            this.log.debug('ending record stream');
             return done();
         });
-        logRes.log.on('info', data => {
-            logRes.info = data;
+        logRes.log.on('info', info => {
+            this.log.debug('received record stream "info" event', { info });
+            logRes.info = info;
         });
         return undefined;
     }
@@ -361,15 +361,13 @@ class LogReader {
     _processPublishEntries(batchState, done) {
         const { entriesToPublish, logRes, logStats } = batchState;
 
-        if (logRes.info.start === null) {
+        // for raft log only
+        if (logRes.info && logRes.info.start === null) {
             return done();
         }
 
         if (config.queuePopulator.logSource === 'mongo') {
-            // We need to store both the timestamp and uniq Oplog id for MongoDB
-            // oplogs, so we concat the string to be '${timestamp}|${uniqID}'
-            batchState.nextLogOffset =
-            `${logRes.info.end.toString()}|${logRes.info.uniqID.toString()}`;
+            batchState.nextLogOffset = logRes.info.end;
         } else {
             batchState.nextLogOffset =
                 logRes.info.start + logStats.nbLogRecordsRead;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/scality/backbeat#readme",
   "dependencies": {
-    "arsenal": "scality/Arsenal#0426f44",
+    "arsenal": "scality/Arsenal#9fb5b8b",
     "async": "^2.3.0",
     "aws-sdk": "2.147.0",
     "backo": "^1.1.0",


### PR DESCRIPTION
- update arsenal dependency

- use the log offset returned as an opaque string

- do not rely on 'info' event being sent at the beginning of the
  stream

Relies on https://github.com/scality/Arsenal/pull/541