### PR TITLE
improvement: ZENKO-762 use redis ha for all redis needs

### DIFF
--- a/bin/queuePopulator.js
+++ b/bin/queuePopulator.js
@@ -9,7 +9,7 @@ const kafkaConfig = config.kafka;
 const extConfigs = config.extensions;
 const qpConfig = config.queuePopulator;
 const mConfig = config.metrics;
-const rLocalCacheConfig = config.localCache;
+const rConfig = config.redis;
 const QueuePopulator = require('../lib/queuePopulator/QueuePopulator');
 const zookeeper = require('node-zookeeper-client');
 
@@ -48,7 +48,7 @@ function queueBatch(queuePopulator, taskState) {
 /* eslint-enable no-param-reassign */
 
 const queuePopulator = new QueuePopulator(zkConfig, kafkaConfig,
-    qpConfig, mConfig, rLocalCacheConfig, extConfigs);
+    qpConfig, mConfig, rConfig, extConfigs);
 
 const healthServer = new HealthProbeServer({
     bindAddress: config.healthcheckServer.bindAddress,

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -11,7 +11,6 @@ const Logger = require('werelogs').Logger;
 const errors = require('arsenal').errors;
 const RoundRobin = require('arsenal').network.RoundRobin;
 
-const config = require('../../../conf/Config');
 const BackbeatProducer = require('../../../lib/BackbeatProducer');
 const BackbeatConsumer = require('../../../lib/BackbeatConsumer');
 const VaultClientCache = require('../../../lib/clients/VaultClientCache');
@@ -96,7 +95,7 @@ class QueueProcessor extends EventEmitter {
         this.destHTTPAgent = new http.Agent({ keepAlive: true });
 
         this._setupVaultclientCache();
-        this._setupRedis();
+        this._setupRedis(redisConfig);
 
         // FIXME support multiple scality destination sites
         if (Array.isArray(destConfig.bootstrapList)) {
@@ -217,13 +216,12 @@ class QueueProcessor extends EventEmitter {
     /**
      * Setup the Redis Subscriber which listens for actions from other processes
      * (i.e. BackbeatAPI for pause/resume)
+     * @param {object} redisConfig - redis ha config
      * @return {undefined}
      */
-    _setupRedis() {
-        // TODO: cleanup
-        const localCache = config.localCache;
+    _setupRedis(redisConfig) {
         // redis pub/sub for pause/resume
-        const redis = new Redis(localCache);
+        const redis = new Redis(redisConfig);
         // redis subscribe to site specific channel
         const channelName = `${this.repConfig.topic}-${this.site}`;
         redis.subscribe(channelName, err => {

--- a/lib/MetricsConsumer.js
+++ b/lib/MetricsConsumer.js
@@ -18,21 +18,21 @@ const CONCURRENCY = 10;
 class MetricsConsumer {
     /**
      * @constructor
-     * @param {object} rLocalCacheConfig - redis local cache configuration
-     * @param {string} rLocalCacheConfig.host - redis local cache host
-     * @param {number} rLocalCacheConfig.port - redis local cache port
+     * @param {object} rConfig - redis ha configuration
+     * @param {string} rConfig.host - redis ha host
+     * @param {number} rConfig.port - redis ha port
      * @param {object} mConfig - metrics configurations
      * @param {string} mConfig.topic - metrics topic name
      * @param {object} kafkaConfig - kafka configurations
      * @param {string} kafkaConfig.hosts - kafka hosts
      *   as "host:port[/chroot]"
      */
-    constructor(rLocalCacheConfig, mConfig, kafkaConfig) {
+    constructor(rConfig, mConfig, kafkaConfig) {
         this.mConfig = mConfig;
         this.kafkaConfig = kafkaConfig;
 
         this.logger = new Logger('Backbeat:MetricsConsumer');
-        const redisClient = new RedisClient(rLocalCacheConfig, this.logger);
+        const redisClient = new RedisClient(rConfig, this.logger);
         this._siteStatsClient = new StatsModel(redisClient, INTERVAL,
             (EXPIRY + INTERVAL));
         this._objectStatsClient = new StatsModel(redisClient, INTERVAL,

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -52,7 +52,6 @@ class BackbeatAPI {
         this._queuePopulator = config.queuePopulator;
         this._kafkaHost = config.kafka.hosts;
         this._redisConfig = config.redis;
-        this._localCacheRedis = config.localCache;
         this._logger = logger;
 
         this._validSites = this._repConfig.destination.bootstrapList.map(
@@ -73,21 +72,19 @@ class BackbeatAPI {
             this._internalStart = Date.now();
         }
         // Redis instance for publishing messages to BackbeatConsumers
-        this._redisPublisher = new Redis(this._localCacheRedis);
+        this._redisPublisher = new Redis(this._redisConfig);
         this._backbeatMetadataProxy =
             new BackbeatMetadataProxy(this._repConfig.source);
         // Redis instance is used for getting/setting keys
-        this._redis = new RedisClient(this._redisConfig, this._logger);
+        this._redisClient = new RedisClient(this._redisConfig, this._logger);
         // Redis expiry increased by an additional interval so we can reference
         // the immediate older data for average throughput calculation
-        this._redisClient = new RedisClient(this._localCacheRedis,
-            this._logger);
         this._statsClient = new StatsModel(this._redisClient, INTERVAL,
             (EXPIRY + INTERVAL));
         this._objectStatsClient = new StatsModel(this._redisClient, INTERVAL,
             (OBJECT_MONITORING_EXPIRY + INTERVAL));
         const metricsConfig = {
-            redisConfig: this._localCacheRedis,
+            redisConfig: this._redisClient,
             validSites: this._validSites,
             internalStart: this._internalStart,
         };
@@ -348,7 +345,7 @@ class BackbeatAPI {
             response.NextMarker = Number.parseInt(cursor, 10);
         }
         return async.eachLimit(keys, 10, (key, next) =>
-            this._redis.batch([['get', key]], (err, res) => {
+            this._redisClient.batch([['get', key]], (err, res) => {
                 if (err) {
                     return next(err);
                 }
@@ -393,7 +390,7 @@ class BackbeatAPI {
      */
     _scanAllKeys(pattern, marker, allKeys, cb) {
         const cmd = ['scan', marker, 'MATCH', pattern, 'COUNT', 1000];
-        this._redis.batch([cmd], (err, res) => {
+        this._redisClient.batch([cmd], (err, res) => {
             if (err) {
                 return cb(err);
             }
@@ -479,7 +476,7 @@ class BackbeatAPI {
      */
     _deleteFailedCRRKey(key, cb) {
         const cmd = ['del', key];
-        return this._redis.batch([cmd], (err, res) => {
+        return this._redisClient.batch([cmd], (err, res) => {
             if (err) {
                 this._logger.error('error deleting redis key', {
                     method: 'BackbeatAPI._deleteFailedCRRKey',
@@ -523,7 +520,7 @@ class BackbeatAPI {
             return process.nextTick(cb);
         }
         const cmds = [['decrby', intervalKey, decrement]];
-        return this._redis.batch(cmds, (err, res) => {
+        return this._redisClient.batch(cmds, (err, res) => {
             if (err) {
                 return cb(err);
             }
@@ -545,7 +542,7 @@ class BackbeatAPI {
         const bytesFailQuerystring = `${site}:${redisKeys.bytesFail}:*`;
         async.parallel([
             // Decrement ops failed count by one
-            next => this._redis.scan(opsFailQuerystring, undefined,
+            next => this._redisClient.scan(opsFailQuerystring, undefined,
                 (err, keys) => {
                     if (err) {
                         return next(err);
@@ -553,7 +550,7 @@ class BackbeatAPI {
                     return this._decrementIntervalKey(keys, timestamp, 1, next);
                 }),
             // Decrement bytes failed by the size of the object which had failed
-            next => this._redis.scan(bytesFailQuerystring, undefined,
+            next => this._redisClient.scan(bytesFailQuerystring, undefined,
                 (err, keys) => {
                     if (err) {
                         return next(err);
@@ -628,14 +625,15 @@ class BackbeatAPI {
         return async.eachLimit(reqBody, 10, (o, next) => {
             const { Bucket, Key, VersionId, StorageClass } = o;
             const key = getFailedCRRKey(Bucket, Key, VersionId, StorageClass);
-            return this._redis.scan(`${key}:*`, undefined, (err, keys) => {
+            return this._redisClient.scan(`${key}:*`, undefined,
+            (err, keys) => {
                 if (err) {
                     return next(err);
                 }
                 // There can only be one failed key. We are only using the glob
                 // because we do not know the original timestamp.
                 const [key] = keys;
-                return this._redis.batch([['get', key]], (err, res) => {
+                return this._redisClient.batch([['get', key]], (err, res) => {
                     if (err) {
                         return next(err);
                     }

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -37,18 +37,18 @@ class QueuePopulator {
      *   configuration (mandatory if logSource is "mongo")
      * @param {Object} mConfig - metrics configuration object
      * @param {string} mConfig.topic - metrics topic
-     * @param {Object} rLocalCacheConfig - redis local cache configuration
+     * @param {Object} rConfig - redis ha configuration
      * @param {Object} extConfigs - configuration of extensions: keys
      *   are extension names and values are extension's config object.
      * object
      */
-    constructor(zkConfig, kafkaConfig, qpConfig, mConfig, rLocalCacheConfig,
+    constructor(zkConfig, kafkaConfig, qpConfig, mConfig, rConfig,
                 extConfigs) {
         this.zkConfig = zkConfig;
         this.kafkaConfig = kafkaConfig;
         this.qpConfig = qpConfig;
         this.mConfig = mConfig;
-        this.rLocalCacheConfig = rLocalCacheConfig;
+        this.rConfig = rConfig;
         this.extConfigs = extConfigs;
 
         this.log = new Logger('Backbeat:QueuePopulator');
@@ -112,7 +112,7 @@ class QueuePopulator {
 
     _setupMetricsClients(cb) {
         // Metrics Consumer
-        this._mConsumer = new MetricsConsumer(this.rLocalCacheConfig,
+        this._mConsumer = new MetricsConsumer(this.rConfig,
             this.mConfig, this.kafkaConfig);
         this._mConsumer.start();
 

--- a/tests/functional/api/BackbeatServer.js
+++ b/tests/functional/api/BackbeatServer.js
@@ -1311,24 +1311,23 @@ describe('Backbeat Server', () => {
             const body = JSON.stringify({ hours: 1 });
             makePOSTRequest(options, body, (err, res) => {
                 assert.ifError(err);
-                getResponseBody(res, err => {
-                    assert.ifError(err);
+                setTimeout(() => {
+                    getResponseBody(res, err => {
+                        assert.ifError(err);
 
-                    assert.strictEqual(cache1.length, 1);
-                    assert.deepStrictEqual(cache1[0].channel, channel1);
-
-                    const message = JSON.parse(cache1[0].message);
-                    assert.equal('resumeService', message.action);
-
-                    const date = new Date();
-                    const scheduleDate = new Date(message.date);
-                    assert(scheduleDate > date);
-
-                    // make sure the scheduled time does not exceed expected
-                    const millisecondPerHour = 60 * 60 * 1000;
-                    assert(scheduleDate - date <= millisecondPerHour);
-                    done();
-                });
+                        assert.strictEqual(cache1.length, 1);
+                        assert.deepStrictEqual(cache1[0].channel, channel1);
+                        const message = JSON.parse(cache1[0].message);
+                        assert.equal('resumeService', message.action);
+                        const date = new Date();
+                        const scheduleDate = new Date(message.date);
+                        assert(scheduleDate > date);
+                        // make sure the scheduled time does not exceed expected
+                        const millisecondPerHour = 60 * 60 * 1000;
+                        assert(scheduleDate - date <= millisecondPerHour);
+                        done();
+                    });
+                }, 1000);
             });
         });
 


### PR DESCRIPTION
This removes the reliance on redis local cache and makes redis ha
the only storage used for HA and persistence