### PR TITLE
ft: Add topic prefix to consumer and producer

### DIFF
--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -13,6 +13,8 @@ const zookeeper = require('node-zookeeper-client');
 const CONCURRENCY_DEFAULT = 1;
 const CLIENT_ID = 'BackbeatConsumer';
 
+const { withTopicPrefix } = require('./util/topic');
+
 class BackbeatConsumer extends EventEmitter {
 
     /**
@@ -84,7 +86,7 @@ class BackbeatConsumer extends EventEmitter {
         this._fromOffset = fromOffset;
         this._autoCommit = autoCommit;
         this._log = new Logger(CLIENT_ID);
-        this._topic = topic;
+        this._topic = withTopicPrefix(topic);
         this._groupId = groupId;
         this._queueProcessor = queueProcessor;
         this._concurrency = concurrency;
@@ -137,7 +139,10 @@ class BackbeatConsumer extends EventEmitter {
         }
         this._consumer = new kafka.KafkaConsumer(consumerParams);
         this._consumer.connect({ timeout: 10000 }, () => {
-            const opts = { topic: 'backbeat-sanitycheck', timeout: 10000 };
+            const opts = {
+                topic: withTopicPrefix('backbeat-sanitycheck'),
+                timeout: 10000,
+            };
             this._consumer.getMetadata(opts, err => {
                 if (err) {
                     this.emit('error', err);

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -6,6 +6,8 @@ const errors = require('arsenal').errors;
 const jsutil = require('arsenal').jsutil;
 const Logger = require('werelogs').Logger;
 
+const { withTopicPrefix } = require('./util/topic');
+
 // waits for an ack for messages
 const REQUIRE_ACKS = 1;
 // time in ms. to wait for acks from Kafka
@@ -54,7 +56,7 @@ class BackbeatProducer extends EventEmitter {
         const { kafka, topic, pollIntervalMs, messageMaxBytes } = validConfig;
         this._kafkaHosts = kafka.hosts;
         this._log = new Logger(CLIENT_ID);
-        this._topic = topic;
+        this._topic = withTopicPrefix(topic);
         this._ready = false;
         this._messageMaxBytes = messageMaxBytes || PRODUCER_MESSAGE_MAX_BYTES;
 
@@ -69,7 +71,10 @@ class BackbeatProducer extends EventEmitter {
         });
         this._ready = false;
         this._producer.connect({ timeout: 30000 }, () => {
-            const opts = { topic: 'backbeat-sanitycheck', timeout: 10000 };
+            const opts = {
+                topic: withTopicPrefix('backbeat-sanitycheck'),
+                timeout: 10000,
+            };
             this._producer.getMetadata(opts, err => {
                 if (err) {
                     this.emit('error', err);

--- a/lib/util/topic.js
+++ b/lib/util/topic.js
@@ -1,0 +1,10 @@
+function withTopicPrefix(topic) {
+    if (process.env.KAFKA_TOPIC_PREFIX) {
+        return process.env.KAFKA_TOPIC_PREFIX + topic;
+    }
+    return topic;
+}
+
+module.exports = {
+    withTopicPrefix,
+};

--- a/tests/unit/backbeatConsumer.js
+++ b/tests/unit/backbeatConsumer.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+
+const BackbeatConsumer = require('../../lib/BackbeatConsumer');
+
+const { kafka } = require('../config.json');
+
+describe('backbeatConsumer', () => {
+    it('should use default topic name without prefix', () => {
+        const backbeatConsumer = new BackbeatConsumer({
+            kafka,
+            groupId: 'unittest-group',
+            topic: 'my-test-topic',
+        });
+        assert.strictEqual(backbeatConsumer._topic, 'my-test-topic');
+    });
+
+    it('should use default topic name with prefix', () => {
+        process.env.KAFKA_TOPIC_PREFIX = 'testing.';
+        const backbeatConsumer = new BackbeatConsumer({
+            kafka,
+            groupId: 'unittest-group',
+            topic: 'my-test-topic',
+        });
+        assert.strictEqual(backbeatConsumer._topic, 'testing.my-test-topic');
+    });
+
+    afterEach(() => {
+        process.env.KAFKA_TOPIC_PREFIX = '';
+    });
+});
+

--- a/tests/unit/backbeatProducer.js
+++ b/tests/unit/backbeatProducer.js
@@ -24,4 +24,25 @@ describe('backbeatProducer', () => {
         });
         assert.strictEqual(backbeatProducer._messageMaxBytes, 1000);
     });
+
+    it('should use default topic name without prefix', () => {
+        const backbeatProducer = new BackbeatProducer({
+            kafka,
+            topic: 'my-test-topic',
+        });
+        assert.strictEqual(backbeatProducer._topic, 'my-test-topic');
+    });
+
+    it('should use default topic name with prefix', () => {
+        process.env.KAFKA_TOPIC_PREFIX = 'testing.';
+        const backbeatProducer = new BackbeatProducer({
+            kafka,
+            topic: 'my-test-topic',
+        });
+        assert.strictEqual(backbeatProducer._topic, 'testing.my-test-topic');
+    });
+
+    afterEach(() => {
+        process.env.KAFKA_TOPIC_PREFIX = '';
+    });
 });


### PR DESCRIPTION
For multi-tenancy (orbit sandboxes for example) kafka topics need to be prefixed. Per-topic docker-entrypoint fixups have proven unscalable so instead we enforce prefixes globally at the consumer/producer level.

This patch has been running production for a few weeks without any issues.