### PR TITLE
bf: ZENKO-917 publish consumer current offset to zk

### DIFF
--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -104,8 +104,6 @@ class BackbeatConsumer extends EventEmitter {
         this._publishOffsetsCronTimer = null;
         this._publishOffsetsCronActive = false;
 
-        this._committedOffsets = null;
-
         this._init();
         return this;
     }
@@ -307,18 +305,11 @@ class BackbeatConsumer extends EventEmitter {
             if (err === kafka.CODES.ERRORS.ERR__NO_OFFSET) {
                 return undefined;
             }
-            this._log.error('error committing offset to kafka',
-                            { errorCode: err });
-            return undefined;
+            this._log.error('error committing offsets to kafka',
+                            { errorCode: err, topicPartitions });
         }
         this._log.debug('commit offsets callback',
                         { topicPartitions });
-        // save latest committed offsets for backlog metrics
-        // NOTE: for an unknown reason, in some cases all partitions
-        // are published but only the committed ones have an offset
-        // field, so we pre-filter here.
-        this._committedOffsets =
-            topicPartitions.filter(p => p.offset !== undefined);
         return undefined;
     }
 
@@ -351,8 +342,23 @@ class BackbeatConsumer extends EventEmitter {
     }
 
     _publishOffsetsCron(cb) {
-        if (!this._committedOffsets || this._publishOffsetsCronActive) {
+        if (this._publishOffsetsCronActive) {
             // skipping
+            if (cb) {
+                return process.nextTick(cb);
+            }
+            return undefined;
+        }
+        let consumerOffsets;
+        try {
+            // NOTE: for an unknown reason, in some cases all
+            // partitions are published but some do not have a set
+            // consumer offset yet, so pre-filter here.
+            consumerOffsets = this._consumer.position()
+                .filter(p => p.offset !== undefined);
+        } catch (err) {
+            this._log.error('error getting consumer current offsets',
+                            { errorCode: err });
             if (cb) {
                 return process.nextTick(cb);
             }
@@ -360,7 +366,6 @@ class BackbeatConsumer extends EventEmitter {
         }
         this._publishOffsetsCronActive = true;
 
-        const consumerOffsets = this._committedOffsets;
         const topicOffsets = [];
         return async.each(consumerOffsets, (p, done) => {
             this._getLatestTopicOffset(p.partition, (err, topicOffset) => {


### PR DESCRIPTION
Change backlog control: instead of publishing committed offset which
may fail, publish consumer current offsets.

That prevents lifecycle from being in a situation where it cannot make
progress because of the backlog being reported as non-null, although
the original error was an offset commit issue, not an actual backlog
still being processed.