### PR TITLE
ft: increase metrics expiry window to 24hrs

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -75,14 +75,14 @@ for an object fails, failed object metrics are considered backlog.
 This route returns the replication completions in number of objects and number
 of total bytes transferred for the specified extension type and location.
 Completions are only collected up to an `EXPIRY` time, which is currently set
-to **15 minutes**.
+to **24 hours**.
 
 **Example Output**:
 
 ```
 "completions":{
     "description":"Number of completed replication operations (count) and number
-    of bytes transferred (size) in the last 900 seconds",
+    of bytes transferred (size) in the last 86400 seconds",
     "results":{
         "count":31,
         "size":"47.04"
@@ -95,14 +95,14 @@ to **15 minutes**.
 This route returns the replication failures in number of objects and number
 of total bytes for the specified extension type and location. Failures are
 collected only up to an `EXPIRY` time, currently set to a default
-**15 minutes**.
+**24 hours**.
 
 **Example Output**:
 
 ```
 "failures":{
     "description":"Number of failed replication operations (count) and bytes
-    (size) in the last 900 seconds",
+    (size) in the last 86400 seconds",
     "results":{
         "count":"5",
         "size":"10.12"
@@ -115,6 +115,9 @@ collected only up to an `EXPIRY` time, currently set to a default
 This route returns the current throughput in number of completed operations per
 second (or number of objects replicating per second) and number of total bytes
 completing per second for the specified type and location name.
+
+Note throughput is averaged over the past 15 minutes of data collected so this
+metric is really an average throughput.
 
 **Example Output**:
 
@@ -203,9 +206,9 @@ sends a Kafka entry, and when the CRR topic `BackbeatConsumer` consumes and
 processes its Kafka entries. The `MetricsConsumer` processes these Kafka metrics
 entries and produces to Redis.
 
-A single-location CRR entry produces four keys in total. The data points
+A single-location CRR entry produces up to six keys in total. The data points
 stored in Redis are saved in intervals (default of 5 minutes) and are available
-up to an expiry time (default of 15 minutes).
+up to an expiry time (default of 24 hours).
 
 An object CRR entry creates one key. An initial key is set when the CRR
 operation begins, storing the total size of the object to be replicated. Then,

--- a/lib/MetricsConsumer.js
+++ b/lib/MetricsConsumer.js
@@ -8,8 +8,7 @@ const redisKeys = require('../extensions/replication/constants').redisKeys;
 
 // StatsClient constant defaults for site metrics
 const INTERVAL = 300; // 5 minutes;
-const EXPIRY = 900; // 15 minutes
-const OBJECT_MONITORING_EXPIRY = 86400; // 24 hours
+const EXPIRY = 86400; // 24 hours
 
 // BackbeatConsumer constant defaults
 const CONSUMER_FETCH_MAX_BYTES = 5000020;
@@ -33,10 +32,7 @@ class MetricsConsumer {
 
         this.logger = new Logger('Backbeat:MetricsConsumer');
         const redisClient = new RedisClient(rConfig, this.logger);
-        this._siteStatsClient = new StatsModel(redisClient, INTERVAL,
-            (EXPIRY + INTERVAL));
-        this._objectStatsClient = new StatsModel(redisClient, INTERVAL,
-            (OBJECT_MONITORING_EXPIRY + INTERVAL));
+        this._statsClient = new StatsModel(redisClient, INTERVAL, EXPIRY);
     }
 
     start() {
@@ -65,14 +61,14 @@ class MetricsConsumer {
     _sendSiteLevelRequests(data) {
         const { type, site, ops, bytes } = data;
         if (type === 'completed') {
-            this._sendSiteLevelRequest(`${site}:${redisKeys.opsDone}`, ops);
-            this._sendSiteLevelRequest(`${site}:${redisKeys.bytesDone}`, bytes);
+            this._sendRequest(`${site}:${redisKeys.opsDone}`, ops);
+            this._sendRequest(`${site}:${redisKeys.bytesDone}`, bytes);
         } else if (type === 'failed') {
-            this._sendSiteLevelRequest(`${site}:${redisKeys.opsFail}`, ops);
-            this._sendSiteLevelRequest(`${site}:${redisKeys.bytesFail}`, bytes);
+            this._sendRequest(`${site}:${redisKeys.opsFail}`, ops);
+            this._sendRequest(`${site}:${redisKeys.bytesFail}`, bytes);
         } else if (type === 'queued') {
-            this._sendSiteLevelRequest(`${site}:${redisKeys.ops}`, ops);
-            this._sendSiteLevelRequest(`${site}:${redisKeys.bytes}`, bytes);
+            this._sendRequest(`${site}:${redisKeys.ops}`, ops);
+            this._sendRequest(`${site}:${redisKeys.bytes}`, bytes);
         }
         return undefined;
     }
@@ -82,11 +78,11 @@ class MetricsConsumer {
         if (type === 'completed') {
             const key = `${site}:${bucketName}:${objectKey}:` +
                 `${versionId}:${redisKeys.objectBytesDone}`;
-            this._sendObjectLevelRequest(key, bytes);
+            this._sendRequest(key, bytes);
         } else if (type === 'queued') {
             const key = `${site}:${bucketName}:${objectKey}:` +
                 `${versionId}:${redisKeys.objectBytes}`;
-            this._sendObjectLevelRequest(key, bytes);
+            this._sendRequest(key, bytes);
         }
         return undefined;
     }
@@ -133,12 +129,8 @@ class MetricsConsumer {
         return done();
     }
 
-    _sendSiteLevelRequest(key, value) {
-        this._siteStatsClient.reportNewRequest(key, value);
-    }
-
-    _sendObjectLevelRequest(key, value) {
-        this._objectStatsClient.reportNewRequest(key, value);
+    _sendRequest(key, value) {
+        this._statsClient.reportNewRequest(key, value);
     }
 }
 

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -25,8 +25,7 @@ const monitoringClient = require('../clients/monitoringHandler').client;
 // StatsClient constant defaults
 // TODO: This should be moved to constants file
 const INTERVAL = 300; // 5 minutes
-const EXPIRY = 900; // 15 minutes
-const OBJECT_MONITORING_EXPIRY = 86400; // 24 hours.
+const EXPIRY = 86400; // 24 hours.
 
 const ZK_CRR_STATE_PATH = '/state';
 
@@ -79,10 +78,7 @@ class BackbeatAPI {
         this._redisClient = new RedisClient(this._redisConfig, this._logger);
         // Redis expiry increased by an additional interval so we can reference
         // the immediate older data for average throughput calculation
-        this._statsClient = new StatsModel(this._redisClient, INTERVAL,
-            (EXPIRY + INTERVAL));
-        this._objectStatsClient = new StatsModel(this._redisClient, INTERVAL,
-            (OBJECT_MONITORING_EXPIRY + INTERVAL));
+        this._statsClient = new StatsModel(this._redisClient, INTERVAL, EXPIRY);
         const metricsConfig = {
             redisConfig: this._redisClient,
             validSites: this._validSites,
@@ -92,6 +88,7 @@ class BackbeatAPI {
         Object.assign(this, {
             _queryStats: metrics._queryStats,
             _getData: metrics._getData,
+            _getMaxUptime: metrics._getMaxUptime,
             getBacklog: metrics.getBacklog,
             getCompletions: metrics.getCompletions,
             getFailedMetrics: metrics.getFailedMetrics,

--- a/package-lock.json
+++ b/package-lock.json
@@ -169,8 +169,8 @@
       "dev": true
     },
     "arsenal": {
-      "version": "github:scality/Arsenal#12c4df722bf7765123c0f17dc8e65660b1d0c2ad",
-      "from": "github:scality/Arsenal#12c4df7",
+      "version": "github:scality/Arsenal#06dfdd96126618170888fe0a10826db93fd45042",
+      "from": "github:scality/Arsenal#06dfdd9",
       "requires": {
         "JSONStream": "^1.0.0",
         "ajv": "4.10.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/scality/backbeat#readme",
   "dependencies": {
-    "arsenal": "scality/Arsenal#12c4df7",
+    "arsenal": "scality/Arsenal#06dfdd9",
     "async": "^2.3.0",
     "aws-sdk": "2.147.0",
     "backo": "^1.1.0",


### PR DESCRIPTION
Changes in this PR:
- Increase metrics expiry to 24 hours
- Update metrics.md
- Replace `OBJECT_MONITORING_EXPIRY` as all redis key expiry
  is now uniform to 24 hours. Use a single instance of
  StatsModel