### PR TITLE
ft: ZENKO-1019 delete scheduled resume

### DIFF
--- a/docs/crr-pause-resume.md
+++ b/docs/crr-pause-resume.md
@@ -1,4 +1,4 @@
-# Cross-Region Replication (CRR) Manual Pause and Resume
+# Cross-Region Replication (CRR) Pause and Resume
 
 ## Description
 
@@ -140,6 +140,19 @@ is resumed, it again resumes consuming entries from its last offset.
         "hours": 6
     }
     ```
+
+    Response:
+    ```json
+    {}
+    ```
+
+* DELETE `/_/backbeat/api/crr/resume/<location-name>/schedule`
+
+    This is a DELETE request to remove a scheduled resume for cross-region
+    replication to a specified location configured as a destination replication
+    endpoint.
+    Specify "all" as a location name to make this request to all available
+    destinations.
 
     Response:
     ```json

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -736,6 +736,7 @@ class BackbeatAPI {
         }
         try {
             reqBody = JSON.parse(body);
+            // default 6 hours if no body value sent by user
             if (!reqBody.hours) {
                 return defaultRes;
             }
@@ -794,6 +795,30 @@ class BackbeatAPI {
             this._redisPublisher.publish(channel, message);
         });
         this._logger.info(`replication service resumed for locations ${sites}`);
+        return cb(null, {});
+    }
+
+    /**
+     * Remove CRR scheduled resume for given site(s)
+     * @param {Object} details - The route details
+     * @param {Function} cb - The callback to call
+     * @return {undefined}
+     */
+    deleteScheduledResumeService(details, cb) {
+        let sites;
+        if (details.site === 'all') {
+            sites = details.extensions.crr.filter(s => s !== 'all');
+        } else {
+            sites = [details.site];
+        }
+        sites.forEach(site => {
+            const channel = `${this._crrTopic}-${site}`;
+            const message = JSON.stringify({
+                action: 'deleteScheduledResumeService',
+            });
+            this._redisPublisher.publish(channel, message);
+        });
+        this._logger.info(`deleted scheduled resume for locations: ${sites}`);
         return cb(null, {});
     }
 

--- a/lib/api/BackbeatServer.js
+++ b/lib/api/BackbeatServer.js
@@ -63,7 +63,7 @@ class BackbeatServer {
                 backbeatRequest);
         }
 
-        const validMethods = ['GET', 'POST'];
+        const validMethods = ['GET', 'POST', 'DELETE'];
         if (!validMethods.includes(req.method)) {
             return this._errorResponse(errors.MethodNotAllowed,
                 backbeatRequest);

--- a/package-lock.json
+++ b/package-lock.json
@@ -169,8 +169,8 @@
       "dev": true
     },
     "arsenal": {
-      "version": "github:scality/Arsenal#06dfdd96126618170888fe0a10826db93fd45042",
-      "from": "github:scality/Arsenal#06dfdd9",
+      "version": "github:scality/Arsenal#79ed68ce9fe89301e9b54b3d66098ab8a5360b42",
+      "from": "github:scality/Arsenal#79ed68c",
       "requires": {
         "JSONStream": "^1.0.0",
         "ajv": "4.10.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/scality/backbeat#readme",
   "dependencies": {
-    "arsenal": "scality/Arsenal#06dfdd9",
+    "arsenal": "scality/Arsenal#79ed68c",
     "async": "^2.3.0",
     "aws-sdk": "2.147.0",
     "backo": "^1.1.0",

--- a/tests/functional/api/BackbeatServer.js
+++ b/tests/functional/api/BackbeatServer.js
@@ -8,8 +8,8 @@ const zookeeper = require('node-zookeeper-client');
 const { RedisClient, StatsModel } = require('arsenal').metrics;
 
 const config = require('../../config.json');
-const { makePOSTRequest, getResponseBody } =
-    require('../utils/makePOSTRequest');
+const { makeRequest, getResponseBody } =
+    require('../utils/makeRequest');
 const S3Mock = require('../utils/S3Mock');
 const VaultMock = require('../utils/VaultMock');
 const redisConfig = { host: '127.0.0.1', port: 6379 };
@@ -57,7 +57,7 @@ function makeRetryPOSTRequest(body, cb) {
         method: 'POST',
         path: '/_/crr/failed',
     });
-    makePOSTRequest(options, body, cb);
+    makeRequest(options, body, cb);
 }
 
 function getRequest(path, done) {
@@ -89,12 +89,6 @@ function getRequest(path, done) {
     });
     req.on('error', err => done(err));
     req.end();
-}
-
-function makeDELETERequest(options, body, cb) {
-    const req = http.request(options, res => cb(null, res));
-    req.on('error', err => cb(err));
-    req.end(body);
 }
 
 describe('Backbeat Server', () => {
@@ -1227,7 +1221,7 @@ describe('Backbeat Server', () => {
                 method: 'POST',
                 path: '/_/crr/pause',
             });
-            makePOSTRequest(options, emptyBody, err => {
+            makeRequest(options, emptyBody, err => {
                 assert.ifError(err);
 
                 setTimeout(() => {
@@ -1253,7 +1247,7 @@ describe('Backbeat Server', () => {
                 method: 'POST',
                 path: `/_/crr/pause/${firstSite}`,
             });
-            makePOSTRequest(options, emptyBody, err => {
+            makeRequest(options, emptyBody, err => {
                 assert.ifError(err);
 
                 setTimeout(() => {
@@ -1276,7 +1270,7 @@ describe('Backbeat Server', () => {
                 method: 'POST',
                 path: '/_/crr/resume',
             });
-            makePOSTRequest(options, emptyBody, err => {
+            makeRequest(options, emptyBody, err => {
                 assert.ifError(err);
 
                 setTimeout(() => {
@@ -1315,7 +1309,7 @@ describe('Backbeat Server', () => {
                 path: `/_/crr/resume/${firstSite}/schedule`,
             });
             const body = JSON.stringify({ hours: 1 });
-            makePOSTRequest(options, body, (err, res) => {
+            makeRequest(options, body, (err, res) => {
                 assert.ifError(err);
                 setTimeout(() => {
                     getResponseBody(res, err => {
@@ -1343,7 +1337,7 @@ describe('Backbeat Server', () => {
                 method: 'POST',
                 path: `/_/crr/resume/${firstSite}/schedule`,
             });
-            makePOSTRequest(options, emptyBody, err => {
+            makeRequest(options, emptyBody, err => {
                 assert.ifError(err);
 
                 setTimeout(() => {
@@ -1372,7 +1366,7 @@ describe('Backbeat Server', () => {
                 method: 'DELETE',
                 path: `/_/crr/resume/${secondSite}/schedule`,
             });
-            makeDELETERequest(options, '', (err, res) => {
+            makeRequest(options, emptyBody, (err, res) => {
                 assert.ifError(err);
 
                 setTimeout(() => {

--- a/tests/functional/utils/makeRequest.js
+++ b/tests/functional/utils/makeRequest.js
@@ -1,6 +1,6 @@
 const http = require('http');
 
-function makePOSTRequest(options, body, cb) {
+function makeRequest(options, body, cb) {
     const req = http.request(options, res => cb(null, res));
     req.on('error', err => cb(err));
     req.end(body);
@@ -14,4 +14,4 @@ function getResponseBody(res, cb) {
     res.on('error', err => cb(err));
 }
 
-module.exports = { makePOSTRequest, getResponseBody };
+module.exports = { makeRequest, getResponseBody };


### PR DESCRIPTION
**Looking to merge this for pre-GA build**

- Add a DELETE route to delete/cancel a scheduled resume for given site(s)
- Small refactor to reuse a test helper method for both POST and DELETE requests
