### PR TITLE
bf: ZENKO-1047 disable api internal start timer

### DIFF
--- a/lib/api/BackbeatServer.js
+++ b/lib/api/BackbeatServer.js
@@ -241,9 +241,10 @@ function run(config, Logger) {
     const apiLogger = new Logger('BackbeatAPI');
     const cluster = new Clustering(WORKERS, logger);
 
-    const isTest = process.env.CI === 'true';
+    // NOTE: internal timer is disabled until an alternative to an
+    //  in-memory uptime is found
     const backbeatAPI = new BackbeatAPI(config, apiLogger,
-        { timer: isTest });
+        { timer: true });
 
     backbeatAPI.setupInternals(err => {
         if (err) {


### PR DESCRIPTION
Disabling this will now query redis up to expiry time rather
than considering uptime. Also, any metric response
descriptions that mention metrics up to a certain time will
by default show up to expiry time.

Disable internal timer since it is an in-memory indicator.
Instead, we should consider relying on uptime of redis
and/or cloudserver.