### PR TITLE
bf: ZENKO-1052 send text/plain type for promclient

### DIFF
--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -154,6 +154,7 @@ class BackbeatAPI {
             const promRoute = routes.filter(r =>
                 r.category === 'monitoring')[0];
             bbRequest.setMatchedRoute(promRoute);
+            bbRequest.setContentType(monitoringClient.register.contentType);
             return null;
         }
 

--- a/lib/api/BackbeatRequest.js
+++ b/lib/api/BackbeatRequest.js
@@ -24,6 +24,8 @@ class BackbeatRequest {
         this._statusCode = 0;
         this._error = null;
         this._routeDetails = {};
+        // default to 'application/json' unless specified by parser
+        this._contentType = 'application/json';
 
         // Use to store matched route from Arsenal list of backbeat routes
         this._matchedRoute = null;
@@ -242,6 +244,25 @@ class BackbeatRequest {
      */
     setMatchedRoute(route) {
         this._matchedRoute = route;
+        return this;
+    }
+
+    /**
+     * Get the content-type of a given request
+     * @return {string} content-type
+     */
+    getContentType() {
+        return this._contentType;
+    }
+
+    /**
+     * Set the content-type of a given request
+     * Specific routes will require specific content types (i.e. promclient)
+     * @param {string} type - content-type for this request
+     * @return {BackbeatRequest} itself
+     */
+    setContentType(type) {
+        this._contentType = type;
         return this;
     }
 

--- a/lib/api/BackbeatServer.js
+++ b/lib/api/BackbeatServer.js
@@ -182,15 +182,22 @@ class BackbeatServer {
         const log = backbeatRequest.getLog();
         const req = backbeatRequest.getRequest();
         const res = backbeatRequest.getResponse();
+        const contentType = backbeatRequest.getContentType();
+        const code = backbeatRequest.getStatusCode();
         log.trace('writing HTTP response', {
             method: 'BackbeatServer._response',
         });
-        const code = backbeatRequest.getStatusCode();
-        const payload = Buffer.from(JSON.stringify(data), 'utf8');
+
+        let payload;
+        if (contentType === 'application/json') {
+            payload = Buffer.from(JSON.stringify(data), 'utf8');
+        } else {
+            payload = data;
+        }
 
         res.writeHead(code, {
-            'Content-Type': 'application/json',
-            'Content-Length': payload.length,
+            'Content-Type': contentType,
+            'Content-Length': Buffer.byteLength(payload, 'utf8'),
         });
         this._logRequestEnd(log, req, res, data);
         return res.end(payload);

--- a/tests/unit/api/BackbeatRequest.spec.js
+++ b/tests/unit/api/BackbeatRequest.spec.js
@@ -34,6 +34,15 @@ describe('BackbeatRequest helper class', () => {
             assert.strictEqual(details2.type, 'backlog');
         });
 
+        it('should have a default content-type of application/json', () => {
+            const req = new BackbeatRequest({
+                url: '/_/metrics/crr/all',
+                method: 'GET',
+            });
+
+            assert.strictEqual(req.getContentType(), 'application/json');
+        });
+
         it('should parse crr failed routes and store internally as route ' +
         'details', () => {
             const req = new BackbeatRequest({
@@ -77,9 +86,12 @@ describe('BackbeatRequest helper class', () => {
                 method: 'POST',
             });
             const details = req.getRouteDetails();
+            const contentType = req.getContentType();
 
             assert.strictEqual(details.category, 'monitoring');
             assert.strictEqual(details.type, 'metrics');
+            // expect promclient data to be returned as 'text/plain'
+            assert.notStrictEqual(contentType !== 'application/json');
         });
 
         it('should parse crr pause/resume routes and store internally as ' +


### PR DESCRIPTION
Our use of promclient route in backbeat expects the response
to be content-type of text/plain as determined by the promclient
library itself using `client.register.contentType`