### PR TITLE
bugfix: add object size for transient source gc delete

### DIFF
--- a/extensions/gc/GarbageCollectorProducer.js
+++ b/extensions/gc/GarbageCollectorProducer.js
@@ -49,6 +49,7 @@ class GarbageCollectorProducer {
      * @param {string} dataLocations[].key - data location key
      * @param {string} dataLocations[].dataStoreName - data location
      *   constraint name
+     * @param {number} dataLocations[].size - object size in bytes
      * @param {Function} cb - The callback function
      * @return {undefined}
      */
@@ -59,11 +60,15 @@ class GarbageCollectorProducer {
                 locations: dataLocations.map(location => ({
                     key: location.key,
                     dataStoreName: location.dataStoreName,
+                    size: location.size,
                 })),
             },
         }) }], err => {
             if (err) {
-                this._log.error('error publishing GC.deleteData entry');
+                this._log.error('error publishing GC.deleteData entry', {
+                    error: err,
+                    method: 'GarbageCollectorProducer.publishDeleteDataEntry',
+                });
             }
             return cb(err);
         });

--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -870,6 +870,9 @@
                                 },
                                 "key": {
                                     "type": "string"
+                                },
+                                "size": {
+                                    "type": "integer"
                                 }
                             }
                         }

--- a/tests/unit/gc/GarbageCollector.spec.js
+++ b/tests/unit/gc/GarbageCollector.spec.js
@@ -69,6 +69,7 @@ describe('garbage collector', () => {
         expectBatchDeleteLocations = [{
             key: 'foo',
             dataStoreName: 'ds',
+            size: 10,
         }];
         gcTask.processQueueEntry({
             action: 'deleteData',


### PR DESCRIPTION
This size property is used to decrement storage used metric for
the specified location