### PR TITLE
bf: ZENKO-1024 use pending metrics for backlog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -160,7 +160,7 @@
       "dev": true
     },
     "arsenal": {
-      "version": "github:scality/Arsenal#2c3172890573e13dbc311e240003416ff6a718d8",
+      "version": "github:scality/Arsenal#9f742d492127da825f16703008991fdc0d85f3eb",
       "requires": {
         "ajv": "4.10.0",
         "async": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/scality/backbeat#readme",
   "dependencies": {
-    "arsenal": "scality/Arsenal#2c31728",
+    "arsenal": "scality/Arsenal#9f742d4",
     "async": "^2.3.0",
     "aws-sdk": "2.147.0",
     "backo": "^1.1.0",

--- a/tests/functional/api/BackbeatServer.js
+++ b/tests/functional/api/BackbeatServer.js
@@ -400,10 +400,9 @@ describe('Backbeat Server', () => {
             getRequest(`/_/metrics/crr/${site1}/backlog`, (err, res) => {
                 assert.ifError(err);
                 const key = Object.keys(res)[0];
-                // Backlog count = OPS - OPS_DONE
-                assert.equal(res[key].results.count, 1275);
-                // Backlog size = BYTES - BYTES_DONE
-                assert.equal(res[key].results.size, 1171);
+                // Backlog now uses pending metrics
+                assert.equal(res[key].results.count, 2);
+                assert.equal(res[key].results.size, 1024);
                 done();
             });
         });
@@ -413,10 +412,9 @@ describe('Backbeat Server', () => {
             getRequest('/_/metrics/crr/all/backlog', (err, res) => {
                 assert.ifError(err);
                 const key = Object.keys(res)[0];
-                // Backlog count = OPS - OPS_DONE
-                assert.equal(res[key].results.count, 1875);
-                // Backlog size = BYTES - BYTES_DONE
-                assert.equal(res[key].results.size, 2240);
+                // Backlog now uses pending metrics
+                assert.equal(res[key].results.count, 4);
+                assert.equal(res[key].results.size, 2048);
                 done();
             });
         });
@@ -452,9 +450,9 @@ describe('Backbeat Server', () => {
             getRequest(`/_/metrics/crr/${site1}/failures`, (err, res) => {
                 assert.ifError(err);
                 const key = Object.keys(res)[0];
-                // Completions count = OPS_FAIL
+                // Failures count = OPS_FAIL
                 assert.equal(res[key].results.count, 150);
-                // Completions bytes = BYTES_FAIL
+                // Failures bytes = BYTES_FAIL
                 assert.equal(res[key].results.size, 375);
                 done();
             });
@@ -465,9 +463,9 @@ describe('Backbeat Server', () => {
             getRequest('/_/metrics/crr/all/failures', (err, res) => {
                 assert.ifError(err);
                 const key = Object.keys(res)[0];
-                // Completions count = OPS_FAIL
+                // Failures count = OPS_FAIL
                 assert.equal(res[key].results.count, 205);
-                // Completions bytes = BYTES_FAIL
+                // Failures bytes = BYTES_FAIL
                 assert.equal(res[key].results.size, 950);
                 done();
             });
@@ -526,16 +524,10 @@ describe('Backbeat Server', () => {
             getRequest(`/_/metrics/crr/${site1}`, (err, res) => {
                 assert.ifError(err);
                 const keys = Object.keys(res);
-                assert(keys.includes('backlog'));
                 assert(keys.includes('completions'));
                 assert(keys.includes('throughput'));
+                assert(keys.includes('failures'));
                 assert(keys.includes('pending'));
-
-                assert(res.backlog.description);
-                // Backlog count = OPS - OPS_DONE
-                assert.equal(res.backlog.results.count, 1275);
-                // Backlog size = BYTES - BYTES_DONE
-                assert.equal(res.backlog.results.size, 1171);
 
                 assert(res.completions.description);
                 // Completions count = OPS_DONE
@@ -548,6 +540,12 @@ describe('Backbeat Server', () => {
                 assert.equal(res.throughput.results.count, 0.5);
                 // Throughput bytes = BYTES_DONE / EXPIRY
                 assert.equal(res.throughput.results.size, 1.14);
+
+                assert(res.failures.description);
+                // Failures count = OPS_FAIL
+                assert.equal(res.failures.results.count, 150);
+                // Failures bytes = BYTES_FAIL
+                assert.equal(res.failures.results.size, 375);
 
                 assert(res.pending.description);
                 assert.equal(res.pending.results.count, 2);
@@ -562,16 +560,10 @@ describe('Backbeat Server', () => {
             getRequest('/_/metrics/crr/all', (err, res) => {
                 assert.ifError(err);
                 const keys = Object.keys(res);
-                assert(keys.includes('backlog'));
                 assert(keys.includes('completions'));
                 assert(keys.includes('throughput'));
+                assert(keys.includes('failures'));
                 assert(keys.includes('pending'));
-
-                assert(res.backlog.description);
-                // Backlog count = OPS - OPS_DONE
-                assert.equal(res.backlog.results.count, 1875);
-                // Backlog size = BYTES - BYTES_DONE
-                assert.equal(res.backlog.results.size, 2240);
 
                 assert(res.completions.description);
                 // Completions count = OPS_DONE
@@ -584,6 +576,12 @@ describe('Backbeat Server', () => {
                 assert.equal(res.throughput.results.count, 0.83);
                 // Throughput bytes = BYTES_DONE / EXPIRY
                 assert.equal(res.throughput.results.size, 3.22);
+
+                assert(res.failures.description);
+                // Failures count = OPS_FAIL
+                assert.equal(res.failures.results.count, 205);
+                // Failures bytes = BYTES_FAIL
+                assert.equal(res.failures.results.size, 950);
 
                 assert(res.pending.description);
                 assert.equal(res.pending.results.count, 4);
@@ -633,14 +631,10 @@ describe('Backbeat Server', () => {
                     assert.ifError(err);
 
                     const keys = Object.keys(res);
-                    assert(keys.includes('backlog'));
                     assert(keys.includes('completions'));
                     assert(keys.includes('throughput'));
+                    assert(keys.includes('failures'));
                     assert(keys.includes('pending'));
-
-                    assert(res.backlog.description);
-                    assert.equal(res.backlog.results.count, 0);
-                    assert.equal(res.backlog.results.size, 0);
 
                     assert(res.completions.description);
                     assert.equal(res.completions.results.count, 0);
@@ -649,6 +643,10 @@ describe('Backbeat Server', () => {
                     assert(res.throughput.description);
                     assert.equal(res.throughput.results.count, 0);
                     assert.equal(res.throughput.results.size, 0);
+
+                    assert(res.failures.description);
+                    assert.equal(res.failures.results.count, 0);
+                    assert.equal(res.failures.results.size, 0);
 
                     assert(res.pending.description);
                     assert.equal(res.pending.results.count, 0);


### PR DESCRIPTION
Pending metrics don't expire which was a cause for problems
with current backlog. This quick fix is to use pending
metrics in place of backlog but keeping the same names
and routes in place to avoid regression.

Additional change includes failures metric validation in all metrics routes

To be merged with https://github.com/scality/Arsenal/pull/556