### PR TITLE
bf: ZENKO-1102 idempotence of CRR from transient source

### DIFF
--- a/docs/transient-crr-source.md
+++ b/docs/transient-crr-source.md
@@ -112,6 +112,21 @@ route for batch deletes.
 Eventually this process could be used to garbage-collect data from
 other processes (e.g. for MPU).
 
+##### CRR data processor
+
+Added a check on source metadata before starting replicating data, to
+skip if the status is COMPLETED for the location the data processor is
+responsible for. This is done on transient source location as well for
+non-transient locations as a sanity check.
+
+Rationale: for transient source it's most important to handle
+duplicate kafka entries from the replication topic, and become
+idempotent in such case, because replication from a transient source
+enforces the read to happen on the local (primary) storage, which does
+not work as soon as the local data has been deleted (the data
+processor would eventually set the status to FAILED on top of the
+COMPLETED one otherwise because of the missing data to replicate).
+
 #### Zenko deployment with Kubernetes
 
 * The garbage collector is a new backbeat service on its own, with its

--- a/extensions/replication/tasks/MultipleBackendTask.js
+++ b/extensions/replication/tasks/MultipleBackendTask.js
@@ -4,6 +4,7 @@ const uuid = require('uuid/v4');
 const errors = require('arsenal').errors;
 const jsutil = require('arsenal').jsutil;
 const ObjectMDLocation = require('arsenal').models.ObjectMDLocation;
+const ObjectQueueEntry = require('../../../lib/models/ObjectQueueEntry');
 
 const ReplicateObject = require('./ReplicateObject');
 const { attachReqUids } = require('../../../lib/clients/utils');
@@ -98,6 +99,36 @@ class MultipleBackendTask extends ReplicateObject {
                 return cb(errors.BadRole);
             }
             return cb(null, roles[0]);
+        });
+    }
+
+    _refreshSourceEntry(sourceEntry, log, cb) {
+        const params = {
+            bucket: sourceEntry.getBucket(),
+            objectKey: sourceEntry.getObjectKey(),
+            encodedVersionId: sourceEntry.getEncodedVersionId(),
+        };
+        return this.backbeatSourceProxy.getMetadata(
+        params, log, (err, blob) => {
+            if (err) {
+                log.error('error getting metadata blob from S3', {
+                    method: 'MultipleBackendTask._refreshSourceEntry',
+                    error: err,
+                });
+                return cb(err);
+            }
+            const parsedEntry = ObjectQueueEntry.createFromBlob(blob.Body);
+            if (parsedEntry.error) {
+                log.error('error parsing metadata blob', {
+                    error: parsedEntry.error,
+                    method: 'MultipleBackendTask._refreshSourceEntry',
+                });
+                return cb(errors.InternalError.
+                    customizeDescription('error parsing metadata blob'));
+            }
+            const refreshedEntry = new ObjectQueueEntry(sourceEntry.getBucket(),
+                sourceEntry.getObjectVersionedKey(), parsedEntry.result);
+            return cb(null, refreshedEntry);
         });
     }
 
@@ -749,16 +780,35 @@ class MultipleBackendTask extends ReplicateObject {
     processQueueEntry(sourceEntry, done) {
         const log = this.logger.newRequestLogger();
         const destEntry = sourceEntry.toMultipleBackendReplicaEntry(this.site);
+        const content = sourceEntry.getReplicationContent();
         log.debug('processing entry', { entry: sourceEntry.getLogInfo() });
 
         return async.waterfall([
             next => this._setupRoles(sourceEntry, log, next),
-            (sourceRole, next) => {
+            (sourceRole, next) =>
+                this._refreshSourceEntry(sourceEntry, log, next),
+            (refreshedEntry, next) => {
                 if (sourceEntry.getIsDeleteMarker()) {
                     return this._putDeleteMarker(sourceEntry, destEntry, log,
                         next);
                 }
-                const content = sourceEntry.getReplicationContent();
+                const status = refreshedEntry.getReplicationSiteStatus(
+                    this.site);
+                log.debug('refreshed entry site replication info', {
+                    entry: refreshedEntry.getLogInfo(),
+                    site: this.site, siteStatus: status,
+                    content,
+                });
+                if (status === 'COMPLETED' && content.includes('DATA')) {
+                    const errMessage = 'skipping replication: ' +
+                          'replication status is already COMPLETED ' +
+                          `on the location ${this.site}`;
+                    log.warn(errMessage, {
+                        entry: refreshedEntry.getLogInfo(),
+                    });
+                    return done(errors.PreconditionFailed.customizeDescription(
+                        errMessage));
+                }
                 if (content.includes('MPU')) {
                     return this._getAndPutMultipartUpload(sourceEntry,
                         destEntry, log, next);

--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -6,6 +6,7 @@ const jsutil = require('arsenal').jsutil;
 const ObjectMDLocation = require('arsenal').models.ObjectMDLocation;
 
 const BackbeatClient = require('../../../lib/clients/BackbeatClient');
+const BackbeatMetadataProxy = require('../utils/BackbeatMetadataProxy');
 
 const { attachReqUids } = require('../../../lib/clients/utils');
 const getExtMetrics = require('../utils/getExtMetrics');
@@ -44,6 +45,7 @@ class ReplicateObject extends BackbeatTask {
         this.s3destCredentials = null;
         this.S3source = null;
         this.backbeatSource = null;
+        this.backbeatSourceProxy = null;
         this.backbeatDest = null;
     }
 
@@ -435,6 +437,9 @@ class ReplicateObject extends BackbeatTask {
             httpOptions: { agent: this.sourceHTTPAgent, timeout: 0 },
             maxRetries: 0,
         });
+        this.backbeatSourceProxy =
+            new BackbeatMetadataProxy(this.sourceConfig, this.sourceHTTPAgent);
+        this.backbeatSourceProxy.setSourceClient(log);
     }
 
     _setupDestClients(targetRole, log) {


### PR DESCRIPTION
Do an extra metadata check on the source before attempting a
replication, so to skip if the status is already COMPLETED and the
entry requests CRR on data.

Note that this PR does not include automated tests, it has been tested manually though and can be included in a test build. An autotest should nevertheless be added next to test specifically the behavior on duplicate kafka entries in backbeat-replication topic.
