### PR TITLE
improvement: ZENKO-1024 add backlog checks in test

### DIFF
--- a/tests/functional/api/BackbeatServer.js
+++ b/tests/functional/api/BackbeatServer.js
@@ -524,10 +524,16 @@ describe('Backbeat Server', () => {
             getRequest(`/_/metrics/crr/${site1}`, (err, res) => {
                 assert.ifError(err);
                 const keys = Object.keys(res);
+                assert(keys.includes('backlog'));
                 assert(keys.includes('completions'));
                 assert(keys.includes('throughput'));
                 assert(keys.includes('failures'));
                 assert(keys.includes('pending'));
+
+                // backlog matches pending
+                assert(res.backlog.description);
+                assert.equal(res.backlog.results.count, 2);
+                assert.equal(res.backlog.results.size, 1024);
 
                 assert(res.completions.description);
                 // Completions count = OPS_DONE
@@ -560,10 +566,16 @@ describe('Backbeat Server', () => {
             getRequest('/_/metrics/crr/all', (err, res) => {
                 assert.ifError(err);
                 const keys = Object.keys(res);
+                assert(keys.includes('backlog'));
                 assert(keys.includes('completions'));
                 assert(keys.includes('throughput'));
                 assert(keys.includes('failures'));
                 assert(keys.includes('pending'));
+
+                // backlog matches pending
+                assert(res.backlog.description);
+                assert.equal(res.backlog.results.count, 4);
+                assert.equal(res.backlog.results.size, 2048);
 
                 assert(res.completions.description);
                 // Completions count = OPS_DONE
@@ -586,6 +598,7 @@ describe('Backbeat Server', () => {
                 assert(res.pending.description);
                 assert.equal(res.pending.results.count, 4);
                 assert.equal(res.pending.results.size, 2048);
+
                 done();
             });
         });
@@ -631,10 +644,15 @@ describe('Backbeat Server', () => {
                     assert.ifError(err);
 
                     const keys = Object.keys(res);
+                    assert(keys.includes('backlog'));
                     assert(keys.includes('completions'));
                     assert(keys.includes('throughput'));
                     assert(keys.includes('failures'));
                     assert(keys.includes('pending'));
+
+                    assert(res.backlog.description);
+                    assert.equal(res.backlog.results.count, 0);
+                    assert.equal(res.backlog.results.size, 0);
 
                     assert(res.completions.description);
                     assert.equal(res.completions.results.count, 0);


### PR DESCRIPTION
For backwards compatability, backlog is still shown in the
metrics all route. Keep these checks in the tests