### PR TITLE
bugfix: ZENKO-1115 Error status for healthcheck

### DIFF
--- a/lib/api/Healthcheck.js
+++ b/lib/api/Healthcheck.js
@@ -60,6 +60,16 @@ class Healthcheck {
     }
 
     /**
+     * Ensure that there is an in-sync replica for each partition.
+     * @param {object} topicMd - topic metadata object
+     * @return {boolean} true if each partition has a replica, false otherwise
+     */
+    _isMissingISR(topicMd) {
+        return topicMd.partitions.some(partition =>
+            (partition.isrs && partition.isrs.length === 0));
+    }
+
+    /**
      * Builds the healthcheck response
      * @param {function} cb - callback(error, data)
      * @return {undefined}
@@ -83,6 +93,14 @@ class Healthcheck {
             if (topicMd) {
                 topics[this._repConfig.topic] = topicMd;
                 connections.isrHealth = this._checkISRHealth(topicMd);
+            }
+            if (topicMd && this._isMissingISR(topicMd)) {
+                const error = {
+                    method: 'Healthcheck.getHealthcheck',
+                    error: 'no in-sync replica for partition',
+                    topicMd,
+                };
+                return cb(error);
             }
             Object.assign(connections, this._getConnectionDetails());
             response.topics = topics;


### PR DESCRIPTION
Return a 500 HTTP status in the following case where an in-sync replica array is empty during a health check:

```
{"topics":{"backbeat-replication":{"name":"backbeat-replication","partitions":[{"id":2,"leader":2,"replicas":[2],"isrs":[2]},{"id":1,"leader":-1,"replicas":[1],"isrs":[]},{"id":0,"leader":0,"replicas":[0],"isrs":[0]}]}},"internalConnections":{"isrHealth":"error","zookeeper":{"status":"ok","details":{"name":"SYNC_CONNECTED","code":3}},"kafkaProducer":{"status":"ok"}}}
```