### PR TITLE
bf: ZENKO-1005 set offset via canary for new locations

### DIFF
--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -480,7 +480,8 @@ class QueueProcessor extends EventEmitter {
                     consumerReady = true;
                     const paused = options && options.paused;
                     this._consumer.subscribe(paused);
-
+                });
+                this._consumer.on('canary', () => {
                     this.logger.info('queue processor is ready to consume ' +
                                      'replication entries');
                     this.emit('ready');
@@ -546,6 +547,10 @@ class QueueProcessor extends EventEmitter {
             this.logger.error('error processing source entry',
                               { error: sourceEntry.error });
             return process.nextTick(() => done(errors.InternalError));
+        }
+        if (sourceEntry.skip) {
+            // skip message, noop
+            return process.nextTick(done);
         }
         let task;
         if (sourceEntry instanceof BucketQueueEntry) {

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -3,12 +3,13 @@ const kafka = require('node-rdkafka');
 const assert = require('assert');
 const async = require('async');
 const joi = require('joi');
-
-const zookeeperHelper = require('./clients/zookeeper');
-const BackbeatProducer = require('./BackbeatProducer');
 const Logger = require('werelogs').Logger;
 const zookeeper = require('node-zookeeper-client');
 
+const zookeeperHelper = require('./clients/zookeeper');
+const BackbeatProducer = require('./BackbeatProducer');
+
+const replicationTopic = require('../conf/Config').extensions.replication.topic;
 // controls the number of messages to process in parallel
 const CONCURRENCY_DEFAULT = 1;
 const CLIENT_ID = 'BackbeatConsumer';
@@ -219,6 +220,10 @@ class BackbeatConsumer extends EventEmitter {
         } else {
             this._log.debug(`consumer is paused for topic ${this._topic}`);
         }
+
+        this._sendCanary(() => {
+            this.emit('canary');
+        });
 
         this._processingQueue = async.queue(
             this._queueProcessor, this._concurrency);
@@ -540,6 +545,69 @@ class BackbeatConsumer extends EventEmitter {
     getServiceStatus() {
         const subscriptions = this._consumer.subscription();
         return subscriptions.length > 0;
+    }
+
+    /**
+     * Helper method to wait for consumers to be assigned to partitions before
+     * proceeding to send canary messages.
+     * @param {number} wait - current accumulated wait time
+     * @param {callback} cb - callback to invoke
+     * @return {undefined}
+     */
+    _waitForAssignment(wait, cb) {
+        setTimeout(() => {
+            const assignments = this._consumer.assignments();
+            if (assignments.length === 0) {
+                if (wait > 50000) {
+                    return cb(true);
+                }
+                return this._waitForAssignment(wait + 2000, cb);
+            }
+            return cb();
+        }, 2000);
+    }
+
+    /**
+     * On start, send canary (noop) messages to set partition offsets for this
+     * consumer group. Necessary to avoid pause/resume bug where new locations
+     * on pause will not be able to queue entries as no current offset to
+     * determine number of entries (lag) to consume on resume.
+     * @param {callback} cb - callback to invoke
+     * @return {undefined}
+     */
+    _sendCanary(cb) {
+        const crrTopic = withTopicPrefix(replicationTopic);
+        if (this._topic !== crrTopic) {
+            return process.nextTick(cb);
+        }
+        return this._waitForAssignment(0, err => {
+            if (err) {
+                this._log.debug('could not send canary on consumer init, ' +
+                'waiting for consumer assignment to partition took too long', {
+                    method: 'BackbeatConsumer._sendCanary',
+                });
+                return cb();
+            }
+            const topicDetails = this._consumer._metadata.topics
+                .find(topic => topic.name === crrTopic);
+            const entries = topicDetails.partitions.map(p => {
+                const contents = '{"canary":true}';
+                return {
+                    key: 'canary',
+                    message: contents,
+                    partition: p.id,
+                };
+            });
+            const producer = new BackbeatProducer({
+                kafka: { hosts: this._kafkaHosts },
+                topic: this._topic,
+            });
+            return producer.on('ready', () => {
+                producer.send(entries, () => {
+                    producer.close(cb);
+                });
+            });
+        });
     }
 
     /**

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -177,14 +177,20 @@ class BackbeatProducer extends EventEmitter {
         const sendCtx = { cbOnce: jsutil.once(cb),
                           pendingReportsCount: entries.length };
         try {
-            entries.forEach(item => this._producer.produce(
-                this._topic,
-                null, // partition
-                new Buffer(item.message), // value
-                item.key, // key (for keyed partitioning)
-                Date.now(), // timestamp
-                sendCtx // opaque
-            ));
+            entries.forEach(item => {
+                let partition = null;
+                if (item.partition !== undefined && item.key === 'canary') {
+                    partition = item.partition;
+                }
+                this._producer.produce(
+                    this._topic,
+                    partition, // partition
+                    new Buffer(item.message), // value
+                    item.key, // key (for keyed partitioning)
+                    Date.now(), // timestamp
+                    sendCtx // opaque
+                );
+            });
         } catch (err) {
             this._log.error('error publishing entries', {
                 error: err,

--- a/lib/models/QueueEntry.js
+++ b/lib/models/QueueEntry.js
@@ -22,6 +22,9 @@ class QueueEntry {
             if (record.bootstrapId) {
                 return { error: 'bootstrap entry' };
             }
+            if (record.canary) {
+                return { skip: 'skip canary entry' };
+            }
             let entry;
             if (record.type === 'del') {
                 entry = new DeleteOpQueueEntry(record.bucket, record.key);

--- a/package-lock.json
+++ b/package-lock.json
@@ -2005,7 +2005,7 @@
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -2019,7 +2019,7 @@
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -3728,9 +3728,9 @@
       "integrity": "sha512-MmbQJ2MTESTjt3Gi/3yG1wGpIMhUfcIypUCGtTizFR9IiccFwxSpfp0vtIZlkFclEqERemxfnSdZEMR9VqqEFQ=="
     },
     "node-rdkafka": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.2.0.tgz",
-      "integrity": "sha1-qdGSjHeFiXY5iY7YGgqkxTNnNqI=",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.3.1.tgz",
+      "integrity": "sha1-HBC4XJlyQ9UKFLCcA+6PI3DfjVY=",
       "requires": {
         "bindings": "1.x",
         "nan": "2.x"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ioredis": "^3.2.2",
     "joi": "^10.6",
     "node-forge": "^0.7.1",
-    "node-rdkafka": "2.2.0",
+    "node-rdkafka": "2.3.1",
     "node-schedule": "^1.2.0",
     "node-zookeeper-client": "^0.2.2",
     "prom-client": "^10.2.3",


### PR DESCRIPTION
Consumer group on startup, send noop/canary entries to set current offsets

Changes in this PR:
- Update node-rdkafka version. See: https://github.com/Blizzard/node-rdkafka/issues/375
- Add specifying partition in kafka entries only for "canary" entries
- On consumer init, check consumer assignment to partition and then send off canary entries.
- On consumption, if entry is canary, skip further processing
