### PR TITLE
bf: ZENKO-1144 update arsenal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -518,7 +518,7 @@
       "dev": true
     },
     "arsenal": {
-      "version": "github:scality/Arsenal#9dca871e1b6d008905550bd6a28b2c6644551299",
+      "version": "github:scality/Arsenal#a89fdde6fde635a476c690d1e868adf0a8a53bdd",
       "requires": {
         "JSONStream": "1.3.4",
         "ajv": "4.10.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/scality/backbeat#readme",
   "dependencies": {
-    "arsenal": "scality/Arsenal#9dca871",
+    "arsenal": "scality/Arsenal#a89fdde",
     "async": "^2.3.0",
     "aws-sdk": "2.147.0",
     "backo": "^1.1.0",


### PR DESCRIPTION

Changes in this commit:
- Arsenal PR#567 add support for Redis sorted sets, add
  helper methods for building normalized hour timestamps
- Arsenal PR#568 remove Redis#scan when querying for metric
  keys
- Arsenal PR#569 fix ttl in Redis expire call