### PR TITLE
bf: ZENKO-1120 decr pending if QProcessor cancels

### DIFF
--- a/extensions/replication/constants.js
+++ b/extensions/replication/constants.js
@@ -11,6 +11,7 @@ const constants = {
     metricsTypeQueued: 'queued',
     metricsTypeCompleted: 'completed',
     metricsTypeFailed: 'failed',
+    metricsError: 'error',
     redisKeys: {
         opsPending: testIsOn ? 'test:bb:opspending' : 'bb:crr:opspending',
         bytesPending: testIsOn ? 'test:bb:bytespending' : 'bb:crr:bytespending',

--- a/lib/MetricsConsumer.js
+++ b/lib/MetricsConsumer.js
@@ -81,6 +81,13 @@ class MetricsConsumer {
                 .incrementKey(`${site}:${redisKeys.bytesPending}`, bytes);
             this._sendRequest(`${site}:${redisKeys.ops}`, ops);
             this._sendRequest(`${site}:${redisKeys.bytes}`, bytes);
+        } else if (type === 'error') {
+            // i.e. duplicate kafka entries, error with entry and never sent
+            //      to status processor, etc
+            this._statsClient
+                .decrementKey(`${site}:${redisKeys.opsPending}`, ops);
+            this._statsClient
+                .decrementKey(`${site}:${redisKeys.bytesPending}`, bytes);
         }
         return undefined;
     }


### PR DESCRIPTION
I'm uncertain if this will address duplicate crr kafka entries, but it seems if an error
occurs on the replication task step, the entry is then ignored/cancelled. To handle
this case, we want to decrement the global pending metric.

If duplicate kafka entries are considered one of these ignored/cancelled cases, I think
this should address duplicates creating problems for pending metrics.

One thing about duplicates is that, like jonathan mentioned before, if pending metrics
keep going up, it means the decrement for pending isn't happening and the decrements
occur in the replication status processor. So if this doesn't address the duplicate entry
problems, then it should be somewhere in the queue processor or maybe there is a
spot right before replication status processor metrics changes occur that the entry
is "cancelled"

Changes in this PR:
- If the QueueProcessor "cancels" an entry, decrement
  pending metrics since this entry will no longer reach the
  status processor