### PR TITLE
bf: ZENKO-1144 edit failures metrics

### DIFF
--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -706,7 +706,7 @@ class BackbeatAPI {
 
     /* eslint-disable */
     /**
-     * Hotfix made here. Use failed object list to get failure metrics
+     * Use failed object sorted set lists to get failure metrics
      * @param {object} details - route details from lib/backbeat/routes.js
      * @param {function} cb - callback(error, data)
      * @param {array} data - optional field providing already fetched data in
@@ -715,23 +715,41 @@ class BackbeatAPI {
      */
     getFailedMetrics(details, cb, data) {
         const { failedCRR } = redisKeys;
-        const site = details.site === 'all' ? '*' : details.site;
-        const pattern = `${failedCRR}:*:${site}:*`;
-
-        this._redisClient.scan(pattern, undefined, (err, keys) => {
+        const sites = details.site === 'all' ?
+            this._validSites : [details.site];
+        const hourTimestamps = this._statsClient.getSortedSetHours(Date.now());
+        // reduce by hourly timestamp
+        return async.reduce(hourTimestamps, 0, (totalSum, timestamp, done) => {
+            const keys = sites.map(s => `${failedCRR}:${s}:${timestamp}`);
+            // reduce by each site for a given hour
+            return async.reduce(keys, 0, (hourlySum, key, next) => {
+                return this._redisClient.zcard(key, (err, count) => {
+                    if (err) {
+                        this._logger.error('error on Redis zcard', {
+                            error: err,
+                            method: 'BackbeatAPI.getFailedMetrics',
+                        });
+                        return next(err);
+                    }
+                    return next(null, hourlySum + count);
+                });
+            }, (err, hourlyTotal) => {
+                if (err) {
+                    return done(err);
+                }
+                return done(null, totalSum + hourlyTotal);
+            });
+        }, (err, totalCount) => {
             if (err) {
-                this._logger.error('error getting metric: failures', {
+                this._logger.error('error getting metrics: failures', {
                     error: err,
                     method: 'BackbeatAPI.getFailedMetrics',
                 });
                 return cb(errors.InternalError);
             }
-            const filteredKeys = this._filterFailObjectKeys(keys);
-            const opsFail = filteredKeys.length;
             // TODO: for now, not returning failures bytes. Instead, rely on
             // retry to return obj sizes
             const bytesFail = 0;
-
             const uptime = this._getMaxUptime(EXPIRY);
             const response = {
                 failures: {
@@ -739,7 +757,7 @@ class BackbeatAPI {
                         '(count) and bytes (size) in the last ' +
                         `${Math.floor(uptime)} seconds`,
                     results: {
-                        count: opsFail,
+                        count: totalCount,
                         size: bytesFail,
                     },
                 },


### PR DESCRIPTION
Failures metrics adjusted to read new sorted set structure for failure object entries

Changes in this PR:
- edit GET failures metrics to use `Redis#zcard` to get count of each hourly sorted set and return sum
- Adjust tests to use sorted sets for failures metrics testing