### PR TITLE
bugfix: ZENKO-1144 fix edge cases

### DIFF
--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -114,7 +114,7 @@ class BackbeatAPI {
         }
         if (sitename !== undefined && sitename === '') {
             return errors.InvalidQueryParameter
-                .customizeDescription('sitename must be a string');
+                .customizeDescription('must be a non-empty string');
         }
         return null;
     }
@@ -335,18 +335,19 @@ class BackbeatAPI {
 
     /**
      * Builds the failed CRR response.
-     * @param {Number} score - The score used for the NextMarker in the response
+     * @param {Number} nextMarkerScore - The score used for the NextMarker in
+     * the response
      * @param {Array} entries - Array of ObjectFailureEntry instances
      * @param {Function} cb - The callback function
      * @return {undefined}
      */
-    _getFailedCRRResponse(score, entries, cb) {
+    _getFailedCRRResponse(nextMarkerScore, entries, cb) {
         const response = {
-            IsTruncated: score !== undefined,
+            IsTruncated: nextMarkerScore !== undefined,
             Versions: [],
         };
         if (response.IsTruncated) {
-            response.NextMarker = Number.parseInt(score, 10);
+            response.NextMarker = Number.parseInt(nextMarkerScore, 10);
         }
         let filteredEntries = this._filterFailureEntries(entries);
         // TODO: enhance tests rather than ignoring key filtering
@@ -399,7 +400,7 @@ class BackbeatAPI {
         // empty string.
         versionId = versionId === undefined ? '' : versionId;
         const member = getSortedSetMember(bucket, key, versionId);
-        return this._getEntriesAcrossSite(member, (err, entries) =>
+        return this._getEntriesAcrossSites(member, (err, entries) =>
             this._getFailedCRRResponse(undefined, entries, cb));
     }
 
@@ -424,7 +425,7 @@ class BackbeatAPI {
      * @param {Function} cb - The callback to call
      * @return {undefined}
      */
-    _getEntriesAcrossSite(member, cb) {
+    _getEntriesAcrossSites(member, cb) {
         const entries = [];
         return async.eachLimit(this._validSites, 10, (site, next) => {
             const keys = this._getSortedSetKeys(site);
@@ -458,7 +459,7 @@ class BackbeatAPI {
         const date = new Date(score);
         const startHour = this._statsClient.normalizeTimestampByHour(date);
         const index = keys.findIndex(key => key.includes(startHour));
-        return keys.slice(index);
+        return index < 0 ? [] : keys.slice(index);
     }
 
     /**
@@ -473,6 +474,10 @@ class BackbeatAPI {
         let score = marker;
         const keys = score ?
             this._reduceSortedSetKeys(score, allKeys) : allKeys;
+        if (keys.length === 0) {
+            // If a given marker did not match a sorted set key.
+            return process.nextTick(() => cb(null, undefined, []));
+        }
         const listingLimit = 1000; // Don't exceed 1000 entries in the response.
         const entries = [];
         let nextMarker;
@@ -572,6 +577,13 @@ class BackbeatAPI {
         });
     }
 
+    /**
+     * Delete the given member from a site sorted set.
+     * @param {String} member - The sorted set member to delete
+     * @param {String} site - The site name
+     * @param {Function} cb - Callback to call
+     * @return {undefined}
+     */
     _findAndDeleteMember(member, site, cb) {
         const keys = this._getSortedSetKeys(site);
         let i = 0;
@@ -584,7 +596,7 @@ class BackbeatAPI {
                 }
                 if (res !== null) {
                     shouldContinue = false;
-                    this._redisClient.zrem(key, member, next);
+                    return this._redisClient.zrem(key, member, next);
                 }
                 return next();
             });


### PR DESCRIPTION
Edge-case cleanups:

* Handle unusual markers, so we respond back with an empty array
* Return callback properly for filtered entries background cleanup
* Update variable naming and JSDocs