### PR TITLE
bugfix: ZENKO-1144: Improve listing response time

### DIFF
--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -342,28 +342,21 @@ class BackbeatAPI {
      * @return {undefined}
      */
     _getFailedCRRResponse(nextMarkerScore, entries, cb) {
-        const response = {
-            IsTruncated: nextMarkerScore !== undefined,
-            Versions: [],
-        };
-        if (response.IsTruncated) {
-            response.NextMarker = Number.parseInt(nextMarkerScore, 10);
-        }
         let filteredEntries = this._filterFailureEntries(entries);
         // TODO: enhance tests rather than ignoring key filtering
         if (process.env.CI === 'true') {
             // ignore filtering keys for tests
             filteredEntries = entries;
         }
-        return async.eachSeries(filteredEntries, (entry, next) =>
+        return async.mapLimit(filteredEntries, 10, (entry, next) =>
             this._getObjectQueueEntry(entry, (err, queueEntry) => {
                 if (err) {
                     // If we cannot retrieve the source object, then we no
                     // longer can consider it a failed operation. Skip the
-                    // retry.
+                    // retry and filter it in the response.
                     return next();
                 }
-                response.Versions.push({
+                return next(null, {
                     Bucket: queueEntry.getBucket(),
                     Key: queueEntry.getObjectKey(),
                     VersionId: queueEntry.getEncodedVersionId(),
@@ -371,9 +364,20 @@ class BackbeatAPI {
                     Size: queueEntry.getContentLength(),
                     LastModified: queueEntry.getLastModified(),
                 });
-                return next();
             }),
-        err => cb(err, response));
+        (err, results) => {
+            if (err) {
+                return cb(err);
+            }
+            const response = {
+                IsTruncated: nextMarkerScore !== undefined,
+                Versions: results.filter(result => (result !== undefined)),
+            };
+            if (response.IsTruncated) {
+                response.NextMarker = Number.parseInt(nextMarkerScore, 10);
+            }
+            return cb(null, response);
+        });
     }
 
     /**
@@ -478,7 +482,7 @@ class BackbeatAPI {
             // If a given marker did not match a sorted set key.
             return process.nextTick(() => cb(null, undefined, []));
         }
-        const listingLimit = 1000; // Don't exceed 1000 entries in the response.
+        const listingLimit = 100; // Don't exceed 100 entries in the response.
         const entries = [];
         let nextMarker;
         let shouldContinue;

--- a/tests/functional/api/BackbeatServer.js
+++ b/tests/functional/api/BackbeatServer.js
@@ -1059,7 +1059,7 @@ describe('Backbeat Server', () => {
                     const memberCount = (150 * 5) * 24;
                     const set = new Set();
                     let marker = 0;
-                    async.timesSeries(40, (i, next) =>
+                    async.timesSeries(memberCount, (i, next) =>
                         getRequest('/_/crr/failed?' +
                             `marker=${marker}&sitename=test-site`,
                             (err, res) => {
@@ -1109,7 +1109,7 @@ describe('Backbeat Server', () => {
                     const memberCount = 2000 * 5;
                     const set = new Set();
                     let marker = 0;
-                    async.timesSeries(10, (i, next) =>
+                    async.timesSeries(memberCount, (i, next) =>
                         getRequest('/_/crr/failed?' +
                             `marker=${marker}&sitename=test-site`,
                             (err, res) => {


### PR DESCRIPTION
Parallelize the GET metadata calls, and limit the response to 100 entries for the failure listing route.