### PR TITLE
bf: ZENKO-1170 pass crr paused state on startup

### DIFF
--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -73,7 +73,7 @@ function checkAndApplyScheduleResume(qp, data, zkClient, site, cb) {
         });
     }
     qp.scheduleResume(scheduleDate);
-    return cb();
+    return cb(null, { paused: true });
 }
 
 /**


### PR DESCRIPTION
Changes in this PR:
- if a scheduled resume exists for a site on startup, need
  to also pass boolean value after re-applying scheduled
  resume to `initAndStart`