### PR TITLE
improvement: change producer acks to min insync replicas

### DIFF
--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -9,7 +9,7 @@ const Logger = require('werelogs').Logger;
 const { withTopicPrefix } = require('./util/topic');
 
 // waits for an ack for messages
-const REQUIRE_ACKS = 1;
+const REQUIRE_ACKS = 'all';
 // time in ms. to wait for acks from Kafka
 const ACK_TIMEOUT = 5000;
 // max time in ms. to wait for flush to complete


### PR DESCRIPTION
This commit sets the request.required.acks to all, which means Producer gets
an ack when the entry is committed to all of the in sync replicas (which is 3
in case of 5 node cluster and 2 in case of 3 node cluster)