### PR TITLE
bugfix: ZENKO-1165 No duplicate entries in listing

### DIFF
--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -482,68 +482,59 @@ class BackbeatAPI {
             // If a given marker did not match a sorted set key.
             return process.nextTick(() => cb(null, undefined, []));
         }
-        const listingLimit = 100; // Don't exceed 100 entries in the response.
+        // Don't exceed 100 entries in the response unless there are entries
+        // in the sorted set with the same score (i.e. they were added in the
+        // same millisecond).
+        const listingLimit = 100;
         const entries = [];
         let nextMarker;
-        let shouldContinue;
+        let lastMemberScore;
         let i = 0;
         return async.doWhilst(next => {
             const key = keys[i++];
-            async.waterfall([
-                done => {
-                    if (score) {
-                        // If the request included a next marker we want to list
-                        // the sorted set from the member with that score.
-                        return this._redisClient
-                            .zrangebyscore(key, '-inf', score, (err, res) => {
-                                if (err) {
-                                    return done(err);
-                                }
-                                // Don't use the score in subsequent sorted set
-                                // range requests.
-                                score = undefined;
-                                return done(null, res);
-                            });
-                    }
-                    return this._redisClient.zrange(key, 0, -1, done);
-                },
-                (results, done) => {
-                    const totalMembers = results.length + entries.length;
-                    if (totalMembers >= listingLimit) {
-                        const index = totalMembers - listingLimit;
-                        const member = results[index - 1];
-                        if (member === undefined) {
-                            // If the sorted set doesn't include the final
-                            // member who's score will be used as the next
-                            // marker, go on to check subsequent sorted sets.
-                            return done(null, results, index, false);
-                        }
-                        return this._redisClient.zscore(key, member,
-                            (err, score) => {
-                                if (err) {
-                                    return done(err);
-                                }
-                                nextMarker = score;
-                                return done(null, results, index, true);
-                            });
-                    }
-                    return done(null, results, undefined, true);
-                },
-                (results, index, hasLastMember, done) => {
-                    const slice = results.slice(index);
-                    slice.forEach(member =>
-                        entries.push(new ObjectFailureEntry(member, sitename)));
-                    // If the listing result didn't include the last member, we
-                    // should continue checking if there is one in subsequent
-                    // sorted sets to retrieve a next marker value. Otherwise we
-                    // only continue if this isn't the last sorted set to check.
-                    shouldContinue = hasLastMember ?
-                        i < keys.length && entries.length < listingLimit :
-                        i < keys.length;
-                    return done();
-                },
-            ], next);
-        }, () => shouldContinue, err => cb(err, nextMarker, entries));
+            if (score) {
+                // If the request included a next marker we want to list the
+                // sorted set from the member with that score, and we don't want
+                // to use the score in subsequent requests.
+                score = undefined;
+                return this._redisClient
+                    .zrangebyscore(key, '-inf', marker, 'withscores', next);
+            }
+            return this._redisClient.zrange(key, 0, -1, 'withscores', next);
+        }, results => {
+            if (lastMemberScore) {
+                // If the previous sorted set didn't include nextMarker, we are
+                // here only to get the marker.
+                nextMarker = results[results.length - 1];
+                return false;
+            }
+            let resultsIndex;
+            // The results include both the member and its score in sequence.
+            const totalMembers = results.length / 2 + entries.length;
+            if (totalMembers >= listingLimit) {
+                resultsIndex = totalMembers * 2 - listingLimit * 2;
+                lastMemberScore = results[resultsIndex + 1];
+                nextMarker = results[resultsIndex - 1];
+                // We keep searching backward until we find a new score. In this
+                // case, we'll include additional members in the listing. If we
+                // reach the end of this sorted set, nextMarker is undefined and
+                // we go on to the next sorted set to find nextMarker.
+                while (nextMarker === lastMemberScore) {
+                    resultsIndex -= 2;
+                    nextMarker = results[resultsIndex - 1];
+                }
+            }
+            const resultsSlice = results.slice(resultsIndex);
+            for (let i = 0; i < resultsSlice.length; i += 2) {
+                entries.push(new ObjectFailureEntry(resultsSlice[i], sitename));
+            }
+            // If the listing result didn't include the next marker, we should
+            // continue checking for one in subsequent sorted sets. Otherwise we
+            // only continue if there are more sorted sets.
+            return nextMarker ?
+                i < keys.length && entries.length < listingLimit :
+                i < keys.length;
+        }, err => cb(err, nextMarker, entries));
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -199,99 +199,6 @@
             }
           }
         },
-        "cdmiclient": {
-          "version": "github:scality/cdmiclient#8f0c2e6331dfa905bfe269fb4e1558d65ca0b866",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "arsenal": "github:scality/Arsenal#e4a66343fb790a97fc7eedc2fa49d3a5b624f97d",
-            "async": "1.4.2",
-            "werelogs": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46"
-          },
-          "dependencies": {
-            "arsenal": {
-              "version": "github:scality/Arsenal#e4a66343fb790a97fc7eedc2fa49d3a5b624f97d",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "ajv": "4.10.0",
-                "async": "2.1.5",
-                "bson": "2.0.4",
-                "debug": "2.3.3",
-                "diskusage": "0.2.4",
-                "fcntl": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
-                "ioctl": "2.0.0",
-                "ioredis": "2.4.0",
-                "ipaddr.js": "1.2.0",
-                "joi": "10.6.0",
-                "JSONStream": "1.3.4",
-                "level": "1.6.0",
-                "level-sublevel": "6.6.5",
-                "mongodb": "3.1.6",
-                "node-forge": "0.7.6",
-                "simple-glob": "0.1.1",
-                "socket.io": "1.7.4",
-                "socket.io-client": "1.7.4",
-                "utf8": "2.1.2",
-                "uuid": "3.3.2",
-                "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-                "xml2js": "0.4.19"
-              },
-              "dependencies": {
-                "async": {
-                  "version": "2.1.5",
-                  "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
-                  "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "lodash": "4.17.10"
-                  }
-                },
-                "werelogs": {
-                  "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-                  "dev": true,
-                  "optional": true,
-                  "requires": {
-                    "safe-json-stringify": "1.0.3"
-                  }
-                }
-              }
-            },
-            "async": {
-              "version": "1.4.2",
-              "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
-              "integrity": "sha1-bJ7csRztTw3S8tQNsNSaEJwIiqs=",
-              "dev": true,
-              "optional": true
-            },
-            "mongodb": {
-              "version": "3.1.6",
-              "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.6.tgz",
-              "integrity": "sha512-E5QJuXQoMlT7KyCYqNNMfAkhfQD79AT4F8Xd+6x37OX+8BL17GyXyWvfm6wuyx4wnzCCPoCSLeMeUN2S7dU9yw==",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "mongodb-core": "3.1.5",
-                "safe-buffer": "5.1.2"
-              }
-            },
-            "werelogs": {
-              "version": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "safe-json-stringify": "1.0.3"
-              }
-            }
-          }
-        },
-        "cron-parser": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-1.1.0.tgz",
-          "integrity": "sha1-B1uExFnBVejEgqtNVq/5na5YNS4=",
-          "dev": true
-        },
         "es6-promise": {
           "version": "3.2.1",
           "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
@@ -318,12 +225,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
-        },
-        "long-timeout": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.0.2.tgz",
-          "integrity": "sha1-82RJuolinROnorJSOk253Wbj/2g=",
           "dev": true
         },
         "mongodb": {
@@ -375,16 +276,6 @@
             }
           }
         },
-        "node-schedule": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-1.2.0.tgz",
-          "integrity": "sha1-8D1OvnGwVz4XCN2uCqRdFlhFDPE=",
-          "dev": true,
-          "requires": {
-            "cron-parser": "1.1.0",
-            "long-timeout": "0.0.2"
-          }
-        },
         "process-nextick-args": {
           "version": "1.0.7",
           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -412,22 +303,6 @@
           "integrity": "sha1-HaUKjQDN7NWUBWWfX/hTSf53N0M=",
           "dev": true
         },
-        "sproxydclient": {
-          "version": "github:scality/sproxydclient#45090b76b24ca1d05482bf151ba84ff6178423d1",
-          "dev": true,
-          "requires": {
-            "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2"
-          },
-          "dependencies": {
-            "werelogs": {
-              "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
-              "dev": true,
-              "requires": {
-                "safe-json-stringify": "1.0.3"
-              }
-            }
-          }
-        },
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
@@ -435,103 +310,6 @@
           "dev": true,
           "requires": {
             "safe-buffer": "5.1.2"
-          }
-        },
-        "utapi": {
-          "version": "github:scality/utapi#f2f1d0c7423ffdec2ad175e3c0e8bcd7aa2ba867",
-          "dev": true,
-          "requires": {
-            "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
-            "async": "2.5.0",
-            "ioredis": "2.4.0",
-            "node-schedule": "1.2.0",
-            "vaultclient": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
-            "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
-          },
-          "dependencies": {
-            "arsenal": {
-              "version": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
-              "dev": true,
-              "requires": {
-                "ajv": "4.10.0",
-                "async": "2.1.5",
-                "debug": "2.3.3",
-                "diskusage": "0.2.4",
-                "ioctl": "2.0.0",
-                "ioredis": "2.4.0",
-                "ipaddr.js": "1.2.0",
-                "joi": "10.6.0",
-                "JSONStream": "1.3.4",
-                "level": "1.6.0",
-                "level-sublevel": "6.6.5",
-                "node-forge": "0.7.6",
-                "simple-glob": "0.1.1",
-                "socket.io": "1.7.4",
-                "socket.io-client": "1.7.4",
-                "utf8": "2.1.2",
-                "uuid": "3.3.2",
-                "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-                "xml2js": "0.4.19"
-              },
-              "dependencies": {
-                "async": {
-                  "version": "2.1.5",
-                  "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
-                  "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
-                  "dev": true,
-                  "requires": {
-                    "lodash": "4.17.10"
-                  }
-                }
-              }
-            },
-            "commander": {
-              "version": "2.9.0",
-              "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-              "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-              "dev": true,
-              "requires": {
-                "graceful-readlink": "1.0.1"
-              }
-            },
-            "vaultclient": {
-              "version": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
-              "dev": true,
-              "requires": {
-                "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
-                "commander": "2.9.0",
-                "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-                "xml2js": "0.4.17"
-              },
-              "dependencies": {
-                "xml2js": {
-                  "version": "0.4.17",
-                  "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-                  "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
-                  "dev": true,
-                  "requires": {
-                    "sax": "1.1.5",
-                    "xmlbuilder": "4.2.1"
-                  }
-                }
-              }
-            },
-            "werelogs": {
-              "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-              "dev": true,
-              "requires": {
-                "safe-json-stringify": "1.0.3"
-              }
-            },
-            "xmlbuilder": {
-              "version": "4.2.1",
-              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-              "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
-              "dev": true,
-              "requires": {
-                "lodash": "4.17.10"
-              }
-            }
           }
         },
         "ws": {
@@ -745,7 +523,7 @@
       "dev": true
     },
     "arsenal": {
-      "version": "github:scality/Arsenal#549ca1f683060bd2fdd2c3ac9c1936cf12a03687",
+      "version": "github:scality/Arsenal#0af0b7696b638aee730b03e7615d67857facae89",
       "requires": {
         "ajv": "4.10.0",
         "async": "2.1.5",
@@ -1319,6 +1097,99 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
+    },
+    "cdmiclient": {
+      "version": "github:scality/cdmiclient#8f0c2e6331dfa905bfe269fb4e1558d65ca0b866",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "arsenal": "github:scality/Arsenal#0117b39dcf02d8b5cb29a5636b5a54189d82d786",
+        "async": "1.4.2",
+        "werelogs": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46"
+      },
+      "dependencies": {
+        "arsenal": {
+          "version": "github:scality/Arsenal#0117b39dcf02d8b5cb29a5636b5a54189d82d786",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.10.0",
+            "async": "2.1.5",
+            "bson": "2.0.4",
+            "debug": "2.3.3",
+            "diskusage": "0.2.4",
+            "fcntl": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
+            "ioctl": "2.0.0",
+            "ioredis": "2.4.0",
+            "ipaddr.js": "1.2.0",
+            "joi": "10.6.0",
+            "JSONStream": "1.3.4",
+            "level": "1.6.0",
+            "level-sublevel": "6.6.5",
+            "mongodb": "3.1.4",
+            "node-forge": "0.7.6",
+            "simple-glob": "0.1.1",
+            "socket.io": "1.7.4",
+            "socket.io-client": "1.7.4",
+            "utf8": "2.1.2",
+            "uuid": "3.3.2",
+            "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+            "xml2js": "0.4.19"
+          },
+          "dependencies": {
+            "async": {
+              "version": "2.1.5",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+              "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "lodash": "4.17.10"
+              }
+            },
+            "werelogs": {
+              "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-json-stringify": "1.0.3"
+              }
+            }
+          }
+        },
+        "async": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
+          "integrity": "sha1-bJ7csRztTw3S8tQNsNSaEJwIiqs=",
+          "dev": true,
+          "optional": true
+        },
+        "ioredis": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.4.0.tgz",
+          "integrity": "sha1-lj97+8huXEDqWGhX4U6/tUgUKog=",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bluebird": "3.5.2",
+            "cluster-key-slot": "1.0.12",
+            "debug": "2.3.3",
+            "double-ended-queue": "2.1.0-0",
+            "flexbuffer": "0.0.6",
+            "lodash": "4.17.10",
+            "redis-commands": "1.3.5",
+            "redis-parser": "1.3.0"
+          }
+        },
+        "werelogs": {
+          "version": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-json-stringify": "1.0.3"
+          }
+        }
+      }
     },
     "chalk": {
       "version": "1.1.3",
@@ -4513,6 +4384,22 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "sproxydclient": {
+      "version": "github:scality/sproxydclient#45090b76b24ca1d05482bf151ba84ff6178423d1",
+      "dev": true,
+      "requires": {
+        "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2"
+      },
+      "dependencies": {
+        "werelogs": {
+          "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+          "dev": true,
+          "requires": {
+            "safe-json-stringify": "1.0.3"
+          }
+        }
+      }
+    },
     "sql-where-parser": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/sql-where-parser/-/sql-where-parser-2.2.1.tgz",
@@ -4870,6 +4757,157 @@
       "dev": true,
       "requires": {
         "os-homedir": "1.0.2"
+      }
+    },
+    "utapi": {
+      "version": "github:scality/utapi#f2f1d0c7423ffdec2ad175e3c0e8bcd7aa2ba867",
+      "dev": true,
+      "requires": {
+        "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
+        "async": "2.6.1",
+        "ioredis": "2.5.0",
+        "node-schedule": "1.2.0",
+        "vaultclient": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
+        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
+      },
+      "dependencies": {
+        "arsenal": {
+          "version": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
+          "dev": true,
+          "requires": {
+            "ajv": "4.10.0",
+            "async": "2.1.5",
+            "debug": "2.3.3",
+            "diskusage": "0.2.4",
+            "ioctl": "2.0.0",
+            "ioredis": "2.4.0",
+            "ipaddr.js": "1.2.0",
+            "joi": "10.6.0",
+            "JSONStream": "1.3.4",
+            "level": "1.6.0",
+            "level-sublevel": "6.6.5",
+            "node-forge": "0.7.6",
+            "simple-glob": "0.1.1",
+            "socket.io": "1.7.4",
+            "socket.io-client": "1.7.4",
+            "utf8": "2.1.2",
+            "uuid": "3.3.2",
+            "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+            "xml2js": "0.4.19"
+          },
+          "dependencies": {
+            "async": {
+              "version": "2.1.5",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+              "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+              "dev": true,
+              "requires": {
+                "lodash": "4.17.10"
+              }
+            },
+            "ioredis": {
+              "version": "2.4.0",
+              "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.4.0.tgz",
+              "integrity": "sha1-lj97+8huXEDqWGhX4U6/tUgUKog=",
+              "dev": true,
+              "requires": {
+                "bluebird": "3.5.2",
+                "cluster-key-slot": "1.0.12",
+                "debug": "2.3.3",
+                "double-ended-queue": "2.1.0-0",
+                "flexbuffer": "0.0.6",
+                "lodash": "4.17.10",
+                "redis-commands": "1.3.5",
+                "redis-parser": "1.3.0"
+              }
+            }
+          }
+        },
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
+        },
+        "cron-parser": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-1.1.0.tgz",
+          "integrity": "sha1-B1uExFnBVejEgqtNVq/5na5YNS4=",
+          "dev": true
+        },
+        "ioredis": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.5.0.tgz",
+          "integrity": "sha1-+2/fChp+CXRhTGe25eETCKjPlbk=",
+          "dev": true,
+          "requires": {
+            "bluebird": "3.5.2",
+            "cluster-key-slot": "1.0.12",
+            "debug": "2.3.3",
+            "double-ended-queue": "2.1.0-0",
+            "flexbuffer": "0.0.6",
+            "lodash": "4.17.10",
+            "redis-commands": "1.3.5",
+            "redis-parser": "1.3.0"
+          }
+        },
+        "long-timeout": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.0.2.tgz",
+          "integrity": "sha1-82RJuolinROnorJSOk253Wbj/2g=",
+          "dev": true
+        },
+        "node-schedule": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-1.2.0.tgz",
+          "integrity": "sha1-8D1OvnGwVz4XCN2uCqRdFlhFDPE=",
+          "dev": true,
+          "requires": {
+            "cron-parser": "1.1.0",
+            "long-timeout": "0.0.2"
+          }
+        },
+        "vaultclient": {
+          "version": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
+          "dev": true,
+          "requires": {
+            "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
+            "commander": "2.9.0",
+            "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+            "xml2js": "0.4.17"
+          },
+          "dependencies": {
+            "xml2js": {
+              "version": "0.4.17",
+              "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+              "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+              "dev": true,
+              "requires": {
+                "sax": "1.2.4",
+                "xmlbuilder": "4.2.1"
+              }
+            }
+          }
+        },
+        "werelogs": {
+          "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+          "dev": true,
+          "requires": {
+            "safe-json-stringify": "1.0.3"
+          }
+        },
+        "xmlbuilder": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+          "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.10"
+          }
+        }
       }
     },
     "utf-8-validate": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/scality/backbeat#readme",
   "dependencies": {
-    "arsenal": "scality/Arsenal#549ca1f",
+    "arsenal": "scality/Arsenal#0af0b76",
     "async": "^2.3.0",
     "aws-sdk": "2.147.0",
     "backo": "^1.1.0",


### PR DESCRIPTION
Depends on https://github.com/scality/Arsenal/pull/575.

The design for storing failed entries in sorted sets using the millisecond in which the failed entry was added did not account for entries being added in the same millisecond. In such a scenario, if the listing happens to provide a marker from a score that occurs more than once in the sorted set, then some failed objects will be listed in subsequent GET requests when passed the value of `NextMarker`.

This scenario, however rare it sounds, actually did occur. Any duplicate entries were filtered out and prevented by the retry locking mechanism, but we just shouldn't have duplicate listings in the first place. 

The proposed solution is to check that the score does not occur more than once, and if it does continue searching the sorted set until the next unique score is found. This means that a listing can potentially be > 100 entries.