### PR TITLE
improvement: allow non-failed entries to be queued

### DIFF
--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -650,7 +650,11 @@ class BackbeatAPI {
                     // If we cannot retrieve the source object, then we no
                     // longer can consider it a failed operation. Delete the
                     // member used to monitor the failure.
-                    return this._redisClient.zrem(key, member, next);
+                    if (key) {
+                        return this._redisClient.zrem(key, member, next);
+                    }
+                    // If it is a forced retry we do not remove the member.
+                    return next();
                 }
                 const site = failureEntry.getSite();
                 const contentLength = queueEntry.getContentLength();
@@ -672,7 +676,13 @@ class BackbeatAPI {
                         return done();
                     }),
                     // Delete the Redis member from the prior failure.
-                    done => this._redisClient.zrem(key, member, done),
+                    done => {
+                        if (key) {
+                            return this._redisClient.zrem(key, member, done);
+                        }
+                        // If it is a forced retry we do not remove the member.
+                        return done();
+                    },
                     // Delete the Redis lock key
                     done => {
                         const bucket = failureEntry.getBucket();
@@ -842,8 +852,23 @@ class BackbeatAPI {
         }
         const entries = [];
         return async.eachLimit(reqBody, 10, (o, next) => {
-            const { Bucket, Key, VersionId, StorageClass } = o;
+            const { Bucket, Key, VersionId, StorageClass, ForceRetry } = o;
             const member = getSortedSetMember(Bucket, Key, VersionId);
+            // The `ForceRetry` field allows for queueing a retry regardless of
+            // whether it is failed.
+            if (ForceRetry) {
+                const lockKey = `${Bucket}:${Key}:${VersionId}:` +
+                    `${StorageClass}:processingFailures`;
+                return this._applyRetryLockKey(lockKey, (err, lockApplied) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    if (lockApplied) {
+                        entries.push({ member, StorageClass });
+                    }
+                    return next();
+                });
+            }
             const keys = this._getSortedSetKeys(StorageClass);
             return async.eachLimit(keys, 10, (key, done) => {
                 this._redisClient.zscore(key, member, (err, res) => {

--- a/tests/functional/api/BackbeatServer.js
+++ b/tests/functional/api/BackbeatServer.js
@@ -1285,6 +1285,35 @@ describe('Backbeat Server', () => {
                 });
             });
 
+            it('should get correct data for POST route: ' +
+            '/_/crr/failed when no key has been matched and ForceRetry ' +
+            'field is specified', done => {
+                const body = JSON.stringify([{
+                    Bucket: 'bucket',
+                    Key: 'key',
+                    VersionId: 'versionId',
+                    StorageClass: 'site',
+                    ForceRetry: true,
+                }]);
+                makeRetryPOSTRequest(body, (err, res) => {
+                    assert.ifError(err);
+                    getResponseBody(res, (err, resBody) => {
+                        assert.ifError(err);
+                        const body = JSON.parse(resBody);
+                        assert.deepStrictEqual(body, [{
+                            Bucket: 'bucket',
+                            Key: 'key',
+                            VersionId: testVersionId,
+                            StorageClass: 'site',
+                            ReplicationStatus: 'PENDING',
+                            LastModified: '2018-03-30T22:22:34.384Z',
+                            Size: 1,
+                        }]);
+                        done();
+                    });
+                });
+            });
+
             it('should get correct data for POST route: /_/crr/failed ' +
             'when there are multiple matching keys', done => {
                 const member = `test-bucket:test-key:${testVersionId}`;


### PR DESCRIPTION
This piggybacks on failed entries processing logic to queue stalled entries