### PR TITLE
bugfix: ZENKO-697 Check MD5 content for NFS CRR

### DIFF
--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -333,6 +333,46 @@
                 }
             }
         },
+        "MultipleBackendAbortMPU": {
+            "http": {
+                "method": "DELETE",
+                "requestUri": "/_/backbeat/multiplebackenddata/{Bucket}/{Key+}?operation=abortmpu"
+            },
+            "input": {
+                "type": "structure",
+                "required": [
+                    "Bucket",
+                    "Key",
+                    "StorageClass"
+                ],
+                "members": {
+                    "Bucket": {
+                        "location": "uri",
+                        "locationName": "Bucket"
+                    },
+                    "Key": {
+                        "location": "uri",
+                        "locationName": "Key"
+                    },
+                    "StorageType": {
+                        "location": "header",
+                        "locationName": "X-Scal-Storage-Type"
+                    },
+                    "StorageClass": {
+                        "location": "header",
+                        "locationName": "X-Scal-Storage-Class"
+                    },
+                    "UploadId": {
+                        "location": "header",
+                        "locationName": "X-Scal-Upload-Id"
+                    }
+                }
+            },
+            "output": {
+                "type": "structure",
+                "members": {}
+            }
+        },
         "MultipleBackendCompleteMPU": {
             "http": {
                 "method": "POST",


### PR DESCRIPTION
Depends on https://github.com/scality/cloudserver/pull/1571.

When an object is non-versioned (i.e. in an NFS source bucket) we need to first check that the object state has not changes since the CRR entry was queued. These changes ensure that the latest source object is the same as that which is queued for replication by comparing the MD5 hash from the kafka entry with latest object metadata MD5 hash.