### PR TITLE
bf: fix kafka consumer topic params field

### DIFF
--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -130,13 +130,14 @@ class BackbeatConsumer extends EventEmitter {
             'enable.auto.commit': this._autoCommit,
             'offset_commit_cb': this._onOffsetCommit.bind(this),
         };
+        const topicParams = {};
         if (this._fromOffset !== undefined) {
-            consumerParams['auto.offset.reset'] = this._fromOffset;
+            topicParams['auto.offset.reset'] = this._fromOffset;
         }
         if (this._fetchMaxBytes !== undefined) {
             consumerParams['fetch.message.max.bytes'] = this._fetchMaxBytes;
         }
-        this._consumer = new kafka.KafkaConsumer(consumerParams);
+        this._consumer = new kafka.KafkaConsumer(consumerParams, topicParams);
         this._consumer.connect({ timeout: 10000 }, () => {
             const opts = {
                 topic: withTopicPrefix('backbeat-sanitycheck'),


### PR DESCRIPTION
Changes in this PR:
- Kafka consumer param 'auto.offset.reset' should be applied
  as a topic level param