### PR TITLE
INTEGRATION [PR#450 > development/8.1] improvement: configurable retry params for clouds

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -97,7 +97,48 @@
             "monitorReplicationFailureExpiryTimeS": 86400,
             "queueProcessor": {
                 "groupId": "backbeat-replication-group",
-                "retryTimeoutS": 300,
+                "retry": {
+                    "aws": {
+                        "maxRetries": 5,
+                        "timeoutS": 300,
+                        "backoff": {
+                            "min": 1000,
+                            "max": 30000,
+                            "jitter": 0.1,
+                            "factor": 1.5
+                        }
+                    },
+                    "azure": {
+                        "maxRetries": 5,
+                        "timeoutS": 300,
+                        "backoff": {
+                            "min": 1000,
+                            "max": 30000,
+                            "jitter": 0.1,
+                            "factor": 1.5
+                        }
+                    },
+                    "gcp": {
+                        "maxRetries": 5,
+                        "timeoutS": 300,
+                        "backoff": {
+                            "min": 1000,
+                            "max": 30000,
+                            "jitter": 0.1,
+                            "factor": 1.5
+                        }
+                    },
+                    "default": {
+                        "maxRetries": 5,
+                        "timeoutS": 300,
+                        "backoff": {
+                            "min": 1000,
+                            "max": 30000,
+                            "jitter": 0.1,
+                            "factor": 1.5
+                        }
+                    }
+                },
                 "concurrency": 10
             },
             "replicationStatusProcessor": {

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -5,6 +5,16 @@ const { hostPortJoi, bootstrapListJoi, adminCredsJoi } =
 
 const transportJoi = joi.alternatives().try('http', 'https')
     .default('http');
+const retryParamsJoi = joi.object({
+    maxRetries: joi.number().required(),
+    timeoutS: joi.number().required(),
+    backoff: joi.object({
+        min: joi.number().required(),
+        max: joi.number().required(),
+        jitter: joi.number().required(),
+        factor: joi.number().required(),
+    }),
+});
 
 const CRR_FAILURE_EXPIRY = 24 * 60 * 60; // Expire Redis keys after 24 hours.
 
@@ -59,7 +69,12 @@ const joiSchema = {
         joi.number().default(CRR_FAILURE_EXPIRY),
     queueProcessor: {
         groupId: joi.string().required(),
-        retryTimeoutS: joi.number().default(300),
+        retry: joi.object({
+            aws: retryParamsJoi,
+            azure: retryParamsJoi,
+            gcp: retryParamsJoi,
+            default: retryParamsJoi,
+        }),
         concurrency: joi.number().greater(0).default(10),
     },
     replicationStatusProcessor: {

--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -34,10 +34,14 @@ class ReplicateObject extends BackbeatTask {
     constructor(qp) {
         const qpState = qp.getStateVars();
         super({
-            retryTimeoutS: qpState.repConfig.queueProcessor.retryTimeoutS,
+            retry: qpState.repConfig.queueProcessor.retry,
         });
         Object.assign(this, qpState);
-
+        this.destType = this.destConfig.bootstrapList
+        .find(endpoint => endpoint.site === this.site);
+        const retryParams = this.repConfig.queueProcessor.retry[this.destType];
+        const defaultRetryParams = this.repConfig.queueProcessor.retry.default;
+        this.retryParams = retryParams || defaultRetryParams;
         this.sourceRole = null;
         this.targetRole = null;
         this.destBackbeatHost = null;

--- a/lib/tasks/BackbeatTask.js
+++ b/lib/tasks/BackbeatTask.js
@@ -1,8 +1,6 @@
 const BackOff = require('backo');
 const joi = require('joi');
 
-const BACKOFF_PARAMS = { min: 1000, max: 300000, jitter: 0.1, factor: 1.5 };
-
 const backbeatTaskConfigJoi = {
     retryTimeoutS: joi.number().default(300),
 };
@@ -26,10 +24,9 @@ class BackbeatTask {
     retry(args, done) {
         const { actionDesc, logFields,
                 actionFunc, shouldRetryFunc, onRetryFunc, log } = args;
-        const backoffCtx = new BackOff(BACKOFF_PARAMS);
+        const backoffCtx = new BackOff(this.retryParams.backoff);
         let nbRetries = 0;
         const startTime = Date.now();
-        const self = this;
 
         function _handleRes(...args) {
             const err = args[0];
@@ -42,30 +39,32 @@ class BackbeatTask {
                 }
 
                 const now = Date.now();
-                if (now > (startTime + self.config.retryTimeoutS * 1000)) {
-                    log.error(
-                        `retried for too long to ${actionDesc}, giving up`,
+                const retriesExceeded = nbRetries > this.retryParams.maxRetries;
+                const timeoutReached = now >
+                    (startTime + this.retryParams.timeoutS * 1000);
+                if (retriesExceeded || timeoutReached) {
+                    log.error('giving up replication as retries exceeded',
                         Object.assign({
                             nbRetries,
                             retryTotalMs: `${now - startTime}`,
+                            actionDesc,
+                            retriesExceeded,
+                            timeoutReached,
                         }, logFields || {}), log);
                     return done(err);
                 }
                 const retryDelayMs = backoffCtx.duration();
-                log.info(`temporary failure to ${actionDesc}, scheduled retry`,
-                         Object.assign({ nbRetries,
-                                         retryDelay: `${retryDelayMs}ms` },
-                                       logFields || {}));
+                log.info('scheduling retry due to temporary failure',
+                    Object.assign({ nbRetries, actionDesc,
+                        retryDelay: `${retryDelayMs}ms` }, logFields || {}));
                 nbRetries += 1;
                 return setTimeout(() => actionFunc(_handleRes), retryDelayMs);
             }
             if (nbRetries > 0) {
-                const now = Date.now();
-                log.info(`succeeded to ${actionDesc} after retries`,
-                         Object.assign({
-                             nbRetries,
-                             retryTotalMs: `${now - startTime}`,
-                         }, logFields || {}));
+                const retryTotalMs = Date.now() - startTime;
+                log.info('replication succeeded after retries',
+                    Object.assign({ actionDesc, nbRetries, retryTotalMs },
+                        logFields || {}));
             }
             return done(...args);
         }


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #450.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/improvement/ZENKO-1217-tuneable-backoff-clouds`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/improvement/ZENKO-1217-tuneable-backoff-clouds
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/improvement/ZENKO-1217-tuneable-backoff-clouds
```

Please always comment pull request #450 instead of this one.