### PR TITLE
ft: S3C-1376 HTTPS support for backbeat replication

### DIFF
--- a/conf/Config.js
+++ b/conf/Config.js
@@ -59,6 +59,28 @@ class Config {
                 { host: '127.0.0.1', port: 6379 });
         }
 
+        // additional certs checks
+        if (parsedConfig.certFilePaths) {
+            const { key, cert, ca } = parsedConfig.certFilePaths;
+
+            const makePath = value =>
+                  (value.startsWith('/') ?
+                   value : `${this._basePath}/${value}`);
+            parsedConfig.https = {};
+            if (key && cert) {
+                const keypath = makePath(key);
+                const certpath = makePath(cert);
+                fs.accessSync(keypath, fs.F_OK | fs.R_OK);
+                fs.accessSync(certpath, fs.F_OK | fs.R_OK);
+                parsedConfig.https.cert = fs.readFileSync(certpath, 'ascii');
+                parsedConfig.https.key = fs.readFileSync(keypath, 'ascii');
+            }
+            if (ca) {
+                const capath = makePath(ca);
+                fs.accessSync(capath, fs.F_OK | fs.R_OK);
+                parsedConfig.https.ca = fs.readFileSync(capath, 'ascii');
+            }
+        }
         // config is validated, safe to assign directly to the config object
         Object.assign(this, parsedConfig);
     }

--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -44,6 +44,11 @@ const joiSchema = {
             })
         ),
     },
+    certFilePaths: joi.object({
+        key: joi.string().empty(''),
+        cert: joi.string().empty(''),
+        ca: joi.string().empty(''),
+    }),
 };
 
 module.exports = joiSchema;

--- a/conf/config.json
+++ b/conf/config.json
@@ -45,11 +45,6 @@
                       "echo": false },
                     { "site": "us-east-1", "type": "aws_s3" }
                 ],
-                "certFilePaths": {
-                    "key": "ssl/key.pem",
-                    "cert": "ssl/cert.crt",
-                    "ca": "ssl/ca.crt"
-                },
                 "auth": {
                     "type": "account",
                     "account": "lisa"
@@ -82,5 +77,10 @@
         },
         "host": "127.0.0.1",
         "port": 8900
+    },
+    "certFilePaths": {
+        "key": "",
+        "cert": "",
+        "ca": ""
     }
 }

--- a/conf/ssl/ca.crt
+++ b/conf/ssl/ca.crt
@@ -1,1 +1,0 @@
-Replace me with a proper CA certificate file

--- a/conf/ssl/cert.crt
+++ b/conf/ssl/cert.crt
@@ -1,1 +1,0 @@
-Replace me with a proper certificate file

--- a/conf/ssl/key.pem
+++ b/conf/ssl/key.pem
@@ -1,1 +1,0 @@
-Replace me with a proper private key file

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -40,11 +40,6 @@ const joiSchema = {
             }),
         }).required(),
         bootstrapList: bootstrapListJoi,
-        certFilePaths: joi.object({
-            key: joi.string().required(),
-            cert: joi.string().required(),
-            ca: joi.string().empty(''),
-        }).required(),
     },
     topic: joi.string().required(),
     replicationStatusTopic: joi.string().required(),
@@ -88,29 +83,6 @@ function configValidator(backbeatConfig, extConfig) {
                 _loadAdminCredentialsFromFile(adminCredentialsFile);
         }
     }
-
-    // additional target certs checks
-    const { certFilePaths } = destination;
-    const { key, cert, ca } = certFilePaths;
-
-    const makePath = value =>
-              (value.startsWith('/') ?
-               value : `${backbeatConfig.getBasePath()}/${value}`);
-    const keypath = makePath(key);
-    const certpath = makePath(cert);
-    let capath = undefined;
-    fs.accessSync(keypath, fs.F_OK | fs.R_OK);
-    fs.accessSync(certpath, fs.F_OK | fs.R_OK);
-    if (ca) {
-        capath = makePath(ca);
-        fs.accessSync(capath, fs.F_OK | fs.R_OK);
-    }
-
-    destination.https = {
-        cert: fs.readFileSync(certpath, 'ascii'),
-        key: fs.readFileSync(keypath, 'ascii'),
-        ca: ca ? fs.readFileSync(capath, 'ascii') : undefined,
-    };
     return validatedConfig;
 }
 

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -9,6 +9,7 @@ const config = require('../../../conf/Config');
 const zkConfig = config.zookeeper;
 const repConfig = config.extensions.replication;
 const sourceConfig = repConfig.source;
+const httpsConfig = config.https;
 const mConfig = config.metrics;
 
 const site = process.argv[2];
@@ -36,6 +37,6 @@ metricsProducer.setupProducer(err => {
         return undefined;
     }
     const queueProcessor = new QueueProcessor(zkConfig, sourceConfig,
-        destConfig, repConfig, site, metricsProducer);
+        destConfig, repConfig, httpsConfig, site, metricsProducer);
     return queueProcessor.start();
 });

--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -1,6 +1,7 @@
 'use strict'; // eslint-disable-line
 
 const http = require('http');
+const https = require('https');
 
 const Logger = require('werelogs').Logger;
 const errors = require('arsenal').errors;
@@ -59,8 +60,11 @@ class ReplicationStatusProcessor {
             new Logger('Backbeat:Replication:ReplicationStatusProcessor');
 
         // global variables
-        // TODO: for SSL support, create HTTPS agents instead
-        this.sourceHTTPAgent = new http.Agent({ keepAlive: true });
+        if (sourceConfig.transport === 'https') {
+            this.sourceHTTPAgent = new https.Agent({ keepAlive: true });
+        } else {
+            this.sourceHTTPAgent = new http.Agent({ keepAlive: true });
+        }
 
         this._setupVaultclientCache();
 

--- a/lib/clients/VaultClientCache.js
+++ b/lib/clients/VaultClientCache.js
@@ -1,3 +1,5 @@
+const config = require('../../conf/Config');
+
 const VaultClient = require('vaultclient').Client;
 
 /**
@@ -83,6 +85,22 @@ class VaultClientCache {
     }
 
     /**
+     * Enable HTTPS to contact the target Vault, and optionally set
+     * client certificates and/or CA bundle
+     *
+     * @param {string} profileName - name of profile to activate HTTPS on
+     * @param {string} [key] - client private key in PEM format
+     * @param {string} [cert] - client certificate in PEM format
+     * @param {string} [ca] - CA bundle in PEM format
+     * @return {VaultClientCache} this
+     */
+    setHttps(profileName, key, cert, ca) {
+        return this._updateProfile(profileName, {
+            useHttps: true, key, cert, ca,
+        });
+    }
+
+    /**
      * Get a VaultClient instance
      *
      * @param {string} profileName - name of profile used as part of
@@ -109,12 +127,17 @@ class VaultClientCache {
         if (this._vaultclients[key] === undefined) {
             this._vaultclients[key] = new VaultClient(
                 vaultHost, vaultPort,
-                undefined, undefined, undefined, undefined, undefined,
+                profile.useHttps, profile.key, profile.cert, profile.ca,
+                undefined,
                 profile.adminCreds && profile.adminCreds.accessKey,
                 profile.adminCreds && profile.adminCreds.secretKey,
                 undefined,
                 profile.proxyPath);
         }
+        this._vaultclients[key].setLoggerConfig({
+            level: config.log.logLevel,
+            dump: config.log.dumpLevel,
+        });
         return this._vaultclients[key];
     }
 }

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -653,7 +653,8 @@ describe('queue processor functional tests with mocking', () => {
                   retryTimeoutS: 5,
                   groupId: 'backbeat-func-test-group-id',
               },
-          }, 'sf', new MetricsMock());
+            }, {
+            }, 'sf', new MetricsMock());
         queueProcessor.start({ disableConsumer: true });
         // create the replication status processor only when the queue
         // processor is ready, so that we ensure the replication

--- a/tests/unit/clients/VaultClientCache.spec.js
+++ b/tests/unit/clients/VaultClientCache.spec.js
@@ -2,6 +2,59 @@ const assert = require('assert');
 
 const VaultClientCache = require('../../../lib/clients/VaultClientCache');
 
+const TEST_SSL_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCjoMnwibTjPlft
+qQwu2BlTzd6cxgzqN4Q2zQzgGm5LcDeSZZSjlduP5QSkAFD0+76v6G9jw3pZx+Iz
+knXDGiZMFjX43NT1aIpeuzzrTkogkel4t31UT5wI7FNIqUfSSWqTCrE0R9GDTJQk
+JoIeNjKtpv5VOj9IGrDrYghbhQ0kf8fRomYlw6aXkmFZ3YpP2n8DRb22gTLfPzwf
+v5qff9MINIt+TSNy6EDx+64r1Wj665sfhm+Mgmes/6sV2LLqfYTdfvX3Ia8dGVxa
+Up79heo7WZl3luIV7bReKLTMzF0MGoPQ0/uQEoOOelkByadUmyT/E72wooEp8dEW
+mbRHJbv/AgMBAAECggEARsedstQOkCH+rQpr/7NwuUSbYBt3qLUdFwt531LvlOhU
+0ZnpQx3m3QbHDB4q5t4i7TrRPElpmn6RRZe8IwojuNP+wsjbwdBX0oSR5IN4I0Ca
+yqIsr5TEPUPk/tBjBf7GABcm8iOC6JXumvihXmo5X86Vw84vY4RQNXGxhc03EysV
+rOicaYyP0jnNkDiVlNQV3699CHuj+TOQBtgm/DHwWDSwCy3IFup28fkFf9CusdXo
+PFgbijVVyA4qzT6k2p4xkpT0bKftCFNZX0EqTdDf9B47ylfntA3zKWlPJnrYq0Ol
+4W4ux/BigRWVWb0BvVpAuUhsx60eBG+93128WZRwyQKBgQDYqdufExa0jb9cC6Ds
+lTnEXFrx4gWdNCBoDqYLciBf4+2fu3u5mBK1D5AKHaL3zWQz4shqLznbSP+l6kZw
+qtk8e54ByQ7gxEZgEYi/4JCrNsi/9e/YF0wwTGrh5CHNY+gCD8MmDX1ztM1XvZ2x
+nDnlxTjNyv7lJ7Cf1BDb5mrHowKBgQDBVe/RREd8l5p5kg2R7oTa8kox4bcQKCh9
+Ho/5pC9pqJkFrd6Kh3hvrcrMQoRXoq6/ZdhYZ3h/2BEm51fnclHAy12uJ0wtqNaV
+EAKc5zLxeYZLRiVDoFuTAt1Fdcq1KvrzfXbf4DKp68ov3BgiTwFfIA3nTuyfRdSg
+mj/Yyldv9QKBgEozAY+cze3PjXVMVjQvdrUUm+CycxG/REnemmbZEtVEDaDiaCDL
+P7zaM44DUEhlAqfyRoh22+2JNmPvs2fqWrMn8pjR7lJzZVaJKrfrhB/ehymWZCkw
+8VqpEQGDS0A3ssDh/QcPH6N8i8Y8ncCxq/JQdH+lwV1hFk/mJE/qvS7ZAoGACJWm
+RmZ/vhqFM2y2yYoLwCUOAlUBaeg+k/+taOpPaKOh18y2mvQU9vCClrtFYRbKJ5mA
+F7zQbuzLJi0TjCVZV/QvvrHkAgsDLC8/znO9oVdCDUmaEfym1EpGRPVMAOtdpT4m
+7x3nYgAkRCfDspJLf0vPEjxA6XmSTWdL+nZRl5kCgYBjNo1DWy705UnoI0Gy/8/l
+gcqQDrZu+hb+q5wGR7YuXeZf6O0GiMYvsth2//jLVxFNtlQbTho4HSdPzZlP+ZUe
+bxtOU+kSWci1f0sbEVFlZWL9DcZovSSGxE0TdXKe4HlMRh0pSXbelhzqSxJjaTiR
+epTXxEtz5JoK768GVi9Png==
+-----END PRIVATE KEY-----
+`;
+
+const TEST_SSL_CERT = `-----BEGIN CERTIFICATE-----
+MIIDaTCCAlGgAwIBAgIJALVuIUks3BFZMA0GCSqGSIb3DQEBCwUAMD4xCzAJBgNV
+BAYTAlVTMQswCQYDVQQIDAJDQTEOMAwGA1UECgwFWmVua28xEjAQBgNVBAMMCWxv
+Y2FsaG9zdDAeFw0xODEwMDExMDAwMDhaFw0xODEwMzExMDAwMDhaMD4xCzAJBgNV
+BAYTAlVTMQswCQYDVQQIDAJDQTEOMAwGA1UECgwFWmVua28xEjAQBgNVBAMMCWxv
+Y2FsaG9zdDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKOgyfCJtOM+
+V+2pDC7YGVPN3pzGDOo3hDbNDOAabktwN5JllKOV24/lBKQAUPT7vq/ob2PDelnH
+4jOSdcMaJkwWNfjc1PVoil67POtOSiCR6Xi3fVRPnAjsU0ipR9JJapMKsTRH0YNM
+lCQmgh42Mq2m/lU6P0gasOtiCFuFDSR/x9GiZiXDppeSYVndik/afwNFvbaBMt8/
+PB+/mp9/0wg0i35NI3LoQPH7rivVaPrrmx+Gb4yCZ6z/qxXYsup9hN1+9fchrx0Z
+XFpSnv2F6jtZmXeW4hXttF4otMzMXQwag9DT+5ASg456WQHJp1SbJP8TvbCigSnx
+0RaZtEclu/8CAwEAAaNqMGgwHQYDVR0OBBYEFIe3z8k5FovvDM4CuYTEOZRk8KOE
+MB8GA1UdIwQYMBaAFIe3z8k5FovvDM4CuYTEOZRk8KOEMA8GA1UdEwEB/wQFMAMB
+Af8wFQYDVR0RBA4wDIcEfwAAAYcErBEABDANBgkqhkiG9w0BAQsFAAOCAQEAALfM
+6GoToDHTPZo0dQBMeiKybLMg3f5CYfc9JLXo2PYEhZkKScEzIL+eftKM5xrIxpSs
+LOIzF5nXzTwbqR1GTIyNIBfVs87xGIFLnZGfjYEsFNSLEHSLUbD6vIbYAtCtEooc
+kRftMOD1tazZv8KwLPlukgCf5zA1dMpJnRo9YHL6h/j8KUsqV8eHNL56wDWdE/w+
+32RKZssIoYRsYzkPsaBh7qPo/GIJGh4gPfeaZaTW6Ez0cGJn867BD2V/ClQzHMzl
+JPhqBrmBy48x1tsHynuNMT4FMGOs7U0vYPM36DuWxsfIidy+bnBa1AONuODqx4sF
+hsIqbYEmH5/4WFXOgQ==
+-----END CERTIFICATE-----
+`;
+
 describe('Vault client cache', () => {
     let client;
     let client2;
@@ -13,6 +66,7 @@ describe('Vault client cache', () => {
         vcc.setPort('source:s3', 8500);
         vcc.setHost('dest:s3', '5.6.7.8');
         vcc.setPort('dest:s3', 8500);
+        vcc.setHttps('dest:s3', TEST_SSL_KEY, TEST_SSL_CERT);
     });
 
     it('should cache client instances', () => {
@@ -29,14 +83,16 @@ describe('Vault client cache', () => {
         assert.strictEqual(client2, client);
     });
 
-    it('should honor setHost()/setPort()', () => {
+    it('should honor setHost()/setPort()/setHttps()', () => {
         client = vcc.getClient('source:s3');
         assert.strictEqual(client.getServerHost(), '1.2.3.4');
         assert.strictEqual(client.getServerPort(), 8500);
+        assert.strictEqual(client.useHttps, false);
 
         client2 = vcc.getClient('dest:s3');
         assert.strictEqual(client2.getServerHost(), '5.6.7.8');
         assert.strictEqual(client2.getServerPort(), 8500);
+        assert.strictEqual(client2.useHttps, true);
 
         client = vcc.getClient('source:s3', '42.42.42.42', 1234);
         // setHost() has precedence


### PR DESCRIPTION
- allow optional use of HTTPS instead of HTTP to connect to remote
  nginx (port 9080), also make IAM route go through the proxy instead
  of port 8600 directly.

- make the configuration of certificates optional (not needed either for
  HTTP mode, or HTTPS without client certificate verification).

- more error messages in EchoBucket, add 'where' info to
  SetupReplication logs

- configure logging of vault clients managed by VaultClientCache to
  backbeat log level

- increase IAM timeout from 1s to 30s