### PR TITLE
bf: S3C-1711 remove vault admin credentials from log

### DIFF
--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -253,13 +253,23 @@ class ReplicateObject extends BackbeatTask {
                 if (err) {
                     // eslint-disable-next-line no-param-reassign
                     err.origin = 'target';
+                    let peer;
+                    if (this.destConfig.auth.type === 'role') {
+                        peer = this.destBackbeatHost;
+                        if (this.destConfig.auth.vault) {
+                            const { host, port } = this.destConfig.auth.vault;
+                            if (host) {
+                                // no proxy is used, log the vault host/port
+                                peer = { host, port };
+                            }
+                        }
+                    }
                     log.error('an error occurred when looking up target ' +
                               'account attributes',
                         { method: 'ReplicateObject._setTargetAccountMdOnce',
                             entry: destEntry.getLogInfo(),
                             origin: 'target',
-                            peer: (this.destConfig.auth.type === 'role' ?
-                                   this.destConfig.auth.vault : undefined),
+                            peer,
                             error: err.message });
                     return cb(err);
                 }


### PR DESCRIPTION
The admin credentials were logged after an error occurred while
looking up target account attributes.