### PR TITLE
INTEGRATION [PR#456 > development/8.0] bf: S3C-1711 remove vault admin credentials from log

### DIFF
--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -258,8 +258,10 @@ class ReplicateObject extends BackbeatTask {
                         { method: 'ReplicateObject._setTargetAccountMdOnce',
                             entry: destEntry.getLogInfo(),
                             origin: 'target',
-                            peer: (this.destConfig.auth.type === 'role' ?
-                                   this.destConfig.auth.vault : undefined),
+                            peer: this.destConfig.auth.type === 'role' ?
+                              { host: this.destConfig.auth.vault.host,
+                                port: this.destConfig.auth.vault.port }
+                              : undefined,
                             error: err.message });
                     return cb(err);
                 }


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #456.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.0/bugfix/S3C-1711-removeVaultAdminCredsFromLog`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.0/bugfix/S3C-1711-removeVaultAdminCredsFromLog
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.0/bugfix/S3C-1711-removeVaultAdminCredsFromLog
```

Please always comment pull request #456 instead of this one.