### PR TITLE
INTEGRATION [PR#456 > development/8.0] bf: S3C-1711 remove vault admin credentials from log

### DIFF
--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -253,13 +253,23 @@ class ReplicateObject extends BackbeatTask {
                 if (err) {
                     // eslint-disable-next-line no-param-reassign
                     err.origin = 'target';
+                    let peer;
+                    if (this.destConfig.auth.type === 'role') {
+                        peer = this.destBackbeatHost;
+                        if (this.destConfig.auth.vault) {
+                            const { host, port } = this.destConfig.auth.vault;
+                            if (host) {
+                                // no proxy is used, log the vault host/port
+                                peer = { host, port };
+                            }
+                        }
+                    }
                     log.error('an error occurred when looking up target ' +
                               'account attributes',
                         { method: 'ReplicateObject._setTargetAccountMdOnce',
                             entry: destEntry.getLogInfo(),
                             origin: 'target',
-                            peer: (this.destConfig.auth.type === 'role' ?
-                                   this.destConfig.auth.vault : undefined),
+                            peer,
                             error: err.message });
                     return cb(err);
                 }


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #456.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.0/bugfix/S3C-1711-removeVaultAdminCredsFromLog`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.0/bugfix/S3C-1711-removeVaultAdminCredsFromLog
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.0/bugfix/S3C-1711-removeVaultAdminCredsFromLog
```

Please always comment pull request #456 instead of this one.