### PR TITLE
ft: S3C-1675 HTTPS support for bucketd -> queue populator

### DIFF
--- a/bin/queuePopulator.js
+++ b/bin/queuePopulator.js
@@ -8,6 +8,7 @@ const zkConfig = config.zookeeper;
 const kafkaConfig = config.kafka;
 const extConfigs = config.extensions;
 const qpConfig = config.queuePopulator;
+const httpsConfig = config.internalHttps;
 const mConfig = config.metrics;
 const rConfig = config.redis;
 const QueuePopulator = require('../lib/queuePopulator/QueuePopulator');
@@ -44,9 +45,8 @@ function queueBatch(queuePopulator, taskState) {
 }
 /* eslint-enable no-param-reassign */
 
-const queuePopulator = new QueuePopulator(zkConfig, kafkaConfig,
-    qpConfig, mConfig,
-    rConfig, extConfigs);
+const queuePopulator = new QueuePopulator(
+    zkConfig, kafkaConfig, qpConfig, httpsConfig, mConfig, rConfig, extConfigs);
 
 async.waterfall([
     done => queuePopulator.open(done),

--- a/bin/replication.js
+++ b/bin/replication.js
@@ -57,6 +57,7 @@ function _createSetupReplication(command, options, log) {
             siteName,
         },
         https: config.https,
+        internalHttps: config.internalHttps,
         checkSanity: true,
         log,
     });

--- a/conf/Config.js
+++ b/conf/Config.js
@@ -61,28 +61,38 @@ class Config {
 
         // additional certs checks
         if (parsedConfig.certFilePaths) {
-            const { key, cert, ca } = parsedConfig.certFilePaths;
-
-            const makePath = value =>
-                  (value.startsWith('/') ?
-                   value : `${this._basePath}/${value}`);
-            parsedConfig.https = {};
-            if (key && cert) {
-                const keypath = makePath(key);
-                const certpath = makePath(cert);
-                fs.accessSync(keypath, fs.F_OK | fs.R_OK);
-                fs.accessSync(certpath, fs.F_OK | fs.R_OK);
-                parsedConfig.https.cert = fs.readFileSync(certpath, 'ascii');
-                parsedConfig.https.key = fs.readFileSync(keypath, 'ascii');
-            }
-            if (ca) {
-                const capath = makePath(ca);
-                fs.accessSync(capath, fs.F_OK | fs.R_OK);
-                parsedConfig.https.ca = fs.readFileSync(capath, 'ascii');
-            }
+            parsedConfig.https = this._parseCertFilePaths(
+                parsedConfig.certFilePaths);
+        }
+        if (parsedConfig.internalCertFilePaths) {
+            parsedConfig.internalHttps = this._parseCertFilePaths(
+                parsedConfig.internalCertFilePaths);
         }
         // config is validated, safe to assign directly to the config object
         Object.assign(this, parsedConfig);
+    }
+
+    _parseCertFilePaths(certFilePaths) {
+        const { key, cert, ca } = certFilePaths;
+
+        const makePath = value =>
+              (value.startsWith('/') ?
+               value : `${this._basePath}/${value}`);
+        const https = {};
+        if (key && cert) {
+            const keypath = makePath(key);
+            const certpath = makePath(cert);
+            fs.accessSync(keypath, fs.F_OK | fs.R_OK);
+            fs.accessSync(certpath, fs.F_OK | fs.R_OK);
+            https.cert = fs.readFileSync(certpath, 'ascii');
+            https.key = fs.readFileSync(keypath, 'ascii');
+        }
+        if (ca) {
+            const capath = makePath(ca);
+            fs.accessSync(capath, fs.F_OK | fs.R_OK);
+            https.ca = fs.readFileSync(capath, 'ascii');
+        }
+        return https;
     }
 
     getBasePath() {

--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -1,7 +1,8 @@
 'use strict'; // eslint-disable-line
 
 const joi = require('joi');
-const { hostPortJoi, logJoi } = require('../lib/config/configItems.joi.js');
+const { hostPortJoi, transportJoi, logJoi, certFilePathsJoi } =
+      require('../lib/config/configItems.joi.js');
 
 const joiSchema = {
     zookeeper: {
@@ -17,6 +18,7 @@ const joiSchema = {
         zookeeperPath: joi.string().required(),
         logSource: joi.alternatives().try('bucketd', 'dmd').required(),
         bucketd: hostPortJoi
+            .keys({ transport: transportJoi })
             .when('logSource', { is: 'bucketd', then: joi.required() }),
         dmd: hostPortJoi.keys({
             logName: joi.string().default('s3-recordlog'),
@@ -44,11 +46,8 @@ const joiSchema = {
             })
         ),
     },
-    certFilePaths: joi.object({
-        key: joi.string().empty(''),
-        cert: joi.string().empty(''),
-        ca: joi.string().empty(''),
-    }),
+    certFilePaths: certFilePathsJoi,
+    internalCertFilePaths: certFilePathsJoi,
 };
 
 module.exports = joiSchema;

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -1,10 +1,7 @@
 const fs = require('fs');
 const joi = require('joi');
-const { hostPortJoi, bootstrapListJoi, adminCredsJoi } =
+const { hostPortJoi, transportJoi, bootstrapListJoi, adminCredsJoi } =
     require('../../lib/config/configItems.joi.js');
-
-const transportJoi = joi.alternatives().try('http', 'https')
-    .default('http');
 
 const joiSchema = {
     source: {

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -48,10 +48,19 @@ class QueueProcessor extends EventEmitter {
      * @param {String} repConfig.topic - replication topic name
      * @param {String} repConfig.queueProcessor - config object
      *   specific to queue processor
-     * @param {Object} [httpsConfig] - HTTPS configuration object
+     * @param {Object} [httpsConfig] - destination SSL termination
+     *   HTTPS configuration object
      * @param {String} [httpsConfig.key] - client private key in PEM format
      * @param {String} [httpsConfig.cert] - client certificate in PEM format
      * @param {String} [httpsConfig.ca] - alternate CA bundle in PEM format
+     * @param {Object} [internalHttpsConfig] - internal source HTTPS
+     *   configuration object
+     * @param {String} [internalHttpsConfig.key] - client private key
+     *   in PEM format
+     * @param {String} [internalHttpsConfig.cert] - client certificate
+     *   in PEM format
+     * @param {String} [internalHttpsConfig.ca] - alternate CA bundle
+     *   in PEM format
      * @param {String} repConfig.queueProcessor.groupId - kafka
      *   consumer group ID
      * @param {String} repConfig.queueProcessor.retryTimeoutS -
@@ -60,14 +69,15 @@ class QueueProcessor extends EventEmitter {
      * @param {String} site - site name
      * @param {MetricsProducer} mProducer - instance of metrics producer
      */
-    constructor(kafkaConfig, sourceConfig, destConfig, repConfig, httpsConfig,
-                site, mProducer) {
+    constructor(kafkaConfig, sourceConfig, destConfig, repConfig,
+                httpsConfig, internalHttpsConfig, site, mProducer) {
         super();
         this.kafkaConfig = kafkaConfig;
         this.sourceConfig = sourceConfig;
         this.destConfig = destConfig;
         this.repConfig = repConfig;
         this.httpsConfig = httpsConfig;
+        this.internalHttpsConfig = internalHttpsConfig;
         this.destHosts = null;
         this.sourceAdminVaultConfigured = false;
         this.destAdminVaultConfigured = false;
@@ -81,7 +91,16 @@ class QueueProcessor extends EventEmitter {
         this.logger = new Logger('Backbeat:Replication:QueueProcessor');
 
         // global variables
-        this.sourceHTTPAgent = new http.Agent({ keepAlive: true });
+        if (sourceConfig.transport === 'https') {
+            this.sourceHTTPAgent = new https.Agent({
+                key: internalHttpsConfig.key,
+                cert: internalHttpsConfig.cert,
+                ca: internalHttpsConfig.ca,
+                keepAlive: true,
+            });
+        } else {
+            this.sourceHTTPAgent = new http.Agent({ keepAlive: true });
+        }
         if (destConfig.transport === 'https') {
             this.destHTTPAgent = new https.Agent({
                 key: httpsConfig.key,
@@ -121,6 +140,13 @@ class QueueProcessor extends EventEmitter {
             this.vaultclientCache
                 .setHost('source:s3', host)
                 .setPort('source:s3', port);
+            if (this.sourceConfig.transport === 'https') {
+                // provision HTTPS credentials for local Vault S3 route
+                this.vaultclientCache.setHttps(
+                    'source:s3', this.internalHttpsConfig.key,
+                    this.internalHttpsConfig.cert,
+                    this.internalHttpsConfig.ca);
+            }
             if (adminCredentials) {
                 this.vaultclientCache
                     .setHost('source:admin', host)
@@ -128,6 +154,13 @@ class QueueProcessor extends EventEmitter {
                     .loadAdminCredentials('source:admin',
                                           adminCredentials.accessKey,
                                           adminCredentials.secretKey);
+                if (this.sourceConfig.transport === 'https') {
+                    // provision HTTPS credentials for local Vault admin route
+                    this.vaultclientCache.setHttps(
+                        'source:admin', this.internalHttpsConfig.key,
+                        this.internalHttpsConfig.cert,
+                        this.internalHttpsConfig.ca);
+                }
                 this.sourceAdminVaultConfigured = true;
             }
         }
@@ -231,6 +264,7 @@ class QueueProcessor extends EventEmitter {
             destConfig: this.destConfig,
             repConfig: this.repConfig,
             httpsConfig: this.httpsConfig,
+            internalHttpsConfig: this.internalHttpsConfig,
             destHosts: this.destHosts,
             sourceHTTPAgent: this.sourceHTTPAgent,
             destHTTPAgent: this.destHTTPAgent,

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -10,6 +10,7 @@ const kafkaConfig = config.kafka;
 const repConfig = config.extensions.replication;
 const sourceConfig = repConfig.source;
 const httpsConfig = config.https;
+const internalHttpsConfig = config.internalHttps;
 const mConfig = config.metrics;
 
 const site = process.argv[2];
@@ -36,7 +37,8 @@ metricsProducer.setupProducer(err => {
         });
         return undefined;
     }
-    const queueProcessor = new QueueProcessor(kafkaConfig, sourceConfig,
-        destConfig, repConfig, httpsConfig, site, metricsProducer);
+    const queueProcessor = new QueueProcessor(
+        kafkaConfig, sourceConfig, destConfig, repConfig,
+        httpsConfig, internalHttpsConfig, site, metricsProducer);
     return queueProcessor.start();
 });

--- a/extensions/replication/replicationStatusProcessor/task.js
+++ b/extensions/replication/replicationStatusProcessor/task.js
@@ -8,9 +8,10 @@ const config = require('../../../conf/Config');
 const kafkaConfig = config.kafka;
 const repConfig = config.extensions.replication;
 const sourceConfig = repConfig.source;
+const internalHttpsConfig = config.internalHttps;
 
-const replicationStatusProcessor =
-          new ReplicationStatusProcessor(kafkaConfig, sourceConfig, repConfig);
+const replicationStatusProcessor = new ReplicationStatusProcessor(
+    kafkaConfig, sourceConfig, repConfig, internalHttpsConfig);
 
 werelogs.configure({ level: config.log.logLevel,
                      dump: config.log.dumpLevel });

--- a/extensions/replication/tasks/EchoBucket.js
+++ b/extensions/replication/tasks/EchoBucket.js
@@ -228,6 +228,7 @@ class EchoBucket extends BackbeatTask {
                     },
                     retryTimeoutS: this.repConfig.queueProcessor.retryTimeoutS,
                     https: this.httpsConfig,
+                    internalHttps: this.internalHttpsConfig,
                     skipSourceBucketCreation: true,
                     log,
                 });

--- a/lib/config/configItems.joi.js
+++ b/lib/config/configItems.joi.js
@@ -2,19 +2,22 @@
 
 const joi = require('joi');
 
-const hostPortJoi = joi.object({
+const hostPortJoi = joi.object().keys({
     host: joi.string().required(),
     port: joi.number().greater(0).required(),
 });
 
-const bootstrapServers = joi.object({
+const transportJoi = joi.alternatives().try('http', 'https')
+    .default('http');
+
+const bootstrapServers = joi.object().keys({
     site: joi.string().required(),
     servers: joi.array().items(joi.string()),
     default: joi.boolean().truthy('yes').falsy('no'),
     echo: joi.boolean().default(false),
 });
 
-const bootstrapCloudBackend = joi.object({
+const bootstrapCloudBackend = joi.object().keys({
     site: joi.string().required(),
     type: joi.string().valid('aws_s3', 'azure'),
     default: joi.boolean().truthy('yes').falsy('no'),
@@ -45,9 +48,17 @@ const adminCredsJoi = joi.object()
           .min(1)
           .pattern(/^[A-Za-z0-9]{20}$/, joi.string());
 
+const certFilePathsJoi = joi.object({
+    key: joi.string().empty(''),
+    cert: joi.string().empty(''),
+    ca: joi.string().empty(''),
+});
+
 module.exports = {
     hostPortJoi,
+    transportJoi,
     bootstrapListJoi,
     logJoi,
     adminCredsJoi,
+    certFilePathsJoi,
 };

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -30,17 +30,22 @@ class QueuePopulator {
      *   configuration (mandatory if logSource is "bucket")
      * @param {Object} [qpConfig.dmd] - dmd source
      *   configuration (mandatory if logSource is "dmd")
+     * @param {Object} [httpsConfig] - HTTPS configuration object
+     * @param {String} [httpsConfig.key] - private key file path
+     * @param {String} [httpsConfig.cert] - certificate file path
+     * @param {String} [httpsConfig.ca] - CA file path
      * @param {Object} mConfig - metrics configuration object
      * @param {string} mConfig.topic - metrics topic
      * @param {Object} rConfig - redis configuration object
      * @param {Object} extConfigs - configuration of extensions: keys
      *   are extension names and values are extension's config object.
      */
-    constructor(zkConfig, kafkaConfig, qpConfig, mConfig, rConfig,
-                extConfigs) {
+    constructor(zkConfig, kafkaConfig, qpConfig, httpsConfig,
+                mConfig, rConfig, extConfigs) {
         this.zkConfig = zkConfig;
         this.kafkaConfig = kafkaConfig;
         this.qpConfig = qpConfig;
+        this.httpsConfig = httpsConfig;
         this.mConfig = mConfig;
         this.rConfig = rConfig;
         this.extConfigs = extConfigs;
@@ -149,6 +154,7 @@ class QueuePopulator {
                     zkClient: this.zkClient,
                     kafkaConfig: this.kafkaConfig,
                     bucketdConfig: this.qpConfig.bucketd,
+                    httpsConfig: this.httpsConfig,
                     raftId,
                     logger: this.log,
                     extensions: this._extensions,

--- a/lib/queuePopulator/RaftLogReader.js
+++ b/lib/queuePopulator/RaftLogReader.js
@@ -6,13 +6,21 @@ const LogReader = require('./LogReader');
 
 class RaftLogReader extends LogReader {
     constructor(params) {
-        const { zkClient, kafkaConfig, bucketdConfig,
+        const { zkClient, kafkaConfig, bucketdConfig, httpsConfig,
                 raftId, logger, extensions, metricsProducer } = params;
         const { host, port } = bucketdConfig;
         logger.info('initializing raft log reader',
             { method: 'RaftLogReader.constructor',
-                bucketdConfig, raftId });
-        const bucketClient = new BucketClient(`${host}:${port}`);
+              bucketdConfig, raftId });
+        const _httpsConfig = httpsConfig || {};
+        let bucketClient;
+        if (bucketdConfig.transport === 'https') {
+            bucketClient = new BucketClient(
+                `${host}:${port}`, undefined, true,
+                _httpsConfig.key, _httpsConfig.cert, _httpsConfig.ca);
+        } else {
+            bucketClient = new BucketClient(`${host}:${port}`);
+        }
         const logConsumer = new LogConsumer({ bucketClient,
             raftSession: raftId,
             logger });

--- a/tests/behavior/queuePopulator.js
+++ b/tests/behavior/queuePopulator.js
@@ -62,6 +62,9 @@ describe('queuePopulator', () => {
                     testConfig.zookeeper,
                     testConfig.kafka,
                     testConfig.queuePopulator,
+                    undefined,
+                    undefined,
+                    undefined,
                     testConfig.extensions);
                 queuePopulator.open(next);
             },

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -655,6 +655,7 @@ describe('queue processor functional tests with mocking', () => {
                   groupId: 'backbeat-func-test-group-id',
               },
             }, {
+            }, {
             }, 'sf', new MetricsMock());
         queueProcessor.start({ disableConsumer: true });
         // create the replication status processor only when the queue
@@ -676,7 +677,8 @@ describe('queue processor functional tests with mocking', () => {
                       retryTimeoutS: 5,
                       groupId: 'backbeat-func-test-group-id',
                   },
-              }, 'sf');
+                }, {
+                });
             replicationStatusProcessor.start({ bootstrap: true }, done);
         });
 


### PR DESCRIPTION
Allow HTTPS transport for queue populator connecting to bucketd (with
optional client certificate)