### PR TITLE
INTEGRATION [PR#466 > development/8.1] ft: S3C-1675 HTTPS support for bucketd -> queue populator

### DIFF
--- a/bin/queuePopulator.js
+++ b/bin/queuePopulator.js
@@ -7,6 +7,7 @@ const config = require('../conf/Config');
 const zkConfig = config.zookeeper;
 const extConfigs = config.extensions;
 const qpConfig = config.queuePopulator;
+const httpsConfig = config.https;
 const mConfig = config.metrics;
 const rConfig = config.redis;
 const QueuePopulator = require('../lib/queuePopulator/QueuePopulator');
@@ -43,8 +44,8 @@ function queueBatch(queuePopulator, taskState) {
 }
 /* eslint-enable no-param-reassign */
 
-const queuePopulator = new QueuePopulator(zkConfig, qpConfig, mConfig,
-    rConfig, extConfigs);
+const queuePopulator = new QueuePopulator(
+    zkConfig, qpConfig, httpsConfig, mConfig, rConfig, extConfigs);
 
 async.waterfall([
     done => queuePopulator.open(done),

--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -1,7 +1,8 @@
 'use strict'; // eslint-disable-line
 
 const joi = require('joi');
-const { hostPortJoi, logJoi } = require('../lib/config/configItems.joi.js');
+const { hostPortJoi, transportJoi, logJoi } =
+      require('../lib/config/configItems.joi.js');
 
 const joiSchema = {
     zookeeper: {
@@ -17,6 +18,7 @@ const joiSchema = {
         zookeeperPath: joi.string().required(),
         logSource: joi.alternatives().try('bucketd', 'dmd').required(),
         bucketd: hostPortJoi
+            .keys({ transport: transportJoi })
             .when('logSource', { is: 'bucketd', then: joi.required() }),
         dmd: hostPortJoi.keys({
             logName: joi.string().default('s3-recordlog'),

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -1,10 +1,7 @@
 const fs = require('fs');
 const joi = require('joi');
-const { hostPortJoi, bootstrapListJoi, adminCredsJoi } =
+const { hostPortJoi, transportJoi, bootstrapListJoi, adminCredsJoi } =
     require('../../lib/config/configItems.joi.js');
-
-const transportJoi = joi.alternatives().try('http', 'https')
-    .default('http');
 
 const joiSchema = {
     source: {

--- a/lib/config/configItems.joi.js
+++ b/lib/config/configItems.joi.js
@@ -2,19 +2,22 @@
 
 const joi = require('joi');
 
-const hostPortJoi = joi.object({
+const hostPortJoi = joi.object().keys({
     host: joi.string().required(),
     port: joi.number().greater(0).required(),
 });
 
-const bootstrapServers = joi.object({
+const transportJoi = joi.alternatives().try('http', 'https')
+    .default('http');
+
+const bootstrapServers = joi.object().keys({
     site: joi.string().required(),
     servers: joi.array().items(joi.string()),
     default: joi.boolean().truthy('yes').falsy('no'),
     echo: joi.boolean().default(false),
 });
 
-const bootstrapCloudBackend = joi.object({
+const bootstrapCloudBackend = joi.object().keys({
     site: joi.string().required(),
     type: joi.string().valid('aws_s3', 'azure'),
     default: joi.boolean().truthy('yes').falsy('no'),
@@ -47,6 +50,7 @@ const adminCredsJoi = joi.object()
 
 module.exports = {
     hostPortJoi,
+    transportJoi,
     bootstrapListJoi,
     logJoi,
     adminCredsJoi,

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -27,15 +27,20 @@ class QueuePopulator {
      *   configuration (mandatory if logSource is "bucket")
      * @param {Object} [qpConfig.dmd] - dmd source
      *   configuration (mandatory if logSource is "dmd")
+     * @param {Object} [httpsConfig] - HTTPS configuration object
+     * @param {String} [httpsConfig.key] - private key file path
+     * @param {String} [httpsConfig.cert] - certificate file path
+     * @param {String} [httpsConfig.ca] - CA file path
      * @param {Object} mConfig - metrics configuration object
      * @param {string} mConfig.topic - metrics topic
      * @param {Object} rConfig - redis configuration object
      * @param {Object} extConfigs - configuration of extensions: keys
      *   are extension names and values are extension's config object.
      */
-    constructor(zkConfig, qpConfig, mConfig, rConfig, extConfigs) {
+    constructor(zkConfig, qpConfig, httpsConfig, mConfig, rConfig, extConfigs) {
         this.zkConfig = zkConfig;
         this.qpConfig = qpConfig;
+        this.httpsConfig = httpsConfig;
         this.mConfig = mConfig;
         this.rConfig = rConfig;
         this.extConfigs = extConfigs;
@@ -144,6 +149,7 @@ class QueuePopulator {
                     zkClient: this.zkClient,
                     zkConfig: this.zkConfig,
                     bucketdConfig: this.qpConfig.bucketd,
+                    httpsConfig: this.httpsConfig,
                     raftId,
                     logger: this.log,
                     extensions: this._extensions,

--- a/lib/queuePopulator/RaftLogReader.js
+++ b/lib/queuePopulator/RaftLogReader.js
@@ -6,13 +6,21 @@ const LogReader = require('./LogReader');
 
 class RaftLogReader extends LogReader {
     constructor(params) {
-        const { zkClient, zkConfig, bucketdConfig,
+        const { zkClient, zkConfig, bucketdConfig, httpsConfig,
                 raftId, logger, extensions, metricsProducer } = params;
         const { host, port } = bucketdConfig;
         logger.info('initializing raft log reader',
             { method: 'RaftLogReader.constructor',
-                bucketdConfig, raftId });
-        const bucketClient = new BucketClient(`${host}:${port}`);
+              bucketdConfig, raftId });
+        const _httpsConfig = httpsConfig || {};
+        let bucketClient;
+        if (bucketdConfig.transport === 'https') {
+            bucketClient = new BucketClient(
+                `${host}:${port}`, undefined, true,
+                _httpsConfig.key, _httpsConfig.cert, _httpsConfig.ca);
+        } else {
+            bucketClient = new BucketClient(`${host}:${port}`);
+        }
         const logConsumer = new LogConsumer({ bucketClient,
             raftSession: raftId,
             logger });

--- a/tests/behavior/queuePopulator.js
+++ b/tests/behavior/queuePopulator.js
@@ -61,6 +61,9 @@ describe('queuePopulator', () => {
                 queuePopulator = new QueuePopulator(
                     testConfig.zookeeper,
                     testConfig.queuePopulator,
+                    undefined,
+                    undefined,
+                    undefined,
                     testConfig.extensions);
                 queuePopulator.open(next);
             },


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #466.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/feature/S3C-1675-backbeatHttpsToBucketd`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/feature/S3C-1675-backbeatHttpsToBucketd
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/feature/S3C-1675-backbeatHttpsToBucketd
```

Please always comment pull request #466 instead of this one.