### PR TITLE
ft: ZENKO-1175 tailable cursor to consume mongo oplog

### DIFF
--- a/bin/ingestion.js
+++ b/bin/ingestion.js
@@ -29,20 +29,14 @@ function queueBatch(queuePopulator, taskState, qConfig, log) {
     log.debug('start queueing replication batch');
     taskState.batchInProgress = true;
     const maxRead = qpConfig.batchMaxRead;
-    queuePopulator.processAllLogEntries({ maxRead }, (err, counters) => {
+    queuePopulator.processLogEntries({ maxRead }, err => {
         taskState.batchInProgress = false;
         if (err) {
             log.error('an error occurred during replication', {
                 method: 'QueuePopulator::task.queueBatch',
                 error: err,
             });
-            return undefined;
         }
-        const logFunc = (counters.some(counter =>
-            Object.keys(counter.queuedEntries).length > 0) ?
-            log.info : log.debug).bind(log);
-        logFunc('replication batch finished', { counters });
-        return undefined;
     });
     return undefined;
 }

--- a/bin/queuePopulator.js
+++ b/bin/queuePopulator.js
@@ -23,26 +23,23 @@ werelogs.configure({ level: config.log.logLevel,
 /* eslint-disable no-param-reassign */
 function queueBatch(queuePopulator, taskState) {
     if (taskState.batchInProgress) {
-        log.warn('skipping replication batch: previous one still in progress');
+        log.debug('skipping batch: previous one still in progress');
         return undefined;
     }
-    log.debug('start queueing replication batch');
+    log.debug('start queueing batch');
     taskState.batchInProgress = true;
     const maxRead = qpConfig.batchMaxRead;
-    queuePopulator.processAllLogEntries({ maxRead }, (err, counters) => {
+    const timeoutMs = qpConfig.batchTimeoutMs;
+    queuePopulator.processLogEntries({ maxRead, timeoutMs }, err => {
         taskState.batchInProgress = false;
         if (err) {
-            log.error('an error occurred during replication', {
+            log.error('an error occurred during batch processing', {
                 method: 'QueuePopulator::task.queueBatch',
                 error: err,
             });
-            return undefined;
+            // exit process and let Kubernetes respawn the pod
+            process.exit(1);
         }
-        const logFunc = (counters.some(counter =>
-            Object.keys(counter.queuedEntries).length > 0) ?
-            log.info : log.debug).bind(log);
-        logFunc('replication batch finished', { counters });
-        return undefined;
     });
     return undefined;
 }

--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -20,6 +20,7 @@ const joiSchema = {
     queuePopulator: {
         cronRule: joi.string().required(),
         batchMaxRead: joi.number().default(10000),
+        batchTimeoutMs: joi.number().default(9000),
         zookeeperPath: joi.string().required(),
 
         logSource: joi.alternatives().try(logSourcesJoi).required(),

--- a/conf/config.json
+++ b/conf/config.json
@@ -13,6 +13,7 @@
     "queuePopulator": {
         "cronRule": "*/5 * * * * *",
         "batchMaxRead": 10000,
+        "batchTimeoutMs": 9000,
         "zookeeperPath": "/queue-populator",
         "logSource": "mongo",
         "bucketd": {

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -134,7 +134,10 @@ class BackbeatProducer extends EventEmitter {
             this.emit('error', error);
             return cbOnce(error);
         }
-        this._log.debug('delivery report received', { report });
+        const { topic, partition, offset } = report;
+        const key = report.key && report.key.toString();
+        this._log.debug('delivery report received',
+                        { topic, partition, offset, key });
         if (sendCtx.pendingReportsCount === 0) {
             // all delivery reports received (if errors occurred, the
             // callback will have been called earlier so this will be

--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -326,33 +326,23 @@ class IngestionPopulator {
         return process.nextTick(done);
     }
 
-    _processAllLogEntries(params, done) {
+    _processLogEntries(params, done) {
         return async.map(
             this.logReaders,
-            (logReader, done) => logReader.processAllLogEntries(params, done),
-            (err, results) => {
-                if (err) {
-                    return done(err);
-                }
-                const annotatedResults = results.map(
-                    (result, i) => Object.assign(result, {
-                        logSource: this.logReaders[i].getLogInfo(),
-                        logOffset: this.logReaders[i].getLogOffset(),
-                    }));
-                return done(null, annotatedResults);
-            });
+            (logReader, cb) => logReader.processLogEntries(params, cb),
+            done);
     }
 
-    processAllLogEntries(params, done) {
+    processLogEntries(params, done) {
         if (this.logReadersUpdate.length >= 1) {
             return this._setupUpdatedReaders(err => {
                 if (err) {
                     return done(err);
                 }
-                return this._processAllLogEntries(params, done);
+                return this._processLogEntries(params, done);
             });
         }
-        return this._processAllLogEntries(params, done);
+        return this._processLogEntries(params, done);
     }
 
     zkStatus() {

--- a/lib/queuePopulator/IngestionReader.js
+++ b/lib/queuePopulator/IngestionReader.js
@@ -203,7 +203,7 @@ class IngestionReader extends LogReader {
             }
             this.newIngestion = false;
             this.remoteLogOffset = null;
-            return this._writeLogOffset(done);
+            return this._writeLogOffset(batchState.logger, done);
         }
         return process.nextTick(() => done());
     }

--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -1,5 +1,7 @@
 const async = require('async');
 
+const jsutil = require('arsenal').jsutil;
+
 const config = require('../../conf/Config');
 const BackbeatProducer = require('../BackbeatProducer');
 const ReplicationQueuePopulator =
@@ -39,6 +41,9 @@ class LogReader {
         this._producers = {};
         this._extensions = params.extensions;
         this._mProducer = params.metricsProducer;
+
+        // internal variable to carry over a tailable cursor across batches
+        this._openLog = null;
     }
 
     _setEntryBatch(entryBatch) {
@@ -75,8 +80,7 @@ class LogReader {
                 return done(err);
             }
             this.logOffset = offset;
-            this.log.info('log reader is ready to populate replication ' +
-                          'queue',
+            this.log.info('log reader is ready to populate backbeat queue(s)',
                 { logSource: this.getLogInfo(),
                     logOffset: this.logOffset });
             return done();
@@ -143,7 +147,7 @@ class LogReader {
         });
     }
 
-    _writeLogOffset(done) {
+    _writeLogOffset(logger, done) {
         const pathToLogOffset = this.pathToLogOffset;
         const offsetString = this.logOffset.toString();
         this.zkClient.setData(
@@ -151,14 +155,14 @@ class LogReader {
             Buffer.from(offsetString), -1,
             err => {
                 if (err) {
-                    this.log.error(
+                    logger.error(
                         'error saving log offset',
                         { method: 'LogReader._writeLogOffset',
                             zkPath: pathToLogOffset,
                             logOffset: this.logOffset });
                     return done(err);
                 }
-                this.log.debug(
+                logger.debug(
                     'saved log offset',
                     { method: 'LogReader._writeLogOffset',
                         zkPath: pathToLogOffset,
@@ -168,23 +172,19 @@ class LogReader {
     }
 
     /**
-     * Process log entries, up to the maximum defined in params
+     * Process log entries, up to the maximum defined in params or
+     * until the timeout is reached waiting for new entries to come
+     * (if tailable oplog)
      *
      * @param {Object} [params] - parameters object
      * @param {Number} [params.maxRead] - max number of records to process
      *   from the log. Records may contain multiple entries and all entries
      *   are not queued, so the number of queued entries is not directly
      *   related to this number.
+     * @param {Number} [params.timeoutMs] - timeout after which the
+     *   batch will be stopped if still running (default 10000ms)
      * @param {function} done - callback when done processing the
-     *   entries. Called with an error, or null and a statistics object as
-     *   second argument. On success, the statistics contain the following:
-     *     - readRecords {Number} - number of records read
-     *     - readEntries {Number} - number of entries read (records can
-     *       hold multiple entries)
-     *     - queuedEntries {Object} - number of new entries queued in
-     *       various kafka topics
-     *     - processedAll {Boolean} - true if the log has no more unread
-     *       records
+     *   entries
      * @return {undefined}
      */
     processLogEntries(params, done) {
@@ -196,6 +196,10 @@ class LogReader {
             },
             entriesToPublish: {},
             publishedEntries: {},
+            maxRead: params.maxRead,
+            startTime: Date.now(),
+            timeoutMs: params.timeoutMs,
+            logger: this.log.newRequestLogger(),
         };
 
         async.waterfall([
@@ -213,74 +217,68 @@ class LogReader {
                 Object.keys(publishedEntries).forEach(topic => {
                     queuedEntries[topic] = publishedEntries[topic].length;
                 });
-                const processedAll = !params
-                          || !params.maxRead
-                          || (batchState.logStats.nbLogRecordsRead
-                              < params.maxRead);
-                return done(null, {
+                const stats = {
                     readRecords: batchState.logStats.nbLogRecordsRead,
                     readEntries: batchState.logStats.nbLogEntriesRead,
+                    skippedRecords: batchState.logStats.skippedRecords,
                     queuedEntries,
-                    processedAll,
+                };
+                // Use heuristics to log when:
+                // - at least one entry is pushed to any topic
+                // - many records have been skipped (e.g. when starting up
+                //   consumption from mongo oplog)
+                // - the batch took a significant time to complete.
+                const useInfoLevel =
+                      Object.keys(stats.queuedEntries).length > 0 ||
+                      stats.skippedRecords > 1000;
+                const endLog = batchState.logger.end();
+                const logFunc = (useInfoLevel ? endLog.info : endLog.debug)
+                      .bind(endLog);
+                logFunc('batch completed', {
+                    stats,
+                    logSource: this.getLogInfo(),
+                    logOffset: this.getLogOffset(),
                 });
+                return done();
             });
         return undefined;
-    }
-
-    processAllLogEntries(params, done) {
-        const self = this;
-        const countersTotal = {
-            readRecords: 0,
-            readEntries: 0,
-            queuedEntries: {},
-        };
-        function cbProcess(err, counters) {
-            if (err) {
-                return done(err);
-            }
-            countersTotal.readRecords += counters.readRecords;
-            countersTotal.readEntries += counters.readEntries;
-            Object.keys(counters.queuedEntries).forEach(topic => {
-                if (countersTotal.queuedEntries[topic] === undefined) {
-                    countersTotal.queuedEntries[topic] = 0;
-                }
-                countersTotal.queuedEntries[topic] +=
-                    counters.queuedEntries[topic];
-            });
-            self.log.debug('process batch finished',
-                           { counters, countersTotal });
-            if (counters.processedAll) {
-                return done(null, countersTotal);
-            }
-            return self.processLogEntries(params, cbProcess);
-        }
-        return self.processLogEntries(params, cbProcess);
     }
 
     /* eslint-disable no-param-reassign */
 
     _processReadRecords(params, batchState, done) {
+        if (this._openLog) {
+            // an open tailable cursor already exists: reuse it
+            batchState.logRes = this._openLog;
+            return done();
+        }
+        const { logger } = batchState;
         const readOptions = {};
         if (this.logOffset !== undefined) {
             readOptions.startSeq = this.logOffset;
         }
         if (params && params.maxRead !== undefined) {
+            // only has effect for non-tailable oplog
             readOptions.limit = params.maxRead;
         }
-        this.log.debug('reading records', { readOptions });
-        this.logConsumer.readRecords(readOptions, (err, res) => {
+        logger.debug('reading records', { readOptions });
+        return this.logConsumer.readRecords(readOptions, (err, res) => {
             if (err) {
-                this.log.error(
+                logger.error(
                     'error while reading log records',
                     { method: 'LogReader._processReadRecords',
                         params, error: err });
                 return done(err);
             }
-            this.log.debug(
+            logger.debug(
                 'readRecords callback',
                 { method: 'LogReader._processReadRecords',
                     params });
             batchState.logRes = res;
+            if (res.tailable) {
+                // carry tailable cursor over for future batches
+                this._openLog = res;
+            }
             return done();
         });
     }
@@ -298,15 +296,18 @@ class LogReader {
     }
 
     _processPrepareEntries(batchState, done) {
-        const { entriesToPublish, logRes, logStats } = batchState;
+        const { entriesToPublish, logRes, logStats, logger } = batchState;
 
         // for raft log only
         if (logRes.info && logRes.info.start === null) {
             return done(null);
         }
-        logRes.log.on('data', record => {
-            this.log.debug('received log data',
-                           { nbEntries: record.entries.length });
+
+        let shipBatchCb;
+        const dataEventHandler = record => {
+            logger.debug('received log data', {
+                nbEntries: record.entries.length,
+            });
             logStats.nbLogRecordsRead += 1;
 
             this._setEntryBatch(entriesToPublish);
@@ -316,21 +317,87 @@ class LogReader {
                 this._processLogEntry(batchState, record, entry);
             });
             this._unsetEntryBatch();
-        });
-        logRes.log.on('error', err => {
-            this.log.error('error fetching entries from log',
-                { method: 'LogReader._processPrepareEntries',
-                    error: err });
-            return done(err);
-        });
-        logRes.log.on('end', () => {
-            this.log.debug('ending record stream');
-            return done();
-        });
-        logRes.log.on('info', info => {
-            this.log.debug('received record stream "info" event', { info });
-            logRes.info = info;
-        });
+
+            // Pause tailable streams when reaching the record batch
+            // limit, as those streams do not emit 'end' events but
+            // continuously send 'data' events as they come.
+            if (logRes.tailable &&
+                logStats.nbLogRecordsRead >= batchState.maxRead) {
+                logger.debug('ending batch', {
+                    method: 'LogReader._processPrepareEntries',
+                    reason: 'limit on number of read records reached',
+                    readRecords: logStats.nbLogRecordsRead,
+                });
+                shipBatchCb();
+            }
+        };
+        const errorEventHandler = err => {
+            logger.error('error fetching entries from log', {
+                method: 'LogReader._processPrepareEntries',
+                error: err,
+            });
+            return shipBatchCb(err);
+        };
+        const endEventHandler = () => {
+            logger.debug('ending record stream', {
+                method: 'LogReader._processPrepareEntries',
+            });
+            return shipBatchCb();
+        };
+        logRes.log.on('data', dataEventHandler);
+        logRes.log.on('error', errorEventHandler);
+        logRes.log.on('end', endEventHandler);
+
+        if (logRes.tailable) {
+            //
+            // For tailable oplog, set an interval check to timely end
+            // and ship the current batch "timeoutMs" after the
+            // beginning of the batch.
+            //
+            // This should guarantee regular updates to the stored
+            // offset in zookeeper, while allowing a batch enough time
+            // to maximize its rate of consumption of log messages
+            // (deemed useful to reduce startup time).
+            //
+            const checker = setInterval(() => {
+                const now = Date.now();
+                if (now >= batchState.startTime + batchState.timeoutMs) {
+                    logger.debug('ending batch', {
+                        method: 'LogReader._processPrepareEntries',
+                        reason: 'batch timeout reached',
+                        readRecords: logStats.nbLogRecordsRead,
+                    });
+                    shipBatchCb();
+                }
+            }, 1000);
+            shipBatchCb = jsutil.once(err => {
+                logRes.log.pause();
+                logRes.log.removeListener('data', dataEventHandler);
+                logRes.log.removeListener('error', errorEventHandler);
+                logRes.log.removeListener('end', endEventHandler);
+                clearInterval(checker);
+                done(err);
+            });
+        } else {
+            shipBatchCb = jsutil.once(done);
+            // for raft log
+            logRes.log.on('info', info => {
+                logger.debug('received record stream "info" event', {
+                    method: 'LogReader._processPrepareEntries',
+                    info,
+                });
+                logRes.info = info;
+            });
+        }
+        if (logRes.tailable && logRes.log.isPaused()) {
+            logger.debug('resuming tailable cursor', {
+                method: 'LogReader._processPrepareEntries',
+            });
+            logRes.log.resume();
+        }
+        if (logRes.log.getSkipCount) {
+            logStats.initialSkipCount = logRes.log.getSkipCount();
+        }
         return undefined;
     }
 
@@ -359,20 +426,24 @@ class LogReader {
     }
 
     _processPublishEntries(batchState, done) {
-        const { entriesToPublish, logRes, logStats } = batchState;
+        const { entriesToPublish, logRes, logStats, logger } = batchState;
 
         // for raft log only
         if (logRes.info && logRes.info.start === null) {
             return done();
         }
 
-        if (config.queuePopulator.logSource === 'mongo') {
-            batchState.nextLogOffset = logRes.info.end;
+        if (logRes.log.getOffset) {
+            batchState.nextLogOffset = logRes.log.getOffset();
         } else {
             batchState.nextLogOffset =
                 logRes.info.start + logStats.nbLogRecordsRead;
         }
-
+        if (logStats.initialSkipCount !== undefined) {
+            const finalSkipCount = logRes.log.getSkipCount();
+            logStats.skippedRecords =
+                finalSkipCount - logStats.initialSkipCount;
+        }
         return async.each(Object.keys(entriesToPublish), (topic, done) => {
             const topicEntries = entriesToPublish[topic];
             if (topicEntries.length === 0) {
@@ -383,7 +454,7 @@ class LogReader {
                 done => this._producers[topic].send(topicEntries, done),
             ], err => {
                 if (err) {
-                    this.log.error(
+                    logger.error(
                         'error publishing entries from log to topic',
                         { method: 'LogReader._processPublishEntries',
                           topic,
@@ -391,9 +462,9 @@ class LogReader {
                           error: err });
                     return done(err);
                 }
-                this.log.debug('entries published successfully to topic',
-                               { method: 'LogReader._processPublishEntries',
-                                 topic, entryCount: topicEntries.length });
+                logger.debug('entries published successfully to topic',
+                             { method: 'LogReader._processPublishEntries',
+                               topic, entryCount: topicEntries.length });
                 batchState.publishedEntries[topic] = topicEntries;
                 return done();
             });
@@ -416,10 +487,12 @@ class LogReader {
     }
 
     _processSaveLogOffset(batchState, done) {
-        if (batchState.nextLogOffset !== undefined &&
-            batchState.nextLogOffset !== this.logOffset) {
-            this.logOffset = batchState.nextLogOffset;
-            return this._writeLogOffset(done);
+        const { logRes, nextLogOffset, logger } = batchState;
+        if (nextLogOffset !== undefined && nextLogOffset !== this.logOffset
+            && (!logRes.log.reachedUnpublishedListing ||
+                logRes.log.reachedUnpublishedListing())) {
+            this.logOffset = nextLogOffset;
+            return this._writeLogOffset(logger, done);
         }
         return process.nextTick(() => done());
     }

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -154,26 +154,17 @@ class QueuePopulator {
             this._subscribeToLogSourceDispatcher('raft-id-dispatcher');
             break;
         case 'mongo':
-            if (this.qpConfig.subscribeToLogSourceDispatcher) {
-                // initialization of mongo log source is deferred until
-                // the dispatcher notifies us we're the single populator
-                // responsible for it
-                this._subscribeToLogSourceDispatcher('mongo-dispatcher');
-            } else {
-                // always consume from mongo log (good for Kubernetes
-                // deployments)
-                this.logReadersUpdate = [
-                    new MongoLogReader({
-                        zkClient: this.zkClient,
-                        kafkaConfig: this.kafkaConfig,
-                        zkConfig: this.zkConfig,
-                        mongoConfig: this.qpConfig.mongo,
-                        logger: this.log,
-                        extensions: this._extensions,
-                        metricsProducer: this._mProducer,
-                    }),
-                ];
-            }
+            this.logReadersUpdate = [
+                new MongoLogReader({
+                    zkClient: this.zkClient,
+                    kafkaConfig: this.kafkaConfig,
+                    zkConfig: this.zkConfig,
+                    mongoConfig: this.qpConfig.mongo,
+                    logger: this.log,
+                    extensions: this._extensions,
+                    metricsProducer: this._mProducer,
+                }),
+            ];
             break;
         case 'dmd':
             this.logReadersUpdate = [
@@ -211,29 +202,16 @@ class QueuePopulator {
                               { zkEndpoint });
             }
             this.logReadersUpdate = items.map(
-                token => {
-                    if (token === 'mongo') {
-                        return new MongoLogReader({
-                            zkClient: this.zkClient,
-                            kafkaConfig: this.kafkaConfig,
-                            zkConfig: this.zkConfig,
-                            mongoConfig: this.qpConfig.mongo,
-                            logger: this.log,
-                            extensions: this._extensions,
-                            metricsProducer: this._mProducer,
-                        });
-                    }
-                    return new RaftLogReader({
-                        zkClient: this.zkClient,
-                        kafkaConfig: this.kafkaConfig,
-                        bucketdConfig: this.qpConfig.bucketd,
-                        httpsConfig: this.httpsConfig,
-                        raftId: token,
-                        logger: this.log,
-                        extensions: this._extensions,
-                        metricsProducer: this._mProducer,
-                    });
-                });
+                token => new RaftLogReader({
+                    zkClient: this.zkClient,
+                    kafkaConfig: this.kafkaConfig,
+                    bucketdConfig: this.qpConfig.bucketd,
+                    httpsConfig: this.httpsConfig,
+                    raftId: token,
+                    logger: this.log,
+                    extensions: this._extensions,
+                    metricsProducer: this._mProducer,
+                }));
             return undefined;
         });
         this.log.info('waiting to be provisioned a log source',
@@ -309,33 +287,23 @@ class QueuePopulator {
         return process.nextTick(done);
     }
 
-    _processAllLogEntries(params, done) {
+    _processLogEntries(params, done) {
         return async.map(
             this.logReaders,
-            (logReader, done) => logReader.processAllLogEntries(params, done),
-            (err, results) => {
-                if (err) {
-                    return done(err);
-                }
-                const annotatedResults = results.map(
-                    (result, i) => Object.assign(result, {
-                        logSource: this.logReaders[i].getLogInfo(),
-                        logOffset: this.logReaders[i].getLogOffset(),
-                    }));
-                return done(null, annotatedResults);
-            });
+            (logReader, cb) => logReader.processLogEntries(params, cb),
+            done);
     }
 
-    processAllLogEntries(params, done) {
+    processLogEntries(params, done) {
         if (this.logReadersUpdate !== null) {
             return this._setupUpdatedReaders(err => {
                 if (err) {
                     return done(err);
                 }
-                return this._processAllLogEntries(params, done);
+                return this._processLogEntries(params, done);
             });
         }
-        return this._processAllLogEntries(params, done);
+        return this._processLogEntries(params, done);
     }
 
     zkStatus() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,12 +79,12 @@
               }
             },
             "mongodb": {
-              "version": "3.1.8",
-              "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.8.tgz",
-              "integrity": "sha512-yNKwYxQ6m00NV6+pMoWoheFTHSQVv1KkSrfOhRDYMILGWDYtUtQRqHrFqU75rmPIY8hMozVft8zdC4KYMWaM3Q==",
+              "version": "3.1.9",
+              "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.9.tgz",
+              "integrity": "sha512-f+Og32wK/ovzVlC1S6Ft7yjVTvNsAOs6pBpDrPd2/3wPO9ijNsQrTNntuECjOSxGZpPVl0aRqgHzF1e9e+KvnQ==",
               "dev": true,
               "requires": {
-                "mongodb-core": "3.1.7",
+                "mongodb-core": "3.1.8",
                 "safe-buffer": "^5.1.2"
               }
             },
@@ -354,7 +354,7 @@
     "abstract-leveldown": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-      "integrity": "sha1-HF6Mal75Za6MNd+zqHcMR2uCxLg=",
+      "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
       "requires": {
         "xtend": "~4.0.0"
       }
@@ -371,7 +371,7 @@
     "acorn": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha1-Z6ojG/iBKXS4UjWpZ3Hra9B+onk=",
+      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
       "dev": true
     },
     "acorn-jsx": {
@@ -422,7 +422,7 @@
     },
     "ansi-escapes": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
@@ -440,12 +440,12 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo="
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
     "are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha1-SzXClE8GKov82mZBB2A1D+nd/CE=",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -473,7 +473,7 @@
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -483,7 +483,7 @@
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
@@ -527,15 +527,9 @@
       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
       "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco="
     },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
     "arsenal": {
-      "version": "github:scality/Arsenal#549ca1f683060bd2fdd2c3ac9c1936cf12a03687",
-      "from": "github:scality/Arsenal#549ca1f",
+      "version": "github:scality/Arsenal#d620fef517886b179f2b693679b1dcecc53fb012",
+      "from": "github:scality/Arsenal#d620fef",
       "requires": {
         "JSONStream": "^1.0.0",
         "ajv": "4.10.0",
@@ -543,6 +537,7 @@
         "bson": "2.0.4",
         "debug": "~2.3.3",
         "diskusage": "^0.2.2",
+        "fcntl": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
         "ioctl": "2.0.0",
         "ioredis": "2.4.0",
         "ipaddr.js": "1.2.0",
@@ -556,6 +551,7 @@
         "socket.io-client": "~1.7.3",
         "utf8": "2.1.2",
         "uuid": "^3.0.1",
+        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
         "xml2js": "~0.4.16"
       },
       "dependencies": {
@@ -565,14 +561,6 @@
           "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
           "requires": {
             "lodash": "^4.14.0"
-          }
-        },
-        "fcntl": {
-          "version": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
-          "from": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
-          "requires": {
-            "bindings": "^1.1.1",
-            "nan": "^2.3.2"
           }
         },
         "ioredis": {
@@ -592,7 +580,7 @@
         },
         "werelogs": {
           "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-          "from": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+          "from": "github:scality/werelogs#0ff7ec82",
           "requires": {
             "safe-json-stringify": "1.0.3"
           }
@@ -617,7 +605,7 @@
     "async": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
         "lodash": "^4.17.10"
       }
@@ -653,13 +641,13 @@
       "dependencies": {
         "sax": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
           "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
         },
         "uuid": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
         },
         "xml2js": {
           "version": "0.4.17",
@@ -794,7 +782,7 @@
     "base64-js": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
-      "integrity": "sha1-yrHmEY8FEJXli1KBrqjBzSK/wOM="
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
     },
     "base64id": {
       "version": "1.0.0",
@@ -821,7 +809,7 @@
     "bindings": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha1-s0b27PapX1qBXFg5/HzbIlAvHtc="
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
     },
     "bintrees": {
       "version": "1.0.1",
@@ -872,14 +860,14 @@
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
     },
     "bluebird": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-      "integrity": "sha1-G+CQjgVKdRdUVJwnBInBUF1KsVo="
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
+      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -906,10 +894,14 @@
     "bucketclient": {
       "version": "github:scality/bucketclient#520d164d264ac74b920a9d517bd4e08f3ff71473",
       "from": "github:scality/bucketclient#520d164",
+      "requires": {
+        "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
+        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
+      },
       "dependencies": {
         "arsenal": {
           "version": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
-          "from": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
+          "from": "github:scality/Arsenal#67365083",
           "requires": {
             "JSONStream": "^1.0.0",
             "ajv": "4.10.0",
@@ -930,15 +922,6 @@
             "uuid": "^3.0.1",
             "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
             "xml2js": "~0.4.16"
-          },
-          "dependencies": {
-            "werelogs": {
-              "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-              "from": "github:scality/werelogs#0ff7ec82",
-              "requires": {
-                "safe-json-stringify": "1.0.3"
-              }
-            }
           }
         },
         "async": {
@@ -966,7 +949,7 @@
         },
         "werelogs": {
           "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-          "from": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+          "from": "github:scality/werelogs#0ff7ec82",
           "requires": {
             "safe-json-stringify": "1.0.3"
           }
@@ -975,7 +958,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "requires": {
         "base64-js": "^1.0.2",
@@ -993,7 +976,7 @@
     "buffer-alloc": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha1-iQ3ZDZI6hz4I4Q5f1RpX5bfM4Ow=",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "requires": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
@@ -1002,7 +985,7 @@
     "buffer-alloc-unsafe": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha1-vX3CauKXLQ7aJTvgYdupkjScGfA="
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -1018,7 +1001,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
     "buffer-shims": {
@@ -1124,13 +1107,13 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "arsenal": "github:scality/Arsenal#18dfc6b4fa93c77f3389ff7ea2abe920dd71dfec",
+        "arsenal": "github:scality/Arsenal#d620fef517886b179f2b693679b1dcecc53fb012",
         "async": "~1.4.2",
         "werelogs": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46"
       },
       "dependencies": {
         "arsenal": {
-          "version": "github:scality/Arsenal#18dfc6b4fa93c77f3389ff7ea2abe920dd71dfec",
+          "version": "github:scality/Arsenal#d620fef517886b179f2b693679b1dcecc53fb012",
           "from": "github:scality/Arsenal#development/8.0",
           "dev": true,
           "optional": true,
@@ -1182,7 +1165,7 @@
         },
         "async": {
           "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.4.2.tgz",
           "integrity": "sha1-bJ7csRztTw3S8tQNsNSaEJwIiqs=",
           "dev": true,
           "optional": true
@@ -1217,7 +1200,7 @@
     },
     "chalk": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
@@ -1231,12 +1214,12 @@
     "chownr": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha1-VHJri4//TfBTxCGH6AH7RBLfFJQ="
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
     },
     "circular-json": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
-      "integrity": "sha1-gVyZ6oT2gJUp0vRXkb34JxE1LWY=",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "cli-cursor": {
@@ -1257,7 +1240,7 @@
     "cluster-key-slot": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.0.12.tgz",
-      "integrity": "sha1-1d7/KlIHF7yYMTl5tocwmy02jik="
+      "integrity": "sha512-21O0kGmvED5OJ7ZTdqQ5lQQ+sjuez33R+d35jZKLwqUb5mqcPHUsxOSzj61+LHVtxGZd1kShbQM3MjB/gBJkVg=="
     },
     "co": {
       "version": "4.6.0",
@@ -1307,7 +1290,7 @@
     "concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -1340,7 +1323,7 @@
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -1364,12 +1347,12 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cron-parser": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-2.6.0.tgz",
-      "integrity": "sha1-riUUztqcy1QCVuIBvdI66BTgNnQ=",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-2.7.0.tgz",
+      "integrity": "sha512-veMY6/CjjOTSyP/y4Vxfd1mSZ1C8FvhwmR+8MZhSyd/cEl72Xq9ySXPMJjrKBeiMuYL12sYLRpUSe68t5Zx4Kw==",
       "requires": {
         "is-nan": "^1.2.1",
-        "moment-timezone": "^0.5.0"
+        "moment-timezone": "^0.5.23"
       }
     },
     "cross-spawn": {
@@ -1402,7 +1385,7 @@
     },
     "d": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
@@ -1437,7 +1420,7 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw="
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1448,7 +1431,7 @@
     "deferred-leveldown": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-      "integrity": "sha1-Os0uC3XRZpkkvApLZChRExFz4es=",
+      "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
       "requires": {
         "abstract-leveldown": "~2.6.0"
       }
@@ -1456,32 +1439,23 @@
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "requires": {
         "object-keys": "^1.0.12"
       }
     },
     "del": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+      "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "dev": true,
       "requires": {
-        "globby": "^5.0.0",
+        "globby": "^6.1.0",
         "is-path-cwd": "^1.0.0",
         "is-path-in-cwd": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
+        "p-map": "^1.1.1",
+        "pify": "^3.0.0",
         "rimraf": "^2.2.8"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
       }
     },
     "delayed-stream": {
@@ -1498,7 +1472,7 @@
     "denque": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.3.0.tgz",
-      "integrity": "sha1-aBCS70SmMCRtP27bKhmSMOro52s="
+      "integrity": "sha512-4SRaSj+PqmrS1soW5/Avd7eJIM2JJIqLLmwhRqIGleZM/8KwZq80njbSS2Iqas+6oARkSkLDHEk4mm78q3JlIg=="
     },
     "detect-libc": {
       "version": "1.0.3",
@@ -1512,11 +1486,11 @@
       "dev": true
     },
     "diskusage": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/diskusage/-/diskusage-0.2.5.tgz",
-      "integrity": "sha1-8uDYaxciwMpShMk44ZQpAgLC5Pg=",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/diskusage/-/diskusage-0.2.6.tgz",
+      "integrity": "sha512-zjXy+rKg52XYNDOBXcIKwNevgP+6rvOSNx8OAX0N7o0BFdEl5sBL8UhuwSi3j5BS0Sd+9Lb6YuCSR00gZi4KQw==",
       "requires": {
-        "nan": "^2.5.0"
+        "nan": "^2.11.1"
       }
     },
     "doctrine": {
@@ -1570,7 +1544,7 @@
     "end-of-stream": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
         "once": "^1.4.0"
       }
@@ -1578,7 +1552,7 @@
     "engine.io": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.5.tgz",
-      "integrity": "sha1-Tr5edcbcEj3uSv3Obl/c7SHrk/Y=",
+      "integrity": "sha512-j1DWIcktw4hRwrv6nWx++5nFH2X64x16MAG2P0Lmi5Dvdfi3I+Jhc7JKJIdAmDJa+5aZ/imHV7dWRPy2Cqjh3A==",
       "requires": {
         "accepts": "1.3.3",
         "base64id": "1.0.0",
@@ -1591,7 +1565,7 @@
     "engine.io-client": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.5.tgz",
-      "integrity": "sha1-/n+2DLDc8vooWUiTKctZaN7esR8=",
+      "integrity": "sha512-AYTgHyeVUPitsseqjoedjhYJapNVoSPShbZ+tEUX9/73jgZ/Z3sUlJf9oYgdEBBdVhupUpUqSxH0kBCXlQnmZg==",
       "requires": {
         "component-emitter": "1.2.1",
         "component-inherit": "0.0.3",
@@ -1616,7 +1590,7 @@
     },
     "engine.io-parser": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
+      "resolved": "http://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
       "integrity": "sha1-k3sHnwAH0Ik+xW1GyyILjLQ1Igo=",
       "requires": {
         "after": "0.8.2",
@@ -1636,7 +1610,7 @@
     "errno": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha1-RoTXF3mtOa8Xfj8AeZb3xnyFJhg=",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
         "prr": "~1.0.1"
       }
@@ -1677,7 +1651,7 @@
     "es5-ext": {
       "version": "0.10.46",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
-      "integrity": "sha1-79mfZ8Wn7Hibqj2qf3mHA4j39XI=",
+      "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
       "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
@@ -1780,7 +1754,7 @@
     },
     "eslint": {
       "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+      "resolved": "http://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
       "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
       "dev": true,
       "requires": {
@@ -1822,7 +1796,7 @@
         "glob": {
           "version": "7.1.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -1836,7 +1810,7 @@
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -1895,13 +1869,13 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "esrecurse": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
       "dev": true,
       "requires": {
         "estraverse": "^4.1.0"
@@ -1965,7 +1939,7 @@
     "expand-template": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
-      "integrity": "sha1-mB8YjAw6h9Lij1WbxUFCb/lPId0="
+      "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg=="
     },
     "extend": {
       "version": "3.0.2",
@@ -1980,9 +1954,9 @@
       "dev": true
     },
     "fast-deep-equal": {
-      "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
     "fast-future": {
@@ -2031,13 +2005,13 @@
       }
     },
     "flat-cache": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
-      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.2.tgz",
+      "integrity": "sha512-KByBY8c98sLUAGpnmjEdWTrtrLZRtZdwds+kAL/ciFXTCb7AZgqKsAnVnYFQj1hxepwO8JKN/8AsRWwLq+RK0A==",
       "dev": true,
       "requires": {
         "circular-json": "^0.3.1",
-        "del": "^2.0.2",
+        "del": "^3.0.0",
         "graceful-fs": "^4.1.2",
         "write": "^0.2.1"
       }
@@ -2105,7 +2079,7 @@
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0="
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -2148,7 +2122,7 @@
     "generate-function": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
-      "integrity": "sha1-8GlhdpDBDIaOc7hGV0Z2T5fDR58=",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
       "dev": true,
       "requires": {
         "is-property": "^1.0.2"
@@ -2200,17 +2174,16 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
     "globby": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
       "dev": true,
       "requires": {
         "array-union": "^1.0.1",
-        "arrify": "^1.0.0",
         "glob": "^7.0.3",
         "object-assign": "^4.0.1",
         "pify": "^2.0.0",
@@ -2220,7 +2193,7 @@
         "glob": {
           "version": "7.1.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -2234,7 +2207,7 @@
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -2289,7 +2262,7 @@
     },
     "google-p12-pem": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.2.tgz",
       "integrity": "sha512-+EuKr4CLlGsnXx4XIJIVkcKYrsa2xkAmCvxRhX2HsazJzUBAJ35wARGeApHUn4nNfPD03Vl057FskNr20VaCyg==",
       "dev": true,
       "requires": {
@@ -2298,9 +2271,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
     "graceful-readlink": {
@@ -2316,7 +2289,7 @@
     },
     "gtoken": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/gtoken/-/gtoken-2.3.0.tgz",
       "integrity": "sha512-Jc9/8mV630cZE9FC5tIlJCZNdUjwunvlwOtCz6IDlaiB4Sz68ki29a1+q97sWTnTYroiuF9B135rod9zrQdHLw==",
       "dev": true,
       "requires": {
@@ -2334,25 +2307,25 @@
       "dev": true
     },
     "har-validator": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.2.tgz",
+      "integrity": "sha512-OFxb5MZXCUMx43X7O8LK4FKggEQx6yC5QPmOcBnYbJ9UjxEcMcrMbaR0af5HZpqeFopw2GwQRQi34ZXI7YLM5w==",
       "dev": true,
       "requires": {
-        "ajv": "^5.3.0",
+        "ajv": "^6.5.5",
         "har-schema": "^2.0.0"
       },
       "dependencies": {
         "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "version": "6.5.5",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
+          "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
           "dev": true,
           "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
+            "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
           }
         }
       }
@@ -2423,8 +2396,8 @@
     },
     "hoek": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs="
+      "resolved": "http://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "hosted-git-info": {
       "version": "2.7.1",
@@ -2484,12 +2457,12 @@
     "ieee754": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
-      "integrity": "sha1-UL8k5bnIu5ivSWTJQc2wkY2ntgs="
+      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA=="
     },
     "ignore": {
       "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
-      "integrity": "sha1-Cpf7h2mG6AgcYxFg+PnziRV/AEM=",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
     },
     "imurmurhash": {
@@ -2521,7 +2494,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc="
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
       "version": "0.12.0",
@@ -2557,7 +2530,7 @@
     "ioredis": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-3.2.2.tgz",
-      "integrity": "sha1-t9X/Ov13u5cYuyghMpuJS5pEwAs=",
+      "integrity": "sha512-g+ShTQYLsCcOUkNOK6CCEZbj3aRDVPw3WOwXk+LxlUKvuS9ujEqP2MppBHyRVYrNNFW/vcPaTBUZ2ctGNSiOCA==",
       "requires": {
         "bluebird": "^3.3.4",
         "cluster-key-slot": "^1.0.6",
@@ -2587,7 +2560,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
           }
@@ -2653,13 +2626,13 @@
     "is-my-ip-valid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-      "integrity": "sha1-ezUbjo7dTTmV1NBmaA5mTZRpaCQ=",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
       "dev": true
     },
     "is-my-json-valid": {
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
-      "integrity": "sha1-j9bkA2PNBrlj+od9REv7Xt3GIXU=",
+      "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
       "dev": true,
       "requires": {
         "generate-function": "^2.0.0",
@@ -2686,7 +2659,7 @@
     "is-path-in-cwd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-      "integrity": "sha1-WsSLNF72dTOb1sekipEhELJBz1I=",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
         "is-path-inside": "^1.0.0"
@@ -2719,7 +2692,7 @@
     "is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha1-+xj4fOH+uSUWnJpAfBkxijIG7Yg=",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
     "is-symbol": {
@@ -2772,7 +2745,7 @@
     "joi": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
-      "integrity": "sha1-Ulh/AtUri3XNsMdPCxZKGRoOH8I=",
+      "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
       "requires": {
         "hoek": "4.x.x",
         "isemail": "2.x.x",
@@ -2783,7 +2756,7 @@
     "js-yaml": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha1-6u1lbsg0TxD1J8a/obbiJE3hZ9E=",
+      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -2820,9 +2793,9 @@
       "dev": true
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
     "json-stable-stringify": {
@@ -2911,12 +2884,12 @@
     "level-codec": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-      "integrity": "sha1-NB8i+QfODxZ2PyS93WgeOVoPuKc="
+      "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
     },
     "level-errors": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-      "integrity": "sha1-g9v7EvC4olFr3JoxxIdgOOInuFk=",
+      "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
       "requires": {
         "errno": "~0.1.1"
       }
@@ -2943,7 +2916,7 @@
     "level-post": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
-      "integrity": "sha1-GczKlEGnzFJ4eaBjUADwbV6PJ9A=",
+      "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
       "requires": {
         "ltgt": "^2.1.2"
       }
@@ -2951,7 +2924,7 @@
     "level-sublevel": {
       "version": "6.6.5",
       "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.5.tgz",
-      "integrity": "sha1-rN36K+AzueUDVE4sZH88A9WiP70=",
+      "integrity": "sha512-SBSR60x+dghhwGUxPKS+BvV1xNqnwsEUBKmnFepPaHJ6VkBXyPK9SImGc3K2BkwBfpxlt7GKkBNlCnrdufsejA==",
       "requires": {
         "bytewise": "~1.1.0",
         "levelup": "~0.19.0",
@@ -3065,7 +3038,7 @@
     "levelup": {
       "version": "1.3.9",
       "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-      "integrity": "sha1-LbyuhFsrsra+qE3zNMR1Uzu9gqs=",
+      "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
       "requires": {
         "deferred-leveldown": "~1.2.1",
         "level-codec": "~7.0.0",
@@ -3118,7 +3091,7 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -3349,7 +3322,7 @@
     "memory-pager": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.1.0.tgz",
-      "integrity": "sha1-kwiRXg6XKEn++65vi8ldazUOc0Q=",
+      "integrity": "sha512-Mf9OHV/Y7h6YWDxTzX/b4ZZ4oh9NSXblQL8dtPCOomOtZciEHxePR78+uHFLLlsk01A6jVHhHsQZZ/WcIPpnzg==",
       "optional": true
     },
     "mime": {
@@ -3374,7 +3347,7 @@
     "mimic-response": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha1-SSNTiHju9CBjy4o+OweYeBSHqxs="
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ=="
     },
     "minimatch": {
       "version": "0.2.14",
@@ -3387,12 +3360,12 @@
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
@@ -3400,7 +3373,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
@@ -3408,7 +3381,7 @@
     "mocha": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -3427,7 +3400,7 @@
       "dependencies": {
         "commander": {
           "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
@@ -3460,7 +3433,7 @@
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -3489,26 +3462,26 @@
       "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
     "moment-timezone": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.21.tgz",
-      "integrity": "sha1-PLokfYRJIXTb9x3iqYSPoTIHuEU=",
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.23.tgz",
+      "integrity": "sha512-WHFH85DkCfiNMDX5D3X7hpNH3/PUhjTGcD0U1SgfBGZxJ3qUmJh5FdvaFjcClxOvB3rzdfj4oRffbI38jEnC1w==",
       "requires": {
         "moment": ">= 2.9.0"
       }
     },
     "mongodb": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.8.tgz",
-      "integrity": "sha512-yNKwYxQ6m00NV6+pMoWoheFTHSQVv1KkSrfOhRDYMILGWDYtUtQRqHrFqU75rmPIY8hMozVft8zdC4KYMWaM3Q==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.9.tgz",
+      "integrity": "sha512-f+Og32wK/ovzVlC1S6Ft7yjVTvNsAOs6pBpDrPd2/3wPO9ijNsQrTNntuECjOSxGZpPVl0aRqgHzF1e9e+KvnQ==",
       "requires": {
-        "mongodb-core": "3.1.7",
+        "mongodb-core": "3.1.8",
         "safe-buffer": "^5.1.2"
       }
     },
     "mongodb-core": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.7.tgz",
-      "integrity": "sha512-YffpSrLmgFNmrvkGx+yX00KyBNk64C0BalfEn6vHHkXtcMUGXw8nxrMmhq5eXPLLlYeBpD/CsgNxE2Chf0o4zQ==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.8.tgz",
+      "integrity": "sha512-reWCqIRNehyuLaqaz5JMOmh3Xd8JIjNX34o8mnewXLK2Fyt/Ky6BZbU+X0OPzy8qbX+JZrOtnuay7ASCieTYZw==",
       "requires": {
         "bson": "^1.1.0",
         "require_optional": "^1.0.1",
@@ -3537,7 +3510,7 @@
     "nan": {
       "version": "2.11.1",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha1-kOIrzLjKV+pM03zIPTgZtS7qZ2Y="
+      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
     },
     "negotiator": {
       "version": "0.6.1",
@@ -3546,14 +3519,14 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
     },
     "node-abi": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.5.tgz",
-      "integrity": "sha1-H9H7ZmQb88Tc9VpUkLoQxGfq2Aw=",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.5.0.tgz",
+      "integrity": "sha512-9g2twBGSP6wIR5PW7tXvAWnEWKJDH/VskdXp168xsw9VVxpEGov8K4jsP4/VeoC7b2ZAyzckvMCuQuQlw44lXg==",
       "requires": {
         "semver": "^5.4.1"
       }
@@ -3561,7 +3534,7 @@
     "node-forge": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
-      "integrity": "sha1-/fO0GK7h+U8O9kLNY0hsd8qXJKw="
+      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
     },
     "node-rdkafka": {
       "version": "2.3.1",
@@ -3575,7 +3548,7 @@
     "node-schedule": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-1.3.0.tgz",
-      "integrity": "sha1-56foFqfyVQ1bFwvRBudl2yi98DA=",
+      "integrity": "sha512-NNwO9SUPjBwFmPh3vXiPVEhJLn4uqYmZYvJV358SRGM06BR4UoIqxJpeJwDDXB6atULsgQA97MfD1zMd5xsu+A==",
       "requires": {
         "cron-parser": "^2.4.0",
         "long-timeout": "0.1.1",
@@ -3644,7 +3617,7 @@
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -3676,7 +3649,7 @@
     "object-keys": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
-      "integrity": "sha1-CcU4VTd1dTEMymL1W7M0q/97PtI="
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
     },
     "once": {
       "version": "1.4.0",
@@ -3688,7 +3661,7 @@
     },
     "onetime": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
@@ -3713,8 +3686,14 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+    },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
     },
     "parse-json": {
       "version": "2.2.0",
@@ -3751,7 +3730,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -3823,7 +3802,7 @@
     "prebuild-install": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
-      "integrity": "sha1-n2XyQngtNwKWNTcQ6byENJDBn2k=",
+      "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
       "requires": {
         "detect-libc": "^1.0.3",
         "expand-template": "^1.0.2",
@@ -3851,7 +3830,7 @@
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o="
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
     "progress": {
       "version": "1.1.8",
@@ -3901,12 +3880,12 @@
     "pull-defer": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/pull-defer/-/pull-defer-0.2.3.tgz",
-      "integrity": "sha1-TuCcbZ4ie+3pk424A5HD2sSJ0RM="
+      "integrity": "sha512-/An3KE7mVjZCqNhZsr22k1Tx8MACnUnHZZNPSJ0S62td8JtYr/AiRG42Vz7Syu31SoTLUzVIe61jtT/pNdjVYA=="
     },
     "pull-level": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
-      "integrity": "sha1-SCLmF1fBC9zHz0oDrwTJJzTJr6w=",
+      "integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
       "requires": {
         "level-post": "^1.0.7",
         "pull-cat": "^1.1.9",
@@ -3934,7 +3913,7 @@
     "pull-stream": {
       "version": "3.6.9",
       "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
-      "integrity": "sha1-x3RyTNY7wJhMNpX3TIGaoC6XcyA="
+      "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
     },
     "pull-window": {
       "version": "2.1.4",
@@ -3947,7 +3926,7 @@
     "pump": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-      "integrity": "sha1-Ejma3W5M91Jtlzy8i1zi4pCLOQk=",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -3972,7 +3951,7 @@
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -4053,7 +4032,7 @@
     },
     "require-uncached": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
@@ -4072,7 +4051,7 @@
     "require_optional": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-      "integrity": "sha1-TPNaQkf2TKPfjC7yCMxJSxyo/C4=",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
       "requires": {
         "resolve-from": "^2.0.0",
         "semver": "^5.1.0"
@@ -4108,7 +4087,7 @@
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
         "glob": "^7.0.5"
@@ -4117,7 +4096,7 @@
         "glob": {
           "version": "7.1.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -4131,7 +4110,7 @@
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -4157,7 +4136,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-json-stringify": {
       "version": "1.0.3",
@@ -4173,7 +4152,7 @@
     "saslprep": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.2.tgz",
-      "integrity": "sha1-2lq5NubqC7rpEf/sd1NL43DJ9S0=",
+      "integrity": "sha512-4cDsYuAjXssUSjxHKRe4DTZC0agDwsCqcMqtJAQPzC74nJ7LfAJflAtC1Zed5hMzEQKj82d3tuzqdGNRsLJ4Gw==",
       "optional": true,
       "requires": {
         "sparse-bitfield": "^3.0.3"
@@ -4182,12 +4161,12 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -4245,7 +4224,7 @@
     "simple-get": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-      "integrity": "sha1-DiLpHUV12HYgYgvJEwjVenf0S10=",
+      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
       "requires": {
         "decompress-response": "^3.3.0",
         "once": "^1.3.1",
@@ -4264,7 +4243,7 @@
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
         }
       }
@@ -4332,7 +4311,7 @@
     },
     "socket.io-parser": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
+      "resolved": "http://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
       "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
       "requires": {
         "component-emitter": "1.1.2",
@@ -4359,7 +4338,7 @@
     "sorted-array-functions": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/sorted-array-functions/-/sorted-array-functions-1.2.0.tgz",
-      "integrity": "sha1-QyZbIdbphbffMWIbHBHMaNjvx8M="
+      "integrity": "sha512-sWpjPhIZJtqO77GN+LD8dDsDKcWZ9GCOJNqKzi1tvtjGIzwfoyuRH8S0psunmc6Z5P+qfDqztSbwYR5X/e1UTg=="
     },
     "sparse-bitfield": {
       "version": "3.0.3",
@@ -4541,7 +4520,7 @@
     },
     "table": {
       "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
@@ -4568,7 +4547,7 @@
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -4589,7 +4568,7 @@
     "tar-fs": {
       "version": "1.16.3",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
-      "integrity": "sha1-lmpiiEHaLEAQQGqCFny9Xgxy1Qk=",
+      "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
       "requires": {
         "chownr": "^1.0.1",
         "mkdirp": "^0.5.1",
@@ -4600,7 +4579,7 @@
         "pump": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-          "integrity": "sha1-Xf6DEcM7v2/BgmH580cCxHwIqVQ=",
+          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -4611,7 +4590,7 @@
     "tar-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-      "integrity": "sha1-jqVdqzeXIlPZqa+Q/c1VmuQ1xVU=",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
       "requires": {
         "bl": "^1.0.0",
         "buffer-alloc": "^1.2.0",
@@ -4644,7 +4623,7 @@
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -4678,7 +4657,7 @@
     "to-buffer": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha1-STvUj2LXxD/N7TE6A9ytsuEhOoA="
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg=="
     },
     "tokenize-this": {
       "version": "1.4.1",
@@ -4688,7 +4667,7 @@
     },
     "topo": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
       "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
       "requires": {
         "hoek": "4.x.x"
@@ -4762,7 +4741,7 @@
     "uc.micro": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.5.tgz",
-      "integrity": "sha1-DGXxX4FaoItWCmHOi023/8P0U3Y=",
+      "integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg==",
       "dev": true
     },
     "ultron": {
@@ -4774,6 +4753,23 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
       "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        }
+      }
     },
     "url": {
       "version": "0.10.3",
@@ -4870,13 +4866,13 @@
         },
         "cron-parser": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/cron-parser/-/cron-parser-1.1.0.tgz",
           "integrity": "sha1-B1uExFnBVejEgqtNVq/5na5YNS4=",
           "dev": true
         },
         "ioredis": {
           "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/ioredis/-/ioredis-2.5.0.tgz",
           "integrity": "sha1-+2/fChp+CXRhTGe25eETCKjPlbk=",
           "dev": true,
           "requires": {
@@ -4992,7 +4988,7 @@
     },
     "utf8": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
+      "resolved": "http://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
       "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
     },
     "util-deprecate": {
@@ -5003,7 +4999,7 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE="
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -5025,13 +5021,15 @@
       "version": "github:scality/vaultclient#754b6e1e1121f44bc3719e35b836a9185d6d5e1a",
       "from": "github:scality/vaultclient#754b6e1",
       "requires": {
+        "arsenal": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
         "commander": "2.9.0",
+        "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
         "xml2js": "0.4.17"
       },
       "dependencies": {
         "arsenal": {
           "version": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
-          "from": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
+          "from": "github:scality/Arsenal#7.4.0.3",
           "requires": {
             "JSONStream": "^1.0.0",
             "ajv": "4.10.0",
@@ -5096,7 +5094,7 @@
         },
         "werelogs": {
           "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
-          "from": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+          "from": "github:scality/werelogs#7.4.0.3",
           "requires": {
             "safe-json-stringify": "^1.0.3"
           }
@@ -5155,7 +5153,7 @@
     "wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
         "string-width": "^1.0.2 || 2"
       }
@@ -5183,7 +5181,7 @@
     "ws": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
-      "integrity": "sha1-y9nm514J/F0skAFfIfDECHXg3VE=",
+      "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
       "requires": {
         "options": ">=0.0.5",
         "ultron": "1.0.x"
@@ -5197,7 +5195,7 @@
     "xml2js": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha1-aGwg8hMgnpSr8NG88e+qKRx4J6c=",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "requires": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~9.0.1"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/scality/backbeat#readme",
   "dependencies": {
-    "arsenal": "scality/Arsenal#549ca1f",
+    "arsenal": "scality/Arsenal#d620fef",
     "async": "^2.3.0",
     "aws-sdk": "2.147.0",
     "backo": "^1.1.0",

--- a/tests/behavior/queuePopulator.js
+++ b/tests/behavior/queuePopulator.js
@@ -121,7 +121,7 @@ describe('queuePopulator', () => {
                 queuePopulator.open(next);
             },
             next => {
-                queuePopulator.processAllLogEntries({ maxRead: 10 }, next);
+                queuePopulator.processLogEntries({ maxRead: 10 }, next);
             },
             (data, next) => {
                 const { connectionString } = testConfig.zookeeper;
@@ -172,15 +172,15 @@ describe('queuePopulator', () => {
             });
         }));
 
-    it('processAllLogEntries with nothing to do', done => {
-        queuePopulator.processAllLogEntries(
+    it('processLogEntries with nothing to do', done => {
+        queuePopulator.processLogEntries(
             { maxRead: 10 }, (err, counters) => {
                 assert.ifError(err);
                 assert.deepStrictEqual(counters[0].queuedEntries, {});
                 done();
             });
     });
-    it('processAllLogEntries with an object to replicate', done => {
+    it('processLogEntries with an object to replicate', done => {
         async.waterfall([
             next => {
                 s3.putObject({ Bucket: testBucket,
@@ -189,7 +189,7 @@ describe('queuePopulator', () => {
                     Tagging: 'mytag=mytagvalue' }, next);
             },
             (data, next) => {
-                queuePopulator.processAllLogEntries({ maxRead: 10 }, next);
+                queuePopulator.processLogEntries({ maxRead: 10 }, next);
             },
             (counters, next) => {
                 // 2 reads expected: master key and and versioned key
@@ -204,7 +204,7 @@ describe('queuePopulator', () => {
             done();
         });
     });
-    it('processAllLogEntries with an object put and delete to replicate',
+    it('processLogEntries with an object put and delete to replicate',
     done => {
         async.waterfall([
             next => {
@@ -214,14 +214,14 @@ describe('queuePopulator', () => {
                     Tagging: 'mytag=mytagvalue' }, next);
             },
             (data, next) => {
-                queuePopulator.processAllLogEntries({ maxRead: 10 }, next);
+                queuePopulator.processLogEntries({ maxRead: 10 }, next);
             },
             (counters, next) => {
                 s3.deleteObject({ Bucket: testBucket,
                     Key: 'keyToReplicate' }, next);
             },
             (data, next) => {
-                queuePopulator.processAllLogEntries({ maxRead: 10 }, next);
+                queuePopulator.processLogEntries({ maxRead: 10 }, next);
             },
             (counters, next) => {
                 // 2 reads expected: master key update + new delete marker
@@ -236,7 +236,7 @@ describe('queuePopulator', () => {
             done();
         });
     });
-    it('processAllLogEntries with 100 objects to replicate in 20 batches',
+    it('processLogEntries with 100 objects to replicate in 20 batches',
     function test100objects(done) {
         this.timeout(10000);
         async.waterfall([
@@ -259,7 +259,7 @@ describe('queuePopulator', () => {
                 }
             },
             next => {
-                queuePopulator.processAllLogEntries({ maxRead: 10 }, next);
+                queuePopulator.processLogEntries({ maxRead: 10 }, next);
             },
             (counters, next) => {
                 // 2 reads expected: master key and and versioned key
@@ -300,7 +300,7 @@ describe('queuePopulator', () => {
                 }, done));
 
             it('should have created the lifecycle bucket data path', done =>
-                queuePopulator.processAllLogEntries({ maxRead: 10 },
+                queuePopulator.processLogEntries({ maxRead: 10 },
                     (err, counters) => {
                         if (err) {
                             return done(err);
@@ -313,13 +313,13 @@ describe('queuePopulator', () => {
             it('should delete lifecycle bucket data path if bucket is deleted',
             done => async.series([
                 next =>
-                    queuePopulator.processAllLogEntries({ maxRead: 10 }, next),
+                    queuePopulator.processLogEntries({ maxRead: 10 }, next),
                 next =>
                     doesBucketNodeExist(true, zkClient, testBucket, next),
                 next =>
                     s3.deleteBucket({ Bucket: testBucket }, next),
                 next =>
-                    queuePopulator.processAllLogEntries({ maxRead: 10 },
+                    queuePopulator.processLogEntries({ maxRead: 10 },
                         next),
                 next =>
                     doesBucketNodeExist(false, zkClient, testBucket, next),
@@ -328,13 +328,13 @@ describe('queuePopulator', () => {
             it('should delete lifecycle bucket data path if lifecycle config ' +
             'is deleted', done => async.series([
                 next =>
-                    queuePopulator.processAllLogEntries({ maxRead: 10 }, next),
+                    queuePopulator.processLogEntries({ maxRead: 10 }, next),
                 next =>
                     doesBucketNodeExist(true, zkClient, testBucket, next),
                 next =>
                     s3.deleteBucketLifecycle({ Bucket: testBucket }, next),
                 next =>
-                    queuePopulator.processAllLogEntries({ maxRead: 10 }, next),
+                    queuePopulator.processLogEntries({ maxRead: 10 }, next),
                 next =>
                     doesBucketNodeExist(false, zkClient, testBucket, next),
             ], done));


### PR DESCRIPTION
Use a tailable custor to keep ordering guarantees for the records we
read. This also means we have to read from the beginning when we
reconnect (at startup), and start processing when we encountered the
unique ID previously stored in zookeeper.

Also removed dispatcher mode with MongoLogReader (was only used for
the short-lived Federation deployment of Zenko).

Depends on PR https://github.com/scality/Arsenal/pull/594