### PR TITLE
backport: S3C-1622 crr metrics changes

### DIFF
--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -37,6 +37,8 @@ const joiSchema = {
         port: joi.number().default(8900),
     },
     redis: {
+        host: joi.string().default('localhost'),
+        port: joi.number().default(6379),
         name: joi.string().default('backbeat'),
         password: joi.string().default('').allow(''),
         sentinels: joi.array().items(

--- a/docs/healthcheck.md
+++ b/docs/healthcheck.md
@@ -1,0 +1,124 @@
+# Zenko Backbeat Healthcheck
+
+Zenko Backbeat exposes a healthcheck route that returns a response with an HTTP
+code.
+
+## Response Codes
+
+```
++----------+------------------------------------------------------------------+
+| Response | Details                                                          |
++==========+==================================================================+
+|   200    | OK: success                                                      |
++----------+------------------------------------------------------------------+
+|   403    | AccessDenied: request IP address must be defined in              |
+|          |   'conf/config.json' in field 'server.healthChecks.allowFrom'    |
++----------+------------------------------------------------------------------+
+|   404    | RouteNotFound: route must be valid                               |
++----------+------------------------------------------------------------------+
+|   405    | MethodNotAllowed: the HTTP verb must be a GET                    |
++----------+------------------------------------------------------------------+
+|   500    | InternalError: this could be caused by one of several            |
+|          |   components: the api server, Kafka, Zookeeper, or one of the    |
+|          |   Producers for a topic                                          |
++----------+------------------------------------------------------------------+
+```
+
+## Routes
+
+### `/_/healthcheck`
+
+Basic healthchecks return details on the health of Kafka and its topics.
+
+If the response is not an HTTP error, it is structured as an object with two
+main keys: *topics* and *internalConnections*.
+
+The `topics` key returns details on the Kafka CRR topic only. The `name` field
+returns the Kafka topic name, and the `partitions` field returns details of each
+partition for the CRR topic. The `id` is the partition id, the `leader` is the
+current node responsible for all reads and writes for the given partition, the
+`replicas` array is the list of nodes that replicate the log for the given
+partition, and the `isrs` array is the list of in-sync replicas.
+
+```
+topics: {
+    <topicName>: {
+        name: <string>,
+        partitions: {
+            id: <number>,
+            leader: <number>,
+            replicas: [<number>, ...],
+            isrs: [<number>, ...],
+        },
+        ...
+    },
+}
+```
+
+The `internalConnections` key returns general details on the health of the
+system as a whole. `isrHealth` checks if the minimum in-sync replicas for every
+partition is met. The `zookeeper` field checks if ZooKeeper is running
+properly. The `kafkaProducer` field checks the health of all Kafka Producers
+for every topic.
+
+The `zookeeper` details field provides a status code and status name provided
+directly from the [node-zookeeper](https://github.com/alexguan/node-zookeeper-client#state)),
+library.
+
+```
+internalConnections: {
+    isrHealth: <ok || error>,
+    zookeeper: {
+        status: <ok || error>,
+        details: {
+            name: <value>,
+            code: <value>
+        }
+    },
+    kafkaProducer: {
+        status: <ok || error>
+    }
+}
+```
+
+**Example Output**:
+
+(**Note:** The following example is redacted for brevity.)
+
+```
+{
+    "topics": {
+        "backbeat-replication": {
+            "name": "backbeat-replication",
+            "partitions": [
+                {
+                    "id": 2,
+                    "leader": 4,
+                    "replicas": [2,3,4],
+                    "isrs": [4,2,3]
+                },
+                ...
+                {
+                    "id": 0,
+                    "leader": 2,
+                    "replicas": [0,1,2],
+                    "isrs": [2,0,1]
+                }
+            ]
+        }
+    },
+    "internalConnections": {
+        "isrHealth": "ok",
+        "zookeeper": {
+            "status": "ok",
+            "details": {
+                "name": "SYNC_CONNECTED",
+                "code": 3
+            }
+        },
+        "kafkaProducer": {
+            "status": "ok"
+        }
+    }
+}
+```

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,234 @@
+# Zenko Backbeat Metrics
+
+Zenko Backbeat exposes various metric routes that return a response with an
+HTTP code.
+
+## Response Codes
+
+```
++----------+------------------------------------------------------------------+
+| Response | Details                                                          |
++==========+==================================================================+
+|   200    | OK: success                                                      |
++----------+------------------------------------------------------------------+
+|   403    | AccessDenied: request IP address must be defined in              |
+|          |   'conf/config.json' in field 'server.healthChecks.allowFrom'    |
++----------+------------------------------------------------------------------+
+|   404    | RouteNotFound: route must be valid                               |
++----------+------------------------------------------------------------------+
+|   405    | MethodNotAllowed: the HTTP verb must be a GET                    |
++----------+------------------------------------------------------------------+
+|   500    | InternalError: this could be caused by one of several            |
+|          |   components: the api server, Kafka, Zookeeper, Redis, or one    |
+|          |   of the Producers for a topic topic                             |
++----------+------------------------------------------------------------------+
+```
+
+## Routes
+
+Routes are organized as follows:
+`/_/metrics/<extension-type>/<location-name/[<metric-type>]/[<bucket>]/[<key>]?[versionId=<version-id>]`
+
+Where:
+
+- `<extension-type>` currently supports only `crr` for replication metrics
+- `<location-name>` represents any current destination replication locations you
+   have defined. To display metrics for all locations, use `all`
+- `<metric-type>` is an optional field. If you specify a metric type, Backbeat
+   returns the specified metric. If you omit it, Backbeat returns all available
+   metrics for the given extension and location.
+- `<bucket>` is an optional field. It carries the name of the bucket in which
+   the object is expected to exist.
+- `<key>` is an optional field. When getting CRR metrics for a particular object,
+   it contains the object's key.
+- `<version-id>` is an optional field. When getting CRR metrics for a particular
+   object, it contains the object's version ID.
+
+### `/_/metrics/crr/<location-name>`
+
+This route gathers all the metrics below, returning one JSON object for the
+specified extension type and location name.
+
+### `/_/metrics/crr/<location-name>/backlog`
+
+This route returns the replication backlog in number of objects and number of
+total bytes for the specified extension type and location name. Replication
+backlog represents the objects that have been queued for replication to another
+location, but for which the replication task is not complete. If replication
+for an object fails, failed object metrics are considered backlog.
+
+**Example Output**:
+
+```
+"backlog":{
+    "description":"Number of incomplete replication operations (count) and
+    number of incomplete bytes transferred (size)",
+    "results":{
+        "count":"1",
+        "size":"1024"
+    }
+}
+```
+
+### `/_/metrics/crr/<location-name>/completions`
+
+This route returns the replication completions in number of objects and number
+of total bytes transferred for the specified extension type and location.
+Completions are only collected up to an `EXPIRY` time, which is currently set
+to **24 hours**.
+
+**Example Output**:
+
+```
+"completions":{
+    "description":"Number of completed replication operations (count) and number
+    of bytes transferred (size) in the last 86400 seconds",
+    "results":{
+        "count":"1",
+        "size":"1024"
+    }
+}
+```
+
+### `/_/metrics/crr/<location-name>/failures`
+
+This route returns the replication failures in number of objects and number
+of total bytes for the specified extension type and location. Failures are
+collected only up to an `EXPIRY` time, currently set to a default
+**24 hours**.
+
+**Example Output**:
+
+```
+"failures":{
+    "description":"Number of failed replication operations (count) and bytes
+    (size) in the last 86400 seconds",
+    "results":{
+        "count":"1",
+        "size":"1024"
+    }
+}
+```
+
+### `/_/metrics/crr/<location-name>/throughput`
+
+This route returns the current throughput in number of completed operations per
+second (or number of objects replicating per second) and number of total bytes
+completing per second for the specified type and location name.
+
+Note throughput is averaged over the past 15 minutes of data collected so this
+metric is really an average throughput.
+
+**Example Output**:
+
+```
+"throughput":{
+    "description":"Current throughput for replication operations in ops/sec
+    (count) and bytes/sec (size)",
+    "results":{
+        "count":"0.00",
+        "size":"0.00"
+    }
+}
+```
+
+### `/_/metrics/crr/<site-name>/progress/<bucket>/<key>?versionId=<version-id>`
+
+This route returns replication progress in bytes transferred for the specified
+object.
+
+**Example Output**:
+
+```
+{
+    "description": "Number of bytes to be replicated (pending), number of bytes
+    transferred to the destination (completed), and percentage of the object
+    that has completed replication (progress)",
+    "pending": 1000000,
+    "completed": 3000000,
+    "progress": "75%"
+}
+```
+
+### `/_/metrics/crr/<site-name>/throughput/<bucket>/<key>?versionId=<version-id>`
+
+This route returns the throughput in number of total bytes completing per second
+for the specified object.
+
+**Example Output**:
+
+```
+{
+    "description": "Current throughput for object replication in bytes/sec
+    (throughput)",
+    "throughput": "0.00"
+}
+```
+
+## Design
+
+For basic metrics, eight data points are collected:
+
+- number of operations (ops)
+- number of pending operations (opspending)
+- number of completed operations (opsdone)
+- number of failed operations (opsfail)
+- number of bytes (bytes)
+- number of pending bytes (bytespending)
+- number of completed bytes (bytesdone)
+- number of failed bytes (bytesfail)
+
+To collect metrics, a separate Kafka Producer and Consumer pair
+(`MetricsProducer` and `MetricsConsumer`) using their own Kafka topic
+(default to "backbeat-metrics") produce their own Kafka entries.
+
+When a new CRR entry is sent to Kafka, a Kafka entry to the metrics topic
+is produced, indicating to increase `ops` and `bytes`. On consumption of this
+metrics entry, Redis keys are generated with the following schema:
+
+Site-level pending CRR metrics Redis key:
+`<site-name>:<default-metrics-key>:<opspending-or-bytespending>`
+
+Site-level CRR metrics Redis key:
+`<site-name>:<default-metrics-key>:<ops-or-bytes>:<normalized-timestamp>`
+
+Object-level CRR metrics Redis key:
+`<site-name>:<bucket-name>:<key-name>:<version-id>:<default-metrics-key>:<ops-or-bytes>:<normalized-timestamp>`
+
+A normalized timestamp determines the time interval on which to set the data.
+The default metrics key ends with the type of data point it represents.
+
+When the CRR entry is consumed from Kafka, processed, and the metadata for
+replication status updated to a completed state (i.e. COMPLETED, FAILED),
+a Kafka entry is sent to the metrics topic indicating to increase `opsdone` and
+`bytesdone` if replication was successful or `opsfail` and `bytesfail` if
+replication was unsuccessful. Again, on consumption of this metrics entry,
+Redis keys are generated for their respective data points.
+
+It is important to note that a `MetricsProducer` is initialized and producing
+to the metrics topic both when the CRR topic `BackbeatProducer` produces and
+sends a Kafka entry, and when the CRR topic `BackbeatConsumer` consumes and
+processes its Kafka entries. The `MetricsConsumer` processes these Kafka metrics
+entries and produces to Redis.
+
+A single-location CRR entry produces up to eight keys in total. The data points
+stored in Redis are saved in intervals (default of 5 minutes) and are available
+up to an expiry time (default of 24 hours), with the exception of pending keys
+which are not bound to an interval and do not expire.
+
+An object CRR entry creates one key. An initial key is set when the CRR
+operation begins, storing the total size of the object to be replicated. Then,
+for each part of the object that is transferred to the destination, another key
+is set (or incremented if a key already exists for the current timestamp) to
+reflect the number of bytes that have completed replication. The data points
+stored in Redis are saved in intervals (default of 5 minutes) and are available
+up to an expiry time (default of 24 hours).
+
+Throughput for object CRR entries are available up to an expiry time (default of
+15 minutes). Object CRR throughput is the average bytes transferred per second
+within the latest 15 minutes.
+
+A `BackbeatServer` (default port 8900) and `BackbeatAPI` expose these metrics
+stored in Redis by querying based on the prepended Redis keys. Using these data
+points, we can calculate simple metrics like backlog, number of completions,
+progress, throughput, etc.

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -32,12 +32,15 @@ stages:
       - ShellCommand:
           name: run unit tests
           command: npm test
+          env:
+            CI: "true"
       - ShellCommand:
           name: run backbeat routes test
           command: bash ./eve/workers/unit_and_feature_tests/run_server_tests.bash ft_test:api:routes
           workdir: '%(prop:builddir)s/build'
           env:
             CI: "true"
+            BACKBEAT_CONFIG_FILE: "tests/config.json"
       - ShellCommand:
           name: run backbeat retry tests with account authentication
           command: bash ./eve/workers/unit_and_feature_tests/run_server_tests.bash ft_test:api:retry
@@ -59,3 +62,4 @@ stages:
           command: npm run ft_test:replication
           env:
             CI: "true"
+            BACKBEAT_CONFIG_FILE: "tests/config.json"

--- a/extensions/replication/ReplicationQueuePopulator.js
+++ b/extensions/replication/ReplicationQueuePopulator.js
@@ -52,8 +52,16 @@ class ReplicationQueuePopulator extends QueuePopulatorExtension {
                      `${queueEntry.getBucket()}/${queueEntry.getObjectKey()}`,
                      JSON.stringify(entry));
 
-        this._incrementMetrics(queueEntry.getSite(),
-            queueEntry.getContentLength());
+        const repSites = queueEntry.getReplicationInfo().backends;
+        const content = queueEntry.getReplicationContent();
+        const bytes = content.includes('DATA') ?
+            queueEntry.getContentLength() : 0;
+
+        // record replication metrics by site
+        repSites.filter(entry => entry.status === 'PENDING')
+            .forEach(backend => {
+                this._incrementMetrics(backend.site, bytes);
+            });
     }
 }
 

--- a/extensions/replication/constants.js
+++ b/extensions/replication/constants.js
@@ -8,12 +8,20 @@ const constants = {
     proxyIAMPath: '/_/backbeat/iam',
     metricsExtension: 'crr',
     metricsTypeQueued: 'queued',
-    metricsTypeProcessed: 'processed',
+    metricsTypeCompleted: 'completed',
+    metricsTypeFailed: 'failed',
     redisKeys: {
+        opsPending: testIsOn ? 'test:bb:opspending' : 'bb:crr:opspending',
+        bytesPending: testIsOn ? 'test:bb:bytespending' : 'bb:crr:bytespending',
         ops: testIsOn ? 'test:bb:ops' : 'bb:crr:ops',
         bytes: testIsOn ? 'test:bb:bytes' : 'bb:crr:bytes',
+        objectBytes: testIsOn ? 'test:bb:object:bytes' : 'bb:crr:object:bytes',
         opsDone: testIsOn ? 'test:bb:opsdone' : 'bb:crr:opsdone',
+        opsFail: testIsOn ? 'test:bb:opsfail' : 'bb:crr:opsfail',
         bytesDone: testIsOn ? 'test:bb:bytesdone' : 'bb:crr:bytesdone',
+        objectBytesDone: testIsOn ?
+            'test:bb:object:bytesdone' : 'bb:crr:object:bytesdone',
+        bytesFail: testIsOn ? 'test:bb:bytesfail' : 'bb:crr:bytesfail',
         failedCRR: testIsOn ? 'test:bb:crr:failed' : 'bb:crr:failed',
     },
 };

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -3,7 +3,6 @@ const assert = require('assert');
 const werelogs = require('werelogs');
 
 const QueueProcessor = require('./QueueProcessor');
-const MetricsProducer = require('../../../lib/MetricsProducer');
 
 const config = require('../../../conf/Config');
 const kafkaConfig = config.kafka;
@@ -24,21 +23,11 @@ assert(bootstrapList.length === 1, 'Invalid site argument. Site must match ' +
 const destConfig = Object.assign({}, repConfig.destination);
 destConfig.bootstrapList = bootstrapList;
 
-const log = new werelogs.Logger('Backbeat:QueueProcessor:task');
 werelogs.configure({ level: config.log.logLevel,
     dump: config.log.dumpLevel });
 
-const metricsProducer = new MetricsProducer(kafkaConfig, mConfig);
-metricsProducer.setupProducer(err => {
-    if (err) {
-        log.error('error starting metrics producer for queue processor', {
-            error: err,
-            method: 'MetricsProducer::setupProducer',
-        });
-        return undefined;
-    }
-    const queueProcessor = new QueueProcessor(
-        kafkaConfig, sourceConfig, destConfig, repConfig,
-        httpsConfig, internalHttpsConfig, site, metricsProducer);
-    return queueProcessor.start();
-});
+const queueProcessor = new QueueProcessor(
+    kafkaConfig, sourceConfig, destConfig, repConfig,
+    mConfig, httpsConfig, internalHttpsConfig, site);
+
+queueProcessor.start();

--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -19,6 +19,10 @@ const {
     getSortedSetMember,
     getSortedSetKey,
 } = require('../../../lib/util/sortedSetHelper');
+const MetricsProducer = require('../../../lib/MetricsProducer');
+
+// StatsClient constant default for site metrics
+const INTERVAL = 300; // 5 minutes;
 
 /**
  * @class ReplicationStatusProcessor
@@ -55,13 +59,18 @@ class ReplicationStatusProcessor {
      *   in PEM format
      * @param {String} [internalHttpsConfig.ca] - alternate CA bundle
      *   in PEM format
+     * @param {Object} mConfig - metrics config
+     * @param {String} mConfig.topic - metrics config kafka topic
      */
-    constructor(kafkaConfig, sourceConfig, repConfig, internalHttpsConfig) {
+    constructor(kafkaConfig, sourceConfig, repConfig, internalHttpsConfig,
+                mConfig) {
         this.kafkaConfig = kafkaConfig;
         this.sourceConfig = sourceConfig;
         this.repConfig = repConfig;
         this.internalHttpsConfig = internalHttpsConfig;
+        this.mConfig = mConfig;
         this._consumer = null;
+        this._mProducer = null;
 
         this.logger =
             new Logger('Backbeat:Replication:ReplicationStatusProcessor');
@@ -80,7 +89,9 @@ class ReplicationStatusProcessor {
 
         this._setupVaultclientCache();
 
-        this._statsClient = new StatsModel(undefined);
+        const { monitorReplicationFailureExpiryTimeS } = this.repConfig;
+        this._statsClient = new StatsModel(undefined, INTERVAL,
+            (monitorReplicationFailureExpiryTimeS + INTERVAL));
         this.taskScheduler = new ReplicationTaskScheduler(
             (ctx, done) => ctx.task.processQueueEntry(ctx.entry, done));
     }
@@ -110,6 +121,7 @@ class ReplicationStatusProcessor {
             internalHttpsConfig: this.internalHttpsConfig,
             sourceHTTPAgent: this.sourceHTTPAgent,
             vaultclientCache: this.vaultclientCache,
+            mProducer: this._mProducer,
             logger: this.logger,
         };
     }
@@ -124,23 +136,43 @@ class ReplicationStatusProcessor {
      * @return {undefined}
      */
     start(options, cb) {
-        this._FailedCRRProducer = new FailedCRRProducer(this.kafkaConfig);
-        this._consumer = new BackbeatConsumer({
-            kafka: { hosts: this.kafkaConfig.hosts },
-            topic: this.repConfig.replicationStatusTopic,
-            groupId: this.repConfig.replicationStatusProcessor.groupId,
-            concurrency:
-            this.repConfig.replicationStatusProcessor.concurrency,
-            queueProcessor: this.processKafkaEntry.bind(this),
-            bootstrap: options && options.bootstrap,
-        });
-        this._consumer.on('error', () => {});
-        this._consumer.on('ready', () => {
-            this.logger.info('replication status processor is ready to ' +
-                             'consume replication status entries');
-            this._consumer.subscribe();
-            this._FailedCRRProducer.setupProducer(cb);
-        });
+        async.parallel([
+            done => {
+                this._failedCRRProducer =
+                    new FailedCRRProducer();
+                this._failedCRRProducer.setupProducer(done);
+            },
+            done => {
+                this._mProducer = new MetricsProducer(this.kafkaConfig,
+                    this.mConfig);
+                this._mProducer.setupProducer(done);
+            },
+            done => {
+                let consumerReady = false;
+                this._consumer = new BackbeatConsumer({
+                    kafka: { hosts: this.kafkaConfig.hosts },
+                    topic: this.repConfig.replicationStatusTopic,
+                    groupId: this.repConfig.replicationStatusProcessor.groupId,
+                    concurrency:
+                    this.repConfig.replicationStatusProcessor.concurrency,
+                    queueProcessor: this.processKafkaEntry.bind(this),
+                    bootstrap: options && options.bootstrap,
+                });
+                this._consumer.on('error', () => {
+                    if (!consumerReady) {
+                        this.logger.fatal('error starting a backbeat consumer');
+                        process.exit(1);
+                    }
+                });
+                this._consumer.on('ready', () => {
+                    consumerReady = true;
+                    this.logger.info('replication status processor is ready ' +
+                                     'to consume replication status entries');
+                    this._consumer.subscribe();
+                    done();
+                });
+            },
+        ], cb);
     }
 
     /**

--- a/extensions/replication/replicationStatusProcessor/task.js
+++ b/extensions/replication/replicationStatusProcessor/task.js
@@ -9,9 +9,10 @@ const kafkaConfig = config.kafka;
 const repConfig = config.extensions.replication;
 const sourceConfig = repConfig.source;
 const internalHttpsConfig = config.internalHttps;
+const mConfig = config.metrics;
 
 const replicationStatusProcessor = new ReplicationStatusProcessor(
-    kafkaConfig, sourceConfig, repConfig, internalHttpsConfig);
+    kafkaConfig, sourceConfig, repConfig, internalHttpsConfig, mConfig);
 
 werelogs.configure({ level: config.log.logLevel,
                      dump: config.log.dumpLevel });

--- a/extensions/replication/utils/getExtMetrics.js
+++ b/extensions/replication/utils/getExtMetrics.js
@@ -1,0 +1,20 @@
+/**
+ * Get the object form to send to the CRR metrics topic.
+ * @param {String} site - The site of the destination object
+ * @param {Number} bytes - The size of the metrics being set in Redis
+ * @param {ObjectQueueEntry} entry - The object queue entry for the object being
+ * monitored
+ * @return {Object} - The object to send to the CRR metrics topic as a message
+ */
+function getExtMetrics(site, bytes, entry) {
+    const extMetrics = {};
+    extMetrics[site] = {
+        bytes,
+        bucketName: entry.getBucket(),
+        objectKey: entry.getObjectKey(),
+        versionId: entry.getEncodedVersionId(),
+    };
+    return extMetrics;
+}
+
+module.exports = getExtMetrics;

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -5,13 +5,7 @@ const async = require('async');
 const joi = require('joi');
 
 const BackbeatProducer = require('./BackbeatProducer');
-const ObjectQueueEntry =
-    require('../extensions/replication/utils/ObjectQueueEntry');
 const Logger = require('werelogs').Logger;
-
-const QueueEntry = require('./models/QueueEntry');
-
-const CRR_TOPIC = require('../conf/Config').extensions.replication.topic;
 
 // controls the number of messages to process in parallel
 const CONCURRENCY_DEFAULT = 1;
@@ -85,8 +79,7 @@ class BackbeatConsumer extends EventEmitter {
         this._consumer = null;
         this._consumerReady = false;
         this._bootstrapping = false;
-        // metrics - consumption
-        this._metricsStore = {};
+
         this._init();
         return this;
     }
@@ -158,9 +151,6 @@ class BackbeatConsumer extends EventEmitter {
             this.emit('consumed', this._messagesConsumed);
             this._messagesConsumed = 0;
 
-            this.emit('metrics', this._metricsStore);
-            this._metricsStore = {};
-
             this._tryConsume();
         };
 
@@ -221,34 +211,8 @@ class BackbeatConsumer extends EventEmitter {
                 entry: { topic, partition, offset, key, timestamp },
             });
             this.emit('error', err, entry);
-        } else if (entry.topic === CRR_TOPIC) {
-            const qEntry = QueueEntry.createFromKafkaEntry(entry);
-            if (!qEntry.error && qEntry instanceof ObjectQueueEntry) {
-                const bytes = qEntry.getContentLength();
-
-                const repSites = qEntry.getReplicationInfo().backends;
-                const sites = repSites.reduce((store, entry) => {
-                    if (entry.status === 'PENDING') {
-                        store.push(entry.site);
-                    }
-                    return store;
-                }, []);
-
-                sites.forEach(site => {
-                    if (!this._metricsStore[site]) {
-                        this._metricsStore[site] = {
-                            ops: 1,
-                            bytes,
-                        };
-                    } else {
-                        this._metricsStore[site].ops++;
-                        this._metricsStore[site].bytes += bytes;
-                    }
-                });
-            }
         }
     }
-
 
     _onOffsetCommit(err, topicPartitions) {
         if (err) {

--- a/lib/MetricsConsumer.js
+++ b/lib/MetricsConsumer.js
@@ -7,9 +7,9 @@ const { StatsModel } = require('arsenal').metrics;
 const BackbeatConsumer = require('./BackbeatConsumer');
 const redisKeys = require('../extensions/replication/constants').redisKeys;
 
-// StatsClient constant defaults
+// StatsClient constant defaults for site metrics
 const INTERVAL = 300; // 5 minutes;
-const EXPIRY = 900; // 15 minutes
+const EXPIRY = 86400; // 24 hours
 
 // BackbeatConsumer constant defaults
 const CONSUMER_FETCH_MAX_BYTES = 5000020;
@@ -32,10 +32,8 @@ class MetricsConsumer {
         this.kafkaConfig = kafkaConfig;
 
         this.logger = new Logger('Backbeat:MetricsConsumer');
-
         const redisClient = new RedisClient(rConfig, this.logger);
-        this._statsClient = new StatsModel(redisClient, INTERVAL,
-            EXPIRY);
+        this._statsClient = new StatsModel(redisClient, INTERVAL, EXPIRY);
     }
 
     start() {
@@ -52,6 +50,47 @@ class MetricsConsumer {
             consumer.subscribe();
             this.logger.info('metrics processor is ready to consume entries');
         });
+    }
+
+    _sendSiteLevelRequests(data) {
+        const { type, site, ops, bytes } = data;
+        if (type === 'completed') {
+            this._statsClient
+                .decrementKey(`${site}:${redisKeys.opsPending}`, ops);
+            this._statsClient
+                .decrementKey(`${site}:${redisKeys.bytesPending}`, bytes);
+            this._sendRequest(`${site}:${redisKeys.opsDone}`, ops);
+            this._sendRequest(`${site}:${redisKeys.bytesDone}`, bytes);
+        } else if (type === 'failed') {
+            this._statsClient
+                .decrementKey(`${site}:${redisKeys.opsPending}`, ops);
+            this._statsClient
+                .decrementKey(`${site}:${redisKeys.bytesPending}`, bytes);
+            this._sendRequest(`${site}:${redisKeys.opsFail}`, ops);
+            this._sendRequest(`${site}:${redisKeys.bytesFail}`, bytes);
+        } else if (type === 'queued') {
+            this._statsClient
+                .incrementKey(`${site}:${redisKeys.opsPending}`, ops);
+            this._statsClient
+                .incrementKey(`${site}:${redisKeys.bytesPending}`, bytes);
+            this._sendRequest(`${site}:${redisKeys.ops}`, ops);
+            this._sendRequest(`${site}:${redisKeys.bytes}`, bytes);
+        }
+        return undefined;
+    }
+
+    _sendObjectLevelRequests(data) {
+        const { type, site, bytes, bucketName, objectKey, versionId } = data;
+        if (type === 'completed') {
+            const key = `${site}:${bucketName}:${objectKey}:` +
+                `${versionId}:${redisKeys.objectBytesDone}`;
+            this._sendRequest(key, bytes);
+        } else if (type === 'queued') {
+            const key = `${site}:${bucketName}:${objectKey}:` +
+                `${versionId}:${redisKeys.objectBytes}`;
+            this._sendRequest(key, bytes);
+        }
+        return undefined;
     }
 
     processKafkaEntry(kafkaEntry, done) {
@@ -76,20 +115,21 @@ class MetricsConsumer {
                 type: 'processed'
             }
         */
-        if (data.type === 'processed') {
-            this._sendRequest(redisKeys.opsDone, data.ops);
-            this._sendRequest(redisKeys.bytesDone, data.bytes);
-        } else if (data.type === 'queued') {
-            this._sendRequest(redisKeys.ops, data.ops);
-            this._sendRequest(redisKeys.bytes, data.bytes);
-        } else {
-            // unknown type
-            log.error('unknown type field encountered in metrics '
-            + 'consumer', {
+        const operationTypes = ['completed', 'failed', 'queued'];
+        const isValidType = operationTypes.includes(data.type);
+        if (!isValidType) {
+            log.error('unknown type field encountered in metrics consumer', {
                 method: 'MetricsConsumer.processKafkaEntry',
                 dataType: data.type,
                 data,
             });
+            log.end();
+            return done();
+        }
+        if (data.bucketName && data.objectKey && data.versionId) {
+            this._sendObjectLevelRequests(data);
+        } else {
+            this._sendSiteLevelRequests(data);
         }
         log.end();
         return done();

--- a/lib/MetricsProducer.js
+++ b/lib/MetricsProducer.js
@@ -40,7 +40,7 @@ class MetricsProducer {
     /**
      * @param {Object} extMetrics - an object where keys are all sites for a
      *   given extension and values are the metrics for the site
-     *   (i.e. { my-site: { ops: 1, bytes: 124 } } )
+     *   (i.e. { my-site: { ops: 1, bytes: 124 }, awsbackend: { ... } } )
      * @param {String} type - type of metric (queueud or processed)
      * @param {String} ext - extension (i.e. 'crr')
      * @param {function} cb - callback
@@ -48,9 +48,10 @@ class MetricsProducer {
      */
     publishMetrics(extMetrics, type, ext, cb) {
         async.each(Object.keys(extMetrics), (siteName, done) => {
-            const { ops, bytes } = extMetrics[siteName];
+            const { ops, bytes, bucketName, objectKey, versionId } =
+                extMetrics[siteName];
             const message = new MetricsModel(ops, bytes, ext, type,
-                siteName).serialize();
+                siteName, bucketName, objectKey, versionId).serialize();
             this._producer.send([{ message }], err => {
                 if (err) {
                     // Using trace here because errors are already logged in

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -4,9 +4,8 @@ const async = require('async');
 const zookeeper = require('node-zookeeper-client');
 
 const { errors } = require('arsenal');
-const { RedisClient } = require('arsenal').metrics;
+const { RedisClient, StatsModel } = require('arsenal').metrics;
 
-const { StatsModel } = require('arsenal').metrics;
 const BackbeatProducer = require('../BackbeatProducer');
 const ObjectQueueEntry =
     require('../../extensions/replication/utils/ObjectQueueEntry');
@@ -19,10 +18,14 @@ const routes = require('./routes');
 const { getSortedSetKey, getSortedSetMember } =
     require('../util/sortedSetHelper');
 
+const { redisKeys } = require('../../extensions/replication/constants');
+
 // StatsClient constant defaults
 // TODO: This should be moved to constants file
 const INTERVAL = 300; // 5 minutes
-const EXPIRY = 900; // 15 minutes
+const EXPIRY = 86400; // 24 hours
+const THROUGHPUT_EXPIRY = 900; // 15 minutes
+const isTest = process.env.CI === 'true';
 
 /**
  * Class representing Backbeat API endpoints and internals
@@ -69,8 +72,7 @@ class BackbeatAPI {
         this._redisClient = new RedisClient(this._redisConfig, this._logger);
         // Redis expiry increased by an additional interval so we can reference
         // the immediate older data for average throughput calculation
-        this._statsClient = new StatsModel(this._redisClient, INTERVAL,
-            (EXPIRY + INTERVAL));
+        this._statsClient = new StatsModel(this._redisClient, INTERVAL, EXPIRY);
     }
 
     /**
@@ -96,77 +98,122 @@ class BackbeatAPI {
     }
 
     /**
-     * Check if incoming request is valid
+     * Find valid route from list of routes defined in Arsenal backbeat routes
+     * Sets the matched route on the BackbeatRequest object with possible
+     * extra properties.
      * @param {BackbeatRequest} bbRequest - holds relevant data about request
-     * @return {boolean} true/false
+     * @return {Object|null} - The error object or `null` if no error
      */
-    isValidRoute(bbRequest) {
+    findValidRoute(bbRequest) {
+        /* eslint-disable no-param-reassign */
         const rDetails = bbRequest.getRouteDetails();
-        if (!rDetails) {
-            return false;
-        }
         const route = bbRequest.getRoute();
-        // first validate healthcheck routes
-        if (route.substring(3) === 'healthcheck') {
-            return true;
+        const addKeys = {};
+
+        // first validate healthcheck routes or prom routes since they do not
+        // have rDetails set
+        if (route === 'healthcheck') {
+            if (bbRequest.getHTTPMethod() !== 'GET') {
+                return errors.MethodNotAllowed;
+            }
+            // TODO: this logic changes with addition of deep healthcheck
+            const healthcheckRoute = routes.filter(r =>
+                r.category === 'healthcheck')[0];
+            bbRequest.setMatchedRoute(healthcheckRoute);
+            return null;
         }
-        /*
-            {
-                category: 'metrics',
-                extension: 'crr',
-                site: 'my-site-name',
-                metric: 'backlog', (optional)
-            }
-        */
-        // check metric routes
-        // Are there any routes with matching extension?
-        const extensions = routes.reduce((store, r) => {
-            if (r.extensions[rDetails.extension] &&
-                r.extensions[rDetails.extension].includes(rDetails.status)) {
-                store.push(Object.keys(r.extensions));
-            } else if (rDetails.category === 'metrics') {
-                store.push(Object.keys(r.extensions));
-            }
-            return store;
-        }, []);
-        if (![].concat.apply([], extensions).includes(rDetails.extension)) {
-            return false;
+
+        // If giving the bucket name, the user must also provide an object key
+        // and version ID.
+        const hasGranularity = rDetails.bucketName ?
+            rDetails.objectKey && rDetails.versionId : true;
+        if (!hasGranularity) {
+            return errors.RouteNotFound.customizeDescription(
+                'must provide object key and version ID in route: ' +
+                `${bbRequest.getRoute()}`);
         }
-        let specifiedType;
-        const validRoutes = [];
-        routes.forEach(r => {
-            if (!r.extensions) {
-                return;
-            }
-            if (!Object.keys(r.extensions).includes(rDetails.extension)) {
-                return;
-            }
-            if (rDetails.site &&
-                !r.extensions[rDetails.extension].includes(rDetails.site)) {
-                return;
-            }
-            if (rDetails.status &&
-                !r.extensions[rDetails.extension].includes(rDetails.status)) {
-                return;
-            }
-            if (rDetails.metric && r.type === rDetails.metric) {
-                specifiedType = r.type;
-            }
-            validRoutes.push(r);
+
+        // All routes at this point have extensions property in use
+        // Match http verb and match extension name
+        let filteredRoutes = routes.filter(r => {
+            const isMatchingMethod = bbRequest.getHTTPMethod() === r.httpMethod;
+            const isMatchingExtension = r.extensions[rDetails.extension];
+            const isMatchingLevel = rDetails.objectKey ?
+                r.level === 'object' :
+                r.level === 'site' || r.level === undefined;
+            return isMatchingMethod && isMatchingExtension && isMatchingLevel;
         });
 
-        if (validRoutes.length === 0) {
-            return false;
+        // if rDetails has a category property. Currently only metrics
+        if (rDetails.category) {
+            filteredRoutes = filteredRoutes.filter(r =>
+                rDetails.category === r.category);
+        }
+        // if rDetails has a status property
+        if (rDetails.status) {
+            if (rDetails.status === 'failed') {
+                const {
+                    extension, marker, sitename, bucket, key, versionId, role,
+                } = rDetails;
+                const type = (bucket && key && versionId) ? 'specific' : 'all';
+                filteredRoutes = filteredRoutes.filter(r => {
+                    const extList = r.extensions[extension];
+                    return extList.includes('failed') && r.type === type;
+                });
+
+                if (type === 'specific') {
+                    addKeys.bucket = bucket;
+                    addKeys.key = key;
+                    addKeys.versionId = versionId;
+                }
+                if (marker) {
+                    // this is optional, so doesn't matter if set or not
+                    addKeys.marker = marker;
+                }
+                if (sitename) {
+                    // this is optional for backward compatibility
+                    addKeys.sitename = sitename;
+                }
+                if (role && this._repConfig.source.auth.type === 'role') {
+                    addKeys.role = role;
+                }
+            }
+        }
+        // if rDetails has a type property
+        if (rDetails.type) {
+            filteredRoutes = filteredRoutes.filter(r =>
+                rDetails.type === r.type);
         }
 
-        // since this is an optional field, if a metric type was specified
-        // in the route and it didn't match any metric types defined in
-        // `routes.js`
-        if (rDetails.metric && !specifiedType) {
-            return false;
+        // if rDetails has a site property. Should only have 1 matched route
+        // at this point, or else there is an error
+        if (rDetails.site && filteredRoutes.length === 1) {
+            filteredRoutes = filteredRoutes.filter(r => {
+                const list = r.extensions[rDetails.extension];
+                return list.includes(rDetails.site);
+            });
+            // add optional site
+            addKeys.site = rDetails.site;
         }
 
-        return true;
+        if (filteredRoutes.length !== 1) {
+            return errors.RouteNotFound.customizeDescription(
+                `path ${bbRequest.getRoute()} does not exist`);
+        }
+
+        if (rDetails.versionId) {
+            addKeys.objectKey = rDetails.objectKey;
+            addKeys.bucketName = rDetails.bucketName;
+            addKeys.versionId = rDetails.versionId;
+        }
+
+        // Matching route found. Set on request object so we do not have to
+        // re-match later
+        const matchedRoute = Object.assign({}, filteredRoutes[0], addKeys);
+        bbRequest.setMatchedRoute(matchedRoute);
+
+        return null;
+        /* eslint-enable no-param-reassign */
     }
 
     /**
@@ -181,15 +228,6 @@ class BackbeatAPI {
     _checkProducersReady() {
         return this._crrProducer.isReady() && this._metricProducer.isReady()
             && this._crrStatusProducer.isReady();
-    }
-
-    /**
-     * Check if Zookeeper and Producer are connected
-     * @return {boolean} true/false
-     */
-    isConnected() {
-        return this._zkClient.getState().name === 'SYNC_CONNECTED'
-            && this._checkProducersReady();
     }
 
     /**
@@ -220,11 +258,26 @@ class BackbeatAPI {
      */
     _getData(details, data, cb) {
         if (!data) {
-            const dataPoints = details.dataPoints;
-            const site = details.site;
-            return this._queryStats(dataPoints, site, cb);
+            const { dataPoints, site, bucketName, objectKey,
+                versionId } = details;
+            return this._queryStats(dataPoints, site, bucketName, objectKey,
+                versionId, cb);
         }
         return cb(null, data);
+    }
+
+    /**
+     * Uptime of server based on this._internalStart up to max of expiry
+     * @param {number} expiry - max expiry
+     * @return {number} uptime of server up to expiry time
+     */
+    _getMaxUptime(expiry) {
+        let secondsSinceStart = (Date.now() - this._internalStart) / 1000;
+        // allow only a minimum value of 1 for uptime
+        if (secondsSinceStart < 1) {
+            secondsSinceStart = 1;
+        }
+        return secondsSinceStart < expiry ? secondsSinceStart : expiry;
     }
 
     /**
@@ -237,28 +290,29 @@ class BackbeatAPI {
      */
     getBacklog(details, cb, data) {
         this._getData(details, data, (err, res) => {
+            if (err && err.type) {
+                this._logger.error('error getting metric: backlog', {
+                    origin: err.method,
+                    method: 'BackbeatAPI.getBacklog',
+                });
+                return cb(err.type.customizeDescription(err.message));
+            }
             if (err || res.length !== details.dataPoints.length) {
                 this._logger.error('error getting metrics: backlog', {
                     method: 'BackbeatAPI.getBacklog',
                 });
                 return cb(errors.InternalError);
             }
-            const d = res.map(r => (
-                r.requests.slice(0, 3).reduce((acc, i) => acc + i)
-            ));
-
-            let opsBacklog = d[0] - d[1];
-            if (opsBacklog < 0) opsBacklog = 0;
-            let bytesBacklog = d[2] - d[3];
-            if (bytesBacklog < 0) bytesBacklog = 0;
+            const count = Number.parseInt(res[0].requests, 10);
+            const size = Number.parseInt(res[1].requests, 10);
             const response = {
                 backlog: {
                     description: 'Number of incomplete replication ' +
                         'operations (count) and number of incomplete bytes ' +
                         'transferred (size)',
                     results: {
-                        count: opsBacklog,
-                        size: bytesBacklog,
+                        count: count < 0 ? 0 : count,
+                        size: size < 0 ? 0 : size,
                     },
                 },
             };
@@ -276,6 +330,13 @@ class BackbeatAPI {
      */
     getCompletions(details, cb, data) {
         this._getData(details, data, (err, res) => {
+            if (err && err.type) {
+                this._logger.error('error getting metric: completions', {
+                    origin: err.method,
+                    method: 'BackbeatAPI.getCompletions',
+                });
+                return cb(err.type.customizeDescription(err.message));
+            }
             if (err || res.length !== details.dataPoints.length) {
                 this._logger.error('error getting metrics: completions', {
                     method: 'BackbeatAPI.getCompletions',
@@ -283,14 +344,10 @@ class BackbeatAPI {
                 return cb(errors.InternalError);
             }
 
-            // Find if time since start is less than EXPIRY time
-            const timeSinceStart = (Date.now() - this._internalStart) / 1000;
-            // Seconds up to a max of EXPIRY seconds
-            const timeDisplay = timeSinceStart < EXPIRY ?
-                (timeSinceStart || 1) : EXPIRY;
-            const numOfIntervals = Math.ceil(timeDisplay / INTERVAL);
+            const uptime = this._getMaxUptime(EXPIRY);
+            const numOfIntervals = Math.ceil(uptime / INTERVAL);
 
-            const d = res.map(r => (
+            const [opsDone, bytesDone] = res.map(r => (
                 r.requests.slice(0, numOfIntervals).reduce((acc, i) =>
                     acc + i, 0)
             ));
@@ -299,10 +356,10 @@ class BackbeatAPI {
                 completions: {
                     description: 'Number of completed replication operations ' +
                         '(count) and number of bytes transferred (size) in ' +
-                        `the last ${Math.floor(timeDisplay)} seconds`,
+                        `the last ${Math.floor(uptime)} seconds`,
                     results: {
-                        count: d[0],
-                        size: d[1],
+                        count: opsDone,
+                        size: bytesDone,
                     },
                 },
             };
@@ -310,8 +367,71 @@ class BackbeatAPI {
         });
     }
 
+    /* eslint-disable */
     /**
-     * Get current throughput in ops/sec and MB/sec
+     * Use failed object sorted set lists to get failure metrics
+     * @param {object} details - route details from lib/backbeat/routes.js
+     * @param {function} cb - callback(error, data)
+     * @param {array} data - optional field providing already fetched data in
+     *   order of dataPoints mentioned for each route in lib/backbeat/routes.js
+     * @return {undefined}
+     */
+    getFailedMetrics(details, cb, data) {
+        const { failedCRR } = redisKeys;
+        const sites = details.site === 'all' ?
+            this._validSites : [details.site];
+        const hourTimestamps = this._statsClient.getSortedSetHours(Date.now());
+        // reduce by hourly timestamp
+        return async.reduce(hourTimestamps, 0, (totalSum, timestamp, done) => {
+            const keys = sites.map(s => `${failedCRR}:${s}:${timestamp}`);
+            // reduce by each site for a given hour
+            return async.reduce(keys, 0, (hourlySum, key, next) => {
+                return this._redisClient.zcard(key, (err, count) => {
+                    if (err) {
+                        this._logger.error('error on Redis zcard', {
+                            error: err,
+                            method: 'BackbeatAPI.getFailedMetrics',
+                        });
+                        return next(err);
+                    }
+                    return next(null, hourlySum + count);
+                });
+            }, (err, hourlyTotal) => {
+                if (err) {
+                    return done(err);
+                }
+                return done(null, totalSum + hourlyTotal);
+            });
+        }, (err, totalCount) => {
+            if (err) {
+                this._logger.error('error getting metrics: failures', {
+                    error: err,
+                    method: 'BackbeatAPI.getFailedMetrics',
+                });
+                return cb(errors.InternalError);
+            }
+            // TODO: for now, not returning failures bytes. Instead, rely on
+            // retry to return obj sizes
+            const bytesFail = 0;
+            const uptime = this._getMaxUptime(EXPIRY);
+            const response = {
+                failures: {
+                    description: 'Number of failed replication operations ' +
+                        '(count) and bytes (size) in the last ' +
+                        `${Math.floor(uptime)} seconds`,
+                    results: {
+                        count: totalCount,
+                        size: bytesFail,
+                    },
+                },
+            };
+            return cb(null, response);
+        });
+    }
+    /* eslint-enable */
+
+    /**
+     * Get current throughput in ops/sec and bytes/sec up to max of 15 minutes
      * Throughput is the number of units processed in a given time
      * @param {object} details - route details from lib/api/routes.js
      * @param {function} cb - callback(error, data)
@@ -321,6 +441,13 @@ class BackbeatAPI {
      */
     getThroughput(details, cb, data) {
         this._getData(details, data, (err, res) => {
+            if (err && err.type) {
+                this._logger.error('error getting metric: throughput', {
+                    origin: err.method,
+                    method: 'BackbeatAPI.getThroughput',
+                });
+                return cb(err.type.customizeDescription(err.message));
+            }
             if (err) {
                 this._logger.error('error getting metrics: throughput', {
                     method: 'BackbeatAPI.getThroughput',
@@ -329,43 +456,181 @@ class BackbeatAPI {
             }
 
             const now = new Date();
-            const timeSinceStart = (now - this._internalStart) / 1000;
-            // Seconds up to a max of EXPIRY seconds
-            const timeDisplay = timeSinceStart < EXPIRY ?
-                (timeSinceStart || 1) : EXPIRY;
-            const numOfIntervals = Math.ceil(timeDisplay / INTERVAL);
+            const uptime = this._getMaxUptime(THROUGHPUT_EXPIRY);
+            const numOfIntervals = Math.ceil(uptime / INTERVAL);
 
             const [opsThroughput, bytesThroughput] = res.map(r => {
                 let total = r.requests.slice(0, numOfIntervals).reduce(
                     (acc, i) => acc + i, 0);
 
-                // if timeDisplay !== EXPIRY, use interval timer and do not
-                // include the extra 4th interval
-                if (timeDisplay === EXPIRY) {
+                // if uptime !== THROUGHPUT_EXPIRY, use interval timer and
+                // do not include the extra 4th interval
+                if (uptime === THROUGHPUT_EXPIRY) {
                     // all intervals apply, including 4th interval
                     const lastInterval =
-                        this._statsClient._normalizeTimestamp(new Date(now));
+                        this._statsClient._normalizeTimestamp(now);
                     // in seconds
                     const diff = (now - lastInterval) / 1000;
-
                     // Get average for last interval depending on time
                     // surpassed so far for newest interval
                     total += ((INTERVAL - diff) / INTERVAL) *
                         r.requests[numOfIntervals];
                 }
 
-                // Divide total by timeDisplay to determine data per second
-                return (total / timeDisplay);
+                // Divide total by uptime to determine data per second
+                return (total / uptime);
             });
 
             const response = {
                 throughput: {
                     description: 'Current throughput for replication ' +
-                        'operations in ops/sec (count) and MB/sec (size) ' +
-                        `in the last ${Math.floor(timeDisplay)} seconds`,
+                        'operations in ops/sec (count) and bytes/sec (size) ' +
+                        `in the last ${Math.floor(uptime)} seconds`,
                     results: {
                         count: opsThroughput.toFixed(2),
                         size: bytesThroughput.toFixed(2),
+                    },
+                },
+            };
+            return cb(null, response);
+        });
+    }
+
+    /**
+     * Get current throughput for an object in bytes/sec. Throughput is the
+     * number of bytes transferred in a given time.
+     * @param {object} details - route details from lib/api/routes.js
+     * @param {function} cb - callback(error, data)
+     * @return {undefined}
+     */
+    getObjectThroughput(details, cb) {
+        this._getData(details, undefined, (err, res) => {
+            if (err && err.type) {
+                this._logger.error('error getting metric: object throughput', {
+                    origin: err.method,
+                    method: 'Metrics.getObjectThroughput',
+                });
+                return cb(err.type.customizeDescription(err.message));
+            }
+            if (err) {
+                this._logger.error('error getting metrics: object throughput', {
+                    method: 'Metrics.getObjectThroughput',
+                    error: err.message,
+                });
+                return cb(errors.InternalError);
+            }
+            const now = new Date();
+            const uptime = this._getMaxUptime(THROUGHPUT_EXPIRY);
+            const numOfIntervals = Math.ceil(uptime / INTERVAL);
+            const { requests } = res[0]; // Bytes done
+            let total = requests.slice(0, numOfIntervals)
+                .reduce((acc, i) => acc + i, 0);
+            // if uptime !== THROUGHPUT_EXPIRY, use internal timer
+            // and do not include the extra 4th interval
+            if (uptime === THROUGHPUT_EXPIRY) {
+                // all intervals apply, including 4th interval
+                const lastInterval =
+                    this._statsClient._normalizeTimestamp(now);
+                // in seconds
+                const diff = (now - lastInterval) / 1000;
+                // Get average for last interval depending on time passed so
+                // far for newest interval
+                total += ((INTERVAL - diff) / INTERVAL) *
+                    requests[numOfIntervals];
+            }
+            // Divide total by timeDisplay to determine data per second
+            const response = {
+                description: 'Current throughput for object replication in ' +
+                    'bytes/sec (throughput)',
+                throughput: (total / uptime).toFixed(2),
+            };
+            return cb(null, response);
+        });
+    }
+
+     /**
+     * Get CRR progress for an object in bytes. Progress is the percentage of
+     * the object that has completed replication.
+     * @param {object} details - route details from lib/api/routes.js
+     * @param {function} cb - callback(error, data)
+     * @return {undefined}
+     */
+    getObjectProgress(details, cb) {
+        this._getData(details, undefined, (err, res) => {
+            if (err && err.type) {
+                this._logger.error('error getting metric: object progress', {
+                    origin: err.method,
+                    method: 'Metrics.getObjectProgress',
+                });
+                return cb(err.type.customizeDescription(err.message));
+            }
+            if (err || res.length !== details.dataPoints.length) {
+                this._logger.error('error getting metrics: object progress', {
+                    method: 'Metrics.getObjectProgress',
+                    error: err.message,
+                });
+                return cb(errors.InternalError);
+            }
+            // Find if time since start is less than EXPIRY time
+            const uptime = this._getMaxUptime(EXPIRY);
+            const numOfIntervals = Math.ceil(uptime / INTERVAL);
+            const [totalBytesToComplete, bytesComplete] = res.map(r => (
+                r.requests.slice(0, numOfIntervals).reduce((acc, i) =>
+                    acc + i, 0)
+            ));
+            const ratio = totalBytesToComplete === 0 ? 0 :
+                bytesComplete / totalBytesToComplete;
+            const percentage = (ratio * 100).toFixed();
+            const response = {
+                description: 'Number of bytes to be replicated ' +
+                    '(pending), number of bytes transferred to the ' +
+                    'destination (completed), and percentage of the ' +
+                    'object that has completed replication (progress)',
+                pending: totalBytesToComplete - bytesComplete,
+                completed: bytesComplete,
+                progress: `${percentage}%`,
+            };
+            return cb(null, response);
+        });
+    }
+
+    /**
+     * Get pending replication stats by ops count and size in bytes
+     * @param {object} details - route details from lib/backbeat/routes.js
+     * @param {function} cb - callback(error, data)
+     * @param {array} data - optional field providing already fetched data in
+     *   order of dataPoints mentioned for each route in lib/backbeat/routes.js
+     * @return {undefined}
+     */
+    getPending(details, cb, data) {
+        this._getData(details, data, (err, res) => {
+            if (err && err.type) {
+                this._logger.error('error getting metric: pending', {
+                    origin: err.method,
+                    method: 'Metrics.getPending',
+                });
+                return cb(err.type.customizeDescription(err.message));
+            }
+            const { dataPoints } = details;
+            if (err || res.length !== dataPoints.length) {
+                this._logger.error('error getting metrics: pending', {
+                    method: 'Metrics.getPending',
+                    error: err,
+                    dataPoints,
+                    res,
+                });
+                return cb(errors.InternalError
+                    .customizeDescription('error getting metrics: pending'));
+            }
+            const count = Number.parseInt(res[0].requests, 10);
+            const size = Number.parseInt(res[1].requests, 10);
+            const response = {
+                pending: {
+                    description: 'Number of pending replication ' +
+                        'operations (count) and bytes (size)',
+                    results: {
+                        count: count < 0 ? 0 : count,
+                        size: size < 0 ? 0 : size,
                     },
                 },
             };
@@ -383,20 +648,35 @@ class BackbeatAPI {
      */
     getAllMetrics(details, cb, data) {
         this._getData(details, data, (err, res) => {
+            if (err && err.type) {
+                this._logger.error('error getting metric: all', {
+                    origin: err.method,
+                    method: 'BackbeatAPI.getAllMetrics',
+                });
+                return cb(err.type.customizeDescription(err.message));
+            }
             if (err || res.length !== details.dataPoints.length) {
                 this._logger.error('error getting metrics: all', {
                     method: 'BackbeatAPI.getAllMetrics',
                 });
                 return cb(errors.InternalError);
             }
-            // res = [ ops, ops_done, bytes, bytes_done ]
+            // NOTE: Edited to fit failed metrics
+            const failMetricsDetails = Object.assign({}, details,
+                { dataPoints: new Array(2) });
+            // res = [ ops, ops_done, ops_fail, bytes, bytes_done, bytes_fail,
+            // opsPending, bytesPending ]
             return async.parallel([
-                done => this.getBacklog({ dataPoints: new Array(4) }, done,
-                    res),
+                done => this.getBacklog({ dataPoints: new Array(2) }, done,
+                    [res[6], res[7]]),
                 done => this.getCompletions({ dataPoints: new Array(2) }, done,
-                    [res[1], res[3]]),
+                    [res[1], res[4]]),
+                done => this.getFailedMetrics(failMetricsDetails, done,
+                    done, [res[2], res[5]]),
                 done => this.getThroughput({ dataPoints: new Array(2) }, done,
-                    [res[1], res[3]]),
+                    [res[1], res[4]]),
+                done => this.getPending({ dataPoints: new Array(2) }, done,
+                    [res[6], res[7]]),
             ], (err, results) => {
                 if (err) {
                     this._logger.error('error getting metrics: all', {
@@ -682,8 +962,14 @@ class BackbeatAPI {
                 this._logger.error('error pushing to kafka topics', {
                     method: 'BackbeatAPI._pushToCRRRetryKafkaTopics',
                 });
+                return cb(err);
             }
-            return cb(err);
+            const opsPendingKey = `${site}:${redisKeys.opsPending}`;
+            const bytesPendingkey = `${site}:${redisKeys.bytesPending}`;
+            const bytes = queueEntry.getContentLength();
+            this._statsClient.incrementKey(opsPendingKey, 1);
+            this._statsClient.incrementKey(bytesPendingkey, bytes);
+            return cb();
         });
     }
 
@@ -828,7 +1114,7 @@ class BackbeatAPI {
                         return done(null, queueEntry);
                     });
                 },
-            ], err => {
+            ], (err, queueEntry) => {
                 if (err) {
                     this._logger.debug('failed to delete duplicate object ' +
                     'fail key', {
@@ -837,6 +1123,15 @@ class BackbeatAPI {
                     });
                     return next();
                 }
+                const contentLength = queueEntry.getContentLength();
+                const site = entry.getSite();
+                const opsPendingKey = `${site}:${redisKeys.opsPending}`;
+                const bytesPendingkey = `${site}:${redisKeys.bytesPending}`;
+                // decrement key as a duplicate failure object key was found.
+                // If removing a duplicate failure object key, we also need to
+                // normalize pending metrics by decrementing
+                this._statsClient.decrementKey(opsPendingKey, 1);
+                this._statsClient.decrementKey(bytesPendingkey, contentLength);
                 return next();
             }));
     }
@@ -999,22 +1294,95 @@ class BackbeatAPI {
                 error: errors.MalformedPOSTRequest.customizeDescription(errMsg),
             };
         }
+        // Bucket, Key, VersionId, StorageClass
+        // filter duplicate version ids if any
+        const uniqueObjs = {};
+        reqBody = reqBody.filter(entry => {
+            const { Bucket, Key, VersionId, StorageClass } = entry;
+            const hash = `${Bucket}:${Key}:${VersionId}:${StorageClass}`;
+            if (!uniqueObjs[hash]) {
+                uniqueObjs[hash] = entry;
+                return true;
+            }
+            return false;
+        });
+
         return { reqBody };
     }
 
     /**
      * Query StatsClient for all ops given
      * @param {array} ops - array of redis key names to query
-     * @param {string} site - site name
+     * @param {string} site - site name or '*' wildcard
+     * @param {string} bucketName - the name of the bucket
+     * @param {string} objectKey - the object key name
+     * @param {string} versionId - the object version ID
      * @param {function} cb - callback(err, res)
      * @return {undefined}
      */
-    _queryStats(ops, site, cb) {
-        // TODO: Querying by site level here will change in future
-        //   For now, since only 'all' sites is supported, query all
+    _queryStats(ops, site, bucketName, objectKey, versionId, cb) {
         return async.map(ops, (op, done) => {
-            this._statsClient.getStats(this._logger, op, done);
+            const hasGlobalKey = this._hasGlobalKey(op);
+            if (site === 'all') {
+                const queryStrings = this._validSites.map(s => {
+                    if (bucketName && objectKey && versionId) {
+                        return `${s}:${bucketName}:${objectKey}:` +
+                               `${versionId}:${op}`;
+                    }
+                    return `${s}:${op}`;
+                });
+                if (hasGlobalKey) {
+                    return this._statsClient.getAllGlobalStats(queryStrings,
+                        this._logger, done);
+                }
+                return this._statsClient.getAllStats(this._logger, queryStrings,
+                    done);
+            }
+            // Query only a single given site or storage class
+            // First, validate the site or storage class
+            if (!this._validSites.includes(site)) {
+                // escalate error to log later
+                return done({
+                    message: 'invalid site name provided',
+                    type: errors.RouteNotFound,
+                    method: 'BackbeatAPI._queryStats',
+                });
+            }
+            let queryString;
+            if (bucketName && objectKey && versionId) {
+                queryString =
+                    `${site}:${bucketName}:${objectKey}:${versionId}:${op}`;
+            } else {
+                queryString = `${site}:${op}`;
+            }
+            if (hasGlobalKey) {
+                return this._redisClient.get(queryString, (err, res) => {
+                    if (err) {
+                        return done({
+                            message: `Redis error: ${err.message}`,
+                            type: errors.InternalError,
+                            method: 'Metrics._queryStats',
+                        });
+                    }
+                    return done(null, { requests: [res || 0] });
+                });
+            }
+            return this._statsClient.getStats(this._logger, queryString, done);
         }, cb);
+    }
+
+    /**
+     * Determines whether the Redis op uses a global counter or interval key.
+     * @param {String} op - The Redis operation
+     * @return {Boolean} true if a global counter, false otherwise
+     */
+    _hasGlobalKey(op) {
+        if (isTest) {
+            return op.includes('test:bb:bytespending') ||
+                op.includes('test:bb:opspending');
+        }
+        return op.includes('bb:crr:bytespending') ||
+            op.includes('bb:crr:opspending');
     }
 
     /**

--- a/lib/api/BackbeatRequest.js
+++ b/lib/api/BackbeatRequest.js
@@ -18,11 +18,17 @@ class BackbeatRequest {
         this._request = req;
         this._response = res;
         this._log = log;
-        this._route = req.url;
+        this._httpMethod = this._request.method;
+        this._route = null;
+        this._hasValidPrefix = null;
         this._statusCode = 0;
         this._error = null;
         this._routeDetails = {};
 
+        // Use to store matched route from Arsenal list of backbeat routes
+        this._matchedRoute = null;
+
+        this.setRoute(this._request.url);
         this._parseRoute();
     }
 
@@ -48,6 +54,23 @@ class BackbeatRequest {
     }
 
     /**
+     * Parse the route details for any of the metrics routes
+     * @param {Array} parts - route schema split by '/'
+     * @param {String} query - The query string.
+     * @return {undefined}
+     */
+    _parseMetricsRoutes(parts, query) {
+        this._routeDetails.category = parts[0];
+        this._routeDetails.extension = parts[1];
+        this._routeDetails.site = parts[2];
+        // optional field, default to 'all'
+        this._routeDetails.type = parts[3] || 'all';
+        this._routeDetails.bucketName = parts[4];
+        this._routeDetails.objectKey = parts.slice(5).join('/');
+        this._routeDetails.versionId = querystring.parse(query).versionId;
+    }
+
+    /**
      * Parse a route and store to this._routeDetails
      * A route will have certain a specific structure following:
      * /_/metrics/<extension>/<site>/<specific-metric>
@@ -55,26 +78,15 @@ class BackbeatRequest {
      * @return {undefined}
      */
     _parseRoute() {
-        // always drop first 3 chars. This is already validated in
-        // BackbeatServer._isValidRequest
-        const route = this._route.substring(3);
-        const { pathname, query } = url.parse(route);
-        // if healthcheck, just skip this
+        const { pathname, query } = url.parse(this._route);
         const parts = pathname ? pathname.split('/') : [];
+
         if (parts[0] === 'crr') {
             this._parseCRRRoutes(parts, query);
-            return;
+        } else if (parts[0] === 'metrics') {
+            this._parseMetricsRoutes(parts, query);
         }
-        if (parts.length < 3 || parts.length > 4) {
-            // leave this._routeDetails undefined
-            return;
-        }
-        this._routeDetails.category = parts[0];
-        this._routeDetails.extension = parts[1];
-        this._routeDetails.site = parts[2];
-        if (parts.length === 4) {
-            this._routeDetails.metric = parts[3];
-        }
+        return;
     }
 
     /**
@@ -166,6 +178,14 @@ class BackbeatRequest {
     }
 
     /**
+     * Get initial route prefix validity check
+     * @return {boolean} true if request.url began with "/_/"
+     */
+    getHasValidPrefix() {
+        return this._hasValidPrefix;
+    }
+
+    /**
      * Get route
      * @return {string} current route
      */
@@ -175,11 +195,35 @@ class BackbeatRequest {
 
     /**
      * Set route
-     * @param {string} route - new route string
+     * @param {string} route - route string
      * @return {BackbeatRequest} itself
      */
     setRoute(route) {
-        this._route = route;
+        this._hasValidPrefix = route.startsWith('/_/');
+        if (this._hasValidPrefix) {
+            this._route = route.substring(3);
+        } else {
+            this._route = route;
+        }
+        return this;
+    }
+
+    /**
+     * Get the matched route from Arsenal list of backbeat routes
+     * @return {Object} matched route object
+     */
+    getMatchedRoute() {
+        return this._matchedRoute;
+    }
+
+    /**
+     * Set the matched route from Arsenal list of backbeat routes
+     * Extra properties may be added from BackbeatAPI.findValidRoute
+     * @param {Object} route - matched route object
+     * @return {BackbeatRequest} itself
+     */
+    setMatchedRoute(route) {
+        this._matchedRoute = route;
         return this;
     }
 

--- a/lib/api/BackbeatServer.js
+++ b/lib/api/BackbeatServer.js
@@ -6,7 +6,6 @@ const { Clustering, errors, ipCheck } = require('arsenal');
 
 const BackbeatRequest = require('./BackbeatRequest');
 const BackbeatAPI = require('./BackbeatAPI');
-const routes = require('./routes');
 
 const WORKERS = 1;
 
@@ -32,9 +31,10 @@ class BackbeatServer {
      * @param {werelogs.newRequestLogger} logger - request logger
      * @param {object} req - request object
      * @param {object} res - response object
+     * @param {object} desc - optional specific message from api
      * @return {undefined}
      */
-    _logRequestEnd(logger, req, res) {
+    _logRequestEnd(logger, req, res, desc) {
         const info = {
             clientIp: req.socket.remoteAddress,
             clientPort: req.socket.remotePort,
@@ -42,6 +42,7 @@ class BackbeatServer {
             httpURL: req.url,
             httpCode: res.statusCode,
             httpMessage: res.statusMessage,
+            description: desc && desc.description,
         };
         logger.end('finished handling request', info);
     }
@@ -63,21 +64,24 @@ class BackbeatServer {
 
         const validMethods = ['GET', 'POST'];
         if (!validMethods.includes(req.method)) {
-            return this._errorResponse(errors.MethodNotAllowed
-                .customizeDescription('invalid http verb'),
+            return this._errorResponse(errors.MethodNotAllowed,
                 backbeatRequest);
         }
 
-        if (!this.backbeatAPI.isValidRoute(backbeatRequest)
-            || !backbeatRequest.getRoute().startsWith('/_/')) {
+        if (!backbeatRequest.getHasValidPrefix()) {
             return this._errorResponse(errors.RouteNotFound
                 .customizeDescription(`path ${backbeatRequest.getRoute()} does `
                     + 'not exist'), backbeatRequest);
         }
 
-        const error = this.backbeatAPI.validateQuery(backbeatRequest);
-        if (error) {
-            return this._errorResponse(error, backbeatRequest);
+        const routeError = this.backbeatAPI.findValidRoute(backbeatRequest);
+        if (routeError) {
+            return this._errorResponse(routeError, backbeatRequest);
+        }
+
+        const queryError = this.backbeatAPI.validateQuery(backbeatRequest);
+        if (queryError) {
+            return this._errorResponse(queryError, backbeatRequest);
         }
 
         return true;
@@ -113,11 +117,12 @@ class BackbeatServer {
      * Get the body of a POST request and route it accordingly.
      * @param {ClientRequest} req - The incoming request
      * @param {BackbeatRequest} bbRequest - The Backbeat API Request
-     * @param {Object} routeDetails - The Backbeat route details
      * @return {undefined}
      */
-    _handlePOSTReq(req, bbRequest, routeDetails) {
+    _handlePOSTReq(req, bbRequest) {
         const data = [];
+        const routeDetails = bbRequest.getMatchedRoute();
+
         req.on('data', chunk => data.push(chunk));
         req.on('end', () => {
             const { method } = routeDetails;
@@ -134,30 +139,6 @@ class BackbeatServer {
     }
 
     /**
-     *
-     * @param {Object} rDetails - The Backbeat request details
-     * @param {ClientRequest} req - The incoming request
-     * @return {Object} The matching Backbeat route
-     */
-    _getRetryRoute(rDetails, req) {
-        const { extension, status, bucket, key, versionId, marker, sitename,
-            role } = rDetails;
-        const route = routes.find(r => {
-            if (r.extensions[extension] &&
-                r.extensions[extension].includes(status)) {
-                return r.httpMethod === req.method &&
-                    (bucket && key && versionId ?
-                    r.type === 'specific' :
-                    r.type === 'all');
-            }
-            return false;
-        });
-        // Include any granularity in the details for the response method.
-        return Object.assign({}, route, { bucket, key, versionId, marker,
-            sitename, role });
-    }
-
-    /**
      * Server incoming request handler
      * @param {object} req - request object
      * @param {object} res - response object
@@ -171,40 +152,15 @@ class BackbeatServer {
         // check request conditions and all internal conditions here
         if (this._isValidRequest(req, bbRequest)
         && (this._areConditionsOk(bbRequest) ||
-        bbRequest.getRoute() === '/_/healthcheck')) {
+        bbRequest.getRoute().startsWith('healthcheck'))) {
             bbRequest.setStatusCode(200);
-            bbRequest.setRoute(bbRequest.getRoute().substring(3));
 
-            /*
-                {
-                    category: 'metrics',
-                    extension: 'crr',
-                    site: 'my-site-name',
-                    metric: 'backlog', (optional)
-                }
-            */
-            // TODO: when adding deep healthcheck, this logic will change
-            let routeDetails;
-            if (bbRequest.getRoute() === 'healthcheck') {
-                routeDetails = routes.find(r => r.category === 'healthcheck');
-            } else {
-                const rDetails = bbRequest.getRouteDetails();
-                if (rDetails.status) {
-                    routeDetails = this._getRetryRoute(rDetails, req);
-                } else if (!rDetails.metric) {
-                    // no metric type is specified, so use all route
-                    routeDetails = routes.find(r => r.type === 'all');
-                } else {
-                    routeDetails = routes.find(r => r.type === rDetails.metric);
-                }
-                routeDetails.site = rDetails.site;
+            if (bbRequest.getHTTPMethod() === 'POST') {
+                return this._handlePOSTReq(req, bbRequest);
             }
 
-            const requestMethod = routeDetails.method;
-            if (routeDetails.httpMethod === 'POST') {
-                return this._handlePOSTReq(req, bbRequest, routeDetails);
-            }
-            this.backbeatAPI[requestMethod](routeDetails, (err, data) => {
+            const routeDetails = bbRequest.getMatchedRoute();
+            this.backbeatAPI[routeDetails.method](routeDetails, (err, data) => {
                 if (err) {
                     this._errorResponse(err, bbRequest);
                 } else {
@@ -233,9 +189,9 @@ class BackbeatServer {
 
         res.writeHead(code, {
             'Content-Type': 'application/json',
-            'Content-Length': payload.length,
+            'Content-Length': Buffer.byteLength(payload, 'utf8'),
         });
-        this._logRequestEnd(log, req, res);
+        this._logRequestEnd(log, req, res, data);
         return res.end(payload);
     }
 

--- a/lib/api/Healthcheck.js
+++ b/lib/api/Healthcheck.js
@@ -60,6 +60,16 @@ class Healthcheck {
     }
 
     /**
+     * Ensure that there is an in-sync replica for each partition.
+     * @param {object} topicMd - topic metadata object
+     * @return {boolean} true if each partition has a replica, false otherwise
+     */
+    _isMissingISR(topicMd) {
+        return topicMd.partitions.some(partition =>
+            (partition.isrs && partition.isrs.length === 0));
+    }
+
+    /**
      * Builds the healthcheck response
      * @param {function} cb - callback(error, data)
      * @return {undefined}
@@ -83,6 +93,14 @@ class Healthcheck {
             if (topicMd) {
                 topics[this._repConfig.topic] = topicMd;
                 connections.isrHealth = this._checkISRHealth(topicMd);
+            }
+            if (topicMd && this._isMissingISR(topicMd)) {
+                const error = {
+                    method: 'Healthcheck.getHealthcheck',
+                    error: 'no in-sync replica for partition',
+                    topicMd,
+                };
+                return cb(error);
             }
             Object.assign(connections, this._getConnectionDetails());
             response.topics = topics;

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -5,7 +5,16 @@
 
 const redisKeys = require('../../extensions/replication/constants').redisKeys;
 
+const testIsOn = process.env.CI === 'true';
+const config = testIsOn ? require('../../tests/config.json') :
+                          require('../../conf/Config');
+
+
+const boostrapList = config.extensions.replication.destination.bootstrapList;
+const allLocations = boostrapList.map(item => item.site);
+
 module.exports = [
+    // Route: /_/healthcheck
     {
         httpMethod: 'GET',
         category: 'healthcheck',
@@ -13,39 +22,81 @@ module.exports = [
         method: 'getHealthcheck',
         extensions: {},
     },
+    // Route: /_/metrics/crr/<location>/pending
+    {
+        httpMethod: 'GET',
+        category: 'metrics',
+        type: 'pending',
+        extensions: { crr: [...allLocations, 'all'] },
+        method: 'getPending',
+        dataPoints: [redisKeys.opsPending, redisKeys.bytesPending],
+    },
+    // Route: /_/metrics/crr/<location>/backlog
     {
         httpMethod: 'GET',
         category: 'metrics',
         type: 'backlog',
-        extensions: { crr: ['all'] },
+        extensions: { crr: [...allLocations, 'all'] },
         method: 'getBacklog',
-        dataPoints: [redisKeys.ops, redisKeys.opsDone, redisKeys.bytes,
-            redisKeys.bytesDone],
+        dataPoints: [redisKeys.opsPending, redisKeys.bytesPending],
     },
+    // Route: /_/metrics/crr/<location>/completions
     {
         httpMethod: 'GET',
         category: 'metrics',
         type: 'completions',
-        extensions: { crr: ['all'] },
+        extensions: { crr: [...allLocations, 'all'] },
         method: 'getCompletions',
         dataPoints: [redisKeys.opsDone, redisKeys.bytesDone],
     },
+    // Route: /_/metrics/crr/<location>/failures
+    {
+        httpMethod: 'GET',
+        category: 'metrics',
+        type: 'failures',
+        extensions: { crr: [...allLocations, 'all'] },
+        method: 'getFailedMetrics',
+        dataPoints: [redisKeys.opsFail, redisKeys.bytesFail],
+    },
+    // Route: /_/metrics/crr/<location>/throughput
     {
         httpMethod: 'GET',
         category: 'metrics',
         type: 'throughput',
-        extensions: { crr: ['all'] },
+        extensions: { crr: [...allLocations, 'all'] },
         method: 'getThroughput',
         dataPoints: [redisKeys.opsDone, redisKeys.bytesDone],
     },
+    // Route: /_/metrics/crr/<location>/all
     {
         httpMethod: 'GET',
         category: 'metrics',
         type: 'all',
-        extensions: { crr: ['all'] },
+        extensions: { crr: [...allLocations, 'all'] },
         method: 'getAllMetrics',
-        dataPoints: [redisKeys.ops, redisKeys.opsDone, redisKeys.bytes,
-            redisKeys.bytesDone],
+        dataPoints: [redisKeys.ops, redisKeys.opsDone, redisKeys.opsFail,
+            redisKeys.bytes, redisKeys.bytesDone, redisKeys.bytesFail,
+            redisKeys.opsPending, redisKeys.bytesPending],
+    },
+    // Route: /_/metrics/crr/<site>/progress/<bucket>/<key>
+    {
+        httpMethod: 'GET',
+        category: 'metrics',
+        type: 'progress',
+        level: 'object',
+        extensions: { crr: [...allLocations] },
+        method: 'getObjectProgress',
+        dataPoints: [redisKeys.objectBytes, redisKeys.objectBytesDone],
+    },
+    // Route: /_/metrics/crr/<site>/throughput/<bucket>/<key>
+    {
+        httpMethod: 'GET',
+        category: 'metrics',
+        type: 'throughput',
+        level: 'object',
+        extensions: { crr: [...allLocations] },
+        method: 'getObjectThroughput',
+        dataPoints: [redisKeys.objectBytesDone],
     },
     // Route: /_/crr/failed?sitename=<site>&marker=<marker>
     {

--- a/lib/models/MetricsModel.js
+++ b/lib/models/MetricsModel.js
@@ -6,17 +6,24 @@ class MetricsModel {
      * @param {Number} ops - number of operations
      * @param {Number} bytes - data size in bytes
      * @param {String} extension - extension
-     * @param {String} type - operation indicator (queued or processed)
+     * @param {String} type - operation indicator (queued, completed, failed)
      * @param {String} site - site name
+     * @param {String} bucketName - bucket name
+     * @param {String} objectKey - object key
+     * @param {String} versionId - object version ID
      */
 
-    constructor(ops, bytes, extension, type, site) {
+    constructor(ops, bytes, extension, type, site, bucketName, objectKey,
+        versionId) {
         this._timestamp = Date.now();
         this._ops = ops;
         this._bytes = bytes;
         this._extension = extension;
         this._type = type;
         this._site = site;
+        this._bucketName = bucketName;
+        this._objectKey = objectKey;
+        this._versionId = versionId;
     }
 
     serialize() {
@@ -27,6 +34,9 @@ class MetricsModel {
             extension: this._extension,
             type: this._type,
             site: this._site,
+            bucketName: this._bucketName,
+            objectKey: this._objectKey,
+            versionId: this._versionId,
         });
     }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/scality/backbeat#readme",
   "dependencies": {
-    "arsenal": "scality/Arsenal#89873b4c",
+    "arsenal": "scality/Arsenal#da847d7",
     "async": "^2.3.0",
     "aws-sdk": "2.147.0",
     "backo": "^1.1.0",
@@ -37,6 +37,7 @@
     "eslint-config-airbnb": "^6.0.0",
     "eslint-config-scality": "scality/Guidelines#71a059ad",
     "eslint-plugin-react": "^4.2.3",
+    "ioredis": "^3.2.2",
     "joi": "^10.6",
     "node-rdkafka": "2.2.0",
     "node-schedule": "^1.2.0",

--- a/tests/config.json
+++ b/tests/config.json
@@ -72,6 +72,8 @@
     },
     "redis": {
         "name": "backbeat-test",
-        "password": ""
+        "password": "",
+        "host": "127.0.0.1",
+        "port": 6379
     }
 }

--- a/tests/config.roleAuth.json
+++ b/tests/config.roleAuth.json
@@ -70,6 +70,8 @@
     },
     "redis": {
         "name": "backbeat-test",
-        "password": ""
+        "password": "",
+        "host": "127.0.0.1",
+        "port": 6379
     }
 }

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -617,10 +617,6 @@ class S3Mock extends TestConfigurator {
     }
 }
 
-class MetricsMock {
-    publishMetrics() {}
-}
-
 /* eslint-enable max-len */
 
 describe('queue processor functional tests with mocking', () => {
@@ -654,9 +650,10 @@ describe('queue processor functional tests with mocking', () => {
                   retryTimeoutS: 5,
                   groupId: 'backbeat-func-test-group-id',
               },
+            },
+            { topic: 'metrics-test-topic' }, {
             }, {
-            }, {
-            }, 'sf', new MetricsMock());
+            }, 'sf');
         queueProcessor.start({ disableConsumer: true });
         // create the replication status processor only when the queue
         // processor is ready, so that we ensure the replication
@@ -678,10 +675,10 @@ describe('queue processor functional tests with mocking', () => {
                       groupId: 'backbeat-func-test-group-id',
                   },
                 }, {
-                });
+                },
+                { topic: 'metrics-test-topic' });
             replicationStatusProcessor.start({ bootstrap: true }, done);
         });
-
         s3mock = new S3Mock();
         httpServer = http.createServer(
             (req, res) => s3mock.onRequest(req, res));

--- a/tests/unit/api/BackbeatRequest.spec.js
+++ b/tests/unit/api/BackbeatRequest.spec.js
@@ -10,20 +10,88 @@ describe('BackbeatRequest helper class', () => {
         assert.deepStrictEqual(details, {});
     });
 
-    it('should parse routes and store internally as route details', () => {
-        const req = new BackbeatRequest({ url: '/_/metrics/crr/all' });
-        const details = req.getRouteDetails();
+    describe('_parseRoute', () => {
+        it('should parse metrics routes and store internally as route details',
+        () => {
+            const req = new BackbeatRequest({
+                url: '/_/metrics/crr/all',
+                method: 'GET',
+            });
+            const details = req.getRouteDetails();
 
-        assert.strictEqual(details.category, 'metrics');
-        assert.strictEqual(details.extension, 'crr');
-        assert.strictEqual(details.site, 'all');
-        assert.strictEqual(details.metric, undefined);
+            assert.strictEqual(details.category, 'metrics');
+            assert.strictEqual(details.extension, 'crr');
+            assert.strictEqual(details.site, 'all');
+            assert.strictEqual(details.type, 'all');
 
-        const req2 = new BackbeatRequest(
-            { url: '/_/metrics/crr/test/backlog' });
-        const details2 = req2.getRouteDetails();
+            const req2 = new BackbeatRequest({
+                url: '/_/metrics/crr/test/backlog',
+                method: 'GET',
+            });
+            const details2 = req2.getRouteDetails();
 
-        assert.strictEqual(details2.site, 'test');
-        assert.strictEqual(details2.metric, 'backlog');
+            assert.strictEqual(details2.site, 'test');
+            assert.strictEqual(details2.type, 'backlog');
+        });
+
+        it('should parse crr failed routes and store internally as route ' +
+        'details', () => {
+            const req = new BackbeatRequest({
+                url: '/_/crr/failed?marker=testmarker',
+                method: 'GET',
+            });
+            const details = req.getRouteDetails();
+
+            assert.strictEqual(details.extension, 'crr');
+            assert.strictEqual(details.status, 'failed');
+            assert.strictEqual(details.marker, 'testmarker');
+            assert.strictEqual(req.getHTTPMethod(), 'GET');
+
+            const req2 = new BackbeatRequest({
+                url: '/_/crr/failed',
+                method: 'POST',
+            });
+            const details2 = req2.getRouteDetails();
+
+            assert.strictEqual(details2.extension, 'crr');
+            assert.strictEqual(details2.status, 'failed');
+            assert.strictEqual(req2.getHTTPMethod(), 'POST');
+
+            const req3 = new BackbeatRequest({
+                url: '/_/crr/failed/mybucket/mykey?versionId=myvId',
+                method: 'GET',
+            });
+            const details3 = req3.getRouteDetails();
+
+            assert.strictEqual(details3.extension, 'crr');
+            assert.strictEqual(details3.status, 'failed');
+            assert.strictEqual(details3.bucket, 'mybucket');
+            assert.strictEqual(details3.key, 'mykey');
+            assert.strictEqual(details3.versionId, 'myvId');
+        });
+    });
+
+    it('should set route without prefix if valid route has valid prefix',
+    () => {
+        const req = new BackbeatRequest({
+            url: '/_/healthcheck',
+            method: 'GET',
+        });
+        const route = req.getRoute();
+        const validPrefix = req.getHasValidPrefix();
+
+        assert.strictEqual(route, 'healthcheck');
+        assert.strictEqual(validPrefix, true);
+
+        const req2 = new BackbeatRequest({
+            url: '/healthcheck',
+            method: 'GET',
+        });
+        const route2 = req2.getRoute();
+        const validPrefix2 = req2.getHasValidPrefix();
+
+        // Uses the original route when prefix is incorrect (for error logs)
+        assert.strictEqual(route2, '/healthcheck');
+        assert.strictEqual(validPrefix2, false);
     });
 });

--- a/tests/unit/replication/ReplicationQueuePopulator.spec.js
+++ b/tests/unit/replication/ReplicationQueuePopulator.spec.js
@@ -1,0 +1,183 @@
+const assert = require('assert');
+
+const ReplicationQueuePopulator =
+    require('../../../extensions/replication/ReplicationQueuePopulator');
+
+const fakeLogger = {
+    debug: () => {},
+    error: () => {},
+    info: () => {},
+    trace: () => {},
+};
+
+const TOPIC = 'test-topic';
+const SITE = 'test-site';
+const SITE2 = 'test-site2';
+
+/**
+ * This mock object is to overwrite the `publish` method and add a way of
+ * getting information on published messages.
+ * @class
+ */
+class ReplicationQueuePopulatorMock extends ReplicationQueuePopulator {
+    constructor(params) {
+        super(params);
+
+        this._state = {};
+    }
+
+    publish(topic, key, message) {
+        assert.equal(topic, TOPIC);
+
+        this._state.key = encodeURIComponent(key);
+        this._state.message = message;
+    }
+
+    getState() {
+        return this._state;
+    }
+
+    resetState() {
+        this._state = {};
+    }
+}
+
+function overwriteBackends(obj, backends) {
+    /* eslint-disable no-param-reassign */
+    obj.replicationInfo.backends = backends;
+    return JSON.stringify(obj);
+    /* eslint-enable no-param-reassign */
+}
+
+describe('replication queue populator', () => {
+    let rqp;
+
+    before(() => {
+        const params = {
+            config: {
+                topic: TOPIC,
+            },
+            logger: fakeLogger,
+        };
+        rqp = new ReplicationQueuePopulatorMock(params);
+    });
+
+    afterEach(() => {
+        rqp.resetState();
+    });
+
+    /* eslint-disable */
+    const repInfo = {
+        status: 'PENDING',
+        backends: [{
+            'site': SITE,
+            'status': 'PENDING',
+            'dataStoreVersionId': '',
+        }],
+        content: [ 'DATA', 'METADATA' ],
+        destination: 'arn:aws:s3:::test-bucket-target',
+        storageClass: 'awsbackend',
+        role: 'arn:aws:iam::922268666771:role/bb-replication-1522257577471',
+        storageType: 'aws_s3',
+        dataStoreVersionId: '',
+    };
+
+    const kafkaValue = {
+        'owner-display-name': 'test_1522198049',
+        'owner-id': 'e166a2080a0c2cf1474dce54654f3f224dd5ae01379f20f338d106b8bc964bb1',
+        'content-length': 128,
+        'content-md5': 'd41d8cd98f00b204e9800118ecf8427e',
+        'x-amz-version-id': 'null',
+        'x-amz-server-version-id': '',
+        'x-amz-storage-class': 'STANDARD',
+        'x-amz-server-side-encryption': '',
+        'x-amz-server-side-encryption-aws-kms-key-id': '',
+        'x-amz-server-side-encryption-customer-algorithm': '',
+        'x-amz-website-redirect-location': '',
+        acl: {
+            Canned: 'private',
+            FULL_CONTROL: [],
+            WRITE_ACP: [],
+            READ: [],
+            READ_ACP: []
+        },
+        key: '',
+        location: null,
+        isDeleteMarker: false,
+        tags: {},
+        dataStoreName: 'dc-1',
+        'last-modified': '2018-03-28T22:10:00.534Z',
+        'md-model-version': 3,
+        versionId: '98477724999464999999RG001  1.30.12',
+    };
+
+    const objectKafkaValue = Object.assign({}, kafkaValue);
+    objectKafkaValue.replicationInfo = repInfo;
+
+    const mdOnlyKafkaValue = Object.assign({}, kafkaValue);
+    mdOnlyKafkaValue.replicationInfo = Object.assign({}, repInfo,
+        { content: [ 'METADATA'] });
+    /* eslint-enable */
+
+    [
+        {
+            desc: 'object entry, not a master key',
+            entry: Object.assign({}, {
+                type: 'put',
+                bucket: 'test-bucket-source',
+                key: 'a-test-key',
+            }, { value: JSON.stringify(objectKafkaValue) }),
+            results: {},
+        },
+        {
+            desc: 'object entry, master key',
+            entry: Object.assign({}, {
+                type: 'put',
+                bucket: 'test-bucket-source',
+                key: 'a-test-key\u000098477724999464999999RG001  1.30.12',
+            }, { value: JSON.stringify(objectKafkaValue) }),
+            results: { [SITE]: { ops: 1, bytes: 128 } },
+        },
+        {
+            desc: 'object entry, master key, multiple backend',
+            entry: Object.assign({}, {
+                type: 'put',
+                bucket: 'test-bucket-source',
+                key: 'a-test-key2\u000098477724999464999999RG001  1.30.12',
+            }, { value:
+                overwriteBackends(objectKafkaValue, [
+                    { site: SITE, status: 'PENDING' },
+                    { site: SITE2, status: 'PENDING' },
+                ]),
+            }),
+            results: {
+                [SITE]: { ops: 1, bytes: 128 },
+                [SITE2]: { ops: 1, bytes: 128 },
+            },
+        },
+        {
+            desc: 'metadata only entry, master key',
+            entry: Object.assign({}, {
+                type: 'put',
+                bucket: 'test-bucket-source',
+                key: 'a-test-key2\u000098477724999464999999RG001  1.30.12',
+            }, { value: JSON.stringify(mdOnlyKafkaValue) }),
+            results: { [SITE]: { ops: 1, bytes: 0 } },
+        },
+    ].forEach(input => {
+        it(`should filter entries properly: ${input.desc}`, () => {
+            rqp.filter(input.entry);
+
+            const metrics = rqp.getAndResetMetrics();
+
+            assert.deepStrictEqual(input.results, metrics);
+
+            if (Object.keys(input.results).length) {
+                assert.deepStrictEqual(JSON.stringify(input.entry),
+                    rqp.getState().message);
+            } else {
+                assert.deepStrictEqual(rqp.getState(), {});
+            }
+        });
+    });
+});


### PR DESCRIPTION
Opening for review. Please do not merge. Goes with https://github.com/scality/Arsenal/pull/596

For this backport, I decided to keep backbeat Metrics methods and api routes file in this repo and only keep StatsModel changes in arsenal.

Note: some commits were partial backports based on
differences of deployment.
backport the following commits from development/8.1:

- 0db307b ft: add site-level metrics
- 03a7cc3 bf: fix metrics redis key site names
- fe30502 ft: add healthcheck and metrics readmes
- 6eb174d bf: instantiate a QueueProcessor per site
- 600882c bf: add test when redis has no metric keys
- 0096f81 fix: ZENKO-331 use metrics route in BBConsumer
- 291d47b fix: ZENKO-331 use extra interval MetricsConsumer
- 95bd296 bf: ZENKO-331 validate http method and rf parser
- de7681c rf: ZENKO-584 collect metrics on status change
- 3952b21 ft: ZENKO-584 update metrics docs
- 39d9e29 ft: ZENKO-584 add failed metrics collection
- 4dc87f0 feature: ZENKO-483 Monitor CRR upload
- 14508d2 improvement: ZENKO-483 Monitor CRR Upload doc
- 29cc74d bugfix: ZENKO-621 Failed CRR metrics retry
- 409cbbb ft: increase metrics expiry window to 24hrs
- 47fbeee bugfix: ZENKO-1024 Add pending counters
- aff3cc2 bf: ZENKO-1024 use pending metrics for backlog
- afeea09 bf: ZENKO-1024 replace failures metrics
- 3391587 improvement: ZENKO-1024 add backlog checks in test
- 87b4eab bf: ZENKO-1024 try to normalize pending counter
- 923412d bugfix: ZENKO-1115 Error status for healthcheck
- 9ac6656 bf: ZENKO-1151 fix metrics bytes for md only
- 63dc12b bf: ZENKO-1144 failures metrics to use sorted sets
- 1210438 improvement: ZENKO-647 update backbeat api doc

Changes also include consolidating arsenal backbeat routes
and metrics methods into backbeat:

- 8fd50cd rf: S3C-1399 Add Backbeat metrics and routes
- 114cbf5 bf: use expired interval to avg out throughput
- f904f04 fix: do not crash on empty backbeat stats
- 659aee2 bf: fix/change byte conversion
- b3b2229 ft: ZENKO-584 add failed CRR metrics route
- c36280a feature: ZENKO-483 Monitor CRR upload
- 1a2ea2f feature: ZENKO-483 Update Redis key schema
- bf95506 ft: ZENKO-925 increase crr metrics expiry to 24hrs
- 06dfdd9 rf: use single StatsModel, use explicit var names
- 125ccbb bugfix: ZENKO-1024 Add pending counters
- 9f742d4 bf: ZENKO-1024 use pending metrics for backlog
- 872a2d8 bf: ZENKO-1144 remove redis scan in crr metrics