### PR TITLE
bf: fix ci tests

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -7,7 +7,6 @@ branches:
   development/*:
     stage: "post-merge"
 
-
 models:
   - SetProperty: &docker_image_name
       name: Set docker image name property
@@ -46,7 +45,8 @@ stages:
           haltOnFailure: True
       - ShellCommand:
           name: Npm install
-          command: npm install --unsafe-perm
+          command: rm -rf node_modules && npm install --unsafe-perm
+          haltOnFailure: True
       - ShellCommand:
           name: run static analysis tools on markdown
           command: npm run --silent lint_md

--- a/eve/workers/unit_and_feature_tests/run_ft_tests.bash
+++ b/eve/workers/unit_and_feature_tests/run_ft_tests.bash
@@ -1,19 +1,22 @@
 #!/bin/bash
 
 set -x
-set -e
+set -eu -o pipefail
+
+# port for cloudserver
+PORT=8000
 
 if [ ! -d "node_modules/@zenko/cloudserver" ]; then
     echo "cloudserver module was not found!"
     exit 1
 fi
 
+trap killandsleep EXIT
 
 killandsleep () {
-  kill -9 $(lsof -t -i:$1) || true
+  kill -9 $(lsof -t -i:$PORT) || true
   sleep 10
 }
 
-cd node_modules/@zenko/cloudserver && npm run mem_backend & bash tests/utils/wait_for_local_port.bash 8000 40 && npm run ft_test
-
-killandsleep 8000
+cd node_modules/@zenko/cloudserver && npm run mem_backend & bash tests/utils/wait_for_local_port.bash $PORT 40
+npm run ft_test

--- a/eve/workers/unit_and_feature_tests/run_server_tests.bash
+++ b/eve/workers/unit_and_feature_tests/run_server_tests.bash
@@ -1,13 +1,17 @@
 #!/bin/bash
 
 set -x
-set -e
+set -eu -o pipefail
+
+# port for backbeat api server
+PORT=8900
+
+trap killandsleep EXIT
 
 killandsleep () {
-  kill -9 $(lsof -t -i:$1) || true
+  kill -9 $(lsof -t -i:$PORT) || true
   sleep 10
 }
 
-npm start & bash tests/utils/wait_for_local_port.bash 8900 40 && npm run ft_server_test
-
-killandsleep 8900
+npm start & bash tests/utils/wait_for_local_port.bash $PORT 40
+npm run ft_server_test

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,18 +5,18 @@
   "requires": true,
   "dependencies": {
     "@zenko/cloudserver": {
-      "version": "git://github.com/scality/S3.git#62df2c09c94ac1ab1d3bd48b4cd8c840e03f901d",
-      "from": "scality/S3#62df2c0",
+      "version": "github:scality/cloudserver#62df2c09c94ac1ab1d3bd48b4cd8c840e03f901d",
+      "from": "github:scality/cloudserver#62df2c0",
       "dev": true,
       "requires": {
-        "arsenal": "git://github.com/scality/Arsenal.git#0d4bf3c17fd9f00e6dedcb7fa486e850624de978",
+        "arsenal": "github:scality/Arsenal#0d4bf3c17fd9f00e6dedcb7fa486e850624de978",
         "async": "~2.5.0",
         "aws-sdk": "2.28.0",
         "azure-storage": "^2.1.0",
         "backo": "^1.1.0",
-        "bucketclient": "git://github.com/scality/bucketclient.git#5aa99d7b25fdfb5a42b787cce7710cdec8ac78f0",
+        "bucketclient": "github:scality/bucketclient#5aa99d7b25fdfb5a42b787cce7710cdec8ac78f0",
         "bufferutil": "^3.0.5",
-        "cdmiclient": "git+ssh://git@github.com/scality/cdmiclient.git#8f0c2e6331dfa905bfe269fb4e1558d65ca0b866",
+        "cdmiclient": "github:scality/cdmiclient#8f0c2e6331dfa905bfe269fb4e1558d65ca0b866",
         "commander": "^2.9.0",
         "diskusage": "0.2.4",
         "google-auto-auth": "^0.9.1",
@@ -28,9 +28,9 @@
         "npm-run-all": "~4.0.2",
         "prom-client": "^10.2.3",
         "request": "^2.81.0",
-        "sproxydclient": "git://github.com/scality/sproxydclient.git#45090b76b24ca1d05482bf151ba84ff6178423d1",
+        "sproxydclient": "github:scality/sproxydclient#45090b76b24ca1d05482bf151ba84ff6178423d1",
         "sql-where-parser": "~2.2.1",
-        "utapi": "git://github.com/scality/utapi.git#f2f1d0c7423ffdec2ad175e3c0e8bcd7aa2ba867",
+        "utapi": "github:scality/utapi#f2f1d0c7423ffdec2ad175e3c0e8bcd7aa2ba867",
         "utf-8-validate": "^4.0.2",
         "utf8": "~2.1.1",
         "uuid": "^3.0.1",
@@ -40,10 +40,68 @@
         "xml2js": "~0.4.16"
       },
       "dependencies": {
+        "arsenal": {
+          "version": "github:scality/Arsenal#0d4bf3c17fd9f00e6dedcb7fa486e850624de978",
+          "from": "github:scality/Arsenal#0d4bf3c",
+          "dev": true,
+          "requires": {
+            "JSONStream": "^1.0.0",
+            "ajv": "4.10.0",
+            "async": "~2.1.5",
+            "bson": "2.0.4",
+            "debug": "~2.3.3",
+            "diskusage": "^0.2.2",
+            "fcntl": "git://github.com/scality/node-fcntl.git#9108603d8881d7762dcadfde1db927a1653dfda5",
+            "ioctl": "2.0.0",
+            "ioredis": "2.4.0",
+            "ipaddr.js": "1.2.0",
+            "joi": "^10.6",
+            "level": "~1.6.0",
+            "level-sublevel": "~6.6.1",
+            "mongodb": "^3.0.1",
+            "node-forge": "^0.7.1",
+            "simple-glob": "^0.1",
+            "socket.io": "~1.7.3",
+            "socket.io-client": "~1.7.3",
+            "utf8": "2.1.2",
+            "uuid": "^3.0.1",
+            "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+            "xml2js": "~0.4.16"
+          },
+          "dependencies": {
+            "async": {
+              "version": "2.1.5",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+              "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+              "dev": true,
+              "requires": {
+                "lodash": "^4.14.0"
+              }
+            },
+            "mongodb": {
+              "version": "3.1.8",
+              "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.8.tgz",
+              "integrity": "sha512-yNKwYxQ6m00NV6+pMoWoheFTHSQVv1KkSrfOhRDYMILGWDYtUtQRqHrFqU75rmPIY8hMozVft8zdC4KYMWaM3Q==",
+              "dev": true,
+              "requires": {
+                "mongodb-core": "3.1.7",
+                "safe-buffer": "^5.1.2"
+              }
+            },
+            "werelogs": {
+              "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+              "from": "github:scality/werelogs#0ff7ec82",
+              "dev": true,
+              "requires": {
+                "safe-json-stringify": "1.0.3"
+              }
+            }
+          }
+        },
         "async": {
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
-          "integrity": "sha1-hDGQ/WtzV6C54clW7d3V7IRitU0=",
+          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
             "lodash": "^4.14.0"
@@ -84,24 +142,18 @@
             }
           }
         },
-        "bson": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
-          "integrity": "sha1-EjGfgyOxJUc5t8a++NPomuBaL1c=",
-          "dev": true
-        },
         "bucketclient": {
-          "version": "git://github.com/scality/bucketclient.git#5aa99d7b25fdfb5a42b787cce7710cdec8ac78f0",
-          "from": "scality/bucketclient#5aa99d7",
+          "version": "github:scality/bucketclient#5aa99d7b25fdfb5a42b787cce7710cdec8ac78f0",
+          "from": "github:scality/bucketclient#5aa99d7",
           "dev": true,
           "requires": {
-            "arsenal": "git://github.com/scality/Arsenal.git#bd1bac6b56e01c65320eb315b26221db5adb4b38",
-            "werelogs": "git://github.com/scality/werelogs.git#a5605431dfd5927fe74871a737b14fcdbbe9b0c2"
+            "arsenal": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
+            "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2"
           },
           "dependencies": {
             "arsenal": {
-              "version": "git://github.com/scality/Arsenal.git#bd1bac6b56e01c65320eb315b26221db5adb4b38",
-              "from": "scality/Arsenal#7.4.0.3",
+              "version": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
+              "from": "github:scality/Arsenal#7.4.0.3",
               "dev": true,
               "requires": {
                 "JSONStream": "^1.0.0",
@@ -121,13 +173,13 @@
                 "socket.io-client": "~1.7.3",
                 "utf8": "2.1.2",
                 "uuid": "^3.0.1",
-                "werelogs": "git://github.com/scality/werelogs.git#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+                "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
                 "xml2js": "~0.4.16"
               },
               "dependencies": {
                 "werelogs": {
-                  "version": "git://github.com/scality/werelogs.git#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
-                  "from": "scality/werelogs#hotfix/7.4.0",
+                  "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+                  "from": "github:scality/werelogs#hotfix/7.4.0",
                   "dev": true,
                   "requires": {
                     "safe-json-stringify": "^1.0.3"
@@ -145,8 +197,8 @@
               }
             },
             "werelogs": {
-              "version": "git://github.com/scality/werelogs.git#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
-              "from": "scality/werelogs#7.4.0.3",
+              "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+              "from": "github:scality/werelogs#7.4.0.3",
               "dev": true,
               "requires": {
                 "safe-json-stringify": "^1.0.3"
@@ -157,7 +209,7 @@
         "diskusage": {
           "version": "0.2.4",
           "resolved": "https://registry.npmjs.org/diskusage/-/diskusage-0.2.4.tgz",
-          "integrity": "sha1-6Vb3oQUeDGoa9wYVTv5iCi7kMuw=",
+          "integrity": "sha512-XCLBopqnV6FUG/DdphILleiubqVERvF1ZRqkvOIiPQeMlU6Im1nvlsYqLUosgmRz1UQOXcwuO0vgqASl7DNg+w==",
           "dev": true,
           "requires": {
             "nan": "^2.5.0"
@@ -165,18 +217,9 @@
         },
         "es6-promise": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+          "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
           "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q=",
           "dev": true
-        },
-        "fcntl": {
-          "version": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
-          "from": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
-          "dev": true,
-          "requires": {
-            "bindings": "^1.1.1",
-            "nan": "^2.3.2"
-          }
         },
         "ioredis": {
           "version": "2.4.0",
@@ -203,22 +246,50 @@
         "mongodb": {
           "version": "2.2.36",
           "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.36.tgz",
-          "integrity": "sha1-HFc2gLKEn7D0esu6PcX6Io3pdfU=",
+          "integrity": "sha512-P2SBLQ8Z0PVx71ngoXwo12+FiSfbNfGOClAao03/bant5DgLNkOPAck5IaJcEk4gKlQhDEURzfR3xuBG1/B+IA==",
           "dev": true,
           "requires": {
             "es6-promise": "3.2.1",
             "mongodb-core": "2.1.20",
             "readable-stream": "2.2.7"
+          },
+          "dependencies": {
+            "bson": {
+              "version": "1.0.9",
+              "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
+              "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg==",
+              "dev": true
+            },
+            "mongodb-core": {
+              "version": "2.1.20",
+              "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.20.tgz",
+              "integrity": "sha512-IN57CX5/Q1bhDq6ShAR6gIv4koFsZP7L8WOK1S0lR0pVDQaScffSMV5jxubLsmZ7J+UdqmykKw4r9hG3XQEGgQ==",
+              "dev": true,
+              "requires": {
+                "bson": "~1.0.4",
+                "require_optional": "~1.0.0"
+              }
+            }
           }
         },
         "mongodb-core": {
-          "version": "2.1.20",
-          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.20.tgz",
-          "integrity": "sha1-/s6N12tZ7n1/LTE7ZTIsFgSS2PE=",
+          "version": "3.1.7",
+          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.7.tgz",
+          "integrity": "sha512-YffpSrLmgFNmrvkGx+yX00KyBNk64C0BalfEn6vHHkXtcMUGXw8nxrMmhq5eXPLLlYeBpD/CsgNxE2Chf0o4zQ==",
           "dev": true,
           "requires": {
-            "bson": "~1.0.4",
-            "require_optional": "~1.0.0"
+            "bson": "^1.1.0",
+            "require_optional": "^1.0.1",
+            "safe-buffer": "^5.1.2",
+            "saslprep": "^1.0.0"
+          },
+          "dependencies": {
+            "bson": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.0.tgz",
+              "integrity": "sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA==",
+              "dev": true
+            }
           }
         },
         "node-uuid": {
@@ -250,31 +321,23 @@
         },
         "sax": {
           "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.5.tgz",
+          "resolved": "http://registry.npmjs.org/sax/-/sax-1.1.5.tgz",
           "integrity": "sha1-HaUKjQDN7NWUBWWfX/hTSf53N0M=",
           "dev": true
         },
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
         },
-        "werelogs": {
-          "version": "github:scality/werelogs#74b121bef4068645e307da143749e61ef416a4c3",
-          "from": "github:scality/werelogs#74b121b",
-          "dev": true,
-          "requires": {
-            "safe-json-stringify": "^1.0.3"
-          }
-        },
         "ws": {
           "version": "5.2.2",
           "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
-          "integrity": "sha1-3/7xSGa46NyRM1glFNG++vlumA8=",
+          "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
           "dev": true,
           "requires": {
             "async-limiter": "~1.0.0"
@@ -291,7 +354,7 @@
           "dependencies": {
             "lodash": {
               "version": "3.5.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz",
+              "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz",
               "integrity": "sha1-Gbs/TVEnjwuMgY7RRcdOz5/kDm0=",
               "dev": true
             }
@@ -356,7 +419,7 @@
     "agent-base": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha1-2J5ZmfeXh1Z0wH2H8mD8Qeg+jKk=",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
       "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
@@ -500,7 +563,7 @@
         "bson": "2.0.4",
         "debug": "~2.3.3",
         "diskusage": "^0.2.2",
-        "fcntl": "git://github.com/scality/node-fcntl.git#9108603d8881d7762dcadfde1db927a1653dfda5",
+        "fcntl": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
         "ioctl": "2.0.0",
         "ioredis": "2.4.0",
         "ipaddr.js": "1.2.0",
@@ -514,7 +577,7 @@
         "socket.io-client": "~1.7.3",
         "utf8": "2.1.2",
         "uuid": "^3.0.1",
-        "werelogs": "git://github.com/scality/werelogs.git#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
         "xml2js": "~0.4.16"
       },
       "dependencies": {
@@ -524,6 +587,14 @@
           "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
           "requires": {
             "lodash": "^4.14.0"
+          }
+        },
+        "fcntl": {
+          "version": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
+          "from": "github:scality/node-fcntl",
+          "requires": {
+            "bindings": "^1.1.1",
+            "nan": "^2.3.2"
           }
         },
         "ioredis": {
@@ -542,8 +613,8 @@
           }
         },
         "werelogs": {
-          "version": "git://github.com/scality/werelogs.git#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-          "from": "scality/werelogs#0ff7ec82",
+          "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+          "from": "github:scality/werelogs#0ff7ec82",
           "requires": {
             "safe-json-stringify": "1.0.3"
           }
@@ -553,7 +624,7 @@
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
@@ -576,7 +647,7 @@
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg=",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
       "dev": true
     },
     "asynckit": {
@@ -640,12 +711,12 @@
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8=",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
     "axios": {
       "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "dev": true,
       "requires": {
@@ -654,13 +725,13 @@
       }
     },
     "azure-storage": {
-      "version": "2.10.1",
-      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.1.tgz",
-      "integrity": "sha1-+MF4C9qXu4A+Wkv31qrXhiMBzYE=",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/azure-storage/-/azure-storage-2.10.2.tgz",
+      "integrity": "sha512-pOyGPya9+NDpAfm5YcFfklo57HfjDbYLXxs4lomPwvRxmb0Di/A+a+RkUmEFzaQ8S13CqxK40bRRB0sjj2ZQxA==",
       "dev": true,
       "requires": {
         "browserify-mime": "~1.2.9",
-        "extend": "~1.2.1",
+        "extend": "^3.0.2",
         "json-edm-parser": "0.1.2",
         "md5.js": "1.3.4",
         "readable-stream": "~2.0.0",
@@ -700,7 +771,7 @@
         },
         "sax": {
           "version": "0.5.8",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+          "resolved": "http://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
           "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=",
           "dev": true
         },
@@ -858,13 +929,13 @@
       "version": "git://github.com/scality/bucketclient.git#520d164d264ac74b920a9d517bd4e08f3ff71473",
       "from": "scality/bucketclient#520d164",
       "requires": {
-        "arsenal": "git://github.com/scality/Arsenal.git#6736508364ed537a8851838ba56cf147234c7bd8",
-        "werelogs": "git://github.com/scality/werelogs.git#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
+        "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
+        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
       },
       "dependencies": {
         "arsenal": {
-          "version": "git://github.com/scality/Arsenal.git#6736508364ed537a8851838ba56cf147234c7bd8",
-          "from": "scality/Arsenal#67365083",
+          "version": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
+          "from": "github:scality/Arsenal#67365083",
           "requires": {
             "JSONStream": "^1.0.0",
             "ajv": "4.10.0",
@@ -883,7 +954,7 @@
             "socket.io-client": "~1.7.3",
             "utf8": "2.1.2",
             "uuid": "^3.0.1",
-            "werelogs": "git://github.com/scality/werelogs.git#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+            "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
             "xml2js": "~0.4.16"
           }
         },
@@ -911,8 +982,8 @@
           }
         },
         "werelogs": {
-          "version": "git://github.com/scality/werelogs.git#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-          "from": "scality/werelogs#0ff7ec82",
+          "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+          "from": "github:scality/werelogs#0ff7ec82",
           "requires": {
             "safe-json-stringify": "1.0.3"
           }
@@ -976,7 +1047,7 @@
     "bufferutil": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-3.0.5.tgz",
-      "integrity": "sha1-ir/Dttp6ymoTJos/JILwx6oF//s=",
+      "integrity": "sha512-0fUEthLqfCkYspEuP0vmiAe+PsXslE+AlILb2rmS9I4tAdm3SmpCI69M66zQL20GQEszdbXyVN6q+cpG/yhYlg==",
       "dev": true,
       "requires": {
         "bindings": "~1.3.0",
@@ -986,14 +1057,14 @@
       "dependencies": {
         "nan": {
           "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha1-ltDNYQ69WNS03pzAxoKM2pnHVI8=",
+          "resolved": "http://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
           "dev": true
         },
         "prebuild-install": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
-          "integrity": "sha1-IGzoEGzl76S2zwYvyKCn2TwX86g=",
+          "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
           "dev": true,
           "requires": {
             "detect-libc": "^1.0.3",
@@ -1065,19 +1136,19 @@
       "dev": true
     },
     "cdmiclient": {
-      "version": "git+ssh://git@github.com/scality/cdmiclient.git#8f0c2e6331dfa905bfe269fb4e1558d65ca0b866",
-      "from": "scality/cdmiclient#8f0c2e6",
+      "version": "github:scality/cdmiclient#8f0c2e6331dfa905bfe269fb4e1558d65ca0b866",
+      "from": "github:scality/cdmiclient#8f0c2e6",
       "dev": true,
       "optional": true,
       "requires": {
-        "arsenal": "git://github.com/scality/Arsenal.git#0d4bf3c17fd9f00e6dedcb7fa486e850624de978",
+        "arsenal": "github:scality/Arsenal#18dfc6b4fa93c77f3389ff7ea2abe920dd71dfec",
         "async": "~1.4.2",
-        "werelogs": "git://github.com/scality/werelogs.git#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46"
+        "werelogs": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46"
       },
       "dependencies": {
         "arsenal": {
-          "version": "git://github.com/scality/Arsenal.git#0d4bf3c17fd9f00e6dedcb7fa486e850624de978",
-          "from": "scality/Arsenal#development/8.0",
+          "version": "github:scality/Arsenal#18dfc6b4fa93c77f3389ff7ea2abe920dd71dfec",
+          "from": "github:scality/Arsenal#development/8.0",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1101,7 +1172,7 @@
             "socket.io-client": "~1.7.3",
             "utf8": "2.1.2",
             "uuid": "^3.0.1",
-            "werelogs": "git://github.com/scality/werelogs.git#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+            "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
             "xml2js": "~0.4.16"
           },
           "dependencies": {
@@ -1116,8 +1187,8 @@
               }
             },
             "werelogs": {
-              "version": "git://github.com/scality/werelogs.git#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-              "from": "scality/werelogs#0ff7ec82",
+              "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+              "from": "github:scality/werelogs#0ff7ec82",
               "dev": true,
               "optional": true,
               "requires": {
@@ -1128,14 +1199,14 @@
         },
         "async": {
           "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.4.2.tgz",
           "integrity": "sha1-bJ7csRztTw3S8tQNsNSaEJwIiqs=",
           "dev": true,
           "optional": true
         },
         "ioredis": {
           "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.4.0.tgz",
+          "resolved": "http://registry.npmjs.org/ioredis/-/ioredis-2.4.0.tgz",
           "integrity": "sha1-lj97+8huXEDqWGhX4U6/tUgUKog=",
           "dev": true,
           "optional": true,
@@ -1151,8 +1222,8 @@
           }
         },
         "werelogs": {
-          "version": "git://github.com/scality/werelogs.git#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46",
-          "from": "scality/werelogs#development/8.0",
+          "version": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46",
+          "from": "github:scality/werelogs#development/8.0",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1218,7 +1289,7 @@
     "combined-stream": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha1-LR0kMXr7ir6V1tLAsHtXgTU52Cg=",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -1332,7 +1403,7 @@
         "lru-cache": {
           "version": "4.1.3",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-          "integrity": "sha1-oRdc80lt/IQ2wVbDNLSVWZK85pw=",
+          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -1590,7 +1661,7 @@
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
@@ -1599,7 +1670,7 @@
     "es-abstract": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
-      "integrity": "sha1-nbvdJ8aFbwABQhyhh4LXhr+KYWU=",
+      "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.1.1",
@@ -1612,7 +1683,7 @@
     "es-to-primitive": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha1-7fckeAM0VujdqO8J4ArZZQcH83c=",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
       "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
@@ -1659,7 +1730,7 @@
     "es6-promise": {
       "version": "4.2.5",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.5.tgz",
-      "integrity": "sha1-2m0NVpLvtGHggsFIF/4kJ9j10FQ=",
+      "integrity": "sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==",
       "dev": true
     },
     "es6-promisify": {
@@ -1807,8 +1878,8 @@
       "from": "scality/Guidelines#e49d1a2",
       "dev": true,
       "requires": {
-        "commander": "^1.3.2",
-        "markdownlint": "^0.0.8"
+        "commander": "1.3.2",
+        "markdownlint": "0.0.8"
       },
       "dependencies": {
         "commander": {
@@ -1878,7 +1949,7 @@
     "event-stream": {
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.6.tgz",
-      "integrity": "sha1-ysEjCJDgfnPsnKzQOPYKW2YXPu8=",
+      "integrity": "sha512-dGXNg4F/FgVzlApjzItL+7naHutA3fDqbV/zAZqDDlXTjiMnQmZKu+prImWKszeBM5UQeGvAl3u1wBiKeDh61g==",
       "dev": true,
       "requires": {
         "duplexer": "^0.1.1",
@@ -1894,7 +1965,7 @@
     "eventemitter3": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.0.tgz",
-      "integrity": "sha1-CQtNbNvWRe0Qv3UNS1QHlC17oWM=",
+      "integrity": "sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==",
       "dev": true
     },
     "events": {
@@ -1927,7 +1998,7 @@
     },
     "fast-deep-equal": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
       "dev": true
     },
@@ -1991,7 +2062,7 @@
     "flatmap-stream": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/flatmap-stream/-/flatmap-stream-0.1.1.tgz",
-      "integrity": "sha1-00857zuapaL8IlAWvTrfKKxa5uo=",
+      "integrity": "sha512-lAq4tLbm3sidmdCN8G3ExaxH7cUCtP5mgDvrYowsx84dcYkJJ4I28N7gkxA6+YlSXzaGLJYIDEi9WGfXzMiXdw==",
       "dev": true
     },
     "flexbuffer": {
@@ -2000,9 +2071,9 @@
       "integrity": "sha1-A5/fI/iCPkQMOPMnfm/vEXQhWzA="
     },
     "follow-redirects": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.8.tgz",
-      "integrity": "sha1-Hb/hPkWtlp+BPobADlKW9SXIhaE=",
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.9.tgz",
+      "integrity": "sha512-Bh65EZI/RU8nx0wbYF9shkFZlqLP+6WT/5FnA3cE/djNSuKNHJEinGGZgu/cQEkeeb2GdFOgenAmn8qaqYke2w==",
       "dev": true,
       "requires": {
         "debug": "=3.1.0"
@@ -2011,7 +2082,7 @@
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -2038,19 +2109,8 @@
       "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "1.0.6",
+        "combined-stream": "^1.0.6",
         "mime-types": "^2.1.12"
-      },
-      "dependencies": {
-        "combined-stream": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-          "dev": true,
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
-        }
       }
     },
     "from": {
@@ -2073,7 +2133,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "gauge": {
@@ -2093,21 +2153,13 @@
     },
     "gcp-metadata": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.6.3.tgz",
-      "integrity": "sha1-RVDAiFnFKLNwRZvXenGH6gvbxKs=",
+      "resolved": "http://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.6.3.tgz",
+      "integrity": "sha512-MSmczZctbz91AxCvqp9GHBoZOSbJKAICV7Ow/AIWSJZRrRchUd5NL1b2P4OfP+4m490BEUPhhARfpHdqCxuCvg==",
       "dev": true,
       "requires": {
         "axios": "^0.18.0",
         "extend": "^3.0.1",
         "retry-axios": "0.3.2"
-      },
-      "dependencies": {
-        "extend": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-          "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
-          "dev": true
-        }
       }
     },
     "generate-function": {
@@ -2216,7 +2268,7 @@
     "google-auth-library": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-1.6.1.tgz",
-      "integrity": "sha1-nHPYMa1yDAwwSKuJ0P/exxTQfdI=",
+      "integrity": "sha512-jYiWC8NA9n9OtQM7ANn0Tk464do9yhKEtaJ72pKcaBiEwn4LwcGYIYOfwtfsSm3aur/ed3tlSxbmg24IAT6gAg==",
       "dev": true,
       "requires": {
         "axios": "^0.18.0",
@@ -2231,7 +2283,7 @@
         "lru-cache": {
           "version": "4.1.3",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-          "integrity": "sha1-oRdc80lt/IQ2wVbDNLSVWZK85pw=",
+          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
@@ -2242,8 +2294,8 @@
     },
     "google-auto-auth": {
       "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.9.7.tgz",
-      "integrity": "sha1-cLNX7J7I4jaM+JplkwmhWhRyWWs=",
+      "resolved": "http://registry.npmjs.org/google-auto-auth/-/google-auto-auth-0.9.7.tgz",
+      "integrity": "sha512-Nro7aIFrL2NP0G7PoGrJqXGMZj8AjdBOcbZXRRm/8T3w08NUHIiNN3dxpuUYzDsZizslH+c8e+7HXL8vh3JXTQ==",
       "dev": true,
       "requires": {
         "async": "^2.3.0",
@@ -2255,7 +2307,7 @@
     "google-p12-pem": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.2.tgz",
-      "integrity": "sha1-yKOENQQBIoOg2//HQwt8dT7NSwc=",
+      "integrity": "sha512-+EuKr4CLlGsnXx4XIJIVkcKYrsa2xkAmCvxRhX2HsazJzUBAJ35wARGeApHUn4nNfPD03Vl057FskNr20VaCyg==",
       "dev": true,
       "requires": {
         "node-forge": "^0.7.4",
@@ -2282,7 +2334,7 @@
     "gtoken": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.3.0.tgz",
-      "integrity": "sha1-Tg/8FkMtcEGhs9vB2XqsF6Xclko=",
+      "integrity": "sha512-Jc9/8mV630cZE9FC5tIlJCZNdUjwunvlwOtCz6IDlaiB4Sz68ki29a1+q97sWTnTYroiuF9B135rod9zrQdHLw==",
       "dev": true,
       "requires": {
         "axios": "^0.18.0",
@@ -2301,7 +2353,7 @@
     "har-validator": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-      "integrity": "sha1-RGV/VoiiLP1LckhugbOj+xF0LCk=",
+      "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
       "dev": true,
       "requires": {
         "ajv": "^5.3.0",
@@ -2325,7 +2377,7 @@
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
@@ -2394,13 +2446,13 @@
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha1-l/I2l3vW4SVAiTD/bePuxigewEc=",
+      "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
     "http-proxy": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.17.0.tgz",
-      "integrity": "sha1-etOElGWPhGBeL220Q230EPTlvpo=",
+      "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
       "dev": true,
       "requires": {
         "eventemitter3": "^3.0.0",
@@ -2422,7 +2474,7 @@
     "https-proxy-agent": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha1-UVUpcPoE1yPgTFbQQXjD+SWSu8A=",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
       "requires": {
         "agent-base": "^4.1.0",
@@ -2430,9 +2482,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.5",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
-          "integrity": "sha1-wkGPv9ein01PcP9M6mBNS2TEZAc=",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -2441,7 +2493,7 @@
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         }
       }
@@ -2583,7 +2635,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-builtin-module": {
@@ -2598,7 +2650,7 @@
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU=",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
     },
     "is-date-object": {
@@ -2690,7 +2742,7 @@
     "is-symbol": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha1-oFX2rlcZLK7jKeeoYBGLSXqVDzg=",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "dev": true,
       "requires": {
         "has-symbols": "^1.0.0"
@@ -2840,7 +2892,7 @@
     "jwa": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.1.6.tgz",
-      "integrity": "sha1-hyQOdsmAjb3hh4PPImTvSSnuUOY=",
+      "integrity": "sha512-tBO/cf++BUsJkYql/kBbJroKOgHWEigTKBAjjBEmrMGYd1QMBC74Hr4Wo2zCZw6ZrVhlJPvoMrkcOnlWR/DJfw==",
       "dev": true,
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
@@ -2851,7 +2903,7 @@
     "jws": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
-      "integrity": "sha1-gNEtBbKT0ehB58uLTmnlYa3Pg08=",
+      "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
       "dev": true,
       "requires": {
         "jwa": "^1.1.5",
@@ -3320,7 +3372,7 @@
     "mime": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
-      "integrity": "sha1-sWIcVNY7l8R9PP5/chX31kUXw2k=",
+      "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
       "dev": true
     },
     "mime-db": {
@@ -3571,7 +3623,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
@@ -3598,7 +3650,7 @@
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -3625,7 +3677,7 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha1-R6ewFrqmi1+g7PPe4IqFxnmsZFU=",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
     "object-assign": {
@@ -3855,7 +3907,7 @@
     "psl": {
       "version": "1.1.29",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha1-YPWA02AXC7cip5fMcEQR5tqFDGc=",
+      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
       "dev": true
     },
     "pull-cat": {
@@ -3926,7 +3978,7 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha1-yzroBuh0BERYTvFUzo7pjUA/PjY=",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
     "querystring": {
@@ -3991,7 +4043,7 @@
     "request": {
       "version": "2.88.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha1-nC/KT301tZLv5Xx/ClXoEFIST+8=",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -4014,14 +4066,6 @@
         "tough-cookie": "~2.4.3",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
-      },
-      "dependencies": {
-        "extend": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-          "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
-          "dev": true
-        }
       }
     },
     "require-uncached": {
@@ -4075,7 +4119,7 @@
     "retry-axios": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/retry-axios/-/retry-axios-0.3.2.tgz",
-      "integrity": "sha1-V1fID1hbTMTEmGqi/9R6YMbTXhM=",
+      "integrity": "sha512-jp4YlI0qyDFfXiXGhkCOliBN1G7fRH03Nqy8YdShzGqbY5/9S2x/IR6C88ls2DFkbWuL3ASkP7QD3pVrNpPgwQ==",
       "dev": true
     },
     "rimraf": {
@@ -4140,7 +4184,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
     "saslprep": {
@@ -4343,19 +4387,10 @@
         "memory-pager": "^1.0.2"
       }
     },
-    "sparse-bitfield": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
-      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
-      "optional": true,
-      "requires": {
-        "memory-pager": "^1.0.2"
-      }
-    },
     "spdx-correct": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.2.tgz",
-      "integrity": "sha1-GbtAnpG0exrVQVkkP3MSqFjbPC4=",
+      "integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -4365,13 +4400,13 @@
     "spdx-exceptions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
       "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -4379,15 +4414,15 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.1.tgz",
-      "integrity": "sha1-4qMDI2ysVLBAMfp6WnnH5wHfhS8=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
+      "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
       "dev": true
     },
     "split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "dev": true,
       "requires": {
         "through": "2"
@@ -4400,16 +4435,16 @@
       "dev": true
     },
     "sproxydclient": {
-      "version": "git://github.com/scality/sproxydclient.git#45090b76b24ca1d05482bf151ba84ff6178423d1",
-      "from": "scality/sproxydclient#45090b7",
+      "version": "github:scality/sproxydclient#45090b76b24ca1d05482bf151ba84ff6178423d1",
+      "from": "github:scality/sproxydclient#45090b7",
       "dev": true,
       "requires": {
-        "werelogs": "git://github.com/scality/werelogs.git#a5605431dfd5927fe74871a737b14fcdbbe9b0c2"
+        "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2"
       },
       "dependencies": {
         "werelogs": {
-          "version": "git://github.com/scality/werelogs.git#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
-          "from": "scality/werelogs#7.4.0.3",
+          "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+          "from": "github:scality/werelogs#7.4.0.3",
           "dev": true,
           "requires": {
             "safe-json-stringify": "^1.0.3"
@@ -4428,9 +4463,9 @@
       }
     },
     "sshpk": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.1.tgz",
-      "integrity": "sha512-mSdgNUaidk+dRU5MhYtN9zebdzF2iG0cNPWy8HG+W8y+fT1JnSkh0fzzpjOa0L7P8i1Rscz38t0h4gPcKz43xA==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
+      "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
       "dev": true,
       "requires": {
         "asn1": "~0.2.3",
@@ -4679,7 +4714,7 @@
     "tough-cookie": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-      "integrity": "sha1-U/Nto/R3g7CSWvoG/587FlKA94E=",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
         "psl": "^1.1.24",
@@ -4776,21 +4811,21 @@
       }
     },
     "utapi": {
-      "version": "git://github.com/scality/utapi.git#f2f1d0c7423ffdec2ad175e3c0e8bcd7aa2ba867",
-      "from": "scality/utapi#f2f1d0c",
+      "version": "github:scality/utapi#f2f1d0c7423ffdec2ad175e3c0e8bcd7aa2ba867",
+      "from": "github:scality/utapi#f2f1d0c",
       "dev": true,
       "requires": {
-        "arsenal": "git://github.com/scality/Arsenal.git#6736508364ed537a8851838ba56cf147234c7bd8",
+        "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
         "async": "^2.0.1",
         "ioredis": "^2.3.0",
         "node-schedule": "1.2.0",
-        "vaultclient": "git://github.com/scality/vaultclient.git#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
-        "werelogs": "git://github.com/scality/werelogs.git#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
+        "vaultclient": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
+        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
       },
       "dependencies": {
         "arsenal": {
-          "version": "git://github.com/scality/Arsenal.git#6736508364ed537a8851838ba56cf147234c7bd8",
-          "from": "scality/Arsenal#67365083",
+          "version": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
+          "from": "github:scality/Arsenal#67365083",
           "dev": true,
           "requires": {
             "JSONStream": "^1.0.0",
@@ -4810,7 +4845,7 @@
             "socket.io-client": "~1.7.3",
             "utf8": "2.1.2",
             "uuid": "^3.0.1",
-            "werelogs": "git://github.com/scality/werelogs.git#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+            "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
             "xml2js": "~0.4.16"
           },
           "dependencies": {
@@ -4825,7 +4860,7 @@
             },
             "ioredis": {
               "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.4.0.tgz",
+              "resolved": "http://registry.npmjs.org/ioredis/-/ioredis-2.4.0.tgz",
               "integrity": "sha1-lj97+8huXEDqWGhX4U6/tUgUKog=",
               "dev": true,
               "requires": {
@@ -4843,7 +4878,7 @@
         },
         "commander": {
           "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
           "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
           "dev": true,
           "requires": {
@@ -4858,7 +4893,7 @@
         },
         "ioredis": {
           "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.5.0.tgz",
+          "resolved": "http://registry.npmjs.org/ioredis/-/ioredis-2.5.0.tgz",
           "integrity": "sha1-+2/fChp+CXRhTGe25eETCKjPlbk=",
           "dev": true,
           "requires": {
@@ -4889,13 +4924,13 @@
           }
         },
         "vaultclient": {
-          "version": "git://github.com/scality/vaultclient.git#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
-          "from": "scality/vaultclient#fbd9988d",
+          "version": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
+          "from": "github:scality/vaultclient#fbd9988d",
           "dev": true,
           "requires": {
-            "arsenal": "git://github.com/scality/Arsenal.git#6736508364ed537a8851838ba56cf147234c7bd8",
+            "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
             "commander": "2.9.0",
-            "werelogs": "git://github.com/scality/werelogs.git#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+            "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
             "xml2js": "0.4.17"
           },
           "dependencies": {
@@ -4912,8 +4947,8 @@
           }
         },
         "werelogs": {
-          "version": "git://github.com/scality/werelogs.git#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-          "from": "scality/werelogs#0ff7ec82",
+          "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+          "from": "github:scality/werelogs#0ff7ec82",
           "dev": true,
           "requires": {
             "safe-json-stringify": "1.0.3"
@@ -4921,7 +4956,7 @@
         },
         "xmlbuilder": {
           "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+          "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
           "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
           "dev": true,
           "requires": {
@@ -4933,7 +4968,7 @@
     "utf-8-validate": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-4.0.2.tgz",
-      "integrity": "sha1-3q3O379exTXjxyh06d3AZjwTlpE=",
+      "integrity": "sha512-CS63Ssp6zynBQ4IxVzgjP5Abdo6LuJ87HFIcgIiVUeY96+MTHkqKtrUhphbwQ6jX8aSGZv8zX6l1DCPpfcAnxA==",
       "dev": true,
       "requires": {
         "bindings": "~1.3.0",
@@ -4943,14 +4978,14 @@
       "dependencies": {
         "nan": {
           "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-          "integrity": "sha1-ltDNYQ69WNS03pzAxoKM2pnHVI8=",
+          "resolved": "http://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+          "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
           "dev": true
         },
         "prebuild-install": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
-          "integrity": "sha1-IGzoEGzl76S2zwYvyKCn2TwX86g=",
+          "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
           "dev": true,
           "requires": {
             "detect-libc": "^1.0.3",
@@ -4990,7 +5025,7 @@
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
@@ -4999,23 +5034,23 @@
     },
     "validator": {
       "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
-      "integrity": "sha1-q/Rm05i1Yc0kMFARLG/x3mzBJmM=",
+      "resolved": "http://registry.npmjs.org/validator/-/validator-9.4.1.tgz",
+      "integrity": "sha512-YV5KjzvRmSyJ1ee/Dm5UED0G+1L4GZnLN3w6/T+zZm8scVua4sOhYKWTUrKa0H/tMiJyO9QLHMPN+9mB/aMunA==",
       "dev": true
     },
     "vaultclient": {
       "version": "git://github.com/scality/vaultclient.git#754b6e1e1121f44bc3719e35b836a9185d6d5e1a",
       "from": "scality/vaultclient#754b6e1",
       "requires": {
-        "arsenal": "git://github.com/scality/Arsenal.git#bd1bac6b56e01c65320eb315b26221db5adb4b38",
+        "arsenal": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
         "commander": "2.9.0",
-        "werelogs": "git://github.com/scality/werelogs.git#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+        "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
         "xml2js": "0.4.17"
       },
       "dependencies": {
         "arsenal": {
-          "version": "git://github.com/scality/Arsenal.git#bd1bac6b56e01c65320eb315b26221db5adb4b38",
-          "from": "scality/Arsenal#7.4.0.3",
+          "version": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
+          "from": "github:scality/Arsenal#7.4.0.3",
           "requires": {
             "JSONStream": "^1.0.0",
             "ajv": "4.10.0",
@@ -5034,13 +5069,13 @@
             "socket.io-client": "~1.7.3",
             "utf8": "2.1.2",
             "uuid": "^3.0.1",
-            "werelogs": "git://github.com/scality/werelogs.git#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+            "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
             "xml2js": "~0.4.16"
           },
           "dependencies": {
             "werelogs": {
-              "version": "git://github.com/scality/werelogs.git#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
-              "from": "scality/werelogs#hotfix/7.4.0",
+              "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+              "from": "github:scality/werelogs#hotfix/7.4.0",
               "requires": {
                 "safe-json-stringify": "^1.0.3"
               }
@@ -5079,8 +5114,8 @@
           }
         },
         "werelogs": {
-          "version": "git://github.com/scality/werelogs.git#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
-          "from": "scality/werelogs#7.4.0.3",
+          "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+          "from": "github:scality/werelogs#7.4.0.3",
           "requires": {
             "safe-json-stringify": "^1.0.3"
           }
@@ -5125,7 +5160,7 @@
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "werelogs": "scality/werelogs#74b121b"
   },
   "devDependencies": {
-    "@zenko/cloudserver": "scality/S3#62df2c0",
+    "@zenko/cloudserver": "scality/cloudserver#62df2c0",
     "eslint": "^2.4.0",
     "eslint-config-airbnb": "^6.0.0",
     "eslint-config-scality": "scality/Guidelines#e49d1a2",

--- a/tests/functional/replication/pauseResumeState.js
+++ b/tests/functional/replication/pauseResumeState.js
@@ -10,6 +10,7 @@ const TimeMachine = require('../utils/timeMachine');
 
 // Configs
 const config = require('../../config.json');
+const constants = require('../../../extensions/replication/constants');
 const redisConfig = {
     host: config.redis.host,
     port: config.redis.port,
@@ -26,7 +27,8 @@ const destConfig = {
 const mConfig = config.metrics;
 
 // Constants
-const ZK_TEST_CRR_STATE_PATH = '/backbeattest/state';
+const ZK_TEST_CRR_STATE_PATH =
+    `${constants.zookeeperReplicationNamespace}/state`;
 const EPHEMERAL_NODE = 1;
 
 // Future Date to be used in tests


### PR DESCRIPTION
CI functional tests were not being run because modules were missing. https://eve.devsca.com/github/scality/backbeat/#/builders/6/builds/3678/steps/8/logs/stdio

Thomas helped in order to delete images on registry, but another problem:
https://eve.devsca.com/github/scality/backbeat/#/builders/6/builds/3726

Removing node modules before installing seems to have helped.
Other changes address the error not being escalated. We were getting green checks even though the install step failed and didn't run any tests. Now the error should be shown and escalated. For example, same error, but with the bash script changes:
https://github.com/scality/backbeat/compare/bugfix/testing-eve-failures?expand=1

Changes in this PR:
- Zenko cloudserver package name changed to match cloudserver
  (named based on a fresh git install of the module).
- Ensure previous node modules are removed and reinstalled.
- In bash files, do not chain server run with npm script. We can capture error on either step this way
- The pause/resume tests were failing because it relied on hard-coded zk path (that recently changed, oops..). Rely on paths defined in constants file instead