### PR TITLE
bf: S3C-1785 fix eve fail escalation

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -21,7 +21,8 @@ stages:
           haltOnFailure: True
       - ShellCommand:
           name: Npm install
-          command: npm install --unsafe-perm
+          command: rm -rf node_modules && npm install --unsafe-perm
+          haltOnFailure: True
       - ShellCommand:
           name: run static analysis tools on markdown
           command: npm run --silent lint_md

--- a/eve/workers/unit_and_feature_tests/run_server_tests.bash
+++ b/eve/workers/unit_and_feature_tests/run_server_tests.bash
@@ -1,16 +1,17 @@
 #!/bin/bash
 
 set -x
-set -e
+set -eu -o pipefail
+
+# port for backbeat server
+PORT=8900
+
+trap killandsleep EXIT
 
 killandsleep () {
-  kill -9 $(lsof -t -i:$1) || true
+  kill -9 $(lsof -t -i:$PORT) || true
   sleep 10
 }
 
-# run backbeat server
-npm start & bash tests/utils/wait_for_local_port.bash 8900 40 && npm run $1
-
-killandsleep 8900
-
-exit $?
+npm start & bash tests/utils/wait_for_local_port.bash $PORT 40
+npm run $1


### PR DESCRIPTION
First updating 7.4, then forward port to 8.0/8.1 with additional changes to address other issues.

Changes in this PR:
- Ensure previous node modules are removed and reinstalled.
- In bash files, do not chain server run with npm script. Error will be escalated properly for each step

Example of raising error:
https://github.com/scality/backbeat/compare/bugfix/testing-eve-failures?expand=1