### PR TITLE
ft: ZENKO-1240 ingestion configs setup

### DIFF
--- a/extensions/ingestion/utils/MongoIngestionInterface.js
+++ b/extensions/ingestion/utils/MongoIngestionInterface.js
@@ -8,7 +8,7 @@ const USERSBUCKET = arsenal.constants.usersBucket;
 const PENSIEVE = 'PENSIEVE';
 const METASTORE = '__metastore';
 
-class MongoMDWrapper extends MongoClientInterface {
+class MongoIngestionInterface extends MongoClientInterface {
     constructor(params) {
         super(Object.assign({}, params, {
             logger: new Logger('Backbeat:MongoIngestionInterface'),
@@ -40,4 +40,4 @@ class MongoMDWrapper extends MongoClientInterface {
     }
 }
 
-module.exports = MongoMDWrapper;
+module.exports = MongoIngestionInterface;

--- a/extensions/ingestion/utils/MongoIngestionInterface.js
+++ b/extensions/ingestion/utils/MongoIngestionInterface.js
@@ -1,0 +1,43 @@
+const arsenal = require('arsenal');
+const Logger = require('werelogs').Logger;
+
+const { MongoClientInterface } = arsenal.storage.metadata.mongoclient;
+const errors = arsenal.errors;
+
+const USERSBUCKET = arsenal.constants.usersBucket;
+const PENSIEVE = 'PENSIEVE';
+const METASTORE = '__metastore';
+
+class MongoMDWrapper extends MongoClientInterface {
+    constructor(params) {
+        super(Object.assign({}, params, {
+            logger: new Logger('Backbeat:MongoIngestionInterface'),
+        }));
+    }
+
+    getIngestionBuckets(callback) {
+        const m = this.getCollection(METASTORE);
+        m.find({
+            '_id': {
+                $nin: [PENSIEVE, USERSBUCKET],
+            },
+            'value.ingestion': {
+                $type: 'object',
+            },
+        }, {
+            'value.name': true,
+            'value.ingestion': true,
+            'value.locationConstraint': true,
+        }).toArray((err, doc) => {
+            if (err) {
+                this.logger.error(
+                    'getIngestionBuckets: error getting ingestion buckets',
+                    { error: err.message });
+                return callback(errors.InternalError);
+            }
+            return callback(null, doc);
+        });
+    }
+}
+
+module.exports = MongoMDWrapper;

--- a/lib/management/index.js
+++ b/lib/management/index.js
@@ -97,6 +97,7 @@ function patchConfiguration(conf, cb) {
                 return obj;
             }, {});
             config.setBootstrapList(locationsWithReplicationBackend);
+            config.setLocations(locationsWithReplicationBackend);
 
             Object.keys(locations).forEach(locName => {
                 config.setIsTransientLocation(


### PR DESCRIPTION
Sorry for all the PR's, opening for visibility and reviews 👍 


This PR adds means of getting the data needed for an ingestion source. A follow-up PR for ticket 1240 should add the management update layer for getting updates to location details and bootstraplist

Changes in this PR:
- Extend Arsenal#MongoClientInterface to add a method for fetching ingestion buckets directly from mongo.
- Save location details (which includes details necessary for a given location constraint, including its credentials, endpoint, bucket name

Edit:
There is probably a better way of getting credentials. I would need the endpoint though in order to setup the IngestionReaders