### PR TITLE
ft: ZENKO-1302 methods to add/remove ingestion readers

### DIFF
--- a/bin/ingestion.js
+++ b/bin/ingestion.js
@@ -10,7 +10,7 @@ const config = require('../conf/Config');
 
 const zkConfig = config.zookeeper;
 const kafkaConfig = config.kafka;
-const extConfigs = config.extensions;
+const ingestionExtConfigs = config.extensions.ingestion;
 const qpConfig = config.queuePopulator;
 const mConfig = config.metrics;
 const rConfig = config.redis;
@@ -44,7 +44,7 @@ function queueBatch(ingestionPopulator, taskState, qConfig, log) {
 /* eslint-enable no-param-reassign */
 
 const ingestionPopulator = new IngestionPopulator(zkConfig, kafkaConfig,
-    qpConfig, mConfig, rConfig, extConfigs, s3Config);
+    qpConfig, mConfig, rConfig, ingestionExtConfigs, s3Config);
 
 const healthServer = new HealthProbeServer({
     bindAddress: config.healthcheckServer.bindAddress,

--- a/conf/config.json
+++ b/conf/config.json
@@ -40,8 +40,9 @@
             "cronRule": "*/5 * * * * *",
             "sources": [
                 {
-                    "name": "source1",
-                    "prefix": "source1",
+                    "name": "zenko-bucket",
+                    "bucket": "src-bucket",
+                    "prefix": "location-name",
                     "cronRule": "*/5 * * * * *",
                     "zookeeperSuffix": "/source1",
                     "host": "localhost",

--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -7,7 +7,6 @@ const ProvisionDispatcher = require('../provisioning/ProvisionDispatcher');
 const IngestionReader = require('./IngestionReader');
 const MetricsProducer = require('../MetricsProducer');
 const MetricsConsumer = require('../MetricsConsumer');
-const MongoLogReader = require('./MongoLogReader');
 
 class IngestionPopulator {
     /**
@@ -58,6 +57,10 @@ class IngestionPopulator {
         // metrics clients
         this._mProducer = null;
         this._mConsumer = null;
+
+        // provisioned ingestion log sources
+        // i.e.: { an-ingestion-location: new ProvisionDispatcher() }
+        this._provisionedIngestionSources = {};
     }
 
     /**
@@ -88,13 +91,7 @@ class IngestionPopulator {
                 }
                 return next(err);
             }),
-            next => this._setupZookeeper(err => {
-                if (err) {
-                    return next(err);
-                }
-                this._setupLogSources();
-                return next();
-            }),
+            next => this._setupZookeeper(next),
         ], err => {
             if (err) {
                 this.log.error('error starting up ingestion populator',
@@ -118,59 +115,45 @@ class IngestionPopulator {
     }
 
     /**
-     * Close provisioned ingestion source
-     * @param {function} cb - callback function
+     * add an Ingestion Reader
+     * @param {Object} source - new source object
+     * @param {Function} cb - callback(error)
      * @return {undefined}
      */
-    close(cb) {
-        return this._closeLogState(cb);
-    }
-
-    _setupLogSources() {
-        this.ingestionConfig.sources.map(sourceObj => {
+    addNewLogSource(source, cb) {
+        this._extension.createZkPath(err => {
+            if (err) {
+                return cb(err);
+            }
             const zookeeperUrlIngest =
                 `${this.zkConfig.connectionString}` +
-                `${this.ingestionConfig.zookeeperPath}/` +
-                `${sourceObj.name}`;
-            const zkEndpointIngest =
-                `${zookeeperUrlIngest}/raft-id-dispatcher`;
-            this._subscribeToLogSourceDispatcher(zkEndpointIngest,
-                sourceObj, this.ingestionConfig.zookeeperPath);
-            return undefined;
-        });
+                `${this.ingestionConfig.zookeeperPath}/${source.name}`;
+            const zkEndpointIngest = `${zookeeperUrlIngest}/raft-id-dispatcher`;
+            return this._subscribeToLogSourceDispatcher(zkEndpointIngest,
+                source, cb);
+        }, source);
     }
 
-    _subscribeToLogSourceDispatcher(zkEndpoint, bucketd, ingestionPath) {
-        // NOTE: Bug where raftIdDispatcher will just be overwritten if more
-        // than one source exists. This will change in a later commit though
-        // when adding the `initManagement` process
-        this.raftIdDispatcher =
+    _subscribeToLogSourceDispatcher(zkEndpoint, bucketd, cb) {
+        const ingestionPath = this.ingestionConfig.zookeeperPath;
+        // TODO: Replace ProvisionDispatcher?
+        const raftIdDispatcher =
             new ProvisionDispatcher({ connectionString: zkEndpoint });
-        this.raftIdDispatcher.subscribe((err, items) => {
+        raftIdDispatcher.subscribe((err, items) => {
             if (err) {
                 this.log.error(
                     'error when receiving log source provision list',
                     { zkEndpoint, error: err });
-                return undefined;
+                return cb(err);
             }
+            const key = bucketd.name;
+            this._provisionedIngestionSources[key] = raftIdDispatcher;
             if (items.length === 0) {
                 this.log.info('no log source provisioned, idling',
                               { zkEndpoint });
             }
-            const newRaftReaders = items.map(
-                token => {
-                    if (token === 'mongo') {
-                        return new MongoLogReader({
-                            zkClient: this.zkClient,
-                            kafkaConfig: this.kafkaConfig,
-                            zkConfig: this.zkConfig,
-                            mongoConfig: this.qpConfig.mongo,
-                            logger: this.log,
-                            extensions: [this._extension],
-                            metricsProducer: this._mProducer,
-                        });
-                    }
-                    return new IngestionReader({
+            const newRaftReaders = items.map(token =>
+                    new IngestionReader({
                         zkClient: this.zkClient,
                         kafkaConfig: this.kafkaConfig,
                         bucketdConfig: bucketd,
@@ -181,10 +164,10 @@ class IngestionPopulator {
                         ingestionPath,
                         qpConfig: this.qpConfig,
                         s3Config: this.s3Config,
-                    });
-                });
+                    })
+                );
             this.logReadersUpdate.push(...newRaftReaders);
-            return undefined;
+            return cb();
         });
         this.log.info('waiting to be provisioned a log source',
                       { zkEndpoint });
@@ -225,18 +208,7 @@ class IngestionPopulator {
     }
 
     _setupIngestionExtension(cb) {
-        this._extension.setupZookeeper(err => {
-            if (err) {
-                return cb(err);
-            }
-            if (this._extension.createZkPath) {
-                return async.each(
-                    this.ingestionConfig.sources,
-                    (src, next) => this._extension.createZkPath(next, src),
-                    cb);
-            }
-            return cb();
-        });
+        return this._extension.setupZookeeper(cb);
     }
 
     _setupUpdatedReaders(done) {
@@ -252,11 +224,43 @@ class IngestionPopulator {
                    });
     }
 
-    _closeLogState(done) {
-        if (this.raftIdDispatcher !== undefined) {
-            return this.raftIdDispatcher.unsubscribe(done);
+    /**
+     * Close all provisioned ingestion sources
+     * @param {function} cb - callback function
+     * @return {undefined}
+     */
+    close(cb) {
+        return async.each(
+            Object.keys(this._provisionedIngestionSources),
+            (raftIdDispatcher, done) => {
+                this.closeLogState(raftIdDispatcher, done);
+            }, cb);
+    }
+
+    /**
+     * remove and close an Ingestion Reader
+     * @param {String} key - source key (zenko bucket name)
+     * @param {Function} cb - callback(error)
+     * @return {undefined}
+     */
+    closeLogState(key, cb) {
+        const raftIdDispatcher = this._provisionedIngestionSources[key];
+        if (raftIdDispatcher !== undefined) {
+            delete this._provisionedIngestionSources[key];
+            this._checkAndRemoveLogReader(key, this.logReaders);
+            this._checkAndRemoveLogReader(key, this.logReadersUpdate);
+
+            return raftIdDispatcher.unsubscribe(cb);
         }
-        return process.nextTick(done);
+        return process.nextTick(cb);
+    }
+
+    _checkAndRemoveLogReader(name, list) {
+        const index = list.findIndex(lr =>
+            lr.getTargetZenkoBucketName() === name);
+        if (index !== -1) {
+            list.splice(index, 1);
+        }
     }
 
     _processLogEntries(params, done) {
@@ -282,6 +286,5 @@ class IngestionPopulator {
         return this.zkClient.getState();
     }
 }
-
 
 module.exports = IngestionPopulator;

--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -5,12 +5,9 @@ const Logger = require('werelogs').Logger;
 const zookeeper = require('../clients/zookeeper');
 const ProvisionDispatcher = require('../provisioning/ProvisionDispatcher');
 const IngestionReader = require('./IngestionReader');
-const BucketFileLogReader = require('./BucketFileLogReader');
 const MetricsProducer = require('../MetricsProducer');
 const MetricsConsumer = require('../MetricsConsumer');
 const MongoLogReader = require('./MongoLogReader');
-const IngestionQueuePopulator =
-    require('../../extensions/ingestion/IngestionQueuePopulator');
 
 class IngestionPopulator {
     /**
@@ -38,18 +35,17 @@ class IngestionPopulator {
      * @param {Object} mConfig - metrics configuration object
      * @param {string} mConfig.topic - metrics topic
      * @param {Object} rConfig - redis configuration object
-     * @param {Object} extConfigs - configuration of extensions: keys
-     *   are extension names and values are extension's config object.
+     * @param {Object} ingestionConfig - ingestion extension configurations
      * @param {Object} s3Config - configuration to connect to S3 Client
      */
     constructor(zkConfig, kafkaConfig, qpConfig, mConfig, rConfig,
-                extConfigs, s3Config) {
+                ingestionConfig, s3Config) {
         this.zkConfig = zkConfig;
         this.kafkaConfig = kafkaConfig;
         this.qpConfig = qpConfig;
         this.mConfig = mConfig;
         this.rConfig = rConfig;
-        this.extConfigs = extConfigs;
+        this.ingestionConfig = ingestionConfig;
         this.s3Config = s3Config;
 
         this.log = new Logger('Backbeat:IngestionPopulator');
@@ -71,7 +67,7 @@ class IngestionPopulator {
      * @return {undefined}
      */
     open(cb) {
-        this._loadExtensions();
+        this._loadExtension();
         async.series([
             next => this._setupMetricsClients(err => {
                 if (err) {
@@ -82,7 +78,7 @@ class IngestionPopulator {
                 }
                 return next(err);
             }),
-            next => this._setupExtensions(err => {
+            next => this._setupIngestionExtension(err => {
                 if (err) {
                     this.log.error(
                         'error setting up ingestion extension', {
@@ -131,66 +127,23 @@ class IngestionPopulator {
     }
 
     _setupLogSources() {
-        switch (this.qpConfig.logSource) {
-        case 'bucketd':
-            // initialization of log source is deferred until the
-            // dispatcher notifies us of which raft sessions we're
-            // responsible for
-            this._subscribeToLogSourceDispatcher('raft-id-dispatcher');
-            break;
-        case 'mongo':
-            if (this.qpConfig.subscribeToLogSourceDispatcher) {
-                // initialization of mongo log source is deferred until
-                // the dispatcher notifies us we're the single populator
-                // responsible for it
-                this._subscribeToLogSourceDispatcher('mongo-dispatcher');
-            } else {
-                // always consume from mongo log (good for Kubernetes
-                // deployments)
-                this.logReadersUpdate = [
-                    new MongoLogReader({
-                        zkClient: this.zkClient,
-                        kafkaConfig: this.kafkaConfig,
-                        zkConfig: this.zkConfig,
-                        mongoConfig: this.qpConfig.mongo,
-                        logger: this.log,
-                        extensions: this._extensions,
-                        metricsProducer: this._mProducer,
-                    }),
-                ];
-            }
-            break;
-        case 'dmd':
-            this.logReadersUpdate = [
-                new BucketFileLogReader({ zkClient: this.zkClient,
-                    kafkaConfig: this.kafkaConfig,
-                    dmdConfig: this.qpConfig.dmd,
-                    logger: this.log,
-                    extensions: this._extensions,
-                    metricsProducer: this._mProducer,
-                }),
-            ];
-            break;
-        default:
-            throw new Error("bad 'logSource' config value: expect 'bucketd,'" +
-                        ` mongo or 'dmd', got '${this.qpConfig.logSource}'`);
-        }
-        if (this.extConfigs.ingestion) {
-            this.extConfigs.ingestion.sources.map(sourceObj => {
-                const zookeeperUrlIngest =
-                    `${this.zkConfig.connectionString}` +
-                    `${this.extConfigs.ingestion.zookeeperPath}/` +
-                    `${sourceObj.name}`;
-                const zkEndpointIngest =
-                    `${zookeeperUrlIngest}/raft-id-dispatcher`;
-                this._subscribeToLogSourceDispatcher(zkEndpointIngest,
-                    sourceObj, this.extConfigs.ingestion.zookeeperPath);
-                return undefined;
-            });
-        }
+        this.ingestionConfig.sources.map(sourceObj => {
+            const zookeeperUrlIngest =
+                `${this.zkConfig.connectionString}` +
+                `${this.ingestionConfig.zookeeperPath}/` +
+                `${sourceObj.name}`;
+            const zkEndpointIngest =
+                `${zookeeperUrlIngest}/raft-id-dispatcher`;
+            this._subscribeToLogSourceDispatcher(zkEndpointIngest,
+                sourceObj, this.ingestionConfig.zookeeperPath);
+            return undefined;
+        });
     }
 
     _subscribeToLogSourceDispatcher(zkEndpoint, bucketd, ingestionPath) {
+        // NOTE: Bug where raftIdDispatcher will just be overwritten if more
+        // than one source exists. This will change in a later commit though
+        // when adding the `initManagement` process
         this.raftIdDispatcher =
             new ProvisionDispatcher({ connectionString: zkEndpoint });
         this.raftIdDispatcher.subscribe((err, items) => {
@@ -213,7 +166,7 @@ class IngestionPopulator {
                             zkConfig: this.zkConfig,
                             mongoConfig: this.qpConfig.mongo,
                             logger: this.log,
-                            extensions: this._extensions,
+                            extensions: [this._extension],
                             metricsProducer: this._mProducer,
                         });
                     }
@@ -223,15 +176,14 @@ class IngestionPopulator {
                         bucketdConfig: bucketd,
                         raftId: token,
                         logger: this.log,
-                        extensions: this._extensions,
+                        extensions: [this._extension],
                         metricsProducer: this._mProducer,
                         ingestionPath,
                         qpConfig: this.qpConfig,
                         s3Config: this.s3Config,
                     });
                 });
-            newRaftReaders.forEach(reader =>
-                this.logReadersUpdate.push(reader));
+            this.logReadersUpdate.push(...newRaftReaders);
             return undefined;
         });
         this.log.info('waiting to be provisioned a log source',
@@ -255,42 +207,36 @@ class IngestionPopulator {
         });
     }
 
-    _loadExtensions() {
-        this._extensions = [];
-        Object.keys(this.extConfigs).forEach(extName => {
-            const extConfig = this.extConfigs[extName];
-            const index = require(`../../extensions/${extName}/index.js`);
-            if (index.queuePopulatorExtension) {
-                // eslint-disable-next-line new-cap
-                const ext = new index.queuePopulatorExtension({
-                    config: extConfig,
-                    logger: this.log,
-                });
-                ext.setZkConfig(this.zkConfig);
-                this.log.info(`${index.name} extension is active`);
-                this._extensions.push(ext);
-            }
+    _loadExtension() {
+        const index = require('../../extensions/ingestion/index.js');
+        if (!index.queuePopulatorExtension) {
+            this.log.fatal('Missing ingestion populator extension file');
+            process.exit(1);
+        }
+        // eslint-disable-next-line new-cap
+        const ext = new index.queuePopulatorExtension({
+            config: this.ingestionConfig,
+            logger: this.log,
         });
+        ext.setZkConfig(this.zkConfig);
+        this._extension = ext;
+
+        this.log.info('ingestion extension is active');
     }
 
-    _setupExtensions(cb) {
-        return async.each(this._extensions, (ext, next) => {
-            ext.setupZookeeper(err => {
-                if (err) {
-                    return next(err);
-                }
-                if (ext.createZkPath) {
-                    if (ext instanceof IngestionQueuePopulator) {
-                        return async.each(
-                            this.extConfigs.ingestion.sources,
-                            (source, next) => ext.createZkPath(next, source),
-                            next);
-                    }
-                    return ext.createZkPath(next);
-                }
-                return next();
-            });
-        }, cb);
+    _setupIngestionExtension(cb) {
+        this._extension.setupZookeeper(err => {
+            if (err) {
+                return cb(err);
+            }
+            if (this._extension.createZkPath) {
+                return async.each(
+                    this.ingestionConfig.sources,
+                    (src, next) => this._extension.createZkPath(next, src),
+                    cb);
+            }
+            return cb();
+        });
     }
 
     _setupUpdatedReaders(done) {
@@ -301,7 +247,7 @@ class IngestionPopulator {
                        if (err) {
                            return done(err);
                        }
-                       this.logReaders = newReaders;
+                       this.logReaders.push(...newReaders);
                        return done();
                    });
     }

--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -8,15 +8,13 @@ const IngestionReader = require('./IngestionReader');
 const BucketFileLogReader = require('./BucketFileLogReader');
 const MetricsProducer = require('../MetricsProducer');
 const MetricsConsumer = require('../MetricsConsumer');
-const FailedCRRConsumer =
-    require('../../extensions/replication/failedCRR/FailedCRRConsumer');
 const MongoLogReader = require('./MongoLogReader');
 const IngestionQueuePopulator =
     require('../../extensions/ingestion/IngestionQueuePopulator');
 
 class IngestionPopulator {
     /**
-     * Create a queue populator object to populate various kafka
+     * Create an ingestion populator object to populate various kafka
      * queues from the metadata log
      *
      * @constructor
@@ -54,7 +52,7 @@ class IngestionPopulator {
         this.extConfigs = extConfigs;
         this.s3Config = s3Config;
 
-        this.log = new Logger('Backbeat:QueuePopulator');
+        this.log = new Logger('Backbeat:IngestionPopulator');
 
         // list of active log readers
         this.logReaders = [];
@@ -67,7 +65,7 @@ class IngestionPopulator {
     }
 
     /**
-     * Open the queue populator
+     * Open the ingestion populator
      *
      * @param {function} cb - callback function
      * @return {undefined}
@@ -78,18 +76,17 @@ class IngestionPopulator {
             next => this._setupMetricsClients(err => {
                 if (err) {
                     this.log.error('error setting up metrics client', {
-                        method: 'QueuePopulator.open',
+                        method: 'IngestionPopulator.open',
                         error: err,
                     });
                 }
                 return next(err);
             }),
-            next => this._setupFailedCRRClients(next),
             next => this._setupExtensions(err => {
                 if (err) {
                     this.log.error(
-                        'error setting up queue populator extensions', {
-                            method: 'QueuePopulator.open',
+                        'error setting up ingestion extension', {
+                            method: 'IngestionPopulator.open',
                             error: err,
                         });
                 }
@@ -104,8 +101,8 @@ class IngestionPopulator {
             }),
         ], err => {
             if (err) {
-                this.log.error('error starting up queue populator',
-                    { method: 'QueuePopulator.open',
+                this.log.error('error starting up ingestion populator',
+                    { method: 'IngestionPopulator.open',
                         error: err });
                 return cb(err);
             }
@@ -125,17 +122,7 @@ class IngestionPopulator {
     }
 
     /**
-     * Set up and start the consumer for retrying failed CRR operations.
-     * @param {Function} cb - The callback function
-     * @return {undefined}
-     */
-    _setupFailedCRRClients(cb) {
-        this._failedCRRConsumer = new FailedCRRConsumer(this.kafkaConfig);
-        return this._failedCRRConsumer.start(cb);
-    }
-
-    /**
-     * Close the queue populator
+     * Close provisioned ingestion source
      * @param {function} cb - callback function
      * @return {undefined}
      */

--- a/lib/queuePopulator/IngestionProducer.js
+++ b/lib/queuePopulator/IngestionProducer.js
@@ -41,8 +41,7 @@ class IngestionProducer {
             },
         };
         this.s3source = s3Config;
-        this.bucketPrefix = sourceConfig.prefix ? sourceConfig.prefix :
-            sourceConfig.name;
+        this._targetZenkoBucket = sourceConfig.name;
         this.requestLogger = this.log.newRequestLogger();
         this.createEntry = new RaftLogEntry();
         this.resLog = [];
@@ -131,10 +130,10 @@ class IngestionProducer {
                 }
                 const bucketMdObj =
                     this.createEntry.createPutBucketMdEntry(data,
-                        this.bucketPrefix);
+                        this._targetZenkoBucket);
                 const bucketObj =
                     this.createEntry.createPutBucketEntry(bucket, data,
-                        this.bucketPrefix);
+                        this._targetZenkoBucket);
                 this.resLog.push(bucketMdObj);
                 this.resLog.push(bucketObj);
                 return cb();
@@ -219,7 +218,7 @@ class IngestionProducer {
             return async.eachLimit(objectMds, 10, (objectMd, cb) => {
                 const objectMdEntry =
                     this.createEntry.createPutEntry(objectMd,
-                        this.bucketPrefix);
+                        this._targetZenkoBucket);
                 this.resLog.push(objectMdEntry);
                 return cb();
             }, err => {

--- a/lib/queuePopulator/IngestionReader.js
+++ b/lib/queuePopulator/IngestionReader.js
@@ -187,12 +187,7 @@ class IngestionReader extends LogReader {
                 batchState.publishedEntries[topic] = topicEntries;
                 return done();
             });
-        }, err => {
-            if (err) {
-                return done(err);
-            }
-            return done();
-        });
+        }, done);
     }
 
     _processSaveLogOffset(batchState, done) {
@@ -207,8 +202,6 @@ class IngestionReader extends LogReader {
         }
         return process.nextTick(() => done());
     }
-
-    /* eslint-enable no-param-reassign */
 
     getLogInfo() {
         return { raftId: this.raftId };

--- a/lib/queuePopulator/IngestionReader.js
+++ b/lib/queuePopulator/IngestionReader.js
@@ -10,7 +10,7 @@ class IngestionReader extends LogReader {
     constructor(params) {
         const { zkClient, kafkaConfig, bucketdConfig, ingestionPath, qpConfig,
             raftId, logger, extensions, metricsProducer, s3Config } = params;
-        const { host, port } = bucketdConfig;
+        const { host, port, zookeeperSuffix, name } = bucketdConfig;
         logger.info('initializing raft log reader',
             { method: 'RaftLogReader.constructor',
                 bucketdConfig, raftId });
@@ -23,15 +23,14 @@ class IngestionReader extends LogReader {
         this.raftId = raftId;
         this._iProducer = new IngestionProducer(bucketdConfig, qpConfig,
             s3Config);
-        this.bucketdPrefix = bucketdConfig.prefix ? bucketdConfig.prefix :
-            bucketdConfig.name;
         this.newIngestion = false;
         this.remoteLogOffset = null;
-        if (ingestionPath) {
-            this.pathToLogOffset = `${ingestionPath}` +
-                `${bucketdConfig.zookeeperSuffix}` +
-                `/logState/raft_${raftId}/logOffset`;
-        }
+        // i.e.: '/ingestion/${bucket}/logState/raft_${raftId}/logOffset'
+        this.pathToLogOffset = `${ingestionPath}${zookeeperSuffix}` +
+            `/logState/raft_${raftId}/logOffset`;
+
+        // identifier - zenko bucket name
+        this._targetZenkoBucket = name;
     }
 
     /* eslint-disable no-param-reassign */
@@ -74,7 +73,9 @@ class IngestionReader extends LogReader {
         ], done);
     }
 
-    _processLogEntry(batchState, record, entry, bucketdPrefix) {
+    _processLogEntry(batchState, record, entry) {
+        // NOTE: Using zenkoName because should be unique to other entries.
+
         // for a "del", entry.value will not exist but we still need to
         // pass through the event
         // for a bucket metadata entry from s3Connector, there will be no
@@ -93,16 +94,17 @@ class IngestionReader extends LogReader {
         } else {
             if (record.db === 'users..bucket') {
                 const keySplit = entry.key.split('..|..');
-                entry.key =
-                    `${keySplit[0]}..|..${bucketdPrefix}-${keySplit[1]}`;
+                entry.key = `${keySplit[0]}..|..` +
+                    `${this._targetZenkoBucket}-${keySplit[1]}`;
             } else if (record.db === 'metastore') {
                 const keySplit = entry.key.split('/');
-                entry.key = `${keySplit[0]}/${bucketdPrefix}-${keySplit[1]}`;
+                entry.key =
+                    `${keySplit[0]}/${this._targetZenkoBucket}-${keySplit[1]}`;
             } else {
                 if (record.db === entry.key) {
-                    entry.key = `${bucketdPrefix}-${entry.key}`;
+                    entry.key = `${this._targetZenkoBucket}-${entry.key}`;
                 }
-                record.db = `${bucketdPrefix}-${record.db}`;
+                record.db = `${this._targetZenkoBucket}-${record.db}`;
             }
             this._extensions.forEach(ext => ext.filter({
                 type: entry.type,
@@ -135,8 +137,7 @@ class IngestionReader extends LogReader {
             logStats.nbLogRecordsRead += 1;
             record.entries.forEach(entry => {
                 logStats.nbLogEntriesRead += 1;
-                this._processLogEntry(batchState, record, entry,
-                    this.bucketdPrefix);
+                this._processLogEntry(batchState, record, entry);
             });
         });
         logRes.log.on('error', err => {
@@ -206,6 +207,10 @@ class IngestionReader extends LogReader {
 
     getLogInfo() {
         return { raftId: this.raftId };
+    }
+
+    getTargetZenkoBucketName() {
+        return this._targetZenkoBucket;
     }
 }
 

--- a/lib/queuePopulator/IngestionReader.js
+++ b/lib/queuePopulator/IngestionReader.js
@@ -37,6 +37,7 @@ class IngestionReader extends LogReader {
     /* eslint-disable no-param-reassign */
 
     _processReadRecords(params, batchState, done) {
+        const { logger } = batchState;
         const readOptions = {};
         if (this.logOffset !== undefined) {
             readOptions.startSeq = this.logOffset;
@@ -44,7 +45,7 @@ class IngestionReader extends LogReader {
         if (params && params.maxRead !== undefined) {
             readOptions.limit = params.maxRead;
         }
-        this.log.debug('reading records', { readOptions });
+        logger.debug('reading records', { readOptions });
         return async.waterfall([
             next => this._readLogOffset((err, res) => {
                 const offset = Number.parseInt(res, 10);
@@ -62,7 +63,7 @@ class IngestionReader extends LogReader {
                 }
                 return this._iProducer.snapshot(this.raftId, (err, res) => {
                     if (err) {
-                        this.log.error('error generating snapshot for ' +
+                        logger.error('error generating snapshot for ' +
                         'ingestion', { err });
                         return next(err);
                     }
@@ -113,7 +114,7 @@ class IngestionReader extends LogReader {
     }
 
     _processPrepareEntries(batchState, done) {
-        const { entriesToPublish, logRes, logStats } = batchState;
+        const { entriesToPublish, logRes, logStats, logger } = batchState;
 
         this._setEntryBatch(entriesToPublish);
 
@@ -139,20 +140,20 @@ class IngestionReader extends LogReader {
             });
         });
         logRes.log.on('error', err => {
-            this.log.error('error fetching entries from log',
+            logger.error('error fetching entries from log',
                 { method: 'LogReader._processPrepareEntries',
                     error: err });
             return done(err);
         });
         logRes.log.on('end', () => {
-            this.log.debug('ending record stream');
+            logger.debug('ending record stream');
             return done();
         });
         return undefined;
     }
 
     _processPublishEntries(batchState, done) {
-        const { entriesToPublish, logRes, logStats } = batchState;
+        const { entriesToPublish, logRes, logStats, logger } = batchState;
 
         if (this.remoteLogOffset /* &&
         config.queuePopulator.logSource.indexOf('ingestion') > -1 */) {
@@ -173,7 +174,7 @@ class IngestionReader extends LogReader {
                 done => this._producers[topic].send(topicEntries, done),
             ], err => {
                 if (err) {
-                    this.log.error(
+                    logger.error(
                         'error publishing entries from log to topic',
                         { method: 'LogReader._processPublishEntries',
                           topic,
@@ -181,7 +182,7 @@ class IngestionReader extends LogReader {
                           error: err });
                     return done(err);
                 }
-                this.log.debug('entries published successfully to topic',
+                logger.debug('entries published successfully to topic',
                                { method: 'LogReader._processPublishEntries',
                                  topic, entryCount: topicEntries.length });
                 batchState.publishedEntries[topic] = topicEntries;

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -238,6 +238,10 @@ class QueuePopulator {
     _loadExtensions() {
         this._extensions = [];
         Object.keys(this.extConfigs).forEach(extName => {
+            if (extName === 'ingestion') {
+                // skip ingestion extension in QueuePopulator
+                return;
+            }
             const extConfig = this.extConfigs[extName];
             const index = require(`../../extensions/${extName}/index.js`);
             if (index.queuePopulatorExtension) {


### PR DESCRIPTION
**Purpose of this PR**:
Idea will be to use a separate ingestion reader for each new ingestion source.
The add/remove methods are to help instantiate new ingestion readers for each new ingestion source created (or removed). This PR only introduces the methods, and a later PR will use these methods along with the management client.
Also, in existing `QueuePopulator`, we avoid loading the ingestion extension to avoid overlap. Once things are more fleshed out for ingestion, maybe we can merge the processes. 

**Changes in this PR**:
- Refactor IngestionPopulator extension mgmt
- Refactor log messages (update with latest LogReader
  changes)
- Allow adding/removing IngestionReaders
- QueuePopulator should ignore ingestion extension. Separate
  out concerns
