### PR TITLE
ft: ZENKO-1240 ingestion init management populator

### DIFF
--- a/bin/ingestion.js
+++ b/bin/ingestion.js
@@ -7,6 +7,7 @@ const { HealthProbeServer } = require('arsenal').network.probe;
 
 const IngestionPopulator = require('../lib/queuePopulator/IngestionPopulator');
 const config = require('../conf/Config');
+const { initManagement } = require('../lib/management/index');
 
 const zkConfig = config.zookeeper;
 const kafkaConfig = config.kafka;
@@ -21,25 +22,41 @@ const log = new werelogs.Logger('Backbeat:IngestionPopulator');
 werelogs.configure({ level: config.log.logLevel,
     dump: config.log.dumpLevel });
 
+let scheduler;
+
 /* eslint-disable no-param-reassign */
-function queueBatch(ingestionPopulator, taskState, qConfig, log) {
+function queueBatch(ingestionPopulator, taskState, log) {
     if (taskState.batchInProgress) {
         log.warn('skipping ingestion batch: previous one still in progress');
         return undefined;
     }
     log.debug('start queueing ingestion batch');
     taskState.batchInProgress = true;
-    const maxRead = qpConfig.batchMaxRead;
-    ingestionPopulator.processLogEntries({ maxRead }, err => {
-        taskState.batchInProgress = false;
+
+    return ingestionPopulator.applyUpdates(err => {
         if (err) {
-            log.error('an error occurred during ingestion', {
-                method: 'IngestionPopulator::task.queueBatch',
+            log.fatal('failed to update ingestion readers', {
+                method: 'IngestionPopulator.applyUpdates',
                 error: err,
             });
+            scheduler.cancel();
+            process.exit(1);
         }
+        log.debug('updated active ingestion readers');
+        const maxRead = qpConfig.batchMaxRead;
+        ingestionPopulator.processLogEntries({ maxRead }, err => {
+            taskState.batchInProgress = false;
+            if (err) {
+                log.error('an error occurred during ingestion', {
+                    method: 'IngestionPopulator::task.queueBatch',
+                    error: err,
+                });
+                // exit process and let Kubernetes respawn the pod
+                process.exit(1);
+            }
+        });
+        return undefined;
     });
-    return undefined;
 }
 /* eslint-enable no-param-reassign */
 
@@ -51,43 +68,60 @@ const healthServer = new HealthProbeServer({
     port: config.healthcheckServer.port,
 });
 
-async.waterfall([
-    done => ingestionPopulator.open(done),
-    done => {
-        const taskState = {
-            batchInProgress: false,
-        };
-        schedule.scheduleJob(qpConfig.cronRule, () => {
-            queueBatch(ingestionPopulator, taskState, qpConfig, log);
-        });
-        done();
-    },
-    done => {
-        healthServer.onReadyCheck(log => {
-            const state = ingestionPopulator.zkStatus();
-            if (state.code === zookeeper.State.SYNC_CONNECTED.code) {
-                return true;
+function initAndStart() {
+    // TODO: change to using ingestion service account
+    const sourceConfig = config.extensions.replication.source;
+    initManagement({
+        serviceName: 'replication',
+        serviceAccount: sourceConfig.auth.account,
+    }, error => {
+        if (error) {
+            log.error('could not load management db', { error });
+            setTimeout(initAndStart, 5000);
+            return;
+        }
+        log.info('management init done');
+
+        async.series([
+            done => ingestionPopulator.open(done),
+            done => {
+                const taskState = {
+                    batchInProgress: false,
+                };
+                scheduler = schedule.scheduleJob(ingestionExtConfigs.cronRule,
+                    () => {
+                        queueBatch(ingestionPopulator, taskState, log);
+                    });
+                done();
+            },
+        ], err => {
+            if (err) {
+                log.fatal('error during ingestion populator initialization', {
+                    method: 'IngestionPopulator::task',
+                    error: err,
+                });
+                process.exit(1);
             }
-            log.error(`Zookeeper is not connected! ${state}`);
-            return false;
+            healthServer.onReadyCheck(() => {
+                const state = ingestionPopulator.zkStatus();
+                if (state.code === zookeeper.State.SYNC_CONNECTED.code) {
+                    return true;
+                }
+                log.error(`Zookeeper is not connected! ${state}`);
+                return false;
+            });
+            log.info('Starting HealthProbe server');
+            healthServer.start();
         });
-        log.info('Starting HealthProbe server');
-        healthServer.start();
-        done();
-    },
-], err => {
-    if (err) {
-        log.error('error during ingestion populator initialization', {
-            method: 'IngestionPopulator::task',
-            error: err,
-        });
-        process.exit(1);
-    }
-});
+    });
+}
+
+initAndStart();
 
 process.on('SIGTERM', () => {
     log.info('received SIGTERM, exiting');
     ingestionPopulator.close(() => {
+        scheduler.cancel();
         process.exit(0);
     });
 });

--- a/conf/config.json
+++ b/conf/config.json
@@ -48,7 +48,7 @@
                     "host": "localhost",
                     "port": 8000,
                     "https": false,
-                    "type": "scality",
+                    "type": "scality_s3",
                     "raftCount": 8
                 }
             ]

--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -1,12 +1,16 @@
 const async = require('async');
+const url = require('url');
 
 const Logger = require('werelogs').Logger;
 
+const config = require('../../conf/Config');
 const zookeeper = require('../clients/zookeeper');
 const ProvisionDispatcher = require('../provisioning/ProvisionDispatcher');
 const IngestionReader = require('./IngestionReader');
 const MetricsProducer = require('../MetricsProducer');
 const MetricsConsumer = require('../MetricsConsumer');
+const MongoIngestionInterface =
+    require('../../extensions/ingestion/utils/MongoIngestionInterface');
 
 class IngestionPopulator {
     /**
@@ -49,6 +53,9 @@ class IngestionPopulator {
 
         this.log = new Logger('Backbeat:IngestionPopulator');
 
+        // mongo client interface for finding ingestion buckets
+        this._mongoClient = null;
+
         // list of active log readers
         this.logReaders = [];
 
@@ -57,6 +64,8 @@ class IngestionPopulator {
         // metrics clients
         this._mProducer = null;
         this._mConsumer = null;
+        // location details to be updated from config initManagement updates
+        this._locationDetails = null;
 
         // provisioned ingestion log sources
         // i.e.: { an-ingestion-location: new ProvisionDispatcher() }
@@ -92,6 +101,19 @@ class IngestionPopulator {
                 return next(err);
             }),
             next => this._setupZookeeper(next),
+            next => {
+                this._mongoClient =
+                    new MongoIngestionInterface(this.qpConfig.mongo);
+                this._mongoClient.setup(err => {
+                    if (err) {
+                        this.log.error('error setting up mongo client', {
+                            method: 'IngestionPopulator.open',
+                            error: err,
+                        });
+                    }
+                    return next(err);
+                });
+            },
         ], err => {
             if (err) {
                 this.log.error('error starting up ingestion populator',
@@ -99,6 +121,10 @@ class IngestionPopulator {
                         error: err });
                 return cb(err);
             }
+            this._locationDetails = config.getLocations();
+            config.on('locations-update', () => {
+                this._locationDetails = config.getLocations();
+            });
             return cb();
         });
     }
@@ -112,6 +138,84 @@ class IngestionPopulator {
         // Metrics Producer
         this._mProducer = new MetricsProducer(this.kafkaConfig, this.mConfig);
         this._mProducer.setupProducer(cb);
+    }
+
+    /**
+     * Check mongo for new buckets and apply any updates
+     * @param {Function} cb - callback(error)
+     * @return {undefined}
+     */
+    applyUpdates(cb) {
+        this._mongoClient.getIngestionBuckets((err, buckets) => {
+            if (err) {
+                return cb(err);
+            }
+            // Example buckets list:
+            // [
+            //     {
+            //         name: 'my-zenko-bucket',
+            //         ingestion: { Status: 'enabled' },
+            //         locationConstraint: 'my-ring'
+            //     },
+            // ]
+
+            // Example this._locationDetails
+            // {
+            //     'my-ring': {
+            //         accessKey: ...,
+            //         secretKey: ...,
+            //         endpoint: 'http://10.100.1.128:8000',
+            //         locationType: 'scality_s3',
+            //         bucketName: 'source-bucket-1'
+            //     }
+            // }
+
+            const sources = Object.keys(this._provisionedIngestionSources);
+
+            return async.series([
+                done => async.each(buckets, (bucket, next) => {
+                    // zenko bucket name
+                    const key = bucket.name;
+                    if (!sources.includes(key)) {
+                        // Add new ingestion source
+                        const locationDetails =
+                            this._locationDetails[bucket.locationConstraint];
+                        const endpoint = url.parse(locationDetails.endpoint);
+                        // TODO: will change for non-ring sources
+                        const newSource = {
+                            // target zenko bucket name
+                            name: bucket.name,
+                            // source bucket name to ingest from
+                            bucket: locationDetails.bucketName,
+                            // location storage name
+                            prefix: bucket.locationConstraint,
+                            // TODO: make configurable
+                            cronRule: '*/5 * * * * *',
+                            zookeeperSuffix: `/${bucket.name}`,
+                            // source (s3c) endpoint
+                            host: endpoint.hostname,
+                            port: parseInt(endpoint.port, 10),
+                            https: endpoint.protocol.slice(0, -1) === 'https',
+                            type: locationDetails.locationType,
+                            raftCount: 8,
+                        };
+                        return this.addNewLogSource(newSource, next);
+                    }
+                    const index = sources.findIndex(s => s === key);
+                    // if an existing source, stop tracking it from
+                    // `sources`
+                    if (index >= 0) {
+                        sources.splice(index, 1);
+                    }
+                    return next();
+                }, done),
+                // Any leftover `sources` have been removed
+                // Close these logs..
+                done => async.each(sources,
+                    (source, next) => this.closeLogState(source, next),
+                    done),
+            ], cb);
+        });
     }
 
     /**
@@ -136,7 +240,7 @@ class IngestionPopulator {
 
     _subscribeToLogSourceDispatcher(zkEndpoint, bucketd, cb) {
         const ingestionPath = this.ingestionConfig.zookeeperPath;
-        // TODO: Replace ProvisionDispatcher?
+        // TODO: Remove/Replace ProvisionDispatcher
         const raftIdDispatcher =
             new ProvisionDispatcher({ connectionString: zkEndpoint });
         raftIdDispatcher.subscribe((err, items) => {

--- a/tests/unit/ingestion/IngestionPopulator.js
+++ b/tests/unit/ingestion/IngestionPopulator.js
@@ -1,0 +1,181 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+
+const config = require('../../../conf/Config');
+const IngestionPopulator =
+    require('../../../lib/queuePopulator/IngestionPopulator');
+
+const zkConfig = config.zookeeper;
+const kafkaConfig = config.kafka;
+const qpConfig = config.queuePopulator;
+const mConfig = config.metrics;
+const rConfig = config.redis;
+const ingestionConfig = config.extensions.ingestion;
+const s3Config = config.s3;
+
+// zenko bucket naming to be used to test with
+const EXISTING_BUCKET = 'my-zenko-bucket';
+const NEW_BUCKET = 'your-zenko-bucket';
+const OLD_BUCKET = 'old-ingestion-bucket';
+
+const locations = [
+    {
+        locationConstraint: 'my-ring',
+        zenkoBucket: EXISTING_BUCKET,
+        ingestion: { Status: 'enabled' },
+        sourceBucket: 'my-ring-bucket',
+        accessKey: 'myAccessKey',
+        secretKey: 'myVerySecretKey',
+        endpoint: 'http://127.0.0.1:8000',
+        locationType: 'scality_s3',
+    },
+    {
+        locationConstraint: 'your-ring',
+        zenkoBucket: NEW_BUCKET,
+        ingestion: { Status: 'enabled' },
+        sourceBucket: 'your-ring-bucket',
+        accessKey: 'yourAccessKey',
+        secretKey: 'yourVerySecretKey',
+        endpoint: 'http://127.0.0.1:8000',
+        locationType: 'scality_s3',
+    },
+];
+
+class MongoMock {
+    getIngestionBuckets(cb) {
+        const bucketList = locations.map(l => ({
+            name: l.zenkoBucket,
+            ingestion: l.ingestion,
+            locationConstraint: l.locationConstraint,
+        }));
+        return cb(null, bucketList);
+    }
+}
+
+class IngestionPopulatorMock extends IngestionPopulator {
+    reset() {
+        this._added = [];
+        this._removed = [];
+    }
+
+    getAdded() {
+        return this._added;
+    }
+
+    getRemoved() {
+        return this._removed;
+    }
+
+    _mockLocationDetails() {
+        const locationDetails = {};
+        locations.forEach(l => {
+            locationDetails[l.locationConstraint] = {
+                accessKey: l.accessKey,
+                secretKey: l.secretKey,
+                endpoint: l.endpoint,
+                locationType: l.locationType,
+                bucketName: l.sourceBucket,
+            };
+        });
+        return locationDetails;
+    }
+
+    setupMock() {
+        // for testing purposes
+        this._added = [];
+        this._removed = [];
+
+        // mocks
+        this._mongoClient = new MongoMock();
+        this._extension = {
+            createZkPath: cb => cb(),
+        };
+        this._locationDetails = this._mockLocationDetails();
+
+        // mock existing provisioned sources
+        this._provisionedIngestionSources = {
+            [OLD_BUCKET]: {},
+            [EXISTING_BUCKET]: {},
+        };
+    }
+
+    addNewLogSource(newSource, cb) {
+        this._added.push(newSource);
+        return cb();
+    }
+
+    closeLogState(source, cb) {
+        this._removed.push(source);
+        return cb();
+    }
+}
+
+describe('Ingestion Populator', () => {
+    describe('applyUpdates helper method', () => {
+        let ip;
+
+        before(() => {
+            ip = new IngestionPopulatorMock(zkConfig, kafkaConfig, qpConfig,
+                mConfig, rConfig, ingestionConfig, s3Config);
+            ip.setupMock();
+        });
+
+        beforeEach(done => {
+            ip.applyUpdates(done);
+        });
+
+        afterEach(() => {
+            ip.reset();
+        });
+
+        it('should attach configuration properties for each new source', () => {
+            ip.getAdded().forEach(newSource => {
+                // default configs
+                assert.strictEqual(newSource.cronRule, '*/5 * * * * *');
+                assert.strictEqual(newSource.zookeeperSuffix,
+                    `/${newSource.name}`);
+                assert.strictEqual(newSource.raftCount, 8);
+
+                // unique configs
+                assert(newSource.name);
+                assert(newSource.bucket);
+                assert(newSource.prefix);
+                assert(newSource.host);
+                assert.strictEqual(typeof newSource.port, 'number');
+                assert.strictEqual(typeof newSource.https, 'boolean');
+                assert(newSource.type);
+            });
+        });
+
+        it('should keep an existing provisioned source', () => {
+            const inAdd = ip.getAdded().findIndex(r =>
+                r.name === EXISTING_BUCKET);
+            const inRemove = ip.getRemoved().findIndex(r =>
+                r === EXISTING_BUCKET);
+
+            assert(inAdd === -1);
+            assert(inRemove === -1);
+        });
+
+        it('should add/provision a new ingestion bucket', () => {
+            const inAdd = ip.getAdded().findIndex(r =>
+                r.name === NEW_BUCKET);
+            const inRemove = ip.getRemoved().findIndex(r =>
+                r === NEW_BUCKET);
+            assert(inAdd >= 0);
+            assert(inRemove === -1);
+        });
+
+        it('should remove a provisioned source that is no longer an ' +
+        'ingestion bucket', () => {
+            const inAdd = ip.getAdded().findIndex(r =>
+                r.name === OLD_BUCKET);
+            const inRemove = ip.getRemoved().findIndex(r =>
+                r === OLD_BUCKET);
+
+            assert(inAdd === -1);
+            assert(inRemove >= 0);
+        });
+    });
+});


### PR DESCRIPTION
Sits on top of PR https://github.com/scality/backbeat/pull/521

**Purpose of this PR**:
Add the management layer, check for new ingestion sources (currently querying mongo directly), and add/remove ingestion readers accordingly.
Each config for ingestion sources can use a refactor, but to keep compliance with existing code, I kept the ingestion source config as is with minor changes.

**Changes in this PR**:
- Add management layer to get config location constraint
  updates
- Each queueBatch call, update ingestion sources list first