### PR TITLE
ft: ZENKO-1240 ingestion init management processor

### DIFF
--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -48,14 +48,17 @@ class MongoQueueProcessor {
      * @param {number} [mongoProcessorConfig.retry.backoff.factor] -
      *  backoff factor
      * @param {Object} mongoClientConfig - config for connecting to mongo
+     * @param {String} site - site name
      */
-    constructor(kafkaConfig, mongoProcessorConfig, mongoClientConfig) {
+    constructor(kafkaConfig, mongoProcessorConfig, mongoClientConfig, site) {
         this.kafkaConfig = kafkaConfig;
         this.mongoProcessorConfig = mongoProcessorConfig;
+        this.mongoClientConfig = mongoClientConfig;
+        this.site = site;
+
         this._consumer = null;
         this.logger =
-            new Logger('Backbeat:MongoProcessor');
-        this.mongoClientConfig = mongoClientConfig;
+            new Logger(`Backbeat:Ingestion:MongoProcessor:${this.site}`);
         this.mongoClientConfig.logger = this.logger;
         this._mongoClient = new MongoClient(this.mongoClientConfig);
     }
@@ -75,7 +78,7 @@ class MongoQueueProcessor {
             let consumerReady = false;
             this._consumer = new BackbeatConsumer({
                 topic: this.mongoProcessorConfig.topic,
-                groupId: `${this.mongoProcessorConfig.groupId}`,
+                groupId: `${this.mongoProcessorConfig.groupId}-${this.site}`,
                 kafka: { hosts: this.kafkaConfig.hosts },
                 queueProcessor: this.processKafkaEntry.bind(this),
             });

--- a/extensions/mongoProcessor/mongoProcessorTask.js
+++ b/extensions/mongoProcessor/mongoProcessorTask.js
@@ -1,10 +1,13 @@
 'use strict'; // eslint-disable-line
+
+const async = require('async');
 const werelogs = require('werelogs');
 const { HealthProbeServer } = require('arsenal').network.probe;
 
 const MongoQueueProcessor = require('./MongoQueueProcessor');
-
 const config = require('../../conf/Config');
+const { initManagement } = require('../../lib/management/index');
+
 const kafkaConfig = config.kafka;
 const mongoProcessorConfig = config.extensions.mongoProcessor;
 // TODO: consider whether we would want a separate mongo config
@@ -16,18 +19,82 @@ const healthServer = new HealthProbeServer({
     port: config.healthcheckServer.port,
 });
 
-const mongoQueueProcessor = new MongoQueueProcessor(kafkaConfig,
-    mongoProcessorConfig, mongoClientConfig);
-
+const log = new werelogs.Logger('Backbeat:MongoProcessor:task');
 werelogs.configure({ level: config.log.logLevel,
     dump: config.log.dumpLevel });
 
-mongoQueueProcessor.start();
-healthServer.onReadyCheck(log => {
-    if (mongoQueueProcessor.isReady()) {
-        return true;
-    }
-    log.error('MongoQueueProcessor is not ready!');
-    return false;
-});
-healthServer.start();
+const activeProcessors = {};
+
+function initAndStart() {
+    // NOTE: using replication service account
+    const sourceConfig = config.extensions.replication.source;
+    initManagement({
+        serviceName: 'replication',
+        serviceAccount: sourceConfig.auth.account,
+    }, error => {
+        if (error) {
+            log.error('could not load management db', { error });
+            setTimeout(initAndStart, 5000);
+            return;
+        }
+        log.info('management init done');
+
+        let bootstrapList = config.getBootstrapList();
+        config.on('bootstrap-list-update', () => {
+            bootstrapList = config.getBootstrapList();
+
+            const active = Object.keys(activeProcessors);
+            const update = bootstrapList.map(i => i.site);
+            const allSites = [...new Set(active.concat(update))];
+
+            async.each(allSites, (site, next) => {
+                if (update.includes(site)) {
+                    if (!active.includes(site)) {
+                        // new site to setup
+                        const mqp = new MongoQueueProcessor(kafkaConfig,
+                            mongoProcessorConfig, mongoClientConfig, site);
+                        mqp.start();
+                        activeProcessors[site] = mqp;
+                    }
+                } else {
+                    // site no longer in bootstrapList
+                    activeProcessors[site].stop(() => {});
+                    delete activeProcessors[site];
+                }
+                return next();
+            }, err => {
+                if (err) {
+                    process.exit(1);
+                }
+            });
+        });
+
+        // Start Processors for each site
+        const siteNames = bootstrapList.map(i => i.site);
+        async.each(siteNames, (site, next) => {
+            const mqp = new MongoQueueProcessor(kafkaConfig,
+                mongoProcessorConfig, mongoClientConfig, site);
+            mqp.start();
+            activeProcessors[site] = mqp;
+            return next();
+        }, err => {
+            if (err) {
+                process.exit(1);
+            }
+        });
+        healthServer.onReadyCheck(() => {
+            let passed = true;
+            Object.keys(activeProcessors).forEach(site => {
+                if (!activeProcessors[site].isReady()) {
+                    passed = false;
+                    log.error(`MongoQueueProcessor for ${site} is not ready`);
+                }
+            });
+            return passed;
+        });
+        log.info('Starting HealthProbe server');
+        healthServer.start();
+    });
+}
+
+initAndStart();


### PR DESCRIPTION
Ingestion Processor side

In order to pause/resume by ingestion location, I'm emulating how replication does this by creating separate consumers and consumer groups by location. This way I can continue to rely on queued entries in kafka

Changes in this PR:
- Add management layer to get config location constraint
  updates
- Add consumers/MongoQueueProcessors by site in order to
  support pause/resume later on