### PR TITLE
ft: ZENKO-1240 ingestion init management processor

### DIFF
--- a/extensions/mongoProcessor/mongoProcessorTask.js
+++ b/extensions/mongoProcessor/mongoProcessorTask.js
@@ -1,10 +1,12 @@
 'use strict'; // eslint-disable-line
+
 const werelogs = require('werelogs');
 const { HealthProbeServer } = require('arsenal').network.probe;
 
 const MongoQueueProcessor = require('./MongoQueueProcessor');
-
 const config = require('../../conf/Config');
+const { initManagement } = require('../../lib/management/index');
+
 const kafkaConfig = config.kafka;
 const mongoProcessorConfig = config.extensions.mongoProcessor;
 // TODO: consider whether we would want a separate mongo config
@@ -16,18 +18,83 @@ const healthServer = new HealthProbeServer({
     port: config.healthcheckServer.port,
 });
 
-const mongoQueueProcessor = new MongoQueueProcessor(kafkaConfig,
-    mongoProcessorConfig, mongoClientConfig);
-
+const log = new werelogs.Logger('Backbeat:MongoProcessor:task');
 werelogs.configure({ level: config.log.logLevel,
     dump: config.log.dumpLevel });
 
-mongoQueueProcessor.start();
-healthServer.onReadyCheck(log => {
-    if (mongoQueueProcessor.isReady()) {
-        return true;
-    }
-    log.error('MongoQueueProcessor is not ready!');
-    return false;
-});
-healthServer.start();
+const activeProcessors = {};
+
+function updateProcessors(bootstrapList) {
+    const active = Object.keys(activeProcessors);
+    const update = bootstrapList.map(i => i.site);
+    const allSites = [...new Set(active.concat(update))];
+
+    allSites.forEach(site => {
+        if (!update.includes(site)) {
+            // remove processor, site is no longer active
+            activeProcessors[site].stop(() => {});
+            delete activeProcessors[site];
+        } else if (!active.includes(site)) {
+            // add new processor, site is new and requires setup
+            const mqp = new MongoQueueProcessor(kafkaConfig,
+                mongoProcessorConfig, mongoClientConfig, site);
+            mqp.start();
+            activeProcessors[site] = mqp;
+        }
+        // else, existing site and has already been setup
+    });
+}
+
+function loadProcessors() {
+    let bootstrapList = config.getBootstrapList();
+    config.on('bootstrap-list-update', () => {
+        bootstrapList = config.getBootstrapList();
+
+        updateProcessors(bootstrapList);
+    });
+
+    // Start Processors for each site
+    const siteNames = bootstrapList.map(i => i.site);
+    siteNames.forEach(site => {
+        const mqp = new MongoQueueProcessor(kafkaConfig,
+            mongoProcessorConfig, mongoClientConfig, site);
+        mqp.start();
+        activeProcessors[site] = mqp;
+    });
+}
+
+function loadHealthcheck() {
+    healthServer.onReadyCheck(() => {
+        let passed = true;
+        Object.keys(activeProcessors).forEach(site => {
+            if (!activeProcessors[site].isReady()) {
+                passed = false;
+                log.error(`MongoQueueProcessor for ${site} is not ready`);
+            }
+        });
+        return passed;
+    });
+    log.info('Starting HealthProbe server');
+    healthServer.start();
+}
+
+function loadManagementDatabase() {
+    // NOTE: using replication service account
+    const sourceConfig = config.extensions.replication.source;
+    initManagement({
+        serviceName: 'replication',
+        serviceAccount: sourceConfig.auth.account,
+    }, error => {
+        if (error) {
+            log.error('could not load management db', { error });
+            setTimeout(loadManagementDatabase, 5000);
+            return;
+        }
+        log.info('management init done');
+
+        loadProcessors();
+        loadHealthcheck();
+    });
+}
+
+loadManagementDatabase();

--- a/lib/queuePopulator/IngestionReader.js
+++ b/lib/queuePopulator/IngestionReader.js
@@ -73,6 +73,8 @@ class IngestionReader extends LogReader {
         ], done);
     }
 
+    // TODO: Processor requires the zenko bucket name
+    //   (currently stored within source ingestion objects on key: `name`)
     _processLogEntry(batchState, record, entry) {
         // NOTE: Using zenkoName because should be unique to other entries.
 


### PR DESCRIPTION
**Purpose of this PR**:
Add management layer on ingestion processor side.
Primarily necessary for pause and resume service for ingestion. Creates separate consumers by each ingestion location

**Changes in this PR**:
- Add management layer to get config location constraint
  updates
- Add consumers/MongoQueueProcessors by site in order to
  support pause/resume later on