### PR TITLE
ft: ZENKO-1283 ingestion processor pause resume

### DIFF
--- a/extensions/ingestion/IngestionConfigValidator.js
+++ b/extensions/ingestion/IngestionConfigValidator.js
@@ -2,7 +2,7 @@ const joi = require('joi');
 
 const joiSchema = {
     auth: joi.object({
-        type: joi.string().valid('service').required(),
+        type: joi.alternatives().try('account', 'service').required(),
         account: joi.string().required(),
     }).required(),
     topic: joi.string().required(),

--- a/extensions/ingestion/constants.js
+++ b/extensions/ingestion/constants.js
@@ -1,0 +1,12 @@
+'use strict'; // eslint-disable-line
+
+const testIsOn = process.env.CI === 'true';
+
+const constants = {
+    zookeeperNamespace:
+        testIsOn ? '/backbeattest/ingestion' : '/backbeat/ingestion',
+    zkStatePath: '/state',
+    zkStateProperties: ['paused', 'scheduledResume'],
+};
+
+module.exports = constants;

--- a/extensions/ingestion/constants.js
+++ b/extensions/ingestion/constants.js
@@ -6,7 +6,6 @@ const constants = {
     zookeeperNamespace:
         testIsOn ? '/backbeattest/ingestion' : '/backbeat/ingestion',
     zkStatePath: '/state',
-    zkStateProperties: ['paused', 'scheduledResume'],
 };
 
 module.exports = constants;

--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -3,6 +3,8 @@
 const async = require('async');
 const AWS = require('aws-sdk');
 const http = require('http');
+const Redis = require('ioredis');
+const schedule = require('node-schedule');
 
 const Logger = require('werelogs').Logger;
 const errors = require('arsenal').errors;
@@ -18,6 +20,12 @@ const ObjectQueueEntry = require('../../lib/models/ObjectQueueEntry');
 const { getAccountCredentials } =
     require('../../lib/credentials/AccountCredentials');
 
+const {
+    zookeeperNamespace,
+    zkStatePath,
+    zkStateProperties,
+} = require('../ingestion/constants');
+
 // TODO - ADD PREFIX BASED ON SOURCE
 // april 6, 2018
 
@@ -31,6 +39,7 @@ class MongoQueueProcessor {
 
     /**
      * @constructor
+     * @param {node-zookeeper-client.Client} zkClient - zookeeper client
      * @param {Object} kafkaConfig - kafka configuration object
      * @param {String} kafkaConfig.hosts - list of kafka brokers
      *   as "host:port[,host:port...]"
@@ -58,10 +67,12 @@ class MongoQueueProcessor {
      *  backoff factor
      * @param {Object} mongoClientConfig - config for connecting to mongo
      * @param {Object} serviceAuth - ingestion service auth
+     * @param {Object} redisConfig - redis configuration
      * @param {String} site - site name
      */
-    constructor(kafkaConfig, s3Config, mongoProcessorConfig, mongoClientConfig,
-                serviceAuth, site) {
+    constructor(zkClient, kafkaConfig, s3Config, mongoProcessorConfig,
+                mongoClientConfig, serviceAuth, redisConfig, site) {
+        this.zkClient = zkClient;
         this.kafkaConfig = kafkaConfig;
         this.mongoProcessorConfig = mongoProcessorConfig;
         this.mongoClientConfig = mongoClientConfig;
@@ -71,10 +82,57 @@ class MongoQueueProcessor {
         this._s3Endpoint = `http://${s3Config.host}:${s3Config.port}`;
         this._s3Client = null;
         this._consumer = null;
+        this.scheduledResume = null;
+
         this.logger =
             new Logger(`Backbeat:Ingestion:MongoProcessor:${this.site}`);
         this.mongoClientConfig.logger = this.logger;
         this._mongoClient = new MongoClient(this.mongoClientConfig);
+
+        this._setupRedis(redisConfig);
+    }
+
+    /**
+     * Setup the Redis Subscriber which listens for actions from other processes
+     * (i.e. BackbeatAPI for pause/resume)
+     * @param {object} redisConfig - redis config
+     * @return {undefined}
+     */
+    _setupRedis(redisConfig) {
+        // redis pub/sub for pause/resume
+        const redis = new Redis(redisConfig);
+        // redis subscribe to site specific channel
+        const channelName = `${this.mongoProcessorConfig.topic}-${this.site}`;
+        redis.subscribe(channelName, err => {
+            if (err) {
+                this.logger.fatal('mongo queue processor failed to subscribe ' +
+                                  'to ingestion redis channel for location ' +
+                                  `${this.site}`,
+                                  { method: 'MongoQueueProcessor.constructor',
+                                    error: err });
+                process.exit(1);
+            }
+            redis.on('message', (channel, message) => {
+                const validActions = {
+                    pauseService: this._pauseService.bind(this),
+                    resumeService: this._resumeService.bind(this),
+                    deleteScheduledResumeService:
+                        this._deleteScheduledResumeService.bind(this),
+                };
+                try {
+                    const { action, date } = JSON.parse(message);
+                    const cmd = validActions[action];
+                    if (channel === channelName && typeof cmd === 'function') {
+                        cmd(date);
+                    }
+                } catch (e) {
+                    this.logger.error('error parsing redis sub message', {
+                        method: 'MongoQueueProcessor._setupRedis',
+                        error: e,
+                    });
+                }
+            });
+        });
     }
 
     /**
@@ -105,9 +163,11 @@ class MongoQueueProcessor {
     /**
      * Start kafka consumer
      *
+     * @param {object} [options] options object
+     * @param {boolean} [options.paused] - if true, kafka consumer is paused
      * @return {undefined}
      */
-    start() {
+    start(options) {
         this.logger.info('starting mongo queue processor');
         const credentials = getAccountCredentials(this._serviceAuth,
                                                   this.logger);
@@ -132,9 +192,209 @@ class MongoQueueProcessor {
             });
             this._consumer.on('ready', () => {
                 consumerReady = true;
-                this._consumer.subscribe();
+                const paused = options && options.paused;
+                this._consumer.subscribe(paused);
                 this.logger.info('mongo queue processor is ready');
             });
+        });
+    }
+
+    /**
+     * Pause consumers
+     * @return {undefined}
+     */
+    _pauseService() {
+        const enabled = this._consumer.getServiceStatus();
+        if (enabled) {
+            // if currently resumed/active, attempt to pause
+            this._updateZkStateNode('paused', true, err => {
+                if (err) {
+                    this.logger.trace('error occurred saving state to ' +
+                    'zookeeper', {
+                        method: 'MongoQueueProcessor._pauseService',
+                    });
+                } else {
+                    this._consumer.pause(this.site);
+                    this.logger.info('paused ingestion for location: ' +
+                        `${this.site}`);
+                    this._deleteScheduledResumeService();
+                }
+            });
+        }
+    }
+
+    /**
+     * Resume consumers
+     * @param {Date} [date] - optional date object for scheduling resume
+     * @return {undefined}
+     */
+    _resumeService(date) {
+        const enabled = this._consumer.getServiceStatus();
+        const now = new Date();
+
+        if (enabled) {
+            this.logger.info(`cannot resume, site ${this.site} is not paused`);
+            return;
+        }
+
+        if (date && now < new Date(date)) {
+            // if date is in the future, attempt to schedule job
+            this._scheduleResume(date);
+        } else {
+            this._updateZkStateNode('paused', false, err => {
+                if (err) {
+                    this.logger.trace('error occurred saving state to ' +
+                    'zookeeper', {
+                        method: 'MongoQueueProcessor._resumeService',
+                    });
+                } else {
+                    this._consumer.resume(this.site);
+                    this.logger.info('resumed ingestion for location: ' +
+                        `${this.site}`);
+                    this._deleteScheduledResumeService();
+                }
+            });
+        }
+    }
+
+    /**
+     * Delete scheduled resume (if any)
+     * @return {undefined}
+     */
+    _deleteScheduledResumeService() {
+        this._updateZkStateNode('scheduledResume', null, err => {
+            if (err) {
+                this.logger.trace('error occurred saving state to zookeeper', {
+                    method: 'MongoQueueProcessor._deleteScheduledResumeService',
+                });
+            } else if (this.scheduledResume) {
+                this.scheduledResume.cancel();
+                this.scheduledResume = null;
+                this.logger.info('deleted scheduled resume for location:' +
+                    ` ${this.site}`);
+            }
+        });
+    }
+
+    _getZkSiteNode() {
+        return `${zookeeperNamespace}${zkStatePath}/${this.site}`;
+    }
+
+    /**
+     * Update zookeeper state node for this site-defined MongoQueueProcessor
+     * @param {String} key - key name to store in zk state node
+     * @param {String|Boolean} value - value
+     * @param {Function} cb - callback(error)
+     * @return {undefined}
+     */
+    _updateZkStateNode(key, value, cb) {
+        if (!zkStateProperties.includes(key)) {
+            const errorMsg = 'incorrect zookeeper state property given';
+            this.logger.error(errorMsg, {
+                method: 'MongoQueueProcessor._updateZkStateNode',
+            });
+            return cb(new Error('incorrect zookeeper state property given'));
+        }
+        const path = this._getZkSiteNode();
+        return async.waterfall([
+            next => this.zkClient.getData(path, (err, data) => {
+                if (err) {
+                    this.logger.error('could not get state from zookeeper', {
+                        method: 'MongoQueueProcessor._updateZkStateNode',
+                        zookeeperPath: path,
+                        error: err.message,
+                    });
+                    return next(err);
+                }
+                try {
+                    const state = JSON.parse(data.toString());
+                    // set revised status
+                    state[key] = value;
+                    const bufferedData = Buffer.from(JSON.stringify(state));
+                    return next(null, bufferedData);
+                } catch (err) {
+                    this.logger.error('could not parse state data from ' +
+                    'zookeeper', {
+                        method: 'MongoQueueProcessor._updateZkStateNode',
+                        zookeeperPath: path,
+                        error: err,
+                    });
+                    return next(err);
+                }
+            }),
+            (data, next) => this.zkClient.setData(path, data, err => {
+                if (err) {
+                    this.logger.error('could not save state data in ' +
+                    'zookeeper', {
+                        method: 'MongoQueueProcessor._updateZkStateNode',
+                        zookeeperPath: path,
+                        error: err,
+                    });
+                    return next(err);
+                }
+                return next();
+            }),
+        ], cb);
+    }
+
+    _scheduleResume(date) {
+        function triggerResume() {
+            this._updateZkStateNode('scheduledResume', null, err => {
+                if (err) {
+                    this.logger.error('error occurred saving state ' +
+                    'to zookeeper for resuming a scheduled resume. Retry ' +
+                    'again in 1 minute', {
+                        method: 'MongoQueueProcessor._scheduleResume',
+                        error: err,
+                    });
+                    // if an error occurs, need to retry
+                    // for now, schedule minute from now
+                    const date = new Date();
+                    date.setMinutes(date.getMinutes() + 1);
+                    this.scheduledResume = schedule.scheduleJob(date,
+                        triggerResume.bind(this));
+                } else {
+                    if (this.scheduledResume) {
+                        this.scheduledResume.cancel();
+                    }
+                    this.scheduledResume = null;
+                    this._resumeService();
+                }
+            });
+        }
+
+        this._updateZkStateNode('scheduledResume', date, err => {
+            if (err) {
+                this.logger.trace('error occurred saving state to zookeeper', {
+                    method: 'MongoQueueProcessor._scheduleResume',
+                });
+            } else {
+                this.scheduledResume = schedule.scheduleJob(date,
+                    triggerResume.bind(this));
+                this.logger.info('scheduled ingestion resume', {
+                    scheduleTime: date.toString(),
+                });
+            }
+        });
+    }
+
+    /**
+     * Cleanup zookeeper node if the site has been removed as a location
+     * @param {function} cb - callback(error)
+     * @return {undefined}
+     */
+    removeZkState(cb) {
+        const path = this._getZkSiteNode();
+        this.zkClient.remove(path, err => {
+            if (err && err.name !== 'NO_NODE') {
+                this.logger.error('failed removing zookeeper state node', {
+                    method: 'MongoQueueProcessor.removeZkState',
+                    zookeeperPath: path,
+                    error: err,
+                });
+                return cb(err);
+            }
+            return cb();
         });
     }
 

--- a/extensions/mongoProcessor/mongoProcessorTask.js
+++ b/extensions/mongoProcessor/mongoProcessorTask.js
@@ -65,7 +65,7 @@ function checkAndApplyScheduleResume(qp, data, zkClient, site, cb) {
         return zkClient.setData(path, Buffer.from(d), err => {
             if (err) {
                 log.fatal('could not set zookeeper status node', {
-                    method: 'MongoProcessor:task',
+                    method: 'mongoProcessorTask:checkAndApplyScheduleResume',
                     zookeeperPath: path,
                     error: err.message,
                 });
@@ -95,7 +95,7 @@ function setupZkSiteNode(qp, zkClient, site, done) {
             return zkClient.getData(path, (err, data) => {
                 if (err) {
                     log.fatal('could not check site status in zookeeper',
-                        { method: 'MongoProcessor:task',
+                        { method: 'mongoProcessorTask:setupZkSiteNode',
                           zookeeperPath: path,
                           error: err.message });
                     return done(err);
@@ -105,7 +105,7 @@ function setupZkSiteNode(qp, zkClient, site, done) {
                     d = JSON.parse(data.toString());
                 } catch (e) {
                     log.fatal('error setting state for queue processor', {
-                        method: 'MongoProcessor:task',
+                        method: 'mongoProcessorTask:setupZkSiteNode',
                         site,
                         error: reshapeExceptionError(e),
                     });
@@ -120,7 +120,7 @@ function setupZkSiteNode(qp, zkClient, site, done) {
         }
         if (err) {
             log.fatal('could not setup zookeeper node', {
-                method: 'MongoProcessor:task',
+                method: 'mongoProcessorTask:setupZkSiteNode',
                 zookeeperPath: path,
                 error: err.message,
             });
@@ -247,7 +247,7 @@ zkClient.once('ready', () => {
     zkClient.mkdirp(path, err => {
         if (err) {
             log.fatal('could not create path in zookeeper', {
-                method: 'MongoProcessor:task',
+                method: 'mongoProcessorTask:task',
                 zookeeperPath: path,
                 error: err.message,
             });

--- a/extensions/mongoProcessor/mongoProcessorTask.js
+++ b/extensions/mongoProcessor/mongoProcessorTask.js
@@ -1,11 +1,15 @@
 'use strict'; // eslint-disable-line
 
+const async = require('async');
 const werelogs = require('werelogs');
 const { HealthProbeServer } = require('arsenal').network.probe;
+const { reshapeExceptionError } = require('arsenal').errorUtils;
 
 const MongoQueueProcessor = require('./MongoQueueProcessor');
 const config = require('../../conf/Config');
 const { initManagement } = require('../../lib/management/index');
+const zookeeper = require('../../lib/clients/zookeeper');
+const { zookeeperNamespace, zkStatePath } = require('../ingestion/constants');
 
 const kafkaConfig = config.kafka;
 const s3Config = config.s3;
@@ -14,6 +18,11 @@ const mongoProcessorConfig = config.extensions.mongoProcessor;
 // for the consumer side
 const mongoClientConfig = config.queuePopulator.mongo;
 const ingestionServiceAuth = config.extensions.ingestion.auth;
+const zkConfig = config.zookeeper;
+const redisConfig = config.redis;
+const { connectionString, autoCreateNamespace } = zkConfig;
+
+const RESUME_NODE = 'scheduledResume';
 
 const healthServer = new HealthProbeServer({
     bindAddress: config.healthcheckServer.bindAddress,
@@ -26,44 +35,165 @@ werelogs.configure({ level: config.log.logLevel,
 
 const activeProcessors = {};
 
-function updateProcessors(bootstrapList) {
+function getStateZkPath() {
+    return `${zookeeperNamespace}${zkStatePath}`;
+}
+
+/**
+ * A scheduled resume is where consumers for a given site are paused and are
+ * scheduled to be resumed at a later date.
+ * If any scheduled resumes exist for a given site, the date is saved within
+ * zookeeper. On startup, we schedule resume jobs to renew prior state.
+ * If date in zookeeper has not expired, schedule the job. If date expired,
+ * resume automatically for the site, and update the "status" node.
+ * @param {MongoQueueProcessor} qp - queue processor instance
+ * @param {Object} data - zookeeper state json data
+ * @param {node-zookeeper-client.Client} zkClient - zookeeper client
+ * @param {String} site - name of location site
+ * @param {Function} cb - callback(error, updatedState) where updatedState is
+ *   an optional, set as true if the schedule resume date has expired
+ * @return {undefined}
+ */
+function checkAndApplyScheduleResume(qp, data, zkClient, site, cb) {
+    const scheduleDate = new Date(data[RESUME_NODE]);
+    const hasExpired = new Date() >= scheduleDate;
+    if (hasExpired) {
+        // if date expired, resume automatically for the site.
+        // remove schedule resume data in zookeeper
+        const path = `${getStateZkPath()}/${site}`;
+        const d = JSON.stringify({ paused: false });
+        return zkClient.setData(path, Buffer.from(d), err => {
+            if (err) {
+                log.fatal('could not set zookeeper status node', {
+                    method: 'MongoProcessor:task',
+                    zookeeperPath: path,
+                    error: err.message,
+                });
+                return cb(err);
+            }
+            return cb(null, { paused: false });
+        });
+    }
+    qp.scheduleResume(scheduleDate);
+    return cb(null, { paused: true });
+}
+
+/**
+ * On startup and when replication sites change, create necessary zookeeper
+ * status node to save persistent state.
+ * @param {QueueProcessor} qp - mongo queue processor instance
+ * @param {node-zookeeper-client.Client} zkClient - zookeeper client
+ * @param {String} site - replication site name
+ * @param {Function} done - callback(error, status) where status is a boolean
+ * @return {undefined}
+ */
+function setupZkSiteNode(qp, zkClient, site, done) {
+    const path = `${getStateZkPath()}/${site}`;
+    const data = JSON.stringify({ paused: { processor: false } });
+    zkClient.create(path, Buffer.from(data), err => {
+        if (err && err.name === 'NODE_EXISTS') {
+            return zkClient.getData(path, (err, data) => {
+                if (err) {
+                    log.fatal('could not check site status in zookeeper',
+                        { method: 'MongoProcessor:task',
+                          zookeeperPath: path,
+                          error: err.message });
+                    return done(err);
+                }
+                let d;
+                try {
+                    d = JSON.parse(data.toString());
+                } catch (e) {
+                    log.fatal('error setting state for queue processor', {
+                        method: 'MongoProcessor:task',
+                        site,
+                        error: reshapeExceptionError(e),
+                    });
+                    return done(e);
+                }
+                if (d[RESUME_NODE]) {
+                    return checkAndApplyScheduleResume(qp, d, zkClient,
+                        site, done);
+                }
+                return done(null, d);
+            });
+        }
+        if (err) {
+            log.fatal('could not setup zookeeper node', {
+                method: 'MongoProcessor:task',
+                zookeeperPath: path,
+                error: err.message,
+            });
+            return done(err);
+        }
+        return done(null, { paused: false });
+    });
+}
+
+function updateProcessors(zkClient, bootstrapList) {
     const active = Object.keys(activeProcessors);
     const update = bootstrapList.map(i => i.site);
     const allSites = [...new Set(active.concat(update))];
 
-    allSites.forEach(site => {
+    async.each(allSites, (site, next) => {
         if (!update.includes(site)) {
             // remove processor, site is no longer active
-            activeProcessors[site].stop(() => {});
-            delete activeProcessors[site];
+            activeProcessors[site].removeZkState(err => {
+                if (err) {
+                    return next(err);
+                }
+                activeProcessors[site].stop(() => {});
+                delete activeProcessors[site];
+                return next();
+            });
         } else if (!active.includes(site)) {
             // add new processor, site is new and requires setup
-            const mqp = new MongoQueueProcessor(kafkaConfig, s3Config,
-                mongoProcessorConfig, mongoClientConfig,
-                ingestionServiceAuth, site);
-            mqp.start();
+            const mqp = new MongoQueueProcessor(zkClient, kafkaConfig, s3Config,
+                mongoProcessorConfig, mongoClientConfig, ingestionServiceAuth,
+                redisConfig, site);
             activeProcessors[site] = mqp;
+            setupZkSiteNode(mqp, zkClient, site, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                mqp.start({ paused: data.paused });
+                return next();
+            });
         }
         // else, existing site and has already been setup
+    }, err => {
+        if (err) {
+            process.exit(1);
+        }
     });
 }
 
-function loadProcessors() {
+function loadProcessors(zkClient) {
     let bootstrapList = config.getBootstrapList();
     config.on('bootstrap-list-update', () => {
         bootstrapList = config.getBootstrapList();
 
-        updateProcessors(bootstrapList);
+        updateProcessors(zkClient, bootstrapList);
     });
 
     // Start Processors for each site
     const siteNames = bootstrapList.map(i => i.site);
-    siteNames.forEach(site => {
-        const mqp = new MongoQueueProcessor(kafkaConfig, s3Config,
-            mongoProcessorConfig, mongoClientConfig,
-            ingestionServiceAuth, site);
-        mqp.start();
+    async.each(siteNames, (site, next) => {
+        const mqp = new MongoQueueProcessor(zkClient, kafkaConfig, s3Config,
+            mongoProcessorConfig, mongoClientConfig, ingestionServiceAuth,
+            redisConfig, site);
         activeProcessors[site] = mqp;
+        return setupZkSiteNode(mqp, zkClient, site, (err, data) => {
+            if (err) {
+                return next(err);
+            }
+            mqp.start({ paused: data.paused });
+            return next();
+        });
+    }, err => {
+        if (err) {
+            process.exit(1);
+        }
     });
 }
 
@@ -82,21 +212,47 @@ function loadHealthcheck() {
     healthServer.start();
 }
 
-function loadManagementDatabase() {
+function loadManagementDatabase(zkClient) {
     initManagement({
         serviceName: 'md-ingestion',
         serviceAccount: ingestionServiceAuth.account,
     }, error => {
         if (error) {
             log.error('could not load management db', { error });
-            setTimeout(loadManagementDatabase, 5000);
+            setTimeout(() => {
+                loadManagementDatabase(zkClient);
+            }, 5000);
             return;
         }
         log.info('management init done');
 
-        loadProcessors();
+        loadProcessors(zkClient);
         loadHealthcheck();
     });
 }
 
-loadManagementDatabase();
+const zkClient = zookeeper.createClient(connectionString, {
+    autoCreateNamespace,
+});
+zkClient.connect();
+zkClient.once('error', err => {
+    log.fatal('error connecting to zookeeper', {
+        error: err.message,
+    });
+    process.exit(1);
+});
+zkClient.once('ready', () => {
+    zkClient.removeAllListeners('error');
+    const path = getStateZkPath();
+    zkClient.mkdirp(path, err => {
+        if (err) {
+            log.fatal('could not create path in zookeeper', {
+                method: 'MongoProcessor:task',
+                zookeeperPath: path,
+                error: err.message,
+            });
+            process.exit(1);
+        }
+        return loadManagementDatabase(zkClient);
+    });
+});

--- a/extensions/replication/constants.js
+++ b/extensions/replication/constants.js
@@ -3,12 +3,10 @@
 const testIsOn = process.env.CI === 'true';
 
 const constants = {
-    zookeeperReplicationNamespace:
+    zookeeperNamespace:
         testIsOn ? '/backbeattest/replication' : '/backbeat/replication',
-    zookeeperIngestionNamespace:
-        testIsOn ? '/backbeattest/ingestion' : '/backbeat/ingestion',
     zkStatePath: '/state',
-    zkCRRStateProperties: ['paused', 'scheduledResume'],
+    zkStateProperties: ['paused', 'scheduledResume'],
     proxyVaultPath: '/_/backbeat/vault',
     proxyIAMPath: '/_/backbeat/iam',
     metricsExtension: 'crr',

--- a/extensions/replication/constants.js
+++ b/extensions/replication/constants.js
@@ -6,7 +6,6 @@ const constants = {
     zookeeperNamespace:
         testIsOn ? '/backbeattest/replication' : '/backbeat/replication',
     zkStatePath: '/state',
-    zkStateProperties: ['paused', 'scheduledResume'],
     proxyVaultPath: '/_/backbeat/vault',
     proxyIAMPath: '/_/backbeat/iam',
     metricsExtension: 'crr',

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -28,9 +28,9 @@ const BucketQueueEntry = require('../../../lib/models/BucketQueueEntry');
 const MetricsProducer = require('../../../lib/MetricsProducer');
 
 const {
-    zookeeperReplicationNamespace,
+    zookeeperNamespace,
     zkStatePath,
-    zkCRRStateProperties,
+    zkStateProperties,
     proxyVaultPath,
     proxyIAMPath,
     replicationBackends,
@@ -406,7 +406,7 @@ class QueueProcessor extends EventEmitter {
     }
 
     _getZkSiteNode() {
-        return `${zookeeperReplicationNamespace}${zkStatePath}/` +
+        return `${zookeeperNamespace}${zkStatePath}/` +
             `${this.site}`;
     }
 
@@ -418,7 +418,7 @@ class QueueProcessor extends EventEmitter {
      * @return {undefined}
      */
     _updateZkStateNode(key, value, cb) {
-        if (!zkCRRStateProperties.includes(key)) {
+        if (!zkStateProperties.includes(key)) {
             const errorMsg = 'incorrect zookeeper state property given';
             this.logger.error(errorMsg, {
                 method: 'QueueProcessor._updateZkStateNode',

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -10,7 +10,7 @@ const { applyBucketReplicationWorkflows } = require('../management');
 const { HealthProbeServer } = require('arsenal').network.probe;
 const { reshapeExceptionError } = require('arsenal').errorUtils;
 const zookeeper = require('../../../lib/clients/zookeeper');
-const { zookeeperReplicationNamespace, zkStatePath } =
+const { zookeeperNamespace, zkStatePath } =
     require('../constants');
 
 const zkConfig = config.zookeeper;
@@ -39,7 +39,7 @@ const healthServer = new HealthProbeServer({
 const activeQProcessors = {};
 
 function getCRRStateZkPath() {
-    return `${zookeeperReplicationNamespace}${zkStatePath}`;
+    return `${zookeeperNamespace}${zkStatePath}`;
 }
 
 /**

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -23,10 +23,14 @@ const monitoringClient = require('../clients/monitoringHandler').client;
 
 const {
     redisKeys,
-    zookeeperReplicationNamespace,
-    zookeeperIngestionNamespace,
-    zkStatePath,
+    zookeeperNamespace: zookeeperReplicationNamespace,
+    zkStatePath: zkReplicationStatePath,
 } = require('../../extensions/replication/constants');
+
+const {
+    zookeeperNamespace: zookeeperIngestionNamespace,
+    zkStatePath: zkIngestionStatePath,
+} = require('../../extensions/ingestion/constants');
 
 // StatsClient constant defaults
 // TODO: This should be moved to constants file
@@ -1164,6 +1168,8 @@ class BackbeatAPI {
         async.each(sites, (site, next) => {
             const zkNamespace = service === 'crr' ?
                 zookeeperReplicationNamespace : zookeeperIngestionNamespace;
+            const zkStatePath = service === 'crr' ?
+                zkReplicationStatePath : zkIngestionStatePath;
             const path = `${zkNamespace}${zkStatePath}/${site}`;
             this._zkClient.getData(path, (err, data) => {
                 if (err) {

--- a/lib/util/pauseResumeHelpers/ProcessorMixin.js
+++ b/lib/util/pauseResumeHelpers/ProcessorMixin.js
@@ -1,0 +1,291 @@
+'use strict'; // eslint-disable-line
+
+const async = require('async');
+const schedule = require('node-schedule');
+
+const { errors } = require('arsenal');
+
+const validStateProperties = ['paused', 'scheduledResume'];
+const serviceMap = {
+    QueueProcessor: 'replication',
+    MongoQueueProcessor: 'ingestion',
+};
+
+/*
+    To use this mixin, must setup Redis on parent class, and
+    must add following required methods on parent class:
+    - getPauseResumeVars
+            return { logger, site, zkClient, consumer }
+    - _getZkSiteNode
+            return `${zkNamespace}/${zkStatePath}/${site}`
+*/
+
+// Mixin for Processor-side pause/resume utilities
+const PauseResumeProcessorMixin = {
+    /* Helper Methods */
+
+    _getServiceName() {
+        const { logger } = this.getPauseResumeVars();
+        const name = serviceMap[this.constructor.name];
+        if (!name) {
+            // for development purpose
+            logger.fatal('pause/resume unavailable for this service', {
+                method: `${this.constructor.name}._getServiceName`,
+                origin: 'lib/util/pauseResumeHelpers/PauseResumeProcessorMixin',
+            });
+            throw errors.InternalError.customizeDescription(
+                'pause/resume unavailable for this service');
+        }
+        return name;
+    },
+
+    _handlePauseResumeRequest(redisClient, message) {
+        const { logger, site } = this.getPauseResumeVars();
+        const validActions = {
+            pauseService: this._pauseService.bind(this),
+            resumeService: this._resumeService.bind(this),
+            deleteScheduledResumeService:
+                this._deleteScheduledResumeService.bind(this),
+        };
+        try {
+            const { action, date } = JSON.parse(message);
+            const cmd = validActions[action];
+            if (typeof cmd === 'function') {
+                cmd(date);
+            }
+        } catch (e) {
+            logger.error('error parsing redis subscribe message', {
+                method: `${this.constructor.name}._setupRedis`,
+                error: e,
+                service: this._getServiceName(),
+                site,
+            });
+        }
+    },
+
+    /**
+     * Update zookeeper state node for this site-defined Processor
+     * @param {String} key - key name to store in zk state node
+     * @param {String|Boolean} value - value
+     * @param {Function} cb - callback(error)
+     * @return {undefined}
+     */
+    _updateZkStateNode(key, value, cb) {
+        const { logger, zkClient } = this.getPauseResumeVars();
+        if (!validStateProperties.includes(key)) {
+            // for development purpose
+            logger.fatal('incorrect zookeeper state property given', {
+                method: `${this.constructor.name}._updateZkStateNode`,
+                origin: 'lib/util/pauseResumeHelpers/PauseResumeProcessorMixin',
+            });
+            throw errors.InternalError.customizeDescription(
+                'incorrect zookeeper state property given');
+        }
+        const path = this._getZkSiteNode();
+        return async.waterfall([
+            next => zkClient.getData(path, (err, data) => {
+                if (err) {
+                    logger.error('could not get state from zookeeper', {
+                        method: `${this.constructor.name}._updateZkStateNode`,
+                        zookeeperPath: path,
+                        error: err.message,
+                    });
+                    return next(err);
+                }
+                let bufferedData;
+                try {
+                    const state = JSON.parse(data.toString());
+                    // set revised status
+                    state[key] = value;
+                    bufferedData = Buffer.from(JSON.stringify(state));
+                } catch (err) {
+                    logger.error('could not parse state data from zookeeper', {
+                        method: `${this.constructor.name}._updateZkStateNode`,
+                        zookeeperPath: path,
+                        error: err,
+                    });
+                    return next(err);
+                }
+                return next(null, bufferedData);
+            }),
+            (data, next) => zkClient.setData(path, data, err => {
+                if (err) {
+                    logger.error('could not save state data in zookeeper', {
+                        method: `${this.constructor.name}._updateZkStateNode`,
+                        zookeeperPath: path,
+                        error: err,
+                    });
+                    return next(err);
+                }
+                return next();
+            }),
+        ], cb);
+    },
+
+    _scheduleResume(date) {
+        const { logger, site } = this.getPauseResumeVars();
+        function triggerResume() {
+            this._updateZkStateNode('scheduledResume', null, err => {
+                if (err) {
+                    logger.trace('error occurred for resuming a scheduled ' +
+                    'resume. Retry again in 1 minute', {
+                        method: `${this.constructor.name}._scheduleResume`,
+                        service: this._getServiceName(),
+                        site,
+                    });
+                    // if an error occurs, need to retry
+                    // for now, schedule 1 minute from now
+                    const date = new Date();
+                    date.setMinutes(date.getMinutes() + 1);
+                    this.scheduledResume = schedule.scheduleJob(date,
+                        triggerResume.bind(this));
+                } else {
+                    if (this.scheduledResume) {
+                        this.scheduledResume.cancel();
+                    }
+                    this.scheduledResume = null;
+                    this._resumeService();
+                }
+            });
+        }
+
+        this._updateZkStateNode('scheduledResume', date, err => {
+            if (err) {
+                logger.trace('error occurred saving state to zookeeper', {
+                    method: `${this.constructor.name}._scheduleResume`,
+                    service: this._getServiceName(),
+                    site,
+                });
+            } else {
+                this.scheduledResume = schedule.scheduleJob(date,
+                    triggerResume.bind(this));
+                logger.info('scheduled resume for service', {
+                    scheduledTime: date.toString(),
+                    service: this._getServiceName(),
+                    site,
+                });
+            }
+        });
+    },
+
+    /* Main Methods
+
+    /**
+     * Cleanup zookeeper node if the site has been removed as a location
+     * @param {function} cb - callback(error)
+     * @return {undefined}
+     */
+    removeZkState(cb) {
+        const { logger, site, zkClient } = this.getPauseResumeVars();
+        const path = this._getZkSiteNode();
+        zkClient.remove(path, err => {
+            if (err && err.name !== 'NO_NODE') {
+                logger.error('failed to remove zookeeper state node', {
+                    method: `${this.constructor.name}.removeZkState`,
+                    zookeeperPath: path,
+                    site,
+                    error: err,
+                });
+                return cb(err);
+            }
+            return cb();
+        });
+    },
+
+    /**
+     * Pause consumer(s)
+     * @return {undefined}
+     */
+    _pauseService() {
+        const { consumer, logger, site } = this.getPauseResumeVars();
+        const enabled = consumer.getServiceStatus();
+        if (enabled) {
+            // if currently resumed/active, attempt to pause
+            this._updateZkStateNode('paused', true, err => {
+                if (err) {
+                    logger.trace('error occurred saving state to zookeeper', {
+                        method: `${this.constructor.name}._pauseService`,
+                        service: this._getServiceName(),
+                        site,
+                    });
+                } else {
+                    consumer.pause(site);
+                    logger.info('paused service processor', {
+                        service: this._getServiceName(),
+                        site,
+                    });
+                    this._deleteScheduledResumeService();
+                }
+            });
+        }
+    },
+
+    /**
+     * Resume consumer(s)
+     * @param {Date} [date] - optional date object for scheduling resume
+     * @return {undefined}
+     */
+    _resumeService(date) {
+        const { consumer, logger, site } = this.getPauseResumeVars();
+        const enabled = consumer.getServiceStatus();
+        const now = new Date();
+
+        if (enabled) {
+            logger.info('cannot resume, service site is not paused', {
+                service: this._getServiceName(),
+                site,
+            });
+            return;
+        }
+
+        if (date && now < new Date(date)) {
+            // if date is in the future, attempt to schedule job
+            this._scheduleResume(date);
+        } else {
+            this._updateZkStateNode('paused', false, err => {
+                if (err) {
+                    logger.trace('error occurred saving state to zookeeper', {
+                        method: `${this.constructor.name}._resumeService`,
+                        service: this._getServiceName(),
+                        site,
+                    });
+                } else {
+                    consumer.resume(site);
+                    logger.info('resumed service processor', {
+                        service: this._getServiceName(),
+                        site,
+                    });
+                    this._deleteScheduledResumeService();
+                }
+            });
+        }
+    },
+
+    /**
+     * Delete scheduled resume (if any)
+     * @return {undefined}
+     */
+    _deleteScheduledResumeService() {
+        const { logger, site } = this.getPauseResumeVars();
+        this._updateZkStateNode('scheduledResume', null, err => {
+            if (err) {
+                logger.trace('error occurred saving state to zookeeper', {
+                    method:
+                    `${this.constructor.name}._deleteScheduledResumeService`,
+                    service: this._getServiceName(),
+                    site,
+                });
+            }
+            if (this.scheduledResume) {
+                this.scheduledResume.cancel();
+                logger.info('deleted scheduled resume', {
+                    service: this._getServiceName(),
+                    site,
+                });
+            }
+            this.scheduledResume = null;
+        });
+    },
+};
+
+module.exports = PauseResumeProcessorMixin;

--- a/tests/config.json
+++ b/tests/config.json
@@ -31,8 +31,8 @@
     "extensions": {
         "ingestion": {
             "auth": {
-                "type": "service",
-                "account": "md-ingestion"
+                "type": "account",
+                "account": "bart"
             },
             "topic": "backbeat-test-ingestion",
             "zookeeperPath": "/ingestion",
@@ -50,6 +50,10 @@
                     "https": false
                 }
             ]
+        },
+        "mongoProcessor": {
+            "topic": "backbeat-test-ingestion",
+            "groupId": "backbeat-mongo-processor-test-group"
         },
         "replication": {
             "topic": "backbeat-test-replication",

--- a/tests/functional/api/routes.js
+++ b/tests/functional/api/routes.js
@@ -7,7 +7,15 @@ const zookeeper = require('node-zookeeper-client');
 const { RedisClient } = require('arsenal').metrics;
 const { StatsModel } = require('arsenal').metrics;
 
-const constants = require('../../../extensions/replication/constants');
+const {
+    zookeeperNamespace: zookeeperReplicationNamespace,
+    zkStatePath: zkReplicationStatePath,
+} = require('../../../extensions/replication/constants');
+const {
+    zookeeperNamespace: zookeeperIngestionNamespace,
+    zkStatePath: zkIngestionStatePath,
+} = require('../../../extensions/ingestion/constants');
+
 const config = require('../../config.json');
 const { makeRequest, getRequest, getResponseBody } =
     require('../utils/httpHelpers');
@@ -20,9 +28,9 @@ const redisConfig = {
     port: config.redis.port,
 };
 const ZK_TEST_CRR_STATE_PATH =
-    `${constants.zookeeperReplicationNamespace}${constants.zkStatePath}`;
+    `${zookeeperReplicationNamespace}${zkReplicationStatePath}`;
 const ZK_TEST_INGESTION_STATE_PATH =
-    `${constants.zookeeperIngestionNamespace}${constants.zkStatePath}`;
+    `${zookeeperIngestionNamespace}${zkIngestionStatePath}`;
 const EPHEMERAL_NODE = 1;
 
 const defaultOptions = {

--- a/tests/functional/ingestion/pauseResumeState.js
+++ b/tests/functional/ingestion/pauseResumeState.js
@@ -1,0 +1,562 @@
+const assert = require('assert');
+const async = require('async');
+const Redis = require('ioredis');
+const schedule = require('node-schedule');
+const zookeeper = require('node-zookeeper-client');
+
+const MongoQueueProcessor =
+    require('../../../extensions/mongoProcessor/MongoQueueProcessor');
+const TimeMachine = require('../utils/timeMachine');
+
+// Configs
+const config = require('../../config.json');
+const constants = require('../../../extensions/ingestion/constants');
+const redisConfig = {
+    host: config.redis.host,
+    port: config.redis.port,
+};
+const kafkaConfig = config.kafka;
+const s3Config = config.s3;
+const mongoProcessorConfig = config.extensions.mongoProcessor;
+const mongoClientConfig = config.queuePopulator.mongo;
+const topic = mongoProcessorConfig.topic;
+const serviceAuth = config.extensions.ingestion.auth;
+
+// Constants
+const ZK_TEST_INGESTION_STATE_PATH =
+    `${constants.zookeeperNamespace}/state`;
+const EPHEMERAL_NODE = 1;
+
+// Future Date to be used in tests
+const futureDate = new Date();
+futureDate.setHours(futureDate.getHours() + 5);
+
+// to mock out mongo client
+class MockMongoClient {
+    setup(cb) {
+        return cb();
+    }
+}
+
+class ZKStateHelper {
+    constructor(zkConfig, firstSite, secondSite) {
+        this.zkConfig = zkConfig;
+        this.zkClient = null;
+
+        this.firstPath = `${ZK_TEST_INGESTION_STATE_PATH}/${firstSite}`;
+        this.secondPath = `${ZK_TEST_INGESTION_STATE_PATH}/${secondSite}`;
+    }
+
+    getClient() {
+        return this.zkClient;
+    }
+
+    get(site, cb) {
+        const path = `${ZK_TEST_INGESTION_STATE_PATH}/${site}`;
+        this.zkClient.getData(path, (err, data) => {
+            if (err) {
+                process.stdout.write('Zookeeper test helper error in ' +
+                'ZKStateHelper.get at zkClient.getData');
+                return cb(err);
+            }
+            let state;
+            try {
+                state = JSON.parse(data.toString());
+            } catch (parseErr) {
+                process.stdout.write('Zookeeper test helper error in ' +
+                'ZKStateHelper.get at JSON.parse');
+                return cb(parseErr);
+            }
+            return cb(null, state);
+        });
+    }
+
+    set(site, state, cb) {
+        const data = Buffer.from(state);
+        const path = `${ZK_TEST_INGESTION_STATE_PATH}/${site}`;
+        this.zkClient.setData(path, data, cb);
+    }
+
+    /**
+     * Setup initial zookeeper state for pause/resume tests. After each test,
+     * state should be reset to this initial state.
+     * State is setup as such:
+     *   - firstSite: { paused: false }
+     *   - secondSite: { paused: true, scheduledResume: futureDate }
+     * Where futureDate is defined at the top of this test file.
+     * @param {function} cb - callback(err)
+     * @return {undefined}
+     */
+    init(cb) {
+        const { connectionString } = config.zookeeper;
+        this.zkClient = zookeeper.createClient(connectionString);
+        this.zkClient.connect();
+        this.zkClient.once('connected', () => {
+            async.series([
+                next => this.zkClient.mkdirp(ZK_TEST_INGESTION_STATE_PATH,
+                    err => {
+                        if (err && err.name !== 'NODE_EXISTS') {
+                            return next(err);
+                        }
+                        return next();
+                    }),
+                next => {
+                    // emulate first site to be active (not paused)
+                    const data =
+                        Buffer.from(JSON.stringify({ paused: false }));
+                    this.zkClient.create(this.firstPath, data, EPHEMERAL_NODE,
+                        next);
+                },
+                next => {
+                    // emulate second site to be paused
+                    const data = Buffer.from(JSON.stringify({
+                        paused: true,
+                        scheduledResume: futureDate.toString(),
+                    }));
+                    this.zkClient.create(this.secondPath, data, EPHEMERAL_NODE,
+                        next);
+                },
+            ], err => {
+                if (err) {
+                    process.stdout.write('Zookeeper test helper error in ' +
+                    'ZKStateHelper.init');
+                    return cb(err);
+                }
+                return cb();
+            });
+        });
+    }
+
+    reset(cb) {
+        // reset state, just overwrite regardless of current state
+        async.parallel([
+            next => {
+                const data = Buffer.from(JSON.stringify({
+                    paused: false,
+                    scheduledResume: null,
+                }));
+                this.zkClient.setData(this.firstPath, data, next);
+            },
+            next => {
+                const data = Buffer.from(JSON.stringify({
+                    paused: true,
+                    scheduledResume: futureDate.toString(),
+                }));
+                this.zkClient.setData(this.secondPath, data, next);
+            },
+        ], err => {
+            if (err) {
+                process.stdout.write('Zookeeper test helper error in ' +
+                'ZKStateHelper.reset');
+                return cb(err);
+            }
+            return cb();
+        });
+    }
+
+    close() {
+        if (this.zkClient) {
+            this.zkClient.close();
+            this.zkClient = null;
+        }
+    }
+}
+
+class MockAPI {
+    constructor() {
+        this.publisher = new Redis();
+    }
+
+    _sendRequest(site, msg) {
+        const channel = `${topic}-${site}`;
+        this.publisher.publish(channel, msg);
+    }
+
+    /**
+     * mock a delete schedule resume call
+     * @param {string} site - site name
+     * @return {undefined}
+     */
+    deleteScheduledResumeService(site) {
+        const message = JSON.stringify({
+            action: 'deleteScheduledResumeService',
+        });
+        this._sendRequest(site, message);
+    }
+
+    /**
+     * mock a resume api call
+     * @param {string} site - site name
+     * @param {Date} [date] - optional date object
+     * @return {undefined}
+     */
+    resumeService(site, date) {
+        const message = {
+            action: 'resumeService',
+        };
+        if (date) {
+            message.date = date;
+        }
+        this._sendRequest(site, JSON.stringify(message));
+    }
+
+    /**
+     * mock a pause api call
+     * @param {string} site - site name
+     * @return {undefined}
+     */
+    pauseService(site) {
+        const message = JSON.stringify({
+            action: 'pauseService',
+        });
+        this._sendRequest(site, message);
+    }
+}
+
+function isConsumerActive(consumer) {
+    return consumer.getServiceStatus();
+}
+
+describe('Ingestion Pause/Resume status updates', function d() {
+    this.timeout(10000);
+    let zkHelper;
+    let mockAPI;
+    let qpSite1;
+    let qpSite2;
+    let consumer1;
+    let consumer2;
+
+    const ingestionSourcesConfig = config.extensions.ingestion.sources;
+    const firstSite = ingestionSourcesConfig[0].name;
+    const secondSite = ingestionSourcesConfig[1].name;
+
+    before(done => {
+        mockAPI = new MockAPI();
+        zkHelper = new ZKStateHelper(config.zookeeper, firstSite,
+            secondSite);
+        zkHelper.init(err => {
+            if (err) {
+                return done(err);
+            }
+            const zkClient = zkHelper.getClient();
+
+            // qpSite1 (first site) is not paused
+            qpSite1 = new MongoQueueProcessor(zkClient, kafkaConfig, s3Config,
+                mongoProcessorConfig, mongoClientConfig, serviceAuth,
+                redisConfig, firstSite);
+            qpSite1._mongoClient = new MockMongoClient();
+            qpSite1.start();
+
+            // qpSite2 (second site) is paused and has a scheduled resume
+            qpSite2 = new MongoQueueProcessor(zkClient, kafkaConfig, s3Config,
+                mongoProcessorConfig, mongoClientConfig, serviceAuth,
+                redisConfig, secondSite);
+            qpSite2._mongoClient = new MockMongoClient();
+            qpSite2.start({ paused: true });
+            qpSite2._scheduleResume(futureDate);
+
+            // wait for clients/jobs to set
+            return async.whilst(() => (
+                !consumer1 && !consumer2 && !qpSite2.scheduledResume
+            ), cb => setTimeout(() => {
+                consumer1 = qpSite1._consumer;
+                consumer2 = qpSite2._consumer;
+                return cb();
+            }, 1000), done);
+        });
+    });
+
+    afterEach(done => {
+        consumer1.resume();
+        consumer2.pause();
+        async.whilst(() => qpSite1.scheduledResume !== null ||
+            !qpSite2.scheduledResume,
+        cb => setTimeout(() => {
+            qpSite1._deleteScheduledResumeService();
+            qpSite2._scheduleResume(futureDate);
+            cb();
+        }, 1000), err => {
+            assert.ifError(err);
+            zkHelper.reset(done);
+        });
+    });
+
+    after(() => {
+        zkHelper.close();
+    });
+
+    it('should pause an active location', done => {
+        let zkPauseState;
+        // send fake api request
+        mockAPI.pauseService(firstSite);
+
+        return async.doWhilst(cb => setTimeout(() => {
+            zkHelper.get(firstSite, (err, data) => {
+                if (err) {
+                    return cb(err);
+                }
+                zkPauseState = data.paused;
+                return cb();
+            });
+        }, 1000), () => isConsumerActive(consumer1),
+        err => {
+            assert.ifError(err);
+            // is zookeeper state shown as paused?
+            assert.strictEqual(zkPauseState, true);
+            // is the consumer currently subscribed to any topics?
+            assert.strictEqual(isConsumerActive(consumer1), false);
+            return done();
+        });
+    });
+
+    it('should not change state if pausing an already paused location',
+    done => {
+        let zkPauseState;
+        let zkScheduleState;
+        // double-check initial state
+        assert.strictEqual(isConsumerActive(consumer2), false);
+        // send fake api request
+        mockAPI.pauseService(secondSite);
+
+        return async.doWhilst(cb => setTimeout(() => {
+            zkHelper.get(secondSite, (err, data) => {
+                if (err) {
+                    return cb(err);
+                }
+                zkPauseState = data.paused;
+                zkScheduleState = data.scheduledResume;
+                return cb();
+            });
+        }, 1000), () => isConsumerActive(consumer2),
+        err => {
+            assert.ifError(err);
+            assert.strictEqual(zkPauseState, true);
+            assert.strictEqual(isConsumerActive(consumer2), false);
+            assert.strictEqual(new Date(zkScheduleState).toString(),
+                futureDate.toString());
+            return done();
+        });
+    });
+
+    it('should resume a paused location', done => {
+        let zkPauseState;
+        // send fake api request
+        mockAPI.resumeService(secondSite);
+
+        return async.doWhilst(cb => setTimeout(() => {
+            zkHelper.get(secondSite, (err, data) => {
+                if (err) {
+                    return cb(err);
+                }
+                zkPauseState = data.paused;
+                return cb();
+            });
+        }, 1000), () => !isConsumerActive(consumer2),
+        err => {
+            assert.ifError(err);
+            assert.strictEqual(zkPauseState, false);
+            assert.strictEqual(isConsumerActive(consumer2), true);
+            return done();
+        });
+    });
+
+    it('should not change state if resuming an already active location',
+    done => {
+        let zkPauseState;
+        // double-check initial state
+        assert.strictEqual(isConsumerActive(consumer1), true);
+        // send fake api request
+        mockAPI.resumeService(firstSite);
+        return async.doWhilst(cb => setTimeout(() => {
+            zkHelper.get(firstSite, (err, data) => {
+                if (err) {
+                    return cb(err);
+                }
+                zkPauseState = data.paused;
+                return cb();
+            });
+        }, 1000), () => isConsumerActive(consumer1) !== true,
+        err => {
+            assert.ifError(err);
+            assert.strictEqual(zkPauseState, false);
+            assert.strictEqual(isConsumerActive(consumer1), true);
+            return done();
+        });
+    });
+
+    it('should cancel a scheduled resume for a given location', done => {
+        let zkScheduleState;
+        // send fake api request
+        mockAPI.deleteScheduledResumeService(secondSite);
+
+        return async.doWhilst(cb => setTimeout(() => {
+            zkHelper.get(secondSite, (err, data) => {
+                if (err) {
+                    return cb(err);
+                }
+                zkScheduleState = data.scheduledResume;
+                return cb();
+            });
+        }, 1000), () => zkScheduleState !== null,
+        err => {
+            assert.ifError(err);
+            assert.strictEqual(zkScheduleState, null);
+            return done();
+        });
+    });
+
+    it('should schedule a resume', done => {
+        let zkPauseState;
+        let zkScheduleState;
+        // since re-using firstSite, pause it first for this test
+        const pauseState = JSON.stringify({ paused: true });
+        zkHelper.set(firstSite, pauseState, err => {
+            assert.ifError(err);
+            consumer1.pause();
+            // send fake api request
+            mockAPI.resumeService(firstSite, futureDate);
+
+            return async.doWhilst(cb => setTimeout(() => {
+                zkHelper.get(firstSite, (err, data) => {
+                    if (err) {
+                        return cb(err);
+                    }
+                    zkPauseState = data.paused;
+                    zkScheduleState = data.scheduledResume;
+                    return cb();
+                });
+            }, 1000), () => {
+                if (zkScheduleState) {
+                    const zkStateDate = new Date(zkScheduleState);
+                    return zkStateDate.getTime() !== futureDate.getTime();
+                }
+                return true;
+            }, err => {
+                assert.ifError(err);
+                assert.strictEqual(zkPauseState, true);
+                assert.strictEqual(new Date(zkScheduleState).toString(),
+                    futureDate.toString());
+                done();
+            });
+        });
+    });
+
+    [
+        // new schedule time is less than current scheduled time
+        {
+            testCase: 'less than',
+            timeChange: -1,
+        },
+        // new schedule time is greater than current scheduled time
+        {
+            testCase: 'greater than',
+            timeChange: 1,
+        },
+    ].forEach(item => {
+        it('should overwrite an existing scheduled resume on new valid ' +
+        `request where new time is ${item.testCase} current scheduled time`,
+        done => {
+            let zkScheduleState;
+            const newScheduledDate = new Date(futureDate);
+            newScheduledDate.setHours(newScheduledDate.getHours() +
+                item.timeChange);
+            // send fake api request
+            mockAPI.resumeService(secondSite, newScheduledDate);
+
+            return async.doWhilst(cb => setTimeout(() => {
+                zkHelper.get(secondSite, (err, data) => {
+                    if (err) {
+                        return cb(err);
+                    }
+                    zkScheduleState = data.scheduledResume;
+                    return cb();
+                });
+            }, 1000), () => {
+                if (zkScheduleState) {
+                    const zkStateDate = new Date(zkScheduleState);
+                    return zkStateDate.getTime() !== newScheduledDate.getTime();
+                }
+                return true;
+            }, err => {
+                assert.ifError(err);
+                assert.strictEqual(new Date(zkScheduleState).toString(),
+                    newScheduledDate.toString());
+                done();
+            });
+        });
+    });
+
+    it('should cancel a scheduled resume when the location is manually ' +
+    'resumed', done => {
+        let zkScheduleState;
+        let zkPauseState;
+        // send fake api request
+        mockAPI.resumeService(secondSite);
+
+        return async.doWhilst(cb => setTimeout(() => {
+            zkHelper.get(secondSite, (err, data) => {
+                if (err) {
+                    return cb(err);
+                }
+                zkPauseState = data.paused;
+                zkScheduleState = data.scheduledResume;
+                return cb();
+            });
+        }, 1000), () => isConsumerActive(consumer2) !== true,
+        err => {
+            assert.ifError(err);
+            assert.strictEqual(zkPauseState, false);
+            assert.strictEqual(zkScheduleState, null);
+            done();
+        });
+    });
+
+    it('should not schedule a resume when the location is already active',
+    done => {
+        // send fake api request
+        mockAPI.resumeService(firstSite, futureDate);
+
+        setTimeout(() => {
+            zkHelper.get(firstSite, (err, data) => {
+                assert.ifError(err);
+
+                assert.strictEqual(data.scheduledResume, null);
+                assert.strictEqual(data.paused, false);
+                assert.strictEqual(isConsumerActive(consumer1), true);
+                done();
+            });
+        }, 1000);
+    });
+
+    it('should resume a location when a scheduled resume triggers',
+    done => {
+        let zkPauseState;
+        let zkScheduleState;
+        // move time forward to trigger scheduled resume
+        const timeMachine = new TimeMachine();
+        timeMachine.install();
+        // hack - for some reason, the scheduled job in QueueProcessor does not
+        // trigger unless I schedule a job here.
+        schedule.scheduleJob(new Date(), () => {});
+        timeMachine.moveTimeForward(6);
+
+        return async.doWhilst(cb => setTimeout(() => {
+            zkHelper.get(secondSite, (err, data) => {
+                if (err) {
+                    return cb(err);
+                }
+                zkPauseState = data.paused;
+                zkScheduleState = data.scheduledResume;
+                return cb();
+            });
+        }, 1000), () => isConsumerActive(consumer2) !== true,
+        err => {
+            timeMachine.uninstall();
+            assert.ifError(err);
+            assert.strictEqual(zkPauseState, false);
+            assert.strictEqual(isConsumerActive(consumer2), true);
+            assert.strictEqual(zkScheduleState, null);
+            done();
+        });
+    });
+});

--- a/tests/functional/ingestion/pauseResumeState.js
+++ b/tests/functional/ingestion/pauseResumeState.js
@@ -259,8 +259,8 @@ describe('Ingestion Pause/Resume status updates', function d() {
             return async.whilst(() => (
                 !consumer1 && !consumer2 && !qpSite2.scheduledResume
             ), cb => setTimeout(() => {
-                consumer1 = qpSite1._consumer;
-                consumer2 = qpSite2._consumer;
+                consumer1 = qpSite1.getPauseResumeVars().consumer;
+                consumer2 = qpSite2.getPauseResumeVars().consumer;
                 return cb();
             }, 1000), done);
         });

--- a/tests/functional/replication/pauseResumeState.js
+++ b/tests/functional/replication/pauseResumeState.js
@@ -28,7 +28,7 @@ const mConfig = config.metrics;
 
 // Constants
 const ZK_TEST_CRR_STATE_PATH =
-    `${constants.zookeeperReplicationNamespace}/state`;
+    `${constants.zookeeperNamespace}/state`;
 const EPHEMERAL_NODE = 1;
 
 // Future Date to be used in tests

--- a/tests/functional/replication/pauseResumeState.js
+++ b/tests/functional/replication/pauseResumeState.js
@@ -250,8 +250,8 @@ describe('CRR Pause/Resume status updates', function d() {
             return async.whilst(() => (
                 !consumer1 && !consumer2 && !qpSite2.scheduledResume
             ), cb => setTimeout(() => {
-                consumer1 = qpSite1._consumer;
-                consumer2 = qpSite2._consumer;
+                consumer1 = qpSite1.getPauseResumeVars().consumer;
+                consumer2 = qpSite2.getPauseResumeVars().consumer;
                 return cb();
             }, 1000), done);
         });

--- a/tests/functional/replication/pauseResumeState.js
+++ b/tests/functional/replication/pauseResumeState.js
@@ -186,7 +186,7 @@ class MockAPI {
      * @param {Date} [date] - optional date object
      * @return {undefined}
      */
-    resumeCRRService(site, date) {
+    resumeService(site, date) {
         const message = {
             action: 'resumeService',
         };
@@ -201,7 +201,7 @@ class MockAPI {
      * @param {string} site - site name
      * @return {undefined}
      */
-    pauseCRRService(site) {
+    pauseService(site) {
         const message = JSON.stringify({
             action: 'pauseService',
         });
@@ -244,7 +244,7 @@ describe('CRR Pause/Resume status updates', function d() {
                 destConfig, repConfig, redisConfig, mConfig, {}, {},
                 secondSite);
             qpSite2.start({ paused: true });
-            qpSite2.scheduleResume(futureDate);
+            qpSite2._scheduleResume(futureDate);
 
             // wait for clients/jobs to set
             return async.whilst(() => (
@@ -264,7 +264,7 @@ describe('CRR Pause/Resume status updates', function d() {
             !qpSite2.scheduledResume,
         cb => setTimeout(() => {
             qpSite1._deleteScheduledResumeService();
-            qpSite2.scheduleResume(futureDate);
+            qpSite2._scheduleResume(futureDate);
             cb();
         }, 1000), err => {
             assert.ifError(err);
@@ -279,7 +279,7 @@ describe('CRR Pause/Resume status updates', function d() {
     it('should pause an active location', done => {
         let zkPauseState;
         // send fake api request
-        mockAPI.pauseCRRService(firstSite);
+        mockAPI.pauseService(firstSite);
 
         return async.doWhilst(cb => setTimeout(() => {
             zkHelper.get(firstSite, (err, data) => {
@@ -307,7 +307,7 @@ describe('CRR Pause/Resume status updates', function d() {
         // double-check initial state
         assert.strictEqual(isConsumerActive(consumer2), false);
         // send fake api request
-        mockAPI.pauseCRRService(secondSite);
+        mockAPI.pauseService(secondSite);
 
         return async.doWhilst(cb => setTimeout(() => {
             zkHelper.get(secondSite, (err, data) => {
@@ -332,7 +332,7 @@ describe('CRR Pause/Resume status updates', function d() {
     it('should resume a paused location', done => {
         let zkPauseState;
         // send fake api request
-        mockAPI.resumeCRRService(secondSite);
+        mockAPI.resumeService(secondSite);
 
         return async.doWhilst(cb => setTimeout(() => {
             zkHelper.get(secondSite, (err, data) => {
@@ -357,7 +357,7 @@ describe('CRR Pause/Resume status updates', function d() {
         // double-check initial state
         assert.strictEqual(isConsumerActive(consumer1), true);
         // send fake api request
-        mockAPI.resumeCRRService(firstSite);
+        mockAPI.resumeService(firstSite);
         return async.doWhilst(cb => setTimeout(() => {
             zkHelper.get(firstSite, (err, data) => {
                 if (err) {
@@ -405,7 +405,7 @@ describe('CRR Pause/Resume status updates', function d() {
             assert.ifError(err);
             consumer1.pause();
             // send fake api request
-            mockAPI.resumeCRRService(firstSite, futureDate);
+            mockAPI.resumeService(firstSite, futureDate);
 
             return async.doWhilst(cb => setTimeout(() => {
                 zkHelper.get(firstSite, (err, data) => {
@@ -452,7 +452,7 @@ describe('CRR Pause/Resume status updates', function d() {
             newScheduledDate.setHours(newScheduledDate.getHours() +
                 item.timeChange);
             // send fake api request
-            mockAPI.resumeCRRService(secondSite, newScheduledDate);
+            mockAPI.resumeService(secondSite, newScheduledDate);
 
             return async.doWhilst(cb => setTimeout(() => {
                 zkHelper.get(secondSite, (err, data) => {
@@ -482,7 +482,7 @@ describe('CRR Pause/Resume status updates', function d() {
         let zkScheduleState;
         let zkPauseState;
         // send fake api request
-        mockAPI.resumeCRRService(secondSite);
+        mockAPI.resumeService(secondSite);
 
         return async.doWhilst(cb => setTimeout(() => {
             zkHelper.get(secondSite, (err, data) => {
@@ -505,7 +505,7 @@ describe('CRR Pause/Resume status updates', function d() {
     it('should not schedule a resume when the location is already active',
     done => {
         // send fake api request
-        mockAPI.resumeCRRService(firstSite, futureDate);
+        mockAPI.resumeService(firstSite, futureDate);
 
         setTimeout(() => {
             zkHelper.get(firstSite, (err, data) => {


### PR DESCRIPTION
**Purpose of this PR**:
Add pause/resume service for ingestion on processor side

**Changes in this PR**:
- Separate out constants defined between replication and ingestion
- Add pause/resume processor-side for ingestion
- Add functional tests pause/resume ingestion
- Refactor: Move pause/resume processor methods to a mixin that can be shared between replication and ingestion