### PR TITLE
ZENKO-557 GC cloud locations

### DIFF
--- a/extensions/gc/GarbageCollectorProducer.js
+++ b/extensions/gc/GarbageCollectorProducer.js
@@ -50,6 +50,8 @@ class GarbageCollectorProducer {
      * @param {string} dataLocations[].dataStoreName - data location
      *   constraint name
      * @param {number} dataLocations[].size - object size in bytes
+     * @param {string} [dataLocations[].dataStoreVersionId] - version
+     *   ID of location, needed for cloud backends
      * @param {Function} cb - The callback function
      * @return {undefined}
      */
@@ -61,6 +63,7 @@ class GarbageCollectorProducer {
                     key: location.key,
                     dataStoreName: location.dataStoreName,
                     size: location.size,
+                    dataStoreVersionId: location.dataStoreVersionId,
                 })),
             },
         }) }], err => {

--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -913,6 +913,9 @@
                                 },
                                 "size": {
                                     "type": "integer"
+                                },
+                                "dataStoreVersionId": {
+                                    "type": "string"
                                 }
                             }
                         }

--- a/tests/unit/gc/GarbageCollector.spec.js
+++ b/tests/unit/gc/GarbageCollector.spec.js
@@ -65,11 +65,27 @@ describe('garbage collector', () => {
             },
         }, done);
     });
-    it('should send batch delete request with locations array', done => {
+    it('should send batch delete request with locations array with ' +
+    'no dataStoreVersionId', done => {
         expectBatchDeleteLocations = [{
             key: 'foo',
             dataStoreName: 'ds',
             size: 10,
+        }];
+        gcTask.processQueueEntry({
+            action: 'deleteData',
+            target: {
+                locations: expectBatchDeleteLocations,
+            },
+        }, done);
+    });
+    it('should send batch delete request with locations array with ' +
+    'some dataStoreVersionId', done => {
+        expectBatchDeleteLocations = [{
+            key: 'foo',
+            dataStoreName: 'ds',
+            size: 10,
+            dataStoreVersionId: 'someversion',
         }];
         gcTask.processQueueEntry({
             action: 'deleteData',

--- a/tests/unit/gc/GarbageCollectorProducer.spec.js
+++ b/tests/unit/gc/GarbageCollectorProducer.spec.js
@@ -1,0 +1,71 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+
+const GarbageCollectorProducer =
+      require('../../../extensions/gc/GarbageCollectorProducer');
+
+class KafkaProducerMock {
+    constructor() {
+        this._messageExpected = null;
+    }
+
+    setExpectedMessage(message) {
+        this._expectedMessage = message;
+    }
+
+    hasProcessedExpectedMessage() {
+        return this._expectedMessage === null;
+    }
+
+    send(messages, cb) {
+        if (this._expectedMessage) {
+            assert.strictEqual(messages.length, 1);
+            assert.deepStrictEqual(this._expectedMessage,
+                                   JSON.parse(messages[0].message));
+            this._expectedMessage = null;
+        }
+        return process.nextTick(cb);
+    }
+}
+
+describe('garbage collector producer', () => {
+    let gcProducer;
+    const kafkaProducerMock = new KafkaProducerMock();
+
+    before(() => {
+        gcProducer = new GarbageCollectorProducer();
+        gcProducer._producer = kafkaProducerMock;
+    });
+    [{
+        testDesc: 'with no dataStoreVersionId',
+        dataLocations: [{
+            key: 'foo',
+            dataStoreName: 'ds',
+            size: 10,
+        }],
+    }, {
+        testDesc: 'with a dataStoreVersionId',
+        dataLocations: [{
+            key: 'foo',
+            dataStoreName: 'ds',
+            size: 10,
+            dataStoreVersionId: 'someversion',
+        }],
+    }].forEach(testSpec => {
+        it(`should send a valid GC message to kafka ${testSpec.testDesc}`,
+        done => {
+            kafkaProducerMock.setExpectedMessage({
+                action: 'deleteData',
+                target: {
+                    locations: testSpec.dataLocations,
+                },
+            });
+            gcProducer.publishDeleteDataEntry(testSpec.dataLocations, err => {
+                assert.ifError(err);
+                assert(kafkaProducerMock.hasProcessedExpectedMessage());
+                done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Add the required code to pass the dataStoreVersionId field of
locations from the GC producer to the backbeat batchDelete route.