### PR TITLE
bf: ZENKO-1374 do not escalate error provisioning

### DIFF
--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -248,7 +248,9 @@ class IngestionPopulator {
                 this.log.error(
                     'error when receiving log source provision list',
                     { zkEndpoint, error: err });
-                return cb(err);
+                // do not escalate error in order to allow retries.
+                // provisioning log source may take a while
+                return cb();
             }
             const key = bucketd.name;
             this._provisionedIngestionSources[key] = raftIdDispatcher;


### PR DESCRIPTION
Provisioning log source may take a while. Do not escalate
error, but instead allow for retries.
Escalating an error will crash the pod