### PR TITLE
bf: S3C-1886 fix "processing" metrics retention

### DIFF
--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -24,8 +24,6 @@ const BucketQueueEntry = require('../utils/BucketQueueEntry');
 const {
     proxyVaultPath,
     proxyIAMPath,
-    metricsExtension,
-    metricsTypeProcessed,
 } = require('../constants');
 
 class QueueProcessor extends EventEmitter {
@@ -272,6 +270,7 @@ class QueueProcessor extends EventEmitter {
             vaultclientCache: this.vaultclientCache,
             accountCredsCache: this.accountCredsCache,
             replicationStatusProducer: this.replicationStatusProducer,
+            mProducer: this._mProducer,
             site: this.site,
             consumer: this._consumer,
             logger: this.logger,
@@ -317,23 +316,6 @@ class QueueProcessor extends EventEmitter {
                 this.logger.info('queue processor is ready to consume ' +
                                  'replication entries');
                 this.emit('ready');
-            });
-            this._consumer.on('metrics', data => {
-                // i.e. data = { my-site: { ops: 1, bytes: 124 } }
-                const filteredData = Object.keys(data).filter(key =>
-                    key === this.site).reduce((store, k) => {
-                        // eslint-disable-next-line no-param-reassign
-                        store[k] = data[this.site];
-                        return store;
-                    }, {});
-                this._mProducer.publishMetrics(filteredData,
-                    metricsTypeProcessed, metricsExtension, err => {
-                        this.logger.trace('error occurred in publishing ' +
-                            'metrics', {
-                                error: err,
-                                method: 'QueueProcessor.start',
-                            });
-                    });
             });
             return undefined;
         });

--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -12,6 +12,7 @@ const AccountCredentials =
           require('../../../lib/credentials/AccountCredentials');
 const RoleCredentials =
           require('../../../lib/credentials/RoleCredentials');
+const { metricsExtension, metricsTypeProcessed } = require('../constants');
 
 const MPU_CONC_LIMIT = 10;
 
@@ -373,6 +374,13 @@ class ReplicateObject extends BackbeatTask {
                 return doneOnce(err);
             }
             partObj.setDataLocation(data.Location[0]);
+            const extMetrics = {};
+            extMetrics[this.site] = {
+                ops: 1,
+                bytes: partObj.getPartSize(),
+            };
+            this.mProducer.publishMetrics(
+                extMetrics, metricsTypeProcessed, metricsExtension, () => {});
             return doneOnce(null, partObj.getValue());
         });
     }

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -5,14 +5,9 @@ const async = require('async');
 const joi = require('joi');
 
 const BackbeatProducer = require('./BackbeatProducer');
-const ObjectQueueEntry =
-    require('../extensions/replication/utils/ObjectQueueEntry');
 const Logger = require('werelogs').Logger;
 
-const QueueEntry = require('./models/QueueEntry');
 const OffsetLedger = require('./OffsetLedger');
-
-const CRR_TOPIC = require('../conf/Config').extensions.replication.topic;
 
 // controls the number of messages to process in parallel
 const CONCURRENCY_DEFAULT = 1;
@@ -93,8 +88,6 @@ class BackbeatConsumer extends EventEmitter {
         this._consumerReady = false;
         this._bootstrapping = false;
         this._consumedEventTimeout = null;
-        // metrics - consumption
-        this._metricsStore = {};
 
         this._init();
         return this;
@@ -264,31 +257,6 @@ class BackbeatConsumer extends EventEmitter {
                 entry: { topic, partition, offset, key, timestamp },
             });
             this.emit('error', err, entry);
-        } else if (entry.topic === CRR_TOPIC) {
-            const qEntry = QueueEntry.createFromKafkaEntry(entry);
-            if (!qEntry.error && qEntry instanceof ObjectQueueEntry) {
-                const bytes = qEntry.getContentLength();
-
-                const repSites = qEntry.getReplicationInfo().backends;
-                const sites = repSites.reduce((store, entry) => {
-                    if (entry.status === 'PENDING') {
-                        store.push(entry.site);
-                    }
-                    return store;
-                }, []);
-
-                sites.forEach(site => {
-                    if (!this._metricsStore[site]) {
-                        this._metricsStore[site] = {
-                            ops: 1,
-                            bytes,
-                        };
-                    } else {
-                        this._metricsStore[site].ops++;
-                        this._metricsStore[site].bytes += bytes;
-                    }
-                });
-            }
         }
         // use setTimeout to do gathering and emit less events
         if (!this._consumedEventTimeout) {
@@ -296,9 +264,6 @@ class BackbeatConsumer extends EventEmitter {
                 if (this._messagesConsumed > 0) {
                     this.emit('consumed', this._messagesConsumed);
                     this._messagesConsumed = 0;
-
-                    this.emit('metrics', this._metricsStore);
-                    this._metricsStore = {};
                 }
                 this._consumedEventTimeout = null;
             }, 100);


### PR DESCRIPTION
The fix consists of a refactor of how metrics are published, in a way
that maps what has been done in 8.0 branch but has not been backported
to 7.4, however the differences between the two branches called for a
custom implementation on 7.4, a simple cherry-pick was not possible.

A simpler fix removing a conditional check on publishing 'metrics'
event would have been possible, but it would not have been easily
testable and would have kept the technical debt that has been fixed in
8.0 branch (i.e. that BackbeatConsumer should not deal with
CRR-specific semantics).

Previously the metrics were published as a "metrics" event in the
BackbeatConsumer class, possibly gathering multiple stats together
before publishing. The condition to publish them was on
"messagesConsumed > 0", which was incorrect as new metrics could have
been published after "messagesConsumed" was reset to 0. By moving the
metrics publishing outside of BackbeatConsumer and in the CRR
extension code, this gets fixed on the way, and it becomes possible to
test published metrics without relying on a specific topic name being
published to.

Note: This PR is only touching 7.4 branch, 8.0 and 8.1 are left untouched.