### PR TITLE
bf: ZENKO-1385 add timeout in flaky retry test

### DIFF
--- a/tests/functional/api/retry.js
+++ b/tests/functional/api/retry.js
@@ -273,17 +273,19 @@ describe('CRR Retry feature', () => {
                         });
                         return next();
                     }),
-            next => async.map([
-                `${TEST_REDIS_KEY_FAILED_CRR}:${site}:${norm1}`,
-                `${TEST_REDIS_KEY_FAILED_CRR}:${site}:${norm2}`,
-            ],
-            (key, cb) => redisClient.zcard(key, cb),
-            (err, results) => {
-                assert.ifError(err);
-                const sum = results[0] + results[1];
-                assert.strictEqual(sum, 1);
-                return next();
-            }),
+            next => setTimeout(() => {
+                async.map([
+                    `${TEST_REDIS_KEY_FAILED_CRR}:${site}:${norm1}`,
+                    `${TEST_REDIS_KEY_FAILED_CRR}:${site}:${norm2}`,
+                ],
+                (key, cb) => redisClient.zcard(key, cb),
+                (err, results) => {
+                    assert.ifError(err);
+                    const sum = results[0] + results[1];
+                    assert.strictEqual(sum, 1);
+                    return next();
+                });
+            }, 2000),
         ], done);
     });
 


### PR DESCRIPTION
Add a setTimeout after a GET request is made to backbeat api and before checking Redis. I believe this addresses the flakiness seen in test 

Flaky test seen here:
https://eve.devsca.com/github/scality/backbeat/#/builders/6/builds/4088/steps/9/logs/stdio

