### PR TITLE
bf: ZENKO-1385 flaky test normalize fail entries

### DIFF
--- a/tests/functional/api/retry.js
+++ b/tests/functional/api/retry.js
@@ -261,17 +261,20 @@ describe('CRR Retry feature', () => {
                         });
                         return next();
                     }),
-            next => async.map([
-                `${TEST_REDIS_KEY_FAILED_CRR}:${site}:${norm1}`,
-                `${TEST_REDIS_KEY_FAILED_CRR}:${site}:${norm2}`,
-            ],
-            (key, cb) => redisClient.zcard(key, cb),
-            (err, results) => {
-                assert.ifError(err);
-                const sum = results[0] + results[1];
-                assert.strictEqual(sum, 1);
-                return next();
-            }),
+            // add setTimeout to give time for normalize method to update Redis
+            next => setTimeout(() => {
+                async.map([
+                    `${TEST_REDIS_KEY_FAILED_CRR}:${site}:${norm1}`,
+                    `${TEST_REDIS_KEY_FAILED_CRR}:${site}:${norm2}`,
+                ],
+                (key, cb) => redisClient.zcard(key, cb),
+                (err, results) => {
+                    assert.ifError(err);
+                    const sum = results[0] + results[1];
+                    assert.strictEqual(sum, 1);
+                    return next();
+                });
+            }, 2000),
         ], done);
     });
 


### PR DESCRIPTION
Add a setTimeout after making the GET request and before
making request to Redis. The normalize method used
internally may be taking longer than the request made
to Redis

The internal normalize method attempts to remove any
duplicate failure entries

Flaky test seen here: https://eve.devsca.com/github/scality/backbeat/#/builders/6/builds/4088/steps/9/logs/stdio