### PR TITLE
ZENKO-1390: fix ingestionProducer.getRaftLog bugs

### DIFF
--- a/lib/queuePopulator/IngestionProducer.js
+++ b/lib/queuePopulator/IngestionProducer.js
@@ -123,7 +123,7 @@ class IngestionProducer {
     getRaftLog(raftId, begin, end, targetLeader, done) {
         const recordStream = new ListRecordStream(this.log);
         recordStream.on('error', err => {
-            this.logger.error('error receiving raft log',
+            this.log.error('error receiving raft log',
             { error: err.message });
             return done(errors.InternalError);
         });
@@ -142,7 +142,7 @@ class IngestionProducer {
             .on('header', header => {
                 recordStream.removeAllListeners('error');
                 return done(null, {
-                    info: header,
+                    info: header.info,
                     log: jsonResponse,
                 });
             })


### PR DESCRIPTION
a. 'this.logger' is undefined
b. 'info' in response from getRaftLog was formatted incorrectly