### PR TITLE
bf: ZENKO-1392 BackbeatClient getObjectMetadata

### DIFF
--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -1074,9 +1074,7 @@
                 }
             },
             "output": {
-                "type": "map",
-                "key": {},
-                "value": {}
+                "shape": "ObjectMetadataObject"
             }
         }
     },
@@ -1299,6 +1297,70 @@
                 }
             }
         },
+        "ReplicationInfoObj": {
+            "type": "structure",
+            "members": {
+                "status": {
+                    "type": "string"
+                },
+                "backends": {
+                    "type": "list",
+                    "members": {
+                        "type": "string"
+                    }
+                },
+                "content": {
+                    "type": "list",
+                    "members": {
+                        "type": "string"
+                    }
+                },
+                "destination": {
+                    "type": "string"
+                },
+                "storageClass": {
+                    "type": "string"
+                },
+                "role": {
+                    "type": "string"
+                },
+                "storageType": {
+                    "type": "string"
+                },
+                "dataStoreVersionId": {
+                    "type": "string"
+                },
+                "isNFS": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "LocationMDObj": {
+            "type": "structure",
+            "members": {
+                "key": {
+                    "type": "string"
+                },
+                "size": {
+                    "type": "integer"
+                },
+                "start": {
+                    "type": "integer"
+                },
+                "dataStoreName": {
+                    "type": "string"
+                },
+                "dataStoreType": {
+                    "type": "string"
+                },
+                "dataStoreETag": {
+                    "type": "string"
+                },
+                "dataStoreVersionId": {
+                    "type": "string"
+                }
+            }
+        },
         "RaftLogOutput": {
             "type": "structure",
             "members": {
@@ -1343,6 +1405,100 @@
                             }
                         }
                     }
+                }
+            }
+        },
+        "ObjectMetadataObject": {
+            "type": "structure",
+            "members": {
+                "owner-display-name": {
+                    "type": "string"
+                },
+                "owner-id": {
+                    "type": "string"
+                },
+                "cache-control": {
+                    "type": "string"
+                },
+                "content-disposition": {
+                    "type": "string"
+                },
+                "content-encoding": {
+                    "type": "string"
+                },
+                "expires": {
+                    "type": "string"
+                },
+                "content-length": {
+                    "type": "integer"
+                },
+                "content-type": {
+                    "type": "string"
+                },
+                "content-md5": {
+                    "type": "string"
+                },
+                "x-amz-version-id": {
+                    "type": "string"
+                },
+                "x-amz-server-version-id": {
+                    "type": "string"
+                },
+                "x-amz-storage-class": {
+                    "type": "string"
+                },
+                "x-amz-server-side-encryption": {
+                    "type": "string"
+                },
+                "x-amz-server-side-encryption-aws-kms-key-id": {
+                    "type": "string"
+                },
+                "x-amz-server-side-encryption-customer-algorithm": {
+                    "type": "string"
+                },
+                "x-amz-website-redirect-location": {
+                    "type": "string"
+                },
+                "acl": {
+                    "shape": "AclObj"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "location": {
+                    "type": "list",
+                    "member": {
+                        "shape": "LocationMDObj"
+                    }
+                },
+                "isNull": {
+                    "type": "boolean"
+                },
+                "nullVersionId": {
+                    "type": "string"
+                },
+                "isDeleteMarker": {
+                    "type": "boolean"
+                },
+                "tags": {
+                    "type": "map",
+                    "key": {},
+                    "value": {}
+                },
+                "replicationInfo": {
+                    "shape": "ReplicationInfoObj"
+                },
+                "dataStoreName": {
+                    "type": "string"
+                },
+                "last-modified": {
+                    "type": "string"
+                },
+                "md-model-version": {
+                    "type": "integer"
+                },
+                "versionId": {
+                    "type": "string"
                 }
             }
         }

--- a/tests/functional/lib/BackbeatClient.js
+++ b/tests/functional/lib/BackbeatClient.js
@@ -24,7 +24,7 @@ const backbeatClient = new BackbeatClient({
 
 const serverMock = new MetadataMock();
 
-describe.only('BackbeatClient unit tests with mock server', () => {
+describe('BackbeatClient unit tests with mock server', () => {
     let httpServer;
     before(done => {
         httpServer = http.createServer(
@@ -116,8 +116,8 @@ describe.only('BackbeatClient unit tests with mock server', () => {
         return destReq.send((err, data) => {
             assert.ifError(err);
             assert.strictEqual(typeof data, 'object');
-            assert(data.metadata);
-            assert.strictEqual(data.metadata, 'dogsAreGood');
+            assert(data.key);
+            assert.strictEqual(data.key, 'dogsAreGood');
             return done();
         });
     });

--- a/tests/utils/MockMetadataServer.js
+++ b/tests/utils/MockMetadataServer.js
@@ -243,7 +243,7 @@ class MetadataMock {
             return res.end(dummyBucketMdObj.serialize());
         } else if (objectMetadataRegex.test(req.url)) {
             return res.end(JSON.stringify({
-                metadata: 'dogsAreGood',
+                key: 'dogsAreGood',
             }));
         } else if
         (objectListRegex.test(req.url)) {


### PR DESCRIPTION
Addresses a bug in the output for the method where nested values were returning a string of "[object Object]". Need to expand the values of the return.

Mapped outputs with ObjectMD definition in Arsenal and also through observations

Changes in this PR:
- Add explicit object metadata output to expand nested values