### PR TITLE
bugfix: ZENKO-1404 Lifecycle replication status

### DIFF
--- a/lib/models/ObjectQueueEntry.js
+++ b/lib/models/ObjectQueueEntry.js
@@ -146,16 +146,14 @@ class ObjectQueueEntry extends ObjectMD {
     }
 
     /**
-     * Set the destination entry to have a REPLICA status and the bucket as the
-     * source bucket (used for context in CloudServers's multiple backend).
+     * Set the bucket as the source bucket (used for context in CloudServers's
+     * multiple backend).
      * @param {String} site - The replication site given in the configuration
      * @return {ObjectQueueEntry} - The replica ObjectQueueEntry
      */
-    toMultipleBackendReplicaEntry(site) {
+    toMultipleBackendReplicaEntry() {
         return this.clone()
-            .setBucket(this.getBucket())
-            .setReplicationSiteStatus(site, 'REPLICA')
-            .setReplicationStatus('REPLICA');
+            .setBucket(this.getBucket());
     }
 
     toCompletedEntry(site) {

--- a/tests/unit/replication/QueueEntry.spec.js
+++ b/tests/unit/replication/QueueEntry.spec.js
@@ -30,7 +30,7 @@ describe('QueueEntry helper class', () => {
         });
 
         it('should convert a kafka entry\'s replication status', () => {
-            const entry = QueueEntry.createFromKafkaEntry(replicationEntry);
+            let entry = QueueEntry.createFromKafkaEntry(replicationEntry);
             assert.strictEqual(entry.error, undefined);
 
             // If one site is a REPLICA, the global status should be REPLICA
@@ -42,17 +42,18 @@ describe('QueueEntry helper class', () => {
                 'PENDING');
             assert.strictEqual(replica.getReplicationStatus(), 'REPLICA');
 
+            entry = QueueEntry.createFromKafkaEntry(replicationEntry);
             const multipleBackendReplica =
                 entry.toMultipleBackendReplicaEntry('sf');
             assert.strictEqual(
                 multipleBackendReplica.getReplicationSiteStatus('sf'),
-                'REPLICA');
+                'PENDING');
             assert.strictEqual(
                 multipleBackendReplica
                     .getReplicationSiteStatus('replicationaws'),
                 'PENDING');
             assert.strictEqual(
-                multipleBackendReplica.getReplicationStatus(), 'REPLICA');
+                multipleBackendReplica.getReplicationStatus(), 'PENDING');
             assert.strictEqual(entry.getBucket(),
                 multipleBackendReplica.getBucket());
 


### PR DESCRIPTION
We do not want to update the replication site status or replication status to 'REPLICA' for lifecycle transition entries being pushed to the replication status processor.