### PR TITLE
ZENKO-1414 avoid replication service account in lifecycle

### DIFF
--- a/extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor.js
+++ b/extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor.js
@@ -129,9 +129,10 @@ class LifecycleBucketProcessor {
             sendBucketEntry: this.sendBucketEntry.bind(this),
             sendObjectEntry: this.sendObjectEntry.bind(this),
             sendTransitionEntry: this.sendTransitionEntry.bind(this),
-            replicationSource: this._repConfig.source,
             bootstrapList: this._repConfig.destination.bootstrapList,
             enabledRules: this._lcConfig.rules,
+            s3Endpoint: this._s3Endpoint,
+            s3Auth: this._lcConfig.auth,
             log: this._log,
         };
     }

--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -6,7 +6,7 @@ const { errors } = require('arsenal');
 const { attachReqUids } = require('../../../lib/clients/utils');
 const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
 const BackbeatMetadataProxy =
-    require('../../replication/utils/BackbeatMetadataProxy');
+    require('../../../lib/BackbeatMetadataProxy');
 const ObjectQueueEntry = require('../../../lib/models/ObjectQueueEntry');
 
 // Default max AWS limit is 1000 for both list objects and list object versions
@@ -782,7 +782,9 @@ class LifecycleTask extends BackbeatTask {
      * @return {undefined}
      */
     _getObjectMetadata(params, log, cb) {
-        return new BackbeatMetadataProxy(this.replicationSource)
+        // FIXME create the proxy instance in LifecycleBucketProcessor
+        // and provide an HTTP agent
+        return new BackbeatMetadataProxy(this.s3Endpoint, this.s3Auth)
             .setSourceClient(log)
             .getMetadata(params, log, (err, res) => {
                 if (err) {

--- a/extensions/replication/tasks/MultipleBackendTask.js
+++ b/extensions/replication/tasks/MultipleBackendTask.js
@@ -5,7 +5,7 @@ const errors = require('arsenal').errors;
 const jsutil = require('arsenal').jsutil;
 const ObjectMD = require('arsenal').models.ObjectMD;
 const ObjectMDLocation = require('arsenal').models.ObjectMDLocation;
-const BackbeatMetadataProxy = require('../utils/BackbeatMetadataProxy');
+const BackbeatMetadataProxy = require('../../../lib/BackbeatMetadataProxy');
 const ObjectQueueEntry = require('../../../lib/models/ObjectQueueEntry');
 
 const ReplicateObject = require('./ReplicateObject');
@@ -765,7 +765,9 @@ class MultipleBackendTask extends ReplicateObject {
      * @return {undefined}
      */
     _getSourceMD(sourceEntry, destEntry, log, cb) {
-        const metadataProxy = new BackbeatMetadataProxy(this.sourceConfig);
+        const { transport, s3, auth } = this.sourceConfig;
+        const metadataProxy = new BackbeatMetadataProxy(
+            `${transport}://${s3.host}:${s3.port}`, auth);
         const sourceRole = sourceEntry.getReplicationRoles().split(',')[0];
         metadataProxy.setSourceRole(sourceRole);
         metadataProxy.setSourceClient(log);

--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -6,7 +6,7 @@ const jsutil = require('arsenal').jsutil;
 const ObjectMDLocation = require('arsenal').models.ObjectMDLocation;
 
 const BackbeatClient = require('../../../lib/clients/BackbeatClient');
-const BackbeatMetadataProxy = require('../utils/BackbeatMetadataProxy');
+const BackbeatMetadataProxy = require('../../../lib/BackbeatMetadataProxy');
 
 const { attachReqUids } = require('../../../lib/clients/utils');
 const getExtMetrics = require('../utils/getExtMetrics');
@@ -479,8 +479,10 @@ class ReplicateObject extends BackbeatTask {
             httpOptions: { agent: this.sourceHTTPAgent, timeout: 0 },
             maxRetries: 0,
         });
-        this.backbeatSourceProxy =
-            new BackbeatMetadataProxy(this.sourceConfig, this.sourceHTTPAgent);
+        this.backbeatSourceProxy = new BackbeatMetadataProxy(
+            `${this.sourceConfig.transport}://` +
+                `${sourceS3.host}:${sourceS3.port}`,
+            this.sourceConfig.auth, this.sourceHTTPAgent);
         this.backbeatSourceProxy.setSourceRole(sourceRole);
         this.backbeatSourceProxy.setSourceClient(log);
     }

--- a/extensions/replication/tasks/UpdateReplicationStatus.js
+++ b/extensions/replication/tasks/UpdateReplicationStatus.js
@@ -5,7 +5,7 @@ const config = require('../../../conf/Config');
 
 const ObjectQueueEntry = require('../../../lib/models/ObjectQueueEntry');
 const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
-const BackbeatMetadataProxy = require('../utils/BackbeatMetadataProxy');
+const BackbeatMetadataProxy = require('../../../lib/BackbeatMetadataProxy');
 const monitoringClient = require('../../../lib/clients/monitoringHandler');
 
 const {
@@ -29,8 +29,9 @@ class UpdateReplicationStatus extends BackbeatTask {
         this.retryParams = this.repConfig.replicationStatusProcessor.retry;
         this.sourceRole = null;
         this.s3sourceCredentials = null;
-        this.backbeatSourceClient =
-            new BackbeatMetadataProxy(this.sourceConfig, this.sourceHTTPAgent);
+        const { transport, s3, auth } = this.sourceConfig;
+        this.backbeatSourceClient = new BackbeatMetadataProxy(
+            `${transport}://${s3.host}:${s3.port}`, auth, this.sourceHTTPAgent);
     }
 
     processQueueEntry(sourceEntry, done) {

--- a/lib/BackbeatMetadataProxy.js
+++ b/lib/BackbeatMetadataProxy.js
@@ -1,28 +1,28 @@
 const http = require('http');
 const errors = require('arsenal').errors;
 const jsutil = require('arsenal').jsutil;
-const VaultClientCache = require('../../../lib/clients/VaultClientCache');
-const BackbeatClient = require('../../../lib/clients/BackbeatClient');
-const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
-const { attachReqUids } = require('../../../lib/clients/utils');
-const RoleCredentials = require('../../../lib/credentials/RoleCredentials');
-const { getAccountCredentials } =
-    require('../../../lib/credentials/AccountCredentials');
+const VaultClientCache = require('./clients/VaultClientCache');
+const BackbeatClient = require('./clients/BackbeatClient');
+const BackbeatTask = require('./tasks/BackbeatTask');
+const { attachReqUids } = require('./clients/utils');
+const RoleCredentials = require('./credentials/RoleCredentials');
+const { getAccountCredentials } = require('./credentials/AccountCredentials');
 
 class BackbeatMetadataProxy extends BackbeatTask {
-    constructor(sourceConfig, sourceHTTPAgent) {
+    constructor(s3Endpoint, s3Auth, sourceHTTPAgent) {
         super();
-        this.sourceConfig = sourceConfig;
+        this._s3Endpoint = s3Endpoint;
+        this._s3Auth = s3Auth;
         // TODO: For SSL support, create HTTPS agents instead.
-        this.sourceHTTPAgent = sourceHTTPAgent ||
+        this._sourceHTTPAgent = sourceHTTPAgent ||
             new http.Agent({ keepAlive: true });
         this._setupVaultclientCache();
     }
 
     _setupVaultclientCache() {
         this.vaultclientCache = new VaultClientCache();
-        if (this.sourceConfig.auth.type === 'role') {
-            const { host, port } = this.sourceConfig.auth.vault;
+        if (this._s3Auth.type === 'role') {
+            const { host, port } = this._s3Auth.vault;
             this.vaultclientCache
                 .setHost('source:s3', host)
                 .setPort('source:s3', port);
@@ -30,8 +30,7 @@ class BackbeatMetadataProxy extends BackbeatTask {
     }
 
     _createCredentials(log) {
-        const authConfig = this.sourceConfig.auth;
-        const accountCredentials = getAccountCredentials(authConfig, log);
+        const accountCredentials = getAccountCredentials(this._s3Auth, log);
         if (accountCredentials) {
             return accountCredentials;
         }
@@ -77,7 +76,7 @@ class BackbeatMetadataProxy extends BackbeatTask {
                     { method: 'BackbeatMetadataProxy._putMetadataOnce',
                       entry: entry.getLogInfo(),
                       origin: 'source',
-                      peer: this.sourceConfig.s3,
+                      peer: this._s3Endpoint,
                       error: err.message });
                 return cb(err);
             }
@@ -159,13 +158,11 @@ class BackbeatMetadataProxy extends BackbeatTask {
     }
 
     setSourceClient(log) {
-        const { transport, s3 } = this.sourceConfig;
-        const { host, port } = s3;
         this.backbeatSource = new BackbeatClient({
-            endpoint: `${transport}://${host}:${port}`,
+            endpoint: this._s3Endpoint,
             credentials: this._createCredentials(log),
-            sslEnabled: transport === 'https',
-            httpOptions: { agent: this.sourceHTTPAgent, timeout: 0 },
+            sslEnabled: this._s3Endpoint.startsWith('https:'),
+            httpOptions: { agent: this._sourceHTTPAgent, timeout: 0 },
             maxRetries: 0, // Disable retries, use our own retry policy
         });
         return this;

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -14,8 +14,7 @@ const ObjectQueueEntry =
     require('../../lib/models/ObjectQueueEntry');
 const ObjectFailureEntry =
     require('../../extensions/replication/utils/ObjectFailureEntry');
-const BackbeatMetadataProxy =
-    require('../../extensions/replication/utils/BackbeatMetadataProxy');
+const BackbeatMetadataProxy = require('../BackbeatMetadataProxy');
 const Healthcheck = require('./Healthcheck');
 const { getSortedSetKey, getSortedSetMember } =
     require('../util/sortedSetHelper');
@@ -79,8 +78,9 @@ class BackbeatAPI {
         }
         // Redis instance for publishing messages to BackbeatConsumers
         this._redisPublisher = new Redis(this._redisConfig);
-        this._backbeatMetadataProxy =
-            new BackbeatMetadataProxy(this._repConfig.source);
+        const { transport, s3, auth } = this._repConfig.source;
+        this._backbeatMetadataProxy = new BackbeatMetadataProxy(
+            `${transport}://${s3.host}:${s3.port}`, auth);
         // Redis instance is used for getting/setting keys
         this._redisClient = new RedisClient(this._redisConfig, this._logger);
         // Redis expiry increased by an additional interval so we can reference

--- a/tests/functional/lifecycle/LifecycleTask.js
+++ b/tests/functional/lifecycle/LifecycleTask.js
@@ -347,7 +347,7 @@ class LifecycleBucketProcessorMock {
     }
 
     getStateVars() {
-        const { replication } = testConfig.extensions;
+        const { lifecycle } = testConfig.extensions;
         return {
             sendBucketEntry: this.sendBucketEntry.bind(this),
             sendTransitionEntry: this.sendTransitionEntry.bind(this),
@@ -356,7 +356,8 @@ class LifecycleBucketProcessorMock {
             enabledRules: this._lcConfig.rules,
             // Corresponds to the default endpoint in the cloudserver config.
             bootstrapList: [{ site: 'us-east-2', type: 'aws_s3' }],
-            replicationSource: replication.source,
+            s3Endpoint: s3config.endpoint,
+            s3Auth: lifecycle.auth,
             log: this._log,
         };
     }

--- a/tests/unit/replication/UpdateReplicationStatus.js
+++ b/tests/unit/replication/UpdateReplicationStatus.js
@@ -34,6 +34,11 @@ describe('update replication status', () => {
             },
             sourceConfig: {
                 auth: {},
+                s3: {
+                    host: 'localhost',
+                    port: 8000,
+                },
+                transport: 'http',
             },
         }),
     };


### PR DESCRIPTION
Modify BackbeatMetadataProxy helper:

- move it from replication extension to backbeat lib so all modules
  can use it

- pass an endpoint and authentication params to the constructor
  (instead of relying on replication config directly) so each module
  can tailor to its needs