### PR TITLE
refactor: ZENKO-734 remove destEntry from MultipleBackendTask

### DIFF
--- a/lib/models/ObjectQueueEntry.js
+++ b/lib/models/ObjectQueueEntry.js
@@ -113,19 +113,6 @@ class ObjectQueueEntry extends ObjectMD {
         return newEntry;
     }
 
-    /**
-     * Set the destination entry to have a REPLICA status and the bucket as the
-     * source bucket (used for context in CloudServers's multiple backend).
-     * @param {String} site - The replication site given in the configuration
-     * @return {ObjectQueueEntry} - The replica ObjectQueueEntry
-     */
-    toMultipleBackendReplicaEntry(site) {
-        return this.clone()
-            .setBucket(this.getBucket())
-            .setReplicationSiteStatus(site, 'REPLICA')
-            .setReplicationStatus('REPLICA');
-    }
-
     toCompletedEntry(site) {
         return this.clone()
             .setReplicationSiteStatus(site, 'COMPLETED')

--- a/tests/unit/replication/MultipleBackendTask.js
+++ b/tests/unit/replication/MultipleBackendTask.js
@@ -3,7 +3,7 @@ const config = require('../../config.json');
 const MultipleBackendTask =
     require('../../../extensions/replication/tasks/MultipleBackendTask');
 const QueueEntry = require('../../../lib/models/QueueEntry');
-const { sourceEntry, destEntry } = require('../../utils/mockEntries');
+const { sourceEntry } = require('../../utils/mockEntries');
 const fakeLogger = require('../../utils/fakeLogger');
 const { replicationEntry } = require('../../utils/kafkaEntries');
 
@@ -33,8 +33,7 @@ describe('MultipleBackendTask', function test() {
             }),
         };
 
-        task._getAndPutMultipartUpload(sourceEntry, destEntry, fakeLogger,
-            err => {
+        task._getAndPutMultipartUpload(sourceEntry, fakeLogger, err => {
                 if (retryable) {
                     assert.ifError(err);
                 }

--- a/tests/unit/replication/QueueEntry.spec.js
+++ b/tests/unit/replication/QueueEntry.spec.js
@@ -42,20 +42,6 @@ describe('QueueEntry helper class', () => {
                 'PENDING');
             assert.strictEqual(replica.getReplicationStatus(), 'REPLICA');
 
-            const multipleBackendReplica =
-                entry.toMultipleBackendReplicaEntry('sf');
-            assert.strictEqual(
-                multipleBackendReplica.getReplicationSiteStatus('sf'),
-                'REPLICA');
-            assert.strictEqual(
-                multipleBackendReplica
-                    .getReplicationSiteStatus('replicationaws'),
-                'PENDING');
-            assert.strictEqual(
-                multipleBackendReplica.getReplicationStatus(), 'REPLICA');
-            assert.strictEqual(entry.getBucket(),
-                multipleBackendReplica.getBucket());
-
             // If one site is FAILED, the global status should be FAILED
             const failed = entry.toFailedEntry('sf');
             assert.strictEqual(failed.getReplicationSiteStatus('sf'),

--- a/tests/utils/mockEntries.js
+++ b/tests/utils/mockEntries.js
@@ -1,4 +1,8 @@
 const sourceEntry = {
+    getBucket: () => {},
+    getObjectKey: () => {},
+    getReplicationStorageType: () => {},
+    getEncodedVersionId: () => {},
     getLogInfo: () => {},
     getLocation: () => ([]),
     getUserMetadata: () => {},
@@ -9,12 +13,4 @@ const sourceEntry = {
     getReplicationIsNFS: () => {},
 };
 
-const destEntry = {
-    getLogInfo: () => {},
-    getBucket: () => {},
-    getObjectKey: () => {},
-    getReplicationStorageType: () => {},
-    getEncodedVersionId: () => {},
-};
-
-module.exports = { sourceEntry, destEntry };
+module.exports = { sourceEntry };


### PR DESCRIPTION
The "destEntry" param is a relic from ReplicateObject base class, that
does not play a role in zenko replication code: "destEntry" in CRR
code represents the metadata pushed to the target site, which has no
materialization in zenko replication as every operation is carried out
by the multiple backend layer.

Also, when it comes to changes related to using the queue processor
for lifecycle transitions, there are more reasons why it can become an
important cleanup.

This commit is a pure refactor, the few extra functions directly come
from ReplicateObject class without their "destEntry" and CRR-specific
behavior, that I deemed appropriate to "duplicate" to avoid
possibilities of code path incompatibility between both classes and
separate the matters better between zenko replication and CRR.