### PR TITLE
bugfix: ZENKO-1418 update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,33 @@
-FROM node:8
+FROM node:8-alpine
 
 WORKDIR /usr/src/app
 
-RUN apt-get update \
-    && apt-get install -y jq wget --no-install-recommends
+RUN apk --no-cache add \
+    bash \
+    g++ \
+    ca-certificates \
+    lz4-dev \
+    musl-dev \
+    cyrus-sasl-dev \
+    openssl-dev \
+    make \
+    python
+
+RUN apk add --no-cache --virtual .build-deps gcc zlib-dev libc-dev bsd-compat-headers py-setuptools bash git
 
 ENV DOCKERIZE_VERSION v0.6.1
-RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
 
 COPY package.json /usr/src/app
 RUN npm install --production \
     && rm -rf /var/lib/apt/lists/* \
     && npm cache clear --force \
     && rm -rf ~/.node-gyp \
-    && rm -rf /tmp/npm-*
-
+    && rm -rf /tmp/npm-* \
+    && apk del .build-deps
 
 # Keep the .git directory in order to properly report version
 COPY . /usr/src/app


### PR DESCRIPTION
This commit addresses the quirks needed to build a clean docker
image. It also changes the base image to alpine-based reducing the
image size by half.