### PR TITLE
INTEGRATION [PR#593 > development/8.0] bugfix: ZENKO-1430 Pass correct arguments

### DIFF
--- a/extensions/replication/tasks/MultipleBackendTask.js
+++ b/extensions/replication/tasks/MultipleBackendTask.js
@@ -181,12 +181,12 @@ class MultipleBackendTask extends ReplicateObject {
         });
     }
 
-    _getAndPutMultipartUpload(sourceEntry, destEntry, part, uploadId, log, cb) {
+    _getAndPutMultipartUpload(sourceEntry, destEntry, log, cb) {
         this.retry({
             actionDesc: 'stream part data',
             logFields: { entry: sourceEntry.getLogInfo() },
             actionFunc: done => this._getAndPutMultipartUploadOnce(sourceEntry,
-                destEntry, part, uploadId, log, done),
+                destEntry, log, done),
             shouldRetryFunc: err => err.retryable,
             log,
         }, cb);


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #593.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.0/bugfix/ZENKO-1430/initiate-mpu-does-not-use-backoff`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.0/bugfix/ZENKO-1430/initiate-mpu-does-not-use-backoff
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.0/bugfix/ZENKO-1430/initiate-mpu-does-not-use-backoff
```

Please always comment pull request #593 instead of this one.