### PR TITLE
INTEGRATION [PR#593 > development/8.0] bugfix: ZENKO-1430 Pass correct arguments

### DIFF
--- a/extensions/replication/tasks/MultipleBackendTask.js
+++ b/extensions/replication/tasks/MultipleBackendTask.js
@@ -181,12 +181,12 @@ class MultipleBackendTask extends ReplicateObject {
         });
     }
 
-    _getAndPutMultipartUpload(sourceEntry, destEntry, part, uploadId, log, cb) {
+    _getAndPutMultipartUpload(sourceEntry, destEntry, log, cb) {
         this.retry({
             actionDesc: 'stream part data',
             logFields: { entry: sourceEntry.getLogInfo() },
             actionFunc: done => this._getAndPutMultipartUploadOnce(sourceEntry,
-                destEntry, part, uploadId, log, done),
+                destEntry, log, done),
             shouldRetryFunc: err => err.retryable,
             log,
         }, cb);

--- a/tests/unit/replication/MultipleBackendTask.js
+++ b/tests/unit/replication/MultipleBackendTask.js
@@ -1,0 +1,53 @@
+const assert = require('assert');
+
+const config = require('../../config.json');
+const MultipleBackendTask =
+    require('../../../extensions/replication/tasks/MultipleBackendTask');
+const log = require('../../utils/fakeLogger');
+const { sourceEntry, destEntry } = require('../../utils/mockEntries');
+
+const multipleBackendTask = new MultipleBackendTask({
+    getStateVars: () => ({
+        repConfig: {
+            queueProcessor: {
+                retryTimeoutS: 300,
+            },
+        },
+        destConfig: config.extensions.replication.destination,
+        site: 'test-site-2',
+    }),
+});
+
+function requestInitiateMPU(params, done) {
+    const { retryable } = params;
+
+    multipleBackendTask.backbeatSource = {
+        multipleBackendInitiateMPU: () => ({
+            httpRequest: { headers: {} },
+            send: cb => cb({ retryable }),
+            on: (action, cb) => cb(),
+        }),
+    };
+
+    multipleBackendTask
+        ._getAndPutMultipartUpload(sourceEntry, destEntry, log, err => {
+            if (retryable) {
+                assert.ifError(err);
+            }
+            return done();
+        });
+}
+
+describe('MultipleBackendTask', function test() {
+    this.timeout(5000);
+
+    describe('::initiateMultipartUpload', () => {
+        it('should use exponential backoff if retryable error ', done => {
+            setTimeout(() => done(), 4000); // Retries will exceed test timeout.
+            requestInitiateMPU({ retryable: true }, done);
+        });
+
+        it('should not use exponential backoff if non-retryable error ', done =>
+            requestInitiateMPU({ retryable: false }, done));
+    });
+});

--- a/tests/utils/fakeLogger.js
+++ b/tests/utils/fakeLogger.js
@@ -1,0 +1,9 @@
+const fakeLogger = {
+    trace: () => {},
+    error: () => {},
+    info: () => {},
+    debug: () => {},
+    getSerializedUids: () => {},
+};
+
+module.exports = fakeLogger;

--- a/tests/utils/mockEntries.js
+++ b/tests/utils/mockEntries.js
@@ -1,0 +1,19 @@
+const sourceEntry = {
+    getLogInfo: () => {},
+    getLocation: () => ([]),
+    getUserMetadata: () => {},
+    getContentType: () => {},
+    getCacheControl: () => {},
+    getContentDisposition: () => {},
+    getContentEncoding: () => {},
+};
+
+const destEntry = {
+    getLogInfo: () => {},
+    getBucket: () => {},
+    getObjectKey: () => {},
+    getReplicationStorageType: () => {},
+    getEncodedVersionId: () => {},
+};
+
+module.exports = { sourceEntry, destEntry };


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #593.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.0/bugfix/ZENKO-1430/initiate-mpu-does-not-use-backoff`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.0/bugfix/ZENKO-1430/initiate-mpu-does-not-use-backoff
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.0/bugfix/ZENKO-1430/initiate-mpu-does-not-use-backoff
```

Please always comment pull request #593 instead of this one.