### PR TITLE
rf: S3C-1944 backport route parsing

### DIFF
--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -96,77 +96,123 @@ class BackbeatAPI {
     }
 
     /**
-     * Check if incoming request is valid
+     * Find valid route from list of routes
+     * Sets the matched route on the BackbeatRequest object with possible
+     * extra properties.
      * @param {BackbeatRequest} bbRequest - holds relevant data about request
-     * @return {boolean} true/false
+     * @return {Object|null} - The error object or `null` if no error
      */
-    isValidRoute(bbRequest) {
+    findValidRoute(bbRequest) {
+        /* eslint-disable no-param-reassign */
         const rDetails = bbRequest.getRouteDetails();
-        if (!rDetails) {
-            return false;
-        }
         const route = bbRequest.getRoute();
-        // first validate healthcheck routes
-        if (route.substring(3) === 'healthcheck') {
-            return true;
+        const addKeys = {};
+
+        // first validate healthcheck routes or prom routes since they do not
+        // have rDetails set
+        if (route === 'healthcheck') {
+            if (bbRequest.getHTTPMethod() !== 'GET') {
+                return errors.MethodNotAllowed;
+            }
+            // TODO: this logic changes with addition of deep healthcheck
+            const healthcheckRoute = routes.filter(r =>
+                r.category === 'healthcheck')[0];
+            bbRequest.setMatchedRoute(healthcheckRoute);
+            return null;
         }
-        /*
-            {
-                category: 'metrics',
-                extension: 'crr',
-                site: 'my-site-name',
-                metric: 'backlog', (optional)
-            }
-        */
-        // check metric routes
-        // Are there any routes with matching extension?
-        const extensions = routes.reduce((store, r) => {
-            if (r.extensions[rDetails.extension] &&
-                r.extensions[rDetails.extension].includes(rDetails.status)) {
-                store.push(Object.keys(r.extensions));
-            } else if (rDetails.category === 'metrics') {
-                store.push(Object.keys(r.extensions));
-            }
-            return store;
-        }, []);
-        if (![].concat.apply([], extensions).includes(rDetails.extension)) {
-            return false;
+
+        // If giving the bucket name, the user must also provide an object key
+        // and version ID.
+        const hasGranularity = rDetails.bucketName ?
+            rDetails.objectKey && rDetails.versionId : true;
+        if (!hasGranularity) {
+            return errors.RouteNotFound.customizeDescription(
+                'must provide object key and version ID in route: ' +
+                `${bbRequest.getRoute()}`);
         }
-        let specifiedType;
-        const validRoutes = [];
-        routes.forEach(r => {
-            if (!r.extensions) {
-                return;
-            }
-            if (!Object.keys(r.extensions).includes(rDetails.extension)) {
-                return;
-            }
-            if (rDetails.site &&
-                !r.extensions[rDetails.extension].includes(rDetails.site)) {
-                return;
-            }
-            if (rDetails.status &&
-                !r.extensions[rDetails.extension].includes(rDetails.status)) {
-                return;
-            }
-            if (rDetails.metric && r.type === rDetails.metric) {
-                specifiedType = r.type;
-            }
-            validRoutes.push(r);
+
+        // All routes at this point have extensions property in use
+        // Match http verb and match extension name
+        let filteredRoutes = routes.filter(r => {
+            const isMatchingMethod = bbRequest.getHTTPMethod() === r.httpMethod;
+            const isMatchingExtension = r.extensions[rDetails.extension];
+            const isMatchingLevel = rDetails.objectKey ?
+                r.level === 'object' :
+                r.level === 'site' || r.level === undefined;
+            return isMatchingMethod && isMatchingExtension && isMatchingLevel;
         });
 
-        if (validRoutes.length === 0) {
-            return false;
+        // if rDetails has a category property. Currently only metrics
+        if (rDetails.category) {
+            filteredRoutes = filteredRoutes.filter(r =>
+                rDetails.category === r.category);
+        }
+        // if rDetails has a status property
+        if (rDetails.status) {
+            if (rDetails.status === 'failed') {
+                const { extension, marker, sitename, bucket, key, versionId,
+                    role } = rDetails;
+                const type = (bucket && key && versionId) ? 'specific' : 'all';
+                filteredRoutes = filteredRoutes.filter(r => {
+                    const extList = r.extensions[extension];
+                    return extList.includes('failed') && r.type === type;
+                });
+
+                if (type === 'specific') {
+                    addKeys.bucket = bucket;
+                    addKeys.key = key;
+                    addKeys.versionId = versionId;
+                }
+                if (marker) {
+                    // this is optional, so doesn't matter if set or not
+                    addKeys.marker = marker;
+                }
+                if (sitename) {
+                    // this is optional for backward compatibility
+                    addKeys.sitename = sitename;
+                }
+                if (role) {
+                    // this is optional, and only applies for development/7.4
+                    addKeys.role = role;
+                }
+            }
+        }
+        // if rDetails has a type property
+        if (rDetails.type) {
+            filteredRoutes = filteredRoutes.filter(r =>
+                rDetails.type === r.type);
         }
 
-        // since this is an optional field, if a metric type was specified
-        // in the route and it didn't match any metric types defined in
-        // `routes.js`
-        if (rDetails.metric && !specifiedType) {
-            return false;
+        // TODO: site level metrics is not currently supported in 7.4
+        // if rDetails has a site property. Should only have 1 matched route
+        // at this point, or else there is an error
+        if (rDetails.site && filteredRoutes.length === 1) {
+            filteredRoutes = filteredRoutes.filter(r => {
+                const list = r.extensions[rDetails.extension];
+                return list.includes(rDetails.site);
+            });
+            // add optional site
+            addKeys.site = rDetails.site;
         }
 
-        return true;
+        if (filteredRoutes.length !== 1) {
+            return errors.RouteNotFound.customizeDescription(
+                `path ${bbRequest.getRoute()} does not exist`);
+        }
+
+        if (rDetails.versionId) {
+            addKeys.objectKey = rDetails.objectKey;
+            addKeys.bucketName = rDetails.bucketName;
+            addKeys.versionId = rDetails.versionId;
+        }
+
+        // Matching route found. Set on request object so we do not have to
+        // re-match later
+        const matchedRoute = Object.assign({}, filteredRoutes[0], addKeys);
+        bbRequest.setMatchedRoute(matchedRoute);
+
+        return null;
+        /* eslint-enable no-param-reassign */
     }
 
     /**

--- a/lib/api/BackbeatRequest.js
+++ b/lib/api/BackbeatRequest.js
@@ -18,11 +18,17 @@ class BackbeatRequest {
         this._request = req;
         this._response = res;
         this._log = log;
-        this._route = req.url;
+        this._httpMethod = this._request.method;
+        this._route = null;
+        this._hasValidPrefix = null;
         this._statusCode = 0;
         this._error = null;
         this._routeDetails = {};
 
+        // Use to store matched route from list of backbeat routes
+        this._matchedRoute = null;
+
+        this.setRoute(this._request.url);
         this._parseRoute();
     }
 
@@ -48,6 +54,19 @@ class BackbeatRequest {
     }
 
     /**
+     * Parse the route details for any of the metrics routes
+     * @param {Array} parts - route schema split by '/'
+     * @return {undefined}
+     */
+    _parseMetricsRoutes(parts) {
+        this._routeDetails.category = parts[0];
+        this._routeDetails.extension = parts[1];
+        this._routeDetails.site = parts[2];
+        // optional field, default to 'all'
+        this._routeDetails.type = parts[3] || 'all';
+    }
+
+    /**
      * Parse a route and store to this._routeDetails
      * A route will have certain a specific structure following:
      * /_/metrics/<extension>/<site>/<specific-metric>
@@ -55,26 +74,16 @@ class BackbeatRequest {
      * @return {undefined}
      */
     _parseRoute() {
-        // always drop first 3 chars. This is already validated in
-        // BackbeatServer._isValidRequest
-        const route = this._route.substring(3);
-        const { pathname, query } = url.parse(route);
-        // if healthcheck, just skip this
+        const { pathname, query } = url.parse(this._route);
         const parts = pathname ? pathname.split('/') : [];
+
+        // crr retry routes
         if (parts[0] === 'crr') {
             this._parseCRRRoutes(parts, query);
-            return;
+        } else if (parts[0] === 'metrics') {
+            this._parseMetricsRoutes(parts);
         }
-        if (parts.length < 3 || parts.length > 4) {
-            // leave this._routeDetails undefined
-            return;
-        }
-        this._routeDetails.category = parts[0];
-        this._routeDetails.extension = parts[1];
-        this._routeDetails.site = parts[2];
-        if (parts.length === 4) {
-            this._routeDetails.metric = parts[3];
-        }
+        return;
     }
 
     /**
@@ -166,6 +175,14 @@ class BackbeatRequest {
     }
 
     /**
+     * Get initial route prefix validity check
+     * @return {boolean} true if request.url began with "/_/"
+     */
+    getHasValidPrefix() {
+        return this._hasValidPrefix;
+    }
+
+    /**
      * Get route
      * @return {string} current route
      */
@@ -175,11 +192,35 @@ class BackbeatRequest {
 
     /**
      * Set route
-     * @param {string} route - new route string
+     * @param {string} route - route string
      * @return {BackbeatRequest} itself
      */
     setRoute(route) {
-        this._route = route;
+        this._hasValidPrefix = route.startsWith('/_/');
+        if (this._hasValidPrefix) {
+            this._route = route.substring(3);
+        } else {
+            this._route = route;
+        }
+        return this;
+    }
+
+    /**
+     * Get the matched route from Arsenal list of backbeat routes
+     * @return {Object} matched route object
+     */
+    getMatchedRoute() {
+        return this._matchedRoute;
+    }
+
+    /**
+     * Set the matched route from Arsenal list of backbeat routes
+     * Extra properties may be added from BackbeatAPI.findValidRoute
+     * @param {Object} route - matched route object
+     * @return {BackbeatRequest} itself
+     */
+    setMatchedRoute(route) {
+        this._matchedRoute = route;
         return this;
     }
 

--- a/lib/api/BackbeatServer.js
+++ b/lib/api/BackbeatServer.js
@@ -6,7 +6,6 @@ const { Clustering, errors, ipCheck } = require('arsenal');
 
 const BackbeatRequest = require('./BackbeatRequest');
 const BackbeatAPI = require('./BackbeatAPI');
-const routes = require('./routes');
 
 const WORKERS = 1;
 
@@ -63,21 +62,24 @@ class BackbeatServer {
 
         const validMethods = ['GET', 'POST'];
         if (!validMethods.includes(req.method)) {
-            return this._errorResponse(errors.MethodNotAllowed
-                .customizeDescription('invalid http verb'),
+            return this._errorResponse(errors.MethodNotAllowed,
                 backbeatRequest);
         }
 
-        if (!this.backbeatAPI.isValidRoute(backbeatRequest)
-            || !backbeatRequest.getRoute().startsWith('/_/')) {
+        if (!backbeatRequest.getHasValidPrefix()) {
             return this._errorResponse(errors.RouteNotFound
                 .customizeDescription(`path ${backbeatRequest.getRoute()} does `
                     + 'not exist'), backbeatRequest);
         }
 
-        const error = this.backbeatAPI.validateQuery(backbeatRequest);
-        if (error) {
-            return this._errorResponse(error, backbeatRequest);
+        const routeError = this.backbeatAPI.findValidRoute(backbeatRequest);
+        if (routeError) {
+            return this._errorResponse(routeError, backbeatRequest);
+        }
+
+        const queryError = this.backbeatAPI.validateQuery(backbeatRequest);
+        if (queryError) {
+            return this._errorResponse(queryError, backbeatRequest);
         }
 
         return true;
@@ -113,11 +115,12 @@ class BackbeatServer {
      * Get the body of a POST request and route it accordingly.
      * @param {ClientRequest} req - The incoming request
      * @param {BackbeatRequest} bbRequest - The Backbeat API Request
-     * @param {Object} routeDetails - The Backbeat route details
      * @return {undefined}
      */
-    _handlePOSTReq(req, bbRequest, routeDetails) {
+    _handlePOSTReq(req, bbRequest) {
         const data = [];
+        const routeDetails = bbRequest.getMatchedRoute();
+
         req.on('data', chunk => data.push(chunk));
         req.on('end', () => {
             const { method } = routeDetails;
@@ -134,30 +137,6 @@ class BackbeatServer {
     }
 
     /**
-     *
-     * @param {Object} rDetails - The Backbeat request details
-     * @param {ClientRequest} req - The incoming request
-     * @return {Object} The matching Backbeat route
-     */
-    _getRetryRoute(rDetails, req) {
-        const { extension, status, bucket, key, versionId, marker, sitename,
-            role } = rDetails;
-        const route = routes.find(r => {
-            if (r.extensions[extension] &&
-                r.extensions[extension].includes(status)) {
-                return r.httpMethod === req.method &&
-                    (bucket && key && versionId ?
-                    r.type === 'specific' :
-                    r.type === 'all');
-            }
-            return false;
-        });
-        // Include any granularity in the details for the response method.
-        return Object.assign({}, route, { bucket, key, versionId, marker,
-            sitename, role });
-    }
-
-    /**
      * Server incoming request handler
      * @param {object} req - request object
      * @param {object} res - response object
@@ -171,40 +150,15 @@ class BackbeatServer {
         // check request conditions and all internal conditions here
         if (this._isValidRequest(req, bbRequest)
         && (this._areConditionsOk(bbRequest) ||
-        bbRequest.getRoute() === '/_/healthcheck')) {
+        bbRequest.getRoute().startsWith('healthcheck'))) {
             bbRequest.setStatusCode(200);
-            bbRequest.setRoute(bbRequest.getRoute().substring(3));
 
-            /*
-                {
-                    category: 'metrics',
-                    extension: 'crr',
-                    site: 'my-site-name',
-                    metric: 'backlog', (optional)
-                }
-            */
-            // TODO: when adding deep healthcheck, this logic will change
-            let routeDetails;
-            if (bbRequest.getRoute() === 'healthcheck') {
-                routeDetails = routes.find(r => r.category === 'healthcheck');
-            } else {
-                const rDetails = bbRequest.getRouteDetails();
-                if (rDetails.status) {
-                    routeDetails = this._getRetryRoute(rDetails, req);
-                } else if (!rDetails.metric) {
-                    // no metric type is specified, so use all route
-                    routeDetails = routes.find(r => r.type === 'all');
-                } else {
-                    routeDetails = routes.find(r => r.type === rDetails.metric);
-                }
-                routeDetails.site = rDetails.site;
+            if (bbRequest.getHTTPMethod() === 'POST') {
+                return this._handlePOSTReq(req, bbRequest);
             }
 
-            const requestMethod = routeDetails.method;
-            if (routeDetails.httpMethod === 'POST') {
-                return this._handlePOSTReq(req, bbRequest, routeDetails);
-            }
-            this.backbeatAPI[requestMethod](routeDetails, (err, data) => {
+            const routeDetails = bbRequest.getMatchedRoute();
+            this.backbeatAPI[routeDetails.method](routeDetails, (err, data) => {
                 if (err) {
                     this._errorResponse(err, bbRequest);
                 } else {

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -6,6 +6,7 @@
 const redisKeys = require('../../extensions/replication/constants').redisKeys;
 
 module.exports = [
+    // Route: /_/healthcheck
     {
         httpMethod: 'GET',
         category: 'healthcheck',
@@ -13,6 +14,7 @@ module.exports = [
         method: 'getHealthcheck',
         extensions: {},
     },
+    // Route: /_/metrics/crr/all/backlog
     {
         httpMethod: 'GET',
         category: 'metrics',
@@ -22,6 +24,7 @@ module.exports = [
         dataPoints: [redisKeys.ops, redisKeys.opsDone, redisKeys.bytes,
             redisKeys.bytesDone],
     },
+    // Route: /_/metrics/crr/all/completions
     {
         httpMethod: 'GET',
         category: 'metrics',
@@ -30,6 +33,7 @@ module.exports = [
         method: 'getCompletions',
         dataPoints: [redisKeys.opsDone, redisKeys.bytesDone],
     },
+    // Route: /_/metrics/crr/all/throughput
     {
         httpMethod: 'GET',
         category: 'metrics',
@@ -38,6 +42,7 @@ module.exports = [
         method: 'getThroughput',
         dataPoints: [redisKeys.opsDone, redisKeys.bytesDone],
     },
+    // Route: /_/metrics/crr/all
     {
         httpMethod: 'GET',
         category: 'metrics',

--- a/tests/unit/api/BackbeatRequest.spec.js
+++ b/tests/unit/api/BackbeatRequest.spec.js
@@ -10,20 +10,88 @@ describe('BackbeatRequest helper class', () => {
         assert.deepStrictEqual(details, {});
     });
 
-    it('should parse routes and store internally as route details', () => {
-        const req = new BackbeatRequest({ url: '/_/metrics/crr/all' });
-        const details = req.getRouteDetails();
+    describe('_parseRoute', () => {
+        it('should parse metrics routes and store internally as route details',
+        () => {
+            const req = new BackbeatRequest({
+                url: '/_/metrics/crr/all',
+                method: 'GET',
+            });
+            const details = req.getRouteDetails();
 
-        assert.strictEqual(details.category, 'metrics');
-        assert.strictEqual(details.extension, 'crr');
-        assert.strictEqual(details.site, 'all');
-        assert.strictEqual(details.metric, undefined);
+            assert.strictEqual(details.category, 'metrics');
+            assert.strictEqual(details.extension, 'crr');
+            assert.strictEqual(details.site, 'all');
+            assert.strictEqual(details.type, 'all');
 
-        const req2 = new BackbeatRequest(
-            { url: '/_/metrics/crr/test/backlog' });
-        const details2 = req2.getRouteDetails();
+            const req2 = new BackbeatRequest({
+                url: '/_/metrics/crr/test/backlog',
+                method: 'GET',
+            });
+            const details2 = req2.getRouteDetails();
 
-        assert.strictEqual(details2.site, 'test');
-        assert.strictEqual(details2.metric, 'backlog');
+            assert.strictEqual(details2.site, 'test');
+            assert.strictEqual(details2.type, 'backlog');
+        });
+
+        it('should parse crr failed routes and store internally as route ' +
+        'details', () => {
+            const req = new BackbeatRequest({
+                url: '/_/crr/failed?marker=testmarker',
+                method: 'GET',
+            });
+            const details = req.getRouteDetails();
+
+            assert.strictEqual(details.extension, 'crr');
+            assert.strictEqual(details.status, 'failed');
+            assert.strictEqual(details.marker, 'testmarker');
+            assert.strictEqual(req.getHTTPMethod(), 'GET');
+
+            const req2 = new BackbeatRequest({
+                url: '/_/crr/failed',
+                method: 'POST',
+            });
+            const details2 = req2.getRouteDetails();
+
+            assert.strictEqual(details2.extension, 'crr');
+            assert.strictEqual(details2.status, 'failed');
+            assert.strictEqual(req2.getHTTPMethod(), 'POST');
+
+            const req3 = new BackbeatRequest({
+                url: '/_/crr/failed/mybucket/mykey?versionId=myvId',
+                method: 'GET',
+            });
+            const details3 = req3.getRouteDetails();
+
+            assert.strictEqual(details3.extension, 'crr');
+            assert.strictEqual(details3.status, 'failed');
+            assert.strictEqual(details3.bucket, 'mybucket');
+            assert.strictEqual(details3.key, 'mykey');
+            assert.strictEqual(details3.versionId, 'myvId');
+        });
+    });
+
+    it('should set route without prefix if valid route has valid prefix',
+    () => {
+        const req = new BackbeatRequest({
+            url: '/_/healthcheck',
+            method: 'GET',
+        });
+        const route = req.getRoute();
+        const validPrefix = req.getHasValidPrefix();
+
+        assert.strictEqual(route, 'healthcheck');
+        assert.strictEqual(validPrefix, true);
+
+        const req2 = new BackbeatRequest({
+            url: '/healthcheck',
+            method: 'GET',
+        });
+        const route2 = req2.getRoute();
+        const validPrefix2 = req2.getHasValidPrefix();
+
+        // Uses the original route when prefix is incorrect (for error logs)
+        assert.strictEqual(route2, '/healthcheck');
+        assert.strictEqual(validPrefix2, false);
     });
 });


### PR DESCRIPTION
This isn't a perfect backport as 7.4 differs quite a bit
with 8.0/8.1. The general parsing logic is being
backported (with additions of additional newer changes
in 8.1) so parsing logic matches between versions.

This is in preparation to adding an additional route to 7.4
and easier forward ports later on. This can also help with
easier backporting in the future from 8.1 back to 7.4. For
example, we still need to backport site-level metrics