### PR TITLE
bf: ZENKO-1447 use getRaftLog Limit param

### DIFF
--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -993,10 +993,10 @@
                         "location": "querystring",
                         "locationName": "begin"
                     },
-                    "End": {
+                    "Limit": {
                         "type": "integer",
                         "location": "querystring",
-                        "locationName": "end"
+                        "locationName": "limit"
                     },
                     "TargetLeader": {
                         "type": "boolean",

--- a/lib/queuePopulator/IngestionProducer.js
+++ b/lib/queuePopulator/IngestionProducer.js
@@ -107,7 +107,7 @@ class IngestionProducer {
         ], err => done(err, this.resLog));
     }
 
-    getRaftLog(raftId, begin, end, targetLeader, done) {
+    getRaftLog(raftId, begin, limit, targetLeader, done) {
         const recordStream = new ListRecordStream(this.log);
         recordStream.on('error', err => {
             if (err.statusCode === 404) {
@@ -135,7 +135,7 @@ class IngestionProducer {
         const req = this.ringReader.getRaftLog({
             LogId: raftId.toString(),
             Begin: begin,
-            End: end,
+            Limit: limit,
             TargetLeader: targetLeader,
         });
         attachReqUids(req, this.requestLogger);


### PR DESCRIPTION
Changes in this PR:
- Update the query param field to specify max logs to fetch
  from `End` to `Limit`