### PR TITLE
bf: ZENKO-1424 bucket cseq snapshot

### DIFF
--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -1076,6 +1076,35 @@
             "output": {
                 "shape": "ObjectMetadataObject"
             }
+        },
+        "GetBucketCseq": {
+            "http": {
+                "method": "GET",
+                "requestUri": "/_/metadata/default/informations/{Bucket}"
+            },
+            "input": {
+                "type": "structure",
+                "required": [
+                    "Bucket"
+                ],
+                "members": {
+                    "Bucket": {
+                        "location": "uri",
+                        "locationName": "Bucket"
+                    }
+                }
+            },
+            "output": {
+                "type": "list",
+                "member": {
+                    "type": "structure",
+                    "members": {
+                        "cseq": {
+                            "type": "integer"
+                        }
+                    }
+                }
+            }
         }
     },
     "shapes": {

--- a/lib/queuePopulator/IngestionProducer.js
+++ b/lib/queuePopulator/IngestionProducer.js
@@ -149,6 +149,7 @@ class IngestionProducer {
      * @param {string} [state.keyMarker] - NextKeyMarker
      * @param {function} done - callback(error, response) where response has:
      *   logRes {object} - metadata logs formed as RaftLogEntry put entries
+     *   cseq {integer} - cseq at start of snapshot phase
      *   initState {object} - returns status for snapshot process
      *   initState.isStatusComplete {boolean} - true/false
      *   [initState.versionMarker] {string} - NextVersionIdMarker, if any
@@ -156,7 +157,21 @@ class IngestionProducer {
      * @return {undefined}
      */
     snapshot(bucketName, state, done) {
+        // get cseq ONLY on first snapshot request, indicated by markers
+        let initialCseq;
         async.waterfall([
+            next => {
+                if (!state.versionMarker && !state.keyMarker) {
+                    return this._getBucketCseq(bucketName, (err, cseq) => {
+                        if (err) {
+                            return next(err);
+                        }
+                        initialCseq = cseq;
+                        return next();
+                    });
+                }
+                return process.nextTick(next);
+            },
             next => this._getObjectVersionsList(bucketName, state, next),
             (data, next) => {
                 const {
@@ -175,6 +190,9 @@ class IngestionProducer {
                             keyMarker
                         },
                     };
+                    if (initialCseq) {
+                        response.initState.cseq = initialCseq;
+                    }
                     return next(null, response);
                 });
             },
@@ -382,6 +400,36 @@ class IngestionProducer {
             });
         }
         return done(null, []);
+    }
+
+    /**
+     * Get bucket cseq
+     * @param {string} bucket - bucket name
+     * @param {function} done - callback(err, cseq) where `cseq` is an integer
+     * @return {undefined}
+     */
+    _getBucketCseq(bucket, done) {
+        return this._ringReader.getBucketCseq({ Bucket: bucket },
+        (err, data) => {
+            if (err) {
+                this.log.error('error getting bucket cseq', {
+                    method: 'IngestionProducer._getBucketCseq',
+                    error: err,
+                    bucket,
+                });
+                return done(err);
+            }
+            if (!data || !data[0] || !data[0].cseq) {
+                this.log.error('could not get cseq data or data is malformed', {
+                    method: 'IngestionProducer._getBucketCseq',
+                    bucket,
+                    data,
+                });
+                return done(errors.InternalError);
+            }
+            // cseq returned by all nodes. Just return the first node response
+            return done(null, data[0].cseq);
+        });
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -120,7 +120,6 @@
             "ioctl": "2.0.1",
             "ioredis": "4.2.0",
             "ipaddr.js": "1.8.1",
-            "joi": "^14.3.0",
             "level": "~4.0.0",
             "level-sublevel": "~6.6.1",
             "mongodb": "^3.0.1",
@@ -934,35 +933,192 @@
           "integrity": "sha512-PdxZGNJBfPiR2RI6DkqmiacL1+ML3gaqEiaC5QXWQt9eSTlGj+BwDCct0s8irn1ed8GyzAHTzcjvU9fmnl6D7A==",
           "requires": {
             "cluster-key-slot": "^1.0.6",
-            "debug": "^3.1.0",
             "denque": "^1.1.0",
             "flexbuffer": "0.0.6",
             "lodash.defaults": "^4.2.0",
             "lodash.flatten": "^4.4.0",
             "redis-commands": "1.4.0",
             "redis-errors": "^1.2.0",
-            "redis-parser": "^3.0.0",
             "standard-as-callback": "^1.0.0"
           },
           "dependencies": {
             "debug": {
-              "version": "3.2.6",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-              "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+              "version": "2.3.3",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+              "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
               "requires": {
-                "ms": "^2.1.1"
+                "ms": "0.7.2"
+              }
+            },
+            "double-ended-queue": {
+              "version": "2.1.0-0",
+              "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+              "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+            },
+            "has-binary": {
+              "version": "0.1.7",
+              "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+              "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow="
+            },
+            "hoek": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+              "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+            },
+            "ioctl": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ioctl/-/ioctl-2.0.0.tgz",
+              "integrity": "sha1-Kqy9c+tv+a0B/fPswzkO5XeBEA4=",
+              "requires": {
+                "bindings": "^1.1.1",
+                "nan": "^2.3.2"
+              }
+            },
+            "ioredis": {
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.5.0.tgz",
+              "integrity": "sha1-+2/fChp+CXRhTGe25eETCKjPlbk=",
+              "requires": {
+                "bluebird": "^3.3.4",
+                "cluster-key-slot": "^1.0.6",
+                "debug": "^2.2.0",
+                "double-ended-queue": "^2.1.0-0",
+                "flexbuffer": "0.0.6",
+                "lodash": "^4.8.2",
+                "redis-commands": "^1.2.0",
+                "redis-parser": "^1.3.0"
+              }
+            },
+            "ipaddr.js": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz",
+              "integrity": "sha1-irpJyRknmVhb3WQ+DMtQ6K53e6Q="
+            },
+            "isemail": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+              "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
+            },
+            "joi": {
+              "version": "10.6.0",
+              "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
+              "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+              "requires": {
+                "hoek": "4.x.x",
+                "isemail": "2.x.x",
+                "items": "2.x.x",
+                "topo": "2.x.x"
+              }
+            },
+            "level": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/level/-/level-1.6.0.tgz",
+              "integrity": "sha1-P8uukWOgkWaLjsep79HS/u8eZiE=",
+              "requires": {
+                "level-packager": "~1.2.0",
+                "leveldown": "~1.6.0"
+              }
+            },
+            "ms": {
+              "version": "0.7.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+              "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+            },
+            "redis-parser": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-1.3.0.tgz",
+              "integrity": "sha1-gG6+e7+3005NfB6e8oLvz60EEmo="
+            },
+            "simple-glob": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/simple-glob/-/simple-glob-0.1.1.tgz",
+              "integrity": "sha1-KCv6AS1yBmQ99h00xrueTOP9dxQ=",
+              "requires": {
+                "glob": "~3.2.8",
+                "lodash": "~2.4.1",
+                "minimatch": "~0.2.14"
+              },
+              "dependencies": {
+                "lodash": {
+                  "version": "2.4.2",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+                  "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+                }
+              }
+            },
+            "socket.io": {
+              "version": "1.7.4",
+              "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.4.tgz",
+              "integrity": "sha1-L37O3DORvy1cc+KR/iM+bjTU3QA=",
+              "requires": {
+                "debug": "2.3.3",
+                "engine.io": "~1.8.4",
+                "has-binary": "0.1.7",
+                "object-assign": "4.1.0",
+                "socket.io-adapter": "0.5.0",
+                "socket.io-client": "1.7.4",
+                "socket.io-parser": "2.3.1"
+              }
+            },
+            "socket.io-client": {
+              "version": "1.7.4",
+              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.4.tgz",
+              "integrity": "sha1-7J+CA1btme9tNX8HVtZIcXvdQoE=",
+              "requires": {
+                "backo2": "1.0.2",
+                "component-bind": "1.0.0",
+                "debug": "2.3.3",
+                "engine.io-client": "~1.8.4",
+                "has-binary": "0.1.7",
+                "indexof": "0.0.1",
+                "object-component": "0.0.3",
+                "parseuri": "0.0.5",
+                "socket.io-parser": "2.3.1",
+                "to-array": "0.1.4"
+              }
+            },
+            "topo": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+              "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+              "requires": {
+                "hoek": "4.x.x"
+              }
+            },
+            "vaultclient": {
+              "version": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
+              "from": "github:scality/vaultclient#fbd9988d",
+              "requires": {
+                "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+                "xml2js": "0.4.17"
+              },
+              "dependencies": {
+                "xml2js": {
+                  "version": "0.4.17",
+                  "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+                  "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+                  "requires": {
+                    "sax": ">=0.6.0",
+                    "xmlbuilder": "^4.1.0"
+                  }
+                }
+              }
+            },
+            "werelogs": {
+              "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+              "from": "github:scality/werelogs#0ff7ec82",
+              "requires": {
+                "safe-json-stringify": "1.0.3"
+              }
+            },
+            "xmlbuilder": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+              "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+              "requires": {
+                "lodash": "^4.0.0"
               }
             }
-          }
-        },
-        "joi": {
-          "version": "14.3.1",
-          "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.1.tgz",
-          "integrity": "sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==",
-          "requires": {
-            "hoek": "6.x.x",
-            "isemail": "3.x.x",
-            "topo": "3.x.x"
           }
         },
         "level-codec": {
@@ -1258,6 +1414,11 @@
             "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2"
           },
           "dependencies": {
+            "sigmund": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+              "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+            },
             "werelogs": {
               "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
               "from": "github:scality/werelogs#7.4.0.3",
@@ -1305,7 +1466,6 @@
                 "socket.io-client": "~1.7.3",
                 "utf8": "2.1.2",
                 "uuid": "^3.0.1",
-                "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
                 "xml2js": "~0.4.16"
               },
               "dependencies": {
@@ -1952,8 +2112,8 @@
       "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
     },
     "arsenal": {
-      "version": "github:scality/Arsenal#ebe2d1f24de9a8cd4832f5933e9e94fc3e294149",
-      "from": "github:scality/Arsenal#ebe2d1f",
+      "version": "github:scality/Arsenal#735ad74bdaf80df643484e1166bc52a6b020a0fb",
+      "from": "github:scality/Arsenal#735ad74",
       "requires": {
         "JSONStream": "^1.0.0",
         "ajv": "4.10.0",
@@ -3171,14 +3331,23 @@
         "which": "^1.2.9"
       },
       "dependencies": {
-        "lru-cache": {
-          "version": "4.1.5",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
-          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "dev": true,
+        "process-nextick-args": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         }
       }
@@ -4635,6 +4804,13 @@
       "integrity": "sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==",
       "requires": {
         "punycode": "2.x.x"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        }
       }
     },
     "isexe": {
@@ -5225,6 +5401,16 @@
       "resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
       "integrity": "sha1-Zs0Md0rz1P7axTeU90LbVtqPCew="
     },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
     "ltgt": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
@@ -5536,6 +5722,11 @@
           "version": "0.2.10",
           "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
           "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+        },
+        "underscore": {
+          "version": "1.4.4",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+          "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
         }
       }
     },
@@ -5968,9 +6159,9 @@
       }
     },
     "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
     },
     "qs": {
       "version": "6.5.2",
@@ -6750,15 +6941,10 @@
       "integrity": "sha1-yIgvobsQksBgBal/NO9chQjjZk4="
     },
     "uc.micro": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.5.tgz",
-      "integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
-    },
-    "underscore": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
     },
     "uri-js": {
       "version": "4.2.2",
@@ -6766,6 +6952,13 @@
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
         "punycode": "^2.1.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        }
       }
     },
     "url": {
@@ -6775,13 +6968,6 @@
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-        }
       }
     },
     "utf-8-validate": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/scality/backbeat#readme",
   "dependencies": {
     "JSONStream": "^1.3.5",
-    "arsenal": "github:scality/Arsenal#ebe2d1f",
+    "arsenal": "github:scality/Arsenal#735ad74",
     "async": "^2.3.0",
     "aws-sdk": "2.147.0",
     "backo": "^1.1.0",

--- a/tests/functional/ingestion/IngestionProducer.js
+++ b/tests/functional/ingestion/IngestionProducer.js
@@ -100,6 +100,14 @@ describe('ingestion producer tests with mock', () => {
         });
     });
 
+    it('should be able to grab bucket cseq', done => {
+        this.iProducer._getBucketCseq('bucket1', (err, cseq) => {
+            assert.ifError(err);
+            assert.strictEqual(cseq, 7);
+            return done();
+        });
+    });
+
     it('can generate a valid snapshot', done => {
         this.iProducer.snapshot(bucket, {}, (err, res) => {
             assert.ifError(err);

--- a/tests/functional/lib/BackbeatClient.js
+++ b/tests/functional/lib/BackbeatClient.js
@@ -137,4 +137,16 @@ describe('BackbeatClient unit tests with mock server', () => {
             return done();
         });
     });
+
+    it('should get bucket specified cseq', done => {
+        const destReq = backbeatClient.getBucketCseq({
+            Bucket: bucketName,
+        });
+        return destReq.send((err, data) => {
+            assert.ifError(err);
+            assert(data[0] && data[0].cseq);
+            assert.strictEqual(data[0].cseq, 7);
+            return done();
+        });
+    });
 });


### PR DESCRIPTION
Only used during snapshot phase

Changes in this PR:
- Introduce metadata route to fetch bucket cseq with
  BackbeatClient
- Fetch cseq and set as `logStats.nbLogRecordsRead`
  during snapshot phase only