### PR TITLE
ft: ZENKO-1452 update snapshot to use s3 api

### DIFF
--- a/lib/queuePopulator/IngestionProducer.js
+++ b/lib/queuePopulator/IngestionProducer.js
@@ -144,14 +144,40 @@ class IngestionProducer {
      * generate a listing of all current objects that exists on the source
      * bucket, including the bucket MD to create the correct entries
      * @param {string} bucketName - name of source bucket
-     * @param {function} done - callback(error, resLog)
+     * @param {object} state - previous state used to paginate version listing
+     * @param {string} [state.versionMarker] - NextVersionIdMarker
+     * @param {string} [state.keyMarker] - NextKeyMarker
+     * @param {function} done - callback(error, response) where response has:
+     *   logRes {object} - metadata logs formed as RaftLogEntry put entries
+     *   initState {object} - returns status for snapshot process
+     *   initState.isStatusComplete {boolean} - true/false
+     *   [initState.versionMarker] {string} - NextVersionIdMarker, if any
+     *   [initState.keyMarker] {string} - KeyMarker, if any
      * @return {undefined}
      */
-    snapshot(bucketName, done) {
+    snapshot(bucketName, state, done) {
         async.waterfall([
-            next => this._getObjectVersionsList(bucketName, next),
-            (versionList, next) =>
-                this._getBucketObjectsMetadata(bucketName, versionList, next),
+            next => this._getObjectVersionsList(bucketName, state, next),
+            (data, next) => {
+                const {
+                    IsTruncated, versionList, versionMarker, keyMarker,
+                } = data;
+                this._getBucketObjectsMetadata(bucketName, versionList,
+                (err, logRes) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    const response = {
+                        logRes,
+                        initState: {
+                            isStatusComplete: !IsTruncated,
+                            versionMarker,
+                            keyMarker
+                        },
+                    };
+                    return next(null, response);
+                });
+            },
         ], done);
     }
 
@@ -232,19 +258,27 @@ class IngestionProducer {
      * Get the list of object versions for a bucket
      *
      * @param {string} bucket - bucket name
+     * @param {object} state - previous state used to paginate version listing
+     * @param {string} [state.versionMarker] - NextVersionIdMarker
+     * @param {string} [state.keyMarker] - NextKeyMarker
      * @param {function} done - callback function
      * @return {object} list of objects for each bucket, including a duplicate
      *   entry for IsLatest versions
      */
-    _getObjectVersionsList(bucket, done) {
+    _getObjectVersionsList(bucket, state, done) {
         if (bucket === constants.usersBucket ||
             bucket === constants.metastoreBucket) {
             return done();
         }
-        // TODO: VersionIdMarker && KeyMarker
+        const { versionMarker, keyMarker } = state;
         const params = {
             Bucket: bucket,
         };
+        // if previous state, should paginate here
+        if (versionMarker && keyMarker) {
+            params.VersionIdMarker = versionMarker;
+            params.KeyMarker = keyMarker;
+        }
         // TODO: For testing, I can set MaxKeys
         const req = this._s3Client.listObjectVersions(params);
         attachReqUids(req, this.requestLogger);
@@ -259,24 +293,19 @@ class IngestionProducer {
             }
             const {
                 IsTruncated,
-                // NextKeyMarker,
-                // NextVersionIdMarker,
+                NextKeyMarker,
+                NextVersionIdMarker,
                 Versions,
                 DeleteMarkers
             } = data;
 
-            if (IsTruncated) {
-                // need NextKeyMarker
-                // need NextVersionIdMarker
-            }
-
-            const versionList = [...Versions, ...DeleteMarkers];
-            // find all IsLatest versions since we need these as separate
-            // metadata entries
-            const latestVersions = versionList.filter(v => v.IsLatest)
-                .map(v => Object.assign({}, v, { isLatest: true }));
-
-            return done(null, versionList.concat(latestVersions));
+            const response = {
+                versionList: [...Versions, ...DeleteMarkers],
+                IsTruncated,
+                versionMarker: NextVersionIdMarker,
+                keyMarker: NextKeyMarker,
+            };
+            return done(null, response);
         });
     }
 
@@ -294,15 +323,10 @@ class IngestionProducer {
             return done();
         }
 
-        return async.mapLimit(versionList, 10, (version, cb) => {
-            const { Key, VersionId, isLatest } = version;
-
-            let objectKey;
-            if (isLatest) {
-                objectKey = Key;
-            } else {
-                objectKey = `${Key}${VID_SEP}${decode(VersionId)}`;
-            }
+        const objectMDList = [];
+        return async.eachLimit(versionList, 10, (version, cb) => {
+            const { Key, VersionId, IsLatest } = version;
+            const objectKey = `${Key}${VID_SEP}${decode(VersionId)}`;
 
             const req = this._ringReader.getObjectMetadata({
                 Bucket: bucket,
@@ -317,17 +341,27 @@ class IngestionProducer {
                     });
                     return cb(err);
                 }
-                return cb(null, {
+                const objectEntry = {
                     res: data,
                     objectKey,
                     bucketName: bucket,
-                });
+                };
+                objectMDList.push(objectEntry);
+                if (IsLatest) {
+                    // duplicate the entry w/out the version id in the object
+                    // key to represent the master key
+                    objectMDList.push(Object.assign({}, objectEntry, {
+                        // key name w/out version id
+                        objectKey: Key,
+                    }));
+                }
+                return cb();
             });
-        }, (err, objectMDs) => {
+        }, err => {
             if (err) {
                 return done(err);
             }
-            return this._createAndPushEntry(objectMDs, done);
+            return this._createAndPushEntry(objectMDList, done);
         });
     }
 

--- a/lib/queuePopulator/IngestionProducer.js
+++ b/lib/queuePopulator/IngestionProducer.js
@@ -1,10 +1,15 @@
 const async = require('async');
 const AWS = require('aws-sdk');
 const http = require('http');
+const https = require('https');
 const jsonStream = require('JSONStream');
 const stream = require('stream');
 const Logger = require('werelogs').Logger;
 const { constants, errors } = require('arsenal');
+
+const { decode } = require('arsenal').versioning.VersionID;
+const VID_SEP = require('arsenal').versioning.VersioningConstants
+          .VersionId.Separator;
 
 const BackbeatClient = require('../clients/BackbeatClient');
 const { attachReqUids } = require('../clients/utils');
@@ -41,26 +46,66 @@ class IngestionProducer {
     constructor(sourceConfig, qpConfig, s3Config) {
         this.log = new Logger('Backbeat:IngestionProducer');
         this.qpConfig = qpConfig;
-        this.s3sourceCredentials = new AWS.Credentials({
-            accessKeyId: sourceConfig.auth.accessKey,
-            secretAccessKey: sourceConfig.auth.secretKey,
-        });
-
-        const { https, host, port } = sourceConfig;
-        const protocol = https ? 'https' : 'http';
-
         this.s3source = s3Config;
         this._targetZenkoBucket = sourceConfig.name;
         this.requestLogger = this.log.newRequestLogger();
         this.createEntry = new RaftLogEntry();
-        this.resLog = [];
-        this.sourceHTTPAgent = new http.Agent({ keepAlive: true });
 
-        this.ringReader = new BackbeatClient({
-            endpoint: `${protocol}://${host}:${port}`,
-            credentials: this.s3sourceCredentials,
+        this._ringReader = null;
+        this._s3Client = null;
+        this._setupClients(sourceConfig);
+    }
+
+    /**
+     * Helper method to create a new HTTP(S) agent
+     * @param {string} protocol - "https" || "http"
+     * @return {http.Agent|https.Agent} new http or https Agent
+     */
+    _createHTTPAgent(protocol) {
+        const params = { keepAlive: true };
+        if (protocol === 'https') {
+            return new https.Agent(params);
+        }
+        return new http.Agent(params);
+    }
+
+    /**
+     * Setup internal clients: `this._ringReader`, `this._s3Client`
+     * @param {object} sourceConfig - source config (also called bucketdConfig)
+     * @return {undefined}
+     */
+    _setupClients(sourceConfig) {
+        const { https, host, port } = sourceConfig;
+        const protocol = https ? 'https' : 'http';
+        const endpoint = `${protocol}://${host}:${port}`;
+        const s3sourceCredentials = new AWS.Credentials({
+            accessKeyId: sourceConfig.auth.accessKey,
+            secretAccessKey: sourceConfig.auth.secretKey,
+        });
+
+        this._ringReader = new BackbeatClient({
+            endpoint,
+            credentials: s3sourceCredentials,
             sslEnabled: protocol === 'https',
-            httpOptions: { agent: this.sourceHTTPAgent, timeout: 0 },
+            httpOptions: {
+                agent: this._createHTTPAgent(protocol),
+                timeout: 0,
+            },
+            maxRetries: 0,
+        });
+        const s3endpoint = process.env.CI === 'true' ?
+                          `${protocol}://${host}:8000` :
+                          endpoint;
+        this._s3Client = new AWS.S3({
+            endpoint: s3endpoint,
+            credentials: s3sourceCredentials,
+            sslEnabled: protocol === 'https',
+            s3ForcePathStyle: true,
+            signatureVersion: 'v4',
+            httpOptions: {
+                agent: this._createHTTPAgent(protocol),
+                timeout: 0,
+            },
             maxRetries: 0,
         });
     }
@@ -72,7 +117,7 @@ class IngestionProducer {
      * @return {number} the raftId that has logs for the bucket
      */
     getRaftId(bucketName, done) {
-        const req = this.ringReader.getRaftId({
+        const req = this._ringReader.getRaftId({
             Bucket: bucketName,
         });
 
@@ -80,7 +125,11 @@ class IngestionProducer {
         req.send((err, data) => {
             if (err) {
                 this.log.error(`could not find bucket ${bucketName} in any` +
-                ' raft session', { method: 'getRaftId', bucketName });
+                ' raft session', {
+                    method: 'IngestionProducer.getRaftId',
+                    bucketName,
+                    error: err,
+                });
                 return done(err);
             } else if (data && data[0]) {
                 return done(null, data[0]);
@@ -95,16 +144,15 @@ class IngestionProducer {
      * generate a listing of all current objects that exists on the source
      * bucket, including the bucket MD to create the correct entries
      * @param {string} bucketName - name of source bucket
-     * @param {function} done - callback function
-     * @return {object} resLog value
-     *
+     * @param {function} done - callback(error, resLog)
+     * @return {undefined}
      */
     snapshot(bucketName, done) {
         async.waterfall([
-            next => this._getBucketObjects([bucketName], next),
-            (bucketList, next) =>
-                this._getBucketObjectsMetadata(bucketList, next),
-        ], err => done(err, this.resLog));
+            next => this._getObjectVersionsList(bucketName, next),
+            (versionList, next) =>
+                this._getBucketObjectsMetadata(bucketName, versionList, next),
+        ], done);
     }
 
     getRaftLog(raftId, begin, limit, targetLeader, done) {
@@ -132,7 +180,7 @@ class IngestionProducer {
             { error: err.message });
             return done(errors.InternalError);
         });
-        const req = this.ringReader.getRaftLog({
+        const req = this._ringReader.getRaftLog({
             LogId: raftId.toString(),
             Begin: begin,
             Limit: limit,
@@ -155,10 +203,6 @@ class IngestionProducer {
         return undefined;
     }
 
-    _parseBucketName(bucketKey) {
-        return bucketKey.split(constants.splitter)[1];
-    }
-
     /**
      * Get the list of buckets using the usersBucket
      * Each bucket is stored as a key in the usersBucket
@@ -168,7 +212,7 @@ class IngestionProducer {
      * @return {Object} list of keys that correspond to list of buckets
      */
     _getBuckets(raftId, done) {
-        const req = this.ringReader.getRaftBuckets({
+        const req = this._ringReader.getRaftBuckets({
             LogId: raftId,
         });
 
@@ -176,7 +220,7 @@ class IngestionProducer {
         req.send((err, data) => {
             if (err) {
                 this.log.error('error getting list of buckets', {
-                    method: 'IngestionProducer:getBuckets', err });
+                    method: 'IngestionProducer._getBuckets', err });
                 return done(err);
             }
             const bucketList = Object.keys(data).map(index => data[index]);
@@ -185,95 +229,125 @@ class IngestionProducer {
     }
 
     /**
-     * get the list of objects for each bucket
+     * Get the list of object versions for a bucket
      *
-     * @param {object} bucketList - list of buckets
+     * @param {string} bucket - bucket name
      * @param {function} done - callback function
-     * @return {object} list of buckets and list of objects for each bucket
+     * @return {object} list of objects for each bucket, including a duplicate
+     *   entry for IsLatest versions
      */
-    _getBucketObjects(bucketList, done) {
-        if (!bucketList) {
-            return done(null, null);
+    _getObjectVersionsList(bucket, done) {
+        if (bucket === constants.usersBucket ||
+            bucket === constants.metastoreBucket) {
+            return done();
         }
-        return async.mapLimit(bucketList, 10, (bucketInfo, cb) => {
-            if (bucketInfo === constants.usersBucket ||
-            bucketInfo === constants.metastoreBucket) {
-                return cb();
+        // TODO: VersionIdMarker && KeyMarker
+        const params = {
+            Bucket: bucket,
+        };
+        // TODO: For testing, I can set MaxKeys
+        const req = this._s3Client.listObjectVersions(params);
+        attachReqUids(req, this.requestLogger);
+        return req.send((err, data) => {
+            if (err) {
+                this.log.error('error getting list of object versions', {
+                    method: 'IngestionProducer._getObjectVersionsList',
+                    error: err,
+                    bucket,
+                });
+                return done(err);
             }
-            const req = this.ringReader.getObjectList({
-                Bucket: bucketInfo,
-            });
-            attachReqUids(req, this.requestLogger);
-            return req.send((err, data) => {
-                if (err) {
-                    this.log.error('error getting list of objects', {
-                        method: 'IngestionProducer:getBucketObjects', err });
-                    return cb(err);
-                }
-                return cb(null, { bucket: bucketInfo, objects: data.Contents });
-            });
-        }, (err, buckets) => done(err, buckets));
+            const {
+                IsTruncated,
+                // NextKeyMarker,
+                // NextVersionIdMarker,
+                Versions,
+                DeleteMarkers
+            } = data;
+
+            if (IsTruncated) {
+                // need NextKeyMarker
+                // need NextVersionIdMarker
+            }
+
+            const versionList = [...Versions, ...DeleteMarkers];
+            // find all IsLatest versions since we need these as separate
+            // metadata entries
+            const latestVersions = versionList.filter(v => v.IsLatest)
+                .map(v => Object.assign({}, v, { isLatest: true }));
+
+            return done(null, versionList.concat(latestVersions));
+        });
     }
 
     /**
-     * get metadata for all objects, and send the info to kafka
+     * Get metadata for all objects, and send the info to kafka
      *
-     * @param {object} bucketObjectList - list of buckets and list of objects
-     * for each bucket
+     * @param {string} bucket - bucket name
+     * @param {array} versionList - list of object versions (including delete
+     *   markers)
      * @param {function} done - callback function
      * @return {undefined}
      */
-    _getBucketObjectsMetadata(bucketObjectList, done) {
-        if (!bucketObjectList) {
-            return done(null, null);
+    _getBucketObjectsMetadata(bucket, versionList, done) {
+        if (versionList.length === 0) {
+            return done();
         }
-        return async.mapSeries(bucketObjectList, (bucket, cb) => {
-            if (!bucket) {
-                return cb();
+
+        return async.mapLimit(versionList, 10, (version, cb) => {
+            const { Key, VersionId, isLatest } = version;
+
+            let objectKey;
+            if (isLatest) {
+                objectKey = Key;
+            } else {
+                objectKey = `${Key}${VID_SEP}${decode(VersionId)}`;
             }
-            const bucketName = bucket.bucket;
-            return async.mapLimit(bucket.objects, 10, (object, cb) => {
-                const objectKey = object.key;
-                const req = this.ringReader.getObjectMetadata({
-                    Bucket: bucketName,
-                    Key: objectKey,
-                });
-                attachReqUids(req, this.requestLogger);
-                return req.send((err, data) => {
-                    if (err) {
-                        this.log.error('error getting metadata for object', {
-                            method: 'IngestionoProducer:getBucketObjects' +
-                            'Metadata', err });
-                    }
-                    return cb(null, { res: data, objectKey, bucketName });
-                });
-            }, (err, objectMDs) => {
+
+            const req = this._ringReader.getObjectMetadata({
+                Bucket: bucket,
+                Key: objectKey,
+            });
+            attachReqUids(req, this.requestLogger);
+            req.send((err, data) => {
                 if (err) {
+                    this.log.error('error getting metadata for object', {
+                        method: 'IngestionProducer._getBucketObjectsMetadata',
+                        error: err
+                    });
                     return cb(err);
                 }
-                return this._createAndPushEntry(objectMDs, cb);
+                return cb(null, {
+                    res: data,
+                    objectKey,
+                    bucketName: bucket,
+                });
             });
-        }, err => done(err));
+        }, (err, objectMDs) => {
+            if (err) {
+                return done(err);
+            }
+            return this._createAndPushEntry(objectMDs, done);
+        });
     }
 
     _createAndPushEntry(objectMds, done) {
         if (objectMds.length > 0) {
-            return async.eachLimit(objectMds, 10, (objectMd, cb) => {
-                const objectMdEntry =
-                    this.createEntry.createPutEntry(objectMd,
+            return async.mapLimit(objectMds, 10, (objectMd, cb) => {
+                const objectMdEntry = this.createEntry.createPutEntry(objectMd,
                         this._targetZenkoBucket);
-                this.resLog.push(objectMdEntry);
-                return cb();
-            }, err => {
+                return cb(null, objectMdEntry);
+            }, (err, entries) => {
                 if (err) {
                     this.log.error('error sending objectMd to kafka', {
-                        err,
+                        method: 'IngestionProducer._createAndPushEntry',
+                        error: err,
                     });
                 }
-                return done(err);
+                return done(err, entries);
             });
         }
-        return done();
+        return done(null, []);
     }
 }
 

--- a/lib/queuePopulator/IngestionReader.js
+++ b/lib/queuePopulator/IngestionReader.js
@@ -1,8 +1,15 @@
 const async = require('async');
+const { errors } = require('arsenal');
+const VID_SEP = require('arsenal').versioning.VersioningConstants
+          .VersionId.Separator;
 
 const IngestionProducer = require('./IngestionProducer');
 const LogReader = require('./LogReader');
 const { decryptLocationSecret } = require('../management/index');
+
+function _isVersionedLogKey(key) {
+    return key.split(VID_SEP)[1] !== undefined;
+}
 
 class IngestionReader extends LogReader {
     constructor(params) {
@@ -13,18 +20,26 @@ class IngestionReader extends LogReader {
         this.qpConfig = qpConfig;
         this.s3Config = s3Config;
         this.bucketdConfig = bucketdConfig;
-
         this.logger = logger;
-        this.logger.info('initializing ingestion reader',
-            { method: 'IngestionReader.constructor',
-                bucketdConfig, raftId: this.raftId });
-        this.newIngestion = false;
-        this.remoteLogOffset = null;
 
         // source ingestion bucket
         this.bucket = bucketdConfig.bucket;
         // zenko bucket to ingest to
         this._targetZenkoBucket = bucketdConfig.name;
+
+        this.zkBasePath = `/${this._targetZenkoBucket}/logState`;
+        this.bucketInitPath = `${this.zkBasePath}/init`;
+        this.pathToLogOffset = null;
+        this.raftId = null;
+        this.logId = null;
+    }
+
+    /**
+     * static method to return a list of ingestion init nodes used in zookeeper
+     * @return {Array} - array of ingestion init nodes as strings
+     */
+    static getInitIngestionNodes() {
+        return ['isStatusComplete', 'versionMarker', 'keyMarker'];
     }
 
     _setupIngestionProducer(cb) {
@@ -57,12 +72,107 @@ class IngestionReader extends LogReader {
                 }
                 this.raftId = data;
                 this.logId = `raft_${this.raftId}`;
-                this.pathToLogOffset = `/${this._targetZenkoBucket}/logState` +
-                    `/${this.logId}/logOffset`;
+                this.pathToLogOffset =
+                    `${this.zkBasePath}/${this.logId}/logOffset`;
 
                 return super.setup(done);
             });
         });
+    }
+
+    /**
+     * Get the init (snapshot) state for this given IngestionReader
+     * @param {Logger.newRequestLogger} logger - request logger object
+     * @param {function} done - callback(error, object)
+     *   where object.versionMarker is the NextVersionIdMarker
+     *   where object.keyMarker is the NextKeyMarker
+     * @return {undefined}
+     */
+    _readInitState(logger, done) {
+        const initPathNodes = IngestionReader.getInitIngestionNodes();
+
+        async.map(initPathNodes, (pathNode, cb) => {
+            const path = `${this.bucketInitPath}/${pathNode}`;
+            return this.zkClient.getData(path, (err, data) => {
+                if (err) {
+                    if (err.name !== 'NO_NODE') {
+                        logger.error(
+                            'Could not fetch ingestion init state',
+                            { method: 'IngestionReader._readInitState',
+                              zkPath: path,
+                              error: err });
+                        return cb(err);
+                    }
+                    return this.zkClient.mkdirp(path, err => {
+                        if (err) {
+                            logger.error(
+                                'Could not pre-create path in zookeeper',
+                                { method: 'IngestionReader._readInitState',
+                                  zkPath: path,
+                                  error: err });
+                            return cb(err);
+                        }
+                        return cb();
+                    });
+                }
+                const d = data && data.toString();
+                logger.debug('fetched ingestion init state node', {
+                    method: 'IngestionReader._readInitState',
+                    zkPath: path,
+                    data: d,
+                });
+                return cb(null, d);
+            });
+        }, (err, data) => {
+            if (err) {
+                return done(err);
+            }
+            const [isStatusComplete, versionMarker, keyMarker] = data;
+            return done(null, {
+                isStatusComplete: isStatusComplete === 'true',
+                versionMarker,
+                keyMarker
+            });
+        });
+    }
+
+    /**
+     * Set the init (snapshot) state for this given IngestionReader
+     * @param {object} initState - initState (snapshot) for ingestion
+     * @param {boolean} initState.isStatusComplete - true/false
+     * @param {string} [initState.versionMarker] - NextVersionIdMarker
+     * @param {string} [initState.keyMarker] - NextKeyMarker
+     * @param {Logger.newRequestLogger} logger - request logger object
+     * @param {function} done - callback(error)
+     * @return {undefined}
+     */
+    _writeInitState(initState, logger, done) {
+        // initState is set by each request of processLogEntries. If undefined,
+        // we did not go through snapshot phase
+        if (!initState) {
+            return process.nextTick(done);
+        }
+        const initPathNodes = IngestionReader.getInitIngestionNodes();
+
+        return async.each(initPathNodes, (pathNode, cb) => {
+            const path = `${this.bucketInitPath}/${pathNode}`;
+            const data = (initState[pathNode] || 'null').toString();
+            return this.zkClient.setData(path, Buffer.from(data), err => {
+                if (err) {
+                    logger.error('error saving init state', {
+                        method: 'IngestionReader._writeInitState',
+                        zkPath: path,
+                        error: err,
+                    });
+                    return cb(err);
+                }
+                logger.debug('saved init state', {
+                    method: 'IngestionReader._writeInitState',
+                    zkPath: path,
+                });
+                return cb();
+            });
+        }, done);
     }
 
     /* eslint-disable no-param-reassign */
@@ -77,43 +187,45 @@ class IngestionReader extends LogReader {
             readOptions.limit = params.maxRead;
         }
         logger.debug('reading records', { readOptions });
+
         return async.waterfall([
-            next => this._readLogOffset((err, res) => {
-                const offset = Number.parseInt(res, 10);
-                if (err) {
-                    return next(err);
-                }
-                if (offset === 1) {
-                    // TODO: need new indicator for this.newIngestion
-                    this.newIngestion = true;
-                }
-                return next();
-            }),
-            next => {
-                if (!this.newIngestion) {
+            next => this._readInitState(logger, next),
+            (initState, next) => {
+                if (initState.isStatusComplete) {
                     return this._iProducer.getRaftLog(this.raftId,
                     readOptions.startSeq, readOptions.limit, false,
                     (err, data) => {
                         if (err) {
-                            this.logger.error('Error retrieving logs', { err,
+                            logger.error('Error retrieving logs', { err,
                                 raftId: this.raftId, method:
                                 'IngestionReader._processReadRecords' });
                             return next(err);
                         }
-                        this.logger.debug('readRecords got raft logs', {
+                        logger.debug('readRecords got raft logs', {
                             method: 'IngestionReader._processReadRecords',
                             params });
                         batchState.logRes = data;
                         return next();
                     });
                 }
-                return this._iProducer.snapshot(this.bucket, (err, res) => {
+                return this._iProducer.snapshot(this.bucket, initState,
+                (err, res) => {
                     if (err) {
                         logger.error('error generating snapshot for ' +
-                        'ingestion', { err });
+                        'ingestion', {
+                            error: err,
+                            method: 'IngestionReader._processReadRecords',
+                        });
                         return next(err);
                     }
-                    batchState.logRes = { info: { start: 1 }, log: res };
+                    if (!res) {
+                        logger.error('failed to get metadata logs', {
+                            method: 'IngestionReader._processReadRecords',
+                        });
+                        return next(errors.InternalError);
+                    }
+                    batchState.logRes = { info: { start: 1 }, log: res.logRes };
+                    batchState.initState = res.initState;
                     return next();
                 });
             },
@@ -169,13 +281,22 @@ class IngestionReader extends LogReader {
     }
 
     _processPrepareEntries(batchState, done) {
-        const { entriesToPublish, logRes, logStats, logger } = batchState;
+        const {
+            entriesToPublish, logRes, logStats, logger, initState,
+        } = batchState;
 
         this._setEntryBatch(entriesToPublish);
 
-        if (this.newIngestion) {
+        // if initState, then these current log entries came from a snapshot
+        if (initState) {
             logRes.log.forEach(entry => {
-                logStats.nbLogRecordsRead += 1;
+                // for snapshot phase, only versioned keys are separate records
+                // and non-versioned keys are only considered entries.
+                // Doing this for logging only. This won't affect offset in zk
+                if (_isVersionedLogKey(entry.key)) {
+                    logStats.nbLogRecordsRead += 1;
+                }
+                logStats.nbLogEntriesRead += 1;
                 this._processLogEntry(batchState, entry, entry);
             });
             return done();
@@ -209,13 +330,20 @@ class IngestionReader extends LogReader {
     }
 
     _processPublishEntries(batchState, done) {
-        const { entriesToPublish, logRes, logStats, logger } = batchState;
+        const {
+            entriesToPublish, logRes, logStats, logger, initState,
+        } = batchState;
 
-        if (this.remoteLogOffset /* &&
-        config.queuePopulator.logSource.indexOf('ingestion') > -1 */) {
-            batchState.nextLogOffset = this.remoteLogOffset;
-            // return done();
-        } else {
+        // initState.cseq is only fetched at very start of snapshot phase.
+        // We want to save cseq right before we started snapshot
+        // phase to guarantee we don't miss any new entries while snapshot
+        // is in process
+        if (initState && initState.cseq) {
+            batchState.nextLogOffset = initState.cseq;
+        }
+        // only set this after snapshot phase is done.
+        // `initState` is only set during snapshot phase.
+        if (!initState) {
             batchState.nextLogOffset =
             logRes.info.start + logStats.nbLogRecordsRead;
         }
@@ -247,16 +375,21 @@ class IngestionReader extends LogReader {
     }
 
     _processSaveLogOffset(batchState, done) {
-        if (batchState.nextLogOffset !== undefined &&
-            batchState.nextLogOffset !== this.logOffset) {
-            if (batchState.nextLogOffset > this.logOffset) {
-                this.logOffset = batchState.nextLogOffset;
-            }
-            this.newIngestion = false;
-            this.remoteLogOffset = null;
-            return this._writeLogOffset(batchState.logger, done);
-        }
-        return process.nextTick(() => done());
+        const { initState, logger } = batchState;
+
+        async.series([
+            next => this._writeInitState(initState, logger, next),
+            next => {
+                if (batchState.nextLogOffset !== undefined &&
+                    batchState.nextLogOffset !== this.logOffset) {
+                    if (batchState.nextLogOffset > this.logOffset) {
+                        this.logOffset = batchState.nextLogOffset;
+                    }
+                    return this._writeLogOffset(logger, done);
+                }
+                return process.nextTick(next);
+            },
+        ], done);
     }
 
     getLogInfo() {

--- a/lib/queuePopulator/IngestionReader.js
+++ b/lib/queuePopulator/IngestionReader.js
@@ -84,6 +84,7 @@ class IngestionReader extends LogReader {
                     return next(err);
                 }
                 if (offset === 1) {
+                    // TODO: need new indicator for this.newIngestion
                     this.newIngestion = true;
                 }
                 return next();
@@ -119,8 +120,6 @@ class IngestionReader extends LogReader {
         ], done);
     }
 
-    // TODO: Processor requires the zenko bucket name
-    //   (currently stored within source ingestion objects on key: `name`)
     _processLogEntry(batchState, record, entry) {
         // NOTE: Using zenkoName because should be unique to other entries.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1952,8 +1952,8 @@
       "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
     },
     "arsenal": {
-      "version": "github:scality/Arsenal#f804aa9657d549be6459ea7fdb8664a9899166c3",
-      "from": "github:scality/Arsenal#f804aa9",
+      "version": "github:scality/Arsenal#ebe2d1f24de9a8cd4832f5933e9e94fc3e294149",
+      "from": "github:scality/Arsenal#ebe2d1f",
       "requires": {
         "JSONStream": "^1.0.0",
         "ajv": "4.10.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/scality/backbeat#readme",
   "dependencies": {
     "JSONStream": "^1.3.5",
-    "arsenal": "github:scality/Arsenal#f804aa9",
+    "arsenal": "github:scality/Arsenal#ebe2d1f",
     "async": "^2.3.0",
     "aws-sdk": "2.147.0",
     "backo": "^1.1.0",

--- a/tests/config.json
+++ b/tests/config.json
@@ -46,8 +46,8 @@
                     "https": false,
                     "type": "scality_s3",
                     "auth": {
-                        "accessKey": "myAccessKey",
-                        "secretKey": "J9K8FUQpjRRVVZbHVm73VQpMNAxK1ZqVbgIuAgaoxlkQ24285VbfK1K/Q2Vcp9RoAGZItiOCTBkRVyp7VLE3bexxRpOWlDbq7k5O2HN1DgxsJrCYMpjUbOSKnVTdu8gsAFKg2q4RgDl6OgPaOMLlClS1n7c6EocOHMbmUeTxC+/hmvvOktMJeSbzXdf9GNwMIbu1IbRmvqw/6TlwtpnrPLJTI4EQdUTYba6YcZnM6jNP8p+hkzc0V6G0lD/a7cI7EeXD/UZlkdWj5P8Z+FZj99Fez5IJuiYY5FyfJeRcznOLCaVgUvg+GjFB01Z2/vcBNCLV950Tmwi0v5X3GZFBcQ=="
+                        "accessKey": "accessKey1",
+                        "secretKey": "o7Q9X25qRv9KNYUewzlXAmfUmnOycFT9yTdgfk5IMntV8kEg4+mqEYl3QhAXyrCw22vbxvSzgdtjh+YhcZBIC6BL/AWurIh5MZyktbaSQabM3ZobTGuEet+qjog0I6Dr9tjHhxM1tfcOdN5Hy2lQk9LTW5uj2/7rtF6jLn5E1HLEn25sAAy60qPqMjBt+pQ0l6Y4JQ6dymZFCv/lZluEQ2mCdH0WlfDh4ZLcNC0KslwjQVJA4kPS5ydE88bB5m5BMscvzMeeRWkObHwdxnu6xN/YJqXvsx05NIC/G4ioeKdoQrBfuRvhlU1MhoCB/+yESdbVRLoM1MppEKkxQbQLTw=="
                     }
                 }
             ]

--- a/tests/functional/ingestion/S3Mock.js
+++ b/tests/functional/ingestion/S3Mock.js
@@ -1,0 +1,114 @@
+const async = require('async');
+const AWS = require('aws-sdk');
+
+const BackbeatClient = require('../../../lib/clients/BackbeatClient');
+
+function _getClients(sourceInfo) {
+    const { port } = sourceInfo;
+
+    const s3sourceCredentials = new AWS.Credentials({
+        accessKeyId: 'accessKey1',
+        secretAccessKey: 'verySecretKey1',
+    });
+
+    const backbeatClient = new BackbeatClient({
+        endpoint: `http://localhost:${port}`,
+        credentials: s3sourceCredentials,
+        sslEnabled: false,
+        maxRetries: 0,
+        httpOptions: { timeout: 0 },
+    });
+    const awsClient = new AWS.S3({
+        endpoint: 'http://localhost:8000',
+        credentials: s3sourceCredentials,
+        sslEnabled: false,
+        maxRetries: 0,
+        httpOptions: { timeout: 0 },
+        s3ForcePathStyle: true,
+        signatureVersion: 'v4',
+    });
+
+    return { backbeatClient, awsClient };
+}
+
+/**
+ * Create list of versioned buckets and objects in each bucket specified by
+ * the metadata mock
+ * @param {Object} sourceInfo - ingestion source info
+ * @param {Function} cb - callback(error)
+ * @return {undefined}
+ */
+function setupS3Mock(sourceInfo, cb) {
+    const { bucket } = sourceInfo;
+    const { backbeatClient, awsClient } = _getClients(sourceInfo);
+
+    async.series([
+        next => awsClient.createBucket({ Bucket: bucket }, next),
+        next => awsClient.putBucketVersioning({
+            Bucket: bucket,
+            VersioningConfiguration: { Status: 'Enabled' },
+        }, next),
+        next => backbeatClient.getObjectList({ Bucket: bucket },
+            (err, res) => {
+                if (err) {
+                    return next(err);
+                }
+
+                return async.each(res.Contents, (entry, done) => {
+                    awsClient.putObject({
+                        Bucket: bucket,
+                        Key: entry.key,
+                    }, done);
+                }, next);
+            }),
+    ], cb);
+}
+
+/**
+ * Remove all versions, delete markers, and the given bucket of a ingestion
+ * source
+ * @param {Object} sourceInfo - ingestion source info
+ * @param {Function} cb - callback(error)
+ * @return {undefined}
+ */
+function emptyAndDeleteVersionedBucket(sourceInfo, cb) {
+    const { bucket } = sourceInfo;
+    const { awsClient } = _getClients(sourceInfo);
+
+    // won't need to worry about 1k+ objects pagination
+    async.series([
+        next => awsClient.listObjectVersions({ Bucket: bucket },
+            (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+
+                const list = [
+                    ...data.Versions.map(v => ({
+                        Key: v.Key,
+                        VersionId: v.VersionId,
+                    })),
+                    ...data.DeleteMarkers.map(dm => ({
+                        Key: dm.Key,
+                        VersionId: dm.VersionId,
+                    })),
+                ];
+
+                if (list.length === 0) {
+                    return next();
+                }
+
+                return awsClient.deleteObjects({
+                    Bucket: bucket,
+                    Delete: { Objects: list },
+                }, next);
+            }),
+        next => awsClient.deleteBucket({ Bucket: bucket }, next),
+    ], cb);
+}
+
+
+module.exports = {
+    setupS3Mock,
+    emptyAndDeleteVersionedBucket
+};


### PR DESCRIPTION
Goes with https://github.com/scality/Arsenal/pull/713

Changes in this PR:
- Add S3 client
- Object list versions to use S3 api
- Snapshot methods to reference a single bucket instead of list of buckets
- Use NextKeyMarker and NextVersionIdMarker for splitting the snapshot phase.
   This allows snapshot to complete processing smaller batches. This also helps with
   pause/resume of ingestion.
- Save state in zookeeper as paths:
      BASE: `/ingestion/<bucket>/logState/init`
      NODES: `status`, `versionMarker`, `keyMarker`
   where status is a string of either `complete` || `incomplete`

Suggestions on naming, especially zookeeper path names, is appreciated!

Edit:
Will implement Rahul's suggestion for following change to zookeeper path:
- Replace `<bucket>` in paths with the unique id of the bucket

This will be done on a later ticket, possibly along with ticket (1441) as I think they relate.
Other suggestions on zookeeper path is welcome!
