### PR TITLE
bf: ZENKO-1464 ingestion log stream sync loop fix

### DIFF
--- a/lib/queuePopulator/IngestionReader.js
+++ b/lib/queuePopulator/IngestionReader.js
@@ -140,22 +140,30 @@ class IngestionReader extends LogReader {
                 value: entry.value,
             }));
         } else {
+            let key;
+            let db;
             if (record.db === 'users..bucket') {
                 const keySplit = entry.key.split('..|..');
-                entry.key = `${keySplit[0]}..|..${this._targetZenkoBucket}`;
+                key = `${keySplit[0]}..|..${this._targetZenkoBucket}`;
             } else if (record.db === 'metastore') {
                 const keySplit = entry.key.split('/');
-                entry.key = `${keySplit[0]}/${this._targetZenkoBucket}`;
+                key = `${keySplit[0]}/${this._targetZenkoBucket}`;
             } else {
                 if (record.db === entry.key) {
-                    entry.key = this._targetZenkoBucket;
+                    key = this._targetZenkoBucket;
                 }
-                record.db = this._targetZenkoBucket;
+                db = this._targetZenkoBucket;
+            }
+            if (db === undefined) {
+                db = record.db;
+            }
+            if (key === undefined) {
+                key = entry.key;
             }
             this._extensions.forEach(ext => ext.filter({
                 type: entry.type,
-                bucket: record.db,
-                key: entry.key,
+                bucket: db,
+                key,
                 value: entry.value,
             }));
         }


### PR DESCRIPTION
Avoid manipulating original record entries so our other entries in sync loop are not impacted

log stream has a sync loop that looks at each entry within a log record. These entries are (for a versioned bucket) one entry for the entry key without a version suffix (to represent IsLatest) and one entry for the entry key with version suffix.
