### PR TITLE
ZENKO-1420 select topic per message in BackbeatProducer

### DIFF
--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -31,7 +31,8 @@ class BackbeatProducer extends EventEmitter {
     /**
     * constructor
     * @param {Object} config - config
-    * @param {string} config.topic - Kafka topic to write to
+    * @param {string} [config.topic] - Kafka topic to write to when
+    * using BackbeatProducer.send() calls
     * @param {boolean} [config.keyedPartitioner=true] - if no
     * partition is set, tell whether the producer should use keyed
     * partitioning or the default partitioning of the kafka client
@@ -46,7 +47,7 @@ class BackbeatProducer extends EventEmitter {
             kafka: joi.object({
                 hosts: joi.string().required(),
             }).required(),
-            topic: joi.string().required(),
+            topic: joi.string(),
             keyedPartitioner: joi.boolean().default(true),
             pollIntervalMs: joi.number().default(2000),
             messageMaxBytes: joi.number(),
@@ -56,7 +57,7 @@ class BackbeatProducer extends EventEmitter {
         const { kafka, topic, pollIntervalMs, messageMaxBytes } = validConfig;
         this._kafkaHosts = kafka.hosts;
         this._log = new Logger(CLIENT_ID);
-        this._topic = withTopicPrefix(topic);
+        this._topic = topic && withTopicPrefix(topic);
         this._ready = false;
         this._messageMaxBytes = messageMaxBytes || PRODUCER_MESSAGE_MAX_BYTES;
 
@@ -156,26 +157,56 @@ class BackbeatProducer extends EventEmitter {
     }
 
     /**
-    * sends entries/messages to the given topic
+    * sends entries/messages to the topic configured in producer
     * @param {Object[]} entries - array of entries objects with properties
     * key and message ([{ key: 'foo', message: 'hello world'}, ...])
     * @param {callback} cb - cb(err)
     * @return {this} current instance
     */
     send(entries, cb) {
-        this._log.debug('publishing entries',
-            { method: 'BackbeatProducer.send' });
-        if (!this._ready) {
-            return process.nextTick(() => {
-                this._log.error('producer is not ready yet', {
+        if (!this._topic) {
+            process.nextTick(() => {
+                this._log.error('no topic configured to send messages to', {
                     method: 'BackbeatProducer.send',
+                });
+                cb(errors.InternalError);
+            });
+            return this;
+        }
+        return this._sendToTopic(this._topic, entries, cb);
+    }
+
+    /**
+    * sends entries/messages to the given topic
+    * @param {string} topic - topic to send messages to
+    * @param {Object[]} entries - array of entries objects with properties
+    * key and message ([{ key: 'foo', message: 'hello world'}, ...])
+    * @param {callback} cb - cb(err)
+    * @return {this} current instance
+    */
+    sendToTopic(topic, entries, cb) {
+        return this._sendToTopic(withTopicPrefix(topic), entries, cb);
+    }
+
+    _sendToTopic(topic, entries, cb) {
+        this._log.debug('publishing entries', {
+            method: 'BackbeatProducer._sendToTopic',
+            topic,
+            entryCount: entries.length,
+        });
+        if (!this._ready) {
+            process.nextTick(() => {
+                this._log.error('producer is not ready yet', {
+                    method: 'BackbeatProducer._sendToTopic',
                     ready: this._ready,
                 });
                 cb(errors.InternalError);
             });
+            return this;
         }
         if (entries.length === 0) {
-            return process.nextTick(cb);
+            process.nextTick(cb);
+            return this;
         }
         const sendCtx = { cbOnce: jsutil.once(cb),
                           pendingReportsCount: entries.length };
@@ -186,7 +217,7 @@ class BackbeatProducer extends EventEmitter {
                     partition = item.partition;
                 }
                 this._producer.produce(
-                    this._topic,
+                    topic,
                     partition, // partition
                     new Buffer(item.message), // value
                     item.key, // key (for keyed partitioning)
@@ -196,10 +227,11 @@ class BackbeatProducer extends EventEmitter {
             });
         } catch (err) {
             this._log.error('error publishing entries', {
-                error: err,
-                method: 'BackbeatProducer.send',
+                method: 'BackbeatProducer._sendToTopic',
+                topic,
+                error: err.message,
             });
-            return process.nextTick(
+            process.nextTick(
                 () => sendCtx.cbOnce(errors.InternalError.
                                      customizeDescription(err.message)));
         }

--- a/tests/unit/backbeatProducer.js
+++ b/tests/unit/backbeatProducer.js
@@ -42,6 +42,32 @@ describe('backbeatProducer', () => {
         assert.strictEqual(backbeatProducer._topic, 'testing.my-test-topic');
     });
 
+    it('should return an error if send() called on producer with no default ' +
+    'topic', done => {
+        const backbeatProducer = new BackbeatProducer({
+            kafka,
+        });
+        backbeatProducer.send([{ key: 'foo', message: 'bar' }], err => {
+            assert(err);
+            done();
+        });
+    });
+
+    it('should send to the topic specified in sendToTopic()', done => {
+        const backbeatProducer = new BackbeatProducer({
+            kafka,
+        });
+        // shunt condition on producer initialization
+        backbeatProducer._ready = true;
+        // shunt produce call
+        backbeatProducer._producer.produce = topic => {
+            assert.strictEqual(topic, 'custom-topic');
+            done();
+        };
+        backbeatProducer.sendToTopic(
+            'custom-topic', [{ key: 'foo', message: 'bar' }], () => {});
+    });
+
     afterEach(() => {
         process.env.KAFKA_TOPIC_PREFIX = '';
     });


### PR DESCRIPTION
Add the ability to select the topic to produce to for each call to
BackbeatProducer.send(), allowing the use of multiple or dynamic
target topics for one producer instance.

The intent is to ask a service to send the outcome of an action
execution to the topic specified by the user in the action message
itself, requiring a dynamic selection of the topic. This is not an
issue as Kafka producer supports this naturally in its API so we just
adapt the BackbeatProducer wrapper.