### PR TITLE
ZENKO-1420 remove ObjectQueueEntry.getUserMetadata()

### DIFF
--- a/lib/models/ObjectQueueEntry.js
+++ b/lib/models/ObjectQueueEntry.js
@@ -95,20 +95,6 @@ class ObjectQueueEntry extends ObjectMD {
         return this.getObjectKey() === this.getObjectVersionedKey();
     }
 
-    getUserMetadata() {
-        const metaHeaders = {};
-        const data = this.getValue();
-        Object.keys(data).forEach(key => {
-            if (key.startsWith('x-amz-meta-')) {
-                metaHeaders[key] = data[key];
-            }
-        });
-        if (Object.keys(metaHeaders).length > 0) {
-            return JSON.stringify(metaHeaders);
-        }
-        return undefined;
-    }
-
     getLogInfo() {
         return {
             bucket: this.getBucket(),

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/scality/backbeat#readme",
   "dependencies": {
     "JSONStream": "^1.3.5",
-    "arsenal": "scality/Arsenal#ea1a7d4",
+    "arsenal": "scality/Arsenal#645433e",
     "async": "^2.3.0",
     "aws-sdk": "2.147.0",
     "backo": "^1.1.0",


### PR DESCRIPTION
It has been moved over to arsenal ObjectMD class.

Depends on PR https://github.com/scality/Arsenal/pull/658, making the function callable from ObjectQueueEntry instances since it inherits ObjectMD.
