### PR TITLE
cleanup: ZENKO-1420 more generic BackbeatMetadataProxy.putMetadata()

### DIFF
--- a/extensions/replication/tasks/MultipleBackendTask.js
+++ b/extensions/replication/tasks/MultipleBackendTask.js
@@ -108,7 +108,7 @@ class MultipleBackendTask extends ReplicateObject {
         const params = {
             bucket: sourceEntry.getBucket(),
             objectKey: sourceEntry.getObjectKey(),
-            encodedVersionId: sourceEntry.getEncodedVersionId(),
+            versionId: sourceEntry.getEncodedVersionId(),
         };
         return this.backbeatSourceProxy.getMetadata(
         params, log, (err, blob) => {
@@ -774,7 +774,7 @@ class MultipleBackendTask extends ReplicateObject {
         metadataProxy.getMetadata({
             bucket: destEntry.getBucket(),
             objectKey: destEntry.getObjectKey(),
-            encodedVersionId: destEntry.getEncodedVersionId(),
+            versionId: destEntry.getEncodedVersionId(),
         }, log, cb);
     }
 

--- a/extensions/replication/tasks/UpdateReplicationStatus.js
+++ b/extensions/replication/tasks/UpdateReplicationStatus.js
@@ -52,7 +52,7 @@ class UpdateReplicationStatus extends BackbeatTask {
         const params = {
             bucket: sourceEntry.getBucket(),
             objectKey: sourceEntry.getObjectKey(),
-            encodedVersionId: sourceEntry.getEncodedVersionId(),
+            versionId: sourceEntry.getEncodedVersionId(),
         };
         return this.backbeatSourceClient
         .getMetadata(params, log, (err, blob) => {
@@ -225,7 +225,12 @@ class UpdateReplicationStatus extends BackbeatTask {
 
     _putMetadata(updatedSourceEntry, log, cb) {
         const client = this.backbeatSourceClient;
-        return client.putMetadata(updatedSourceEntry, log, err => {
+        return client.putMetadata({
+            bucket: updatedSourceEntry.getBucket(),
+            objectKey: updatedSourceEntry.getObjectKey(),
+            versionId: updatedSourceEntry.getEncodedVersionId(),
+            mdBlob: updatedSourceEntry.getSerialized(),
+        }, log, err => {
             if (err) {
                 log.error('an error occurred when updating metadata', {
                     entry: updatedSourceEntry.getLogInfo(),

--- a/lib/BackbeatMetadataProxy.js
+++ b/lib/BackbeatMetadataProxy.js
@@ -40,27 +40,43 @@ class BackbeatMetadataProxy extends BackbeatTask {
         return new RoleCredentials(vaultclient, extension, role, log);
     }
 
-    putMetadata(entry, log, cb) {
+    /**
+     * Write raw object metadata blob in JSON to MongoDB
+     *
+     * @param {object} params - params object
+     * @param {string} params.bucket - bucket name
+     * @param {string} params.objectKey - object key
+     * @param {string} [params.versionId] - encoded version ID
+     * @param {Buffer} params.mdBlob - raw metadata blob
+     * @param {Logger} log - logger object
+     * @param {function} cb - callback: cb(error, { versionId })
+     * @return {undefined}
+     */
+    putMetadata(params, log, cb) {
         this.retry({
             actionDesc: 'update metadata on source',
-            logFields: { entry: entry.getLogInfo() },
-            actionFunc: done => this._putMetadataOnce(entry, log, done),
+            logFields: { bucket: params.bucket,
+                         objectKey: params.objectKey,
+                         versionId: params.versionId },
+            actionFunc: done =>
+                this._putMetadataOnce(params, log, done),
             shouldRetryFunc: err => err.retryable,
             log,
         }, cb);
     }
 
-    _putMetadataOnce(entry, log, cb) {
-        log.debug('putting metadata',
-                  { where: 'source', entry: entry.getLogInfo(),
-                    replicationStatus: entry.getReplicationStatus() });
+    _putMetadataOnce(params, log, cb) {
+        const { bucket, objectKey, versionId, mdBlob } = params;
+        log.debug('putting metadata', {
+            where: 'source',
+            bucket, objectKey, versionId,
+        });
 
         // sends extra header x-scal-replication-content to the target
         // if it's a metadata operation only
-        const mdBlob = entry.getSerialized();
         const req = this.backbeatSource.putMetadata({
-            Bucket: entry.getBucket(),
-            Key: entry.getObjectKey(),
+            Bucket: bucket,
+            Key: objectKey,
             ContentLength: Buffer.byteLength(mdBlob),
             Body: mdBlob,
         });
@@ -74,20 +90,39 @@ class BackbeatMetadataProxy extends BackbeatTask {
                 }
                 log.error('an error occurred when putting metadata to S3',
                     { method: 'BackbeatMetadataProxy._putMetadataOnce',
-                      entry: entry.getLogInfo(),
+                      bucket, objectKey, versionId,
                       origin: 'source',
-                      peer: this._s3Endpoint,
+                      endpoint: this._s3Endpoint,
                       error: err.message });
                 return cb(err);
             }
+            log.debug('PutMetadata returned with payload', {
+                method: 'BackbeatMetadataProxy._putMetadataOnce',
+                bucket, objectKey, versionId,
+                endpoint: this._s3Endpoint,
+                payload: data,
+            });
             return cb(null, data);
         });
     }
 
+    /**
+     * Retrieve raw object metadata in JSON from MongoDB
+     *
+     * @param {object} params - params object
+     * @param {string} params.bucket - bucket name
+     * @param {string} params.objectKey - object key
+     * @param {string} [params.versionId] - encoded version ID
+     * @param {Logger} log - logger object
+     * @param {function} cb - callback: cb(error, { Body: mdBlob })
+     * @return {undefined}
+     */
     getMetadata(params, log, cb) {
         this.retry({
             actionDesc: 'get metadata from source',
-            logFields: { entry: params },
+            logFields: { bucket: params.bucket,
+                         objectKey: params.objectKey,
+                         versionId: params.versionId },
             actionFunc: done => this._getMetadataOnce(params, log, done),
             shouldRetryFunc: err => err.retryable,
             log,
@@ -95,18 +130,19 @@ class BackbeatMetadataProxy extends BackbeatTask {
     }
 
     _getMetadataOnce(params, log, cb) {
+        const { bucket, objectKey, versionId } = params;
         log.debug('getting metadata', {
             where: 'source',
-            entry: params,
+            bucket, objectKey, versionId,
             method: 'BackbeatMetadataProxy._getMetadataOnce',
         });
 
         const cbOnce = jsutil.once(cb);
 
         const req = this.backbeatSource.getMetadata({
-            Bucket: params.bucket,
-            Key: params.objectKey,
-            VersionId: params.encodedVersionId,
+            Bucket: bucket,
+            Key: objectKey,
+            VersionId: versionId,
         });
         attachReqUids(req, log);
         req.send((err, data) => {
@@ -118,8 +154,9 @@ class BackbeatMetadataProxy extends BackbeatTask {
                 }
                 log.error('an error occurred when getting metadata from S3', {
                     method: 'BackbeatMetadataProxy._getMetadataOnce',
-                    entry: params.logInfo,
+                    bucket, objectKey, versionId,
                     origin: 'source',
+                    endpoint: this._s3Endpoint,
                     error: err,
                     errMsg: err.message,
                     errCode: err.code,

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -324,7 +324,7 @@ class BackbeatAPI {
         const params = {
             bucket: entry.getBucket(),
             objectKey: entry.getObjectKey(),
-            encodedVersionId: entry.getEncodedVersionId(),
+            versionId: entry.getEncodedVersionId(),
         };
         return this._backbeatMetadataProxy
             .setSourceClient(log)


### PR DESCRIPTION
Make the putMetadata() call more generic by taking separate params
like bucket name etc. and a metadata blob, instead of using an
ObjectQueueEntry directly. This will be useful to update metadata
based on action message fields that will not be converted into an
ObjectQueueEntry.

For consistency, also renamed "encodedVersionId" to "versionId" in
getMetadata(), as the encoded form is the common form used in AWS API
the name can be kept short.