### PR TITLE
INTEGRATION [PR#612 > development/8.1] bugfix: ZENKO-1470 Attempt to abort MPU on failure

### DIFF
--- a/extensions/replication/tasks/MultipleBackendTask.js
+++ b/extensions/replication/tasks/MultipleBackendTask.js
@@ -133,6 +133,35 @@ class MultipleBackendTask extends ReplicateObject {
     }
 
     /**
+     * Used when an operation performed in the process of replicating a
+     * multipart upload fails.
+     * @param {ObjectQueueEntry} sourceEntry - The source object entry
+     * @param {String} uploadId - The upload ID of the initiated MPU
+     * @param {Werelogs} log - The logger instance
+     * @param {Function} cb - The callback to call
+     * @return {undefined}
+     */
+    _handleMPUFailure(sourceEntry, uploadId, log, cb) {
+        this._multipleBackendAbortMPU(sourceEntry, uploadId, log, err => {
+            if (err) {
+                log.error('an error occurred when aborting a MPU', {
+                    method: 'MultipleBackendTask._handleMPUFailure',
+                    entry: sourceEntry.getLogInfo(),
+                    origin: 'target',
+                    peer: this.destBackbeatHost,
+                    error: err.message,
+                });
+                return cb(err);
+            }
+            log.info('successfully aborted a MPU', {
+                method: 'MultipleBackendTask._handleMPUFailure',
+                entry: sourceEntry.getLogInfo(),
+            });
+            return cb();
+        });
+    }
+
+    /**
      * This is a retry wrapper for calling _getRangeAndPutMPUPartOnce.
      * @param {ObjectQueueEntry} sourceEntry - The source object entry
      * @param {ObjectQueueEntry} destEntry - The destination object entry
@@ -231,7 +260,11 @@ class MultipleBackendTask extends ReplicateObject {
                     peer: this.destBackbeatHost,
                     error: err.message,
                 });
-                return doneOnce(err);
+                // Attempt to abort the MPU, but pass the error from
+                // multipleBackendCompleteMPU because that operation's result
+                // should determine the replication's success or failure.
+                return this._handleMPUFailure(sourceEntry, uploadId, log, () =>
+                    doneOnce(err));
             }
             sourceEntry.setReplicationSiteDataStoreVersionId(this.site,
                 data.versionId);
@@ -489,7 +522,11 @@ class MultipleBackendTask extends ReplicateObject {
                         peer: this.destBackbeatHost,
                         error: err.message,
                     });
-                    return doneOnce(err);
+                    // Attempt to abort the MPU, but pass an error from
+                    // multipleBackendPutMPUPart because that operation's result
+                    // should determine the replication's success or failure.
+                    return this._handleMPUFailure(sourceEntry, uploadId, log,
+                        () => doneOnce(err));
                 }
                 return this._completeMPU(sourceEntry, destEntry, uploadId, data,
                     log, doneOnce);


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #612.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/ZENKO-1470/attempt-to-abort-mpu-on-failure`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/ZENKO-1470/attempt-to-abort-mpu-on-failure
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/ZENKO-1470/attempt-to-abort-mpu-on-failure
```

Please always comment pull request #612 instead of this one.