### PR TITLE
refactor: ZENKO-1420 only one producer in bucket processor

### DIFF
--- a/extensions/lifecycle/bucketProcessor/task.js
+++ b/extensions/lifecycle/bucketProcessor/task.js
@@ -35,7 +35,7 @@ function startHealthProbe() {
         if (bucketProcessor.isReady()) {
             return true;
         }
-        log.error('LifecycleBucketProcessor is not ready!');
+        log.error('lifecycle bucket processor is not ready!');
         return false;
     });
     logger.info('Starting HealthProbe server');

--- a/extensions/lifecycle/conductor/service.js
+++ b/extensions/lifecycle/conductor/service.js
@@ -30,7 +30,7 @@ lcConductor.start(err => {
         if (lcConductor.isReady()) {
             return true;
         }
-        log.error('LifecycleConductor is not ready!');
+        log.error('lifecycle conductor is not ready!');
         return false;
     });
     logger.info('Starting HealthProbe server');

--- a/extensions/lifecycle/objectProcessor/task.js
+++ b/extensions/lifecycle/objectProcessor/task.js
@@ -40,7 +40,7 @@ function initAndStart() {
             if (objectProcessor.isReady()) {
                 return true;
             }
-            log.error('LifecycleConductor is not ready!');
+            log.error('lifecycle object processor is not ready!');
             return false;
         });
         log.info('Starting HealthProbe server');

--- a/tests/unit/lifecycle/LifecycleTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleTask.spec.js
@@ -1087,9 +1087,9 @@ describe('lifecycle task helper methods', () => {
         ];
 
         before(() => {
-            // overwrite sendObjectEntry to read entry sent
+            // overwrite _sendObjectEntry to read entry sent
             class LifecycleTaskMock extends LifecycleTask {
-                sendObjectEntry(entry, cb) {
+                _sendObjectEntry(entry, cb) {
                     this.latestEntry = entry;
                     return cb();
                 }


### PR DESCRIPTION
Since we're going to publish to a third topic and we now have a way to
use a single producer to publish to multiple topics, convert the code
to only use one producer instance. Rework a bit some helpers to send
messages so that they are defined in the LifecycleTask class directly.