### PR TITLE
bugfix: ZENKO-1386 bump node-rdkafka version to 2.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,11 @@
       "from": "github:scality/cloudserver#5839daf",
       "dev": true,
       "requires": {
-        "arsenal": "github:scality/Arsenal#9fe16c64fa3ba3d1b78aad5a777b86fafb98a779",
         "async": "~2.5.0",
         "aws-sdk": "2.28.0",
         "azure-storage": "^2.1.0",
         "backo": "^1.1.0",
-        "bucketclient": "github:scality/bucketclient#5aa99d7b25fdfb5a42b787cce7710cdec8ac78f0",
         "bufferutil": "^3.0.5",
-        "cdmiclient": "github:scality/cdmiclient#8f0c2e6331dfa905bfe269fb4e1558d65ca0b866",
         "commander": "^2.9.0",
         "diskusage": "0.2.4",
         "google-auto-auth": "^0.9.1",
@@ -28,22 +25,17 @@
         "npm-run-all": "~4.0.2",
         "prom-client": "^10.2.3",
         "request": "^2.81.0",
-        "sproxydclient": "github:scality/sproxydclient#45090b76b24ca1d05482bf151ba84ff6178423d1",
         "sql-where-parser": "~2.2.1",
-        "utapi": "github:scality/utapi#f2f1d0c7423ffdec2ad175e3c0e8bcd7aa2ba867",
         "utf-8-validate": "^4.0.2",
         "utf8": "~2.1.1",
         "uuid": "^3.0.1",
-        "vaultclient": "github:scality/vaultclient#754b6e1e1121f44bc3719e35b836a9185d6d5e1a",
-        "werelogs": "github:scality/werelogs#74b121bef4068645e307da143749e61ef416a4c3",
         "ws": "^5.1.0",
         "xml2js": "~0.4.16"
       },
       "dependencies": {
         "arsenal": {
           "version": "github:scality/Arsenal#9fe16c64fa3ba3d1b78aad5a777b86fafb98a779",
-          "from": "github:scality/Arsenal#9fe16c6",
-          "dev": true,
+          "from": "github:scality/Arsenal#9fe16c64fa3ba3d1b78aad5a777b86fafb98a779",
           "requires": {
             "JSONStream": "^1.0.0",
             "ajv": "4.10.0",
@@ -73,25 +65,22 @@
               "version": "2.1.5",
               "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
               "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
-              "dev": true,
               "requires": {
                 "lodash": "^4.14.0"
               }
             },
             "mongodb": {
-              "version": "3.1.10",
-              "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.10.tgz",
-              "integrity": "sha512-Uml42GeFxhTGQVml1XQ4cD0o/rp7J2ROy0fdYUcVitoE7vFqEhKH4TYVqRDpQr/bXtCJVxJdNQC1ntRxNREkPQ==",
-              "dev": true,
+              "version": "3.1.13",
+              "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.13.tgz",
+              "integrity": "sha512-sz2dhvBZQWf3LRNDhbd30KHVzdjZx9IKC0L+kSZ/gzYquCF5zPOgGqRz6sSCqYZtKP2ekB4nfLxhGtzGHnIKxA==",
               "requires": {
-                "mongodb-core": "3.1.9",
+                "mongodb-core": "3.1.11",
                 "safe-buffer": "^5.1.2"
               }
             },
             "werelogs": {
               "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
               "from": "github:scality/werelogs#0ff7ec82",
-              "dev": true,
               "requires": {
                 "safe-json-stringify": "1.0.3"
               }
@@ -102,7 +91,6 @@
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
           "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-          "dev": true,
           "requires": {
             "lodash": "^4.14.0"
           }
@@ -144,17 +132,15 @@
         },
         "bucketclient": {
           "version": "github:scality/bucketclient#5aa99d7b25fdfb5a42b787cce7710cdec8ac78f0",
-          "from": "github:scality/bucketclient#5aa99d7",
-          "dev": true,
+          "from": "github:scality/bucketclient#5aa99d7b25fdfb5a42b787cce7710cdec8ac78f0",
           "requires": {
-            "arsenal": "github:scality/Arsenal#25f991311db1d23816af183db05c0b664fe296e9",
-            "werelogs": "github:scality/werelogs#f1e9a17b23acf9cd3d6a2ff460db5b47bbc0c512"
+            "arsenal": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
+            "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2"
           },
           "dependencies": {
             "arsenal": {
-              "version": "github:scality/Arsenal#25f991311db1d23816af183db05c0b664fe296e9",
+              "version": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
               "from": "github:scality/Arsenal#7.4.0.3",
-              "dev": true,
               "requires": {
                 "JSONStream": "^1.0.0",
                 "ajv": "4.10.0",
@@ -180,7 +166,6 @@
                 "werelogs": {
                   "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
                   "from": "github:scality/werelogs#hotfix/7.4.0",
-                  "dev": true,
                   "requires": {
                     "safe-json-stringify": "^1.0.3"
                   }
@@ -191,26 +176,105 @@
               "version": "2.1.5",
               "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
               "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
-              "dev": true,
               "requires": {
                 "lodash": "^4.14.0"
               }
             },
             "werelogs": {
-              "version": "github:scality/werelogs#f1e9a17b23acf9cd3d6a2ff460db5b47bbc0c512",
+              "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
               "from": "github:scality/werelogs#7.4.0.3",
-              "dev": true,
               "requires": {
                 "safe-json-stringify": "^1.0.3"
               }
             }
           }
         },
+        "cdmiclient": {
+          "version": "github:scality/cdmiclient#8f0c2e6331dfa905bfe269fb4e1558d65ca0b866",
+          "from": "github:scality/cdmiclient#8f0c2e6331dfa905bfe269fb4e1558d65ca0b866",
+          "requires": {
+            "arsenal": "github:scality/Arsenal#40a802b715e57336de0cbbe8b021486bea191f13",
+            "async": "~1.4.2",
+            "werelogs": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46"
+          },
+          "dependencies": {
+            "arsenal": {
+              "version": "github:scality/Arsenal#40a802b715e57336de0cbbe8b021486bea191f13",
+              "from": "github:scality/Arsenal#development/8.0",
+              "requires": {
+                "JSONStream": "^1.0.0",
+                "ajv": "4.10.0",
+                "async": "~2.1.5",
+                "bson": "2.0.4",
+                "debug": "~2.3.3",
+                "diskusage": "^0.2.2",
+                "fcntl": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
+                "ioctl": "2.0.0",
+                "ioredis": "2.4.0",
+                "ipaddr.js": "1.2.0",
+                "joi": "^10.6",
+                "level": "~1.6.0",
+                "level-sublevel": "~6.6.1",
+                "mongodb": "^3.0.1",
+                "node-forge": "^0.7.1",
+                "simple-glob": "^0.1",
+                "socket.io": "~1.7.3",
+                "socket.io-client": "~1.7.3",
+                "utf8": "2.1.2",
+                "uuid": "^3.0.1",
+                "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+                "xml2js": "~0.4.16"
+              },
+              "dependencies": {
+                "async": {
+                  "version": "2.1.5",
+                  "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+                  "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+                  "requires": {
+                    "lodash": "^4.14.0"
+                  }
+                },
+                "werelogs": {
+                  "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+                  "from": "github:scality/werelogs#0ff7ec82",
+                  "requires": {
+                    "safe-json-stringify": "1.0.3"
+                  }
+                }
+              }
+            },
+            "async": {
+              "version": "1.4.2",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
+              "integrity": "sha1-bJ7csRztTw3S8tQNsNSaEJwIiqs="
+            },
+            "mongodb": {
+              "version": "3.1.13",
+              "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.13.tgz",
+              "integrity": "sha512-sz2dhvBZQWf3LRNDhbd30KHVzdjZx9IKC0L+kSZ/gzYquCF5zPOgGqRz6sSCqYZtKP2ekB4nfLxhGtzGHnIKxA==",
+              "requires": {
+                "mongodb-core": "3.1.11",
+                "safe-buffer": "^5.1.2"
+              }
+            },
+            "werelogs": {
+              "version": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46",
+              "from": "github:scality/werelogs#development/8.0",
+              "requires": {
+                "safe-json-stringify": "1.0.3"
+              }
+            }
+          }
+        },
+        "cron-parser": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-1.1.0.tgz",
+          "integrity": "sha1-B1uExFnBVejEgqtNVq/5na5YNS4="
+        },
         "diskusage": {
           "version": "0.2.4",
           "resolved": "https://registry.npmjs.org/diskusage/-/diskusage-0.2.4.tgz",
           "integrity": "sha512-XCLBopqnV6FUG/DdphILleiubqVERvF1ZRqkvOIiPQeMlU6Im1nvlsYqLUosgmRz1UQOXcwuO0vgqASl7DNg+w==",
-          "dev": true,
           "requires": {
             "nan": "^2.5.0"
           }
@@ -223,9 +287,8 @@
         },
         "ioredis": {
           "version": "2.4.0",
-          "resolved": "http://registry.npmjs.org/ioredis/-/ioredis-2.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.4.0.tgz",
           "integrity": "sha1-lj97+8huXEDqWGhX4U6/tUgUKog=",
-          "dev": true,
           "requires": {
             "bluebird": "^3.3.4",
             "cluster-key-slot": "^1.0.6",
@@ -242,6 +305,11 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
+        },
+        "long-timeout": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.0.2.tgz",
+          "integrity": "sha1-82RJuolinROnorJSOk253Wbj/2g="
         },
         "mongodb": {
           "version": "2.2.36",
@@ -273,10 +341,9 @@
           }
         },
         "mongodb-core": {
-          "version": "3.1.9",
-          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.9.tgz",
-          "integrity": "sha512-MJpciDABXMchrZphh3vMcqu8hkNf/Mi+Gk6btOimVg1XMxLXh87j6FAvRm+KmwD1A9fpu3qRQYcbQe4egj23og==",
-          "dev": true,
+          "version": "3.1.11",
+          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.11.tgz",
+          "integrity": "sha512-rD2US2s5qk/ckbiiGFHeu+yKYDXdJ1G87F6CG3YdaZpzdOm5zpoAZd/EKbPmFO6cQZ+XVXBXBJ660sSI0gc6qg==",
           "requires": {
             "bson": "^1.1.0",
             "require_optional": "^1.0.1",
@@ -287,9 +354,17 @@
             "bson": {
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.0.tgz",
-              "integrity": "sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA==",
-              "dev": true
+              "integrity": "sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA=="
             }
+          }
+        },
+        "node-schedule": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-1.2.0.tgz",
+          "integrity": "sha1-8D1OvnGwVz4XCN2uCqRdFlhFDPE=",
+          "requires": {
+            "cron-parser": "1.1.0",
+            "long-timeout": "0.0.2"
           }
         },
         "node-uuid": {
@@ -322,8 +397,23 @@
         "sax": {
           "version": "1.1.5",
           "resolved": "http://registry.npmjs.org/sax/-/sax-1.1.5.tgz",
-          "integrity": "sha1-HaUKjQDN7NWUBWWfX/hTSf53N0M=",
-          "dev": true
+          "integrity": "sha1-HaUKjQDN7NWUBWWfX/hTSf53N0M="
+        },
+        "sproxydclient": {
+          "version": "github:scality/sproxydclient#45090b76b24ca1d05482bf151ba84ff6178423d1",
+          "from": "github:scality/sproxydclient#45090b76b24ca1d05482bf151ba84ff6178423d1",
+          "requires": {
+            "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2"
+          },
+          "dependencies": {
+            "werelogs": {
+              "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+              "from": "github:scality/werelogs#7.4.0.3",
+              "requires": {
+                "safe-json-stringify": "^1.0.3"
+              }
+            }
+          }
         },
         "string_decoder": {
           "version": "1.0.3",
@@ -332,6 +422,192 @@
           "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
+          }
+        },
+        "utapi": {
+          "version": "github:scality/utapi#f2f1d0c7423ffdec2ad175e3c0e8bcd7aa2ba867",
+          "from": "github:scality/utapi#f2f1d0c7423ffdec2ad175e3c0e8bcd7aa2ba867",
+          "requires": {
+            "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
+            "async": "^2.0.1",
+            "ioredis": "^2.3.0",
+            "node-schedule": "1.2.0",
+            "vaultclient": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
+            "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
+          },
+          "dependencies": {
+            "arsenal": {
+              "version": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
+              "from": "github:scality/Arsenal#67365083",
+              "requires": {
+                "JSONStream": "^1.0.0",
+                "ajv": "4.10.0",
+                "async": "~2.1.5",
+                "debug": "~2.3.3",
+                "diskusage": "^0.2.2",
+                "ioctl": "2.0.0",
+                "ioredis": "2.4.0",
+                "ipaddr.js": "1.2.0",
+                "joi": "^10.6",
+                "level": "~1.6.0",
+                "level-sublevel": "~6.6.1",
+                "node-forge": "^0.7.1",
+                "simple-glob": "^0.1",
+                "socket.io": "~1.7.3",
+                "socket.io-client": "~1.7.3",
+                "utf8": "2.1.2",
+                "uuid": "^3.0.1",
+                "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+                "xml2js": "~0.4.16"
+              },
+              "dependencies": {
+                "async": {
+                  "version": "2.1.5",
+                  "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+                  "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+                  "requires": {
+                    "lodash": "^4.14.0"
+                  }
+                }
+              }
+            },
+            "commander": {
+              "version": "2.9.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+              "requires": {
+                "graceful-readlink": ">= 1.0.0"
+              }
+            },
+            "vaultclient": {
+              "version": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
+              "from": "github:scality/vaultclient#fbd9988d",
+              "requires": {
+                "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
+                "commander": "2.9.0",
+                "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+                "xml2js": "0.4.17"
+              },
+              "dependencies": {
+                "xml2js": {
+                  "version": "0.4.17",
+                  "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+                  "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+                  "requires": {
+                    "sax": ">=0.6.0",
+                    "xmlbuilder": "^4.1.0"
+                  }
+                }
+              }
+            },
+            "werelogs": {
+              "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+              "from": "github:scality/werelogs#0ff7ec82",
+              "requires": {
+                "safe-json-stringify": "1.0.3"
+              }
+            },
+            "xmlbuilder": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+              "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+              "requires": {
+                "lodash": "^4.0.0"
+              }
+            }
+          }
+        },
+        "vaultclient": {
+          "version": "github:scality/vaultclient#754b6e1e1121f44bc3719e35b836a9185d6d5e1a",
+          "from": "github:scality/vaultclient#754b6e1e1121f44bc3719e35b836a9185d6d5e1a",
+          "requires": {
+            "arsenal": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
+            "commander": "2.9.0",
+            "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+            "xml2js": "0.4.17"
+          },
+          "dependencies": {
+            "arsenal": {
+              "version": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
+              "from": "github:scality/Arsenal#7.4.0.3",
+              "requires": {
+                "JSONStream": "^1.0.0",
+                "ajv": "4.10.0",
+                "async": "~2.1.5",
+                "debug": "~2.3.3",
+                "diskusage": "^0.2.2",
+                "ioctl": "2.0.0",
+                "ioredis": "2.4.0",
+                "ipaddr.js": "1.2.0",
+                "joi": "^10.6",
+                "level": "~1.6.0",
+                "level-sublevel": "~6.6.1",
+                "node-forge": "^0.7.1",
+                "simple-glob": "^0.1",
+                "socket.io": "~1.7.3",
+                "socket.io-client": "~1.7.3",
+                "utf8": "2.1.2",
+                "uuid": "^3.0.1",
+                "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+                "xml2js": "~0.4.16"
+              },
+              "dependencies": {
+                "werelogs": {
+                  "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+                  "from": "github:scality/werelogs#hotfix/7.4.0",
+                  "requires": {
+                    "safe-json-stringify": "^1.0.3"
+                  }
+                }
+              }
+            },
+            "async": {
+              "version": "2.1.5",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+              "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+              "requires": {
+                "lodash": "^4.14.0"
+              }
+            },
+            "commander": {
+              "version": "2.9.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+              "requires": {
+                "graceful-readlink": ">= 1.0.0"
+              }
+            },
+            "werelogs": {
+              "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+              "from": "github:scality/werelogs#7.4.0.3",
+              "requires": {
+                "safe-json-stringify": "^1.0.3"
+              }
+            },
+            "xml2js": {
+              "version": "0.4.17",
+              "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+              "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+              "requires": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "^4.1.0"
+              }
+            },
+            "xmlbuilder": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+              "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+              "requires": {
+                "lodash": "^4.0.0"
+              }
+            }
+          }
+        },
+        "werelogs": {
+          "version": "github:scality/werelogs#74b121bef4068645e307da143749e61ef416a4c3",
+          "from": "github:scality/werelogs#74b121bef4068645e307da143749e61ef416a4c3",
+          "requires": {
+            "safe-json-stringify": "^1.0.3"
           }
         },
         "ws": {
@@ -557,7 +833,6 @@
         "bson": "2.0.4",
         "debug": "~2.3.3",
         "diskusage": "^0.2.2",
-        "fcntl": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
         "ioctl": "2.0.0",
         "ioredis": "2.4.0",
         "ipaddr.js": "1.2.0",
@@ -571,7 +846,6 @@
         "socket.io-client": "~1.7.3",
         "utf8": "2.1.2",
         "uuid": "^3.0.1",
-        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
         "xml2js": "~0.4.16"
       },
       "dependencies": {
@@ -581,6 +855,14 @@
           "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
           "requires": {
             "lodash": "^4.14.0"
+          }
+        },
+        "fcntl": {
+          "version": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
+          "from": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
+          "requires": {
+            "bindings": "^1.1.1",
+            "nan": "^2.3.2"
           }
         },
         "ioredis": {
@@ -600,7 +882,7 @@
         },
         "werelogs": {
           "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-          "from": "github:scality/werelogs#0ff7ec82",
+          "from": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
           "requires": {
             "safe-json-stringify": "1.0.3"
           }
@@ -914,14 +1196,10 @@
     "bucketclient": {
       "version": "github:scality/bucketclient#520d164d264ac74b920a9d517bd4e08f3ff71473",
       "from": "github:scality/bucketclient#520d164",
-      "requires": {
-        "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
-        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
-      },
       "dependencies": {
         "arsenal": {
           "version": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
-          "from": "github:scality/Arsenal#67365083",
+          "from": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
           "requires": {
             "JSONStream": "^1.0.0",
             "ajv": "4.10.0",
@@ -942,6 +1220,15 @@
             "uuid": "^3.0.1",
             "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
             "xml2js": "~0.4.16"
+          },
+          "dependencies": {
+            "werelogs": {
+              "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+              "from": "github:scality/werelogs#0ff7ec82",
+              "requires": {
+                "safe-json-stringify": "1.0.3"
+              }
+            }
           }
         },
         "async": {
@@ -954,7 +1241,7 @@
         },
         "ioredis": {
           "version": "2.4.0",
-          "resolved": "http://registry.npmjs.org/ioredis/-/ioredis-2.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.4.0.tgz",
           "integrity": "sha1-lj97+8huXEDqWGhX4U6/tUgUKog=",
           "requires": {
             "bluebird": "^3.3.4",
@@ -969,7 +1256,7 @@
         },
         "werelogs": {
           "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-          "from": "github:scality/werelogs#0ff7ec82",
+          "from": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
           "requires": {
             "safe-json-stringify": "1.0.3"
           }
@@ -1120,103 +1407,6 @@
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
-    },
-    "cdmiclient": {
-      "version": "github:scality/cdmiclient#8f0c2e6331dfa905bfe269fb4e1558d65ca0b866",
-      "from": "github:scality/cdmiclient#8f0c2e6",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "arsenal": "github:scality/Arsenal#9a009746be40ee68f5f1d774731f336d27b8a7e3",
-        "async": "~1.4.2",
-        "werelogs": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46"
-      },
-      "dependencies": {
-        "arsenal": {
-          "version": "github:scality/Arsenal#9a009746be40ee68f5f1d774731f336d27b8a7e3",
-          "from": "github:scality/Arsenal#development/8.0",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "JSONStream": "^1.0.0",
-            "ajv": "4.10.0",
-            "async": "~2.1.5",
-            "bson": "2.0.4",
-            "debug": "~2.3.3",
-            "diskusage": "^0.2.2",
-            "fcntl": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
-            "ioctl": "2.0.0",
-            "ioredis": "2.4.0",
-            "ipaddr.js": "1.2.0",
-            "joi": "^10.6",
-            "level": "~1.6.0",
-            "level-sublevel": "~6.6.1",
-            "mongodb": "^3.0.1",
-            "node-forge": "^0.7.1",
-            "simple-glob": "^0.1",
-            "socket.io": "~1.7.3",
-            "socket.io-client": "~1.7.3",
-            "utf8": "2.1.2",
-            "uuid": "^3.0.1",
-            "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-            "xml2js": "~0.4.16"
-          },
-          "dependencies": {
-            "async": {
-              "version": "2.1.5",
-              "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
-              "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "lodash": "^4.14.0"
-              }
-            },
-            "werelogs": {
-              "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-              "from": "github:scality/werelogs#0ff7ec82",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "safe-json-stringify": "1.0.3"
-              }
-            }
-          }
-        },
-        "async": {
-          "version": "1.4.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.4.2.tgz",
-          "integrity": "sha1-bJ7csRztTw3S8tQNsNSaEJwIiqs=",
-          "dev": true,
-          "optional": true
-        },
-        "ioredis": {
-          "version": "2.4.0",
-          "resolved": "http://registry.npmjs.org/ioredis/-/ioredis-2.4.0.tgz",
-          "integrity": "sha1-lj97+8huXEDqWGhX4U6/tUgUKog=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "bluebird": "^3.3.4",
-            "cluster-key-slot": "^1.0.6",
-            "debug": "^2.2.0",
-            "double-ended-queue": "^2.1.0-0",
-            "flexbuffer": "0.0.6",
-            "lodash": "^4.8.2",
-            "redis-commands": "^1.2.0",
-            "redis-parser": "^1.3.0"
-          }
-        },
-        "werelogs": {
-          "version": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46",
-          "from": "github:scality/werelogs#development/8.0",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-json-stringify": "1.0.3"
-          }
-        }
-      }
     },
     "chalk": {
       "version": "1.1.3",
@@ -2022,6 +2212,11 @@
         "flat-cache": "^1.2.1",
         "object-assign": "^4.0.1"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "flat-cache": {
       "version": "1.3.2",
@@ -3550,12 +3745,22 @@
       "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
     },
     "node-rdkafka": {
-      "version": "2.3.1",
-      "resolved": "http://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.3.1.tgz",
-      "integrity": "sha1-HBC4XJlyQ9UKFLCcA+6PI3DfjVY=",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.5.1.tgz",
+      "integrity": "sha512-tC7LeyshdZEds+nx0RicLn9Cam0ahpGIDNY+QAD82K/UpD2rAMIM4K/Z8NUnlnvCaLukA7229agSMogG23XcTA==",
       "requires": {
-        "bindings": "1.x",
-        "nan": "2.x"
+        "bindings": "^1.3.1",
+        "nan": "^2.11.1"
+      },
+      "dependencies": {
+        "bindings": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.4.0.tgz",
+          "integrity": "sha512-7znEVX22Djn+nYjxCWKDne0RRloa9XfYa84yk3s+HkE3LpDYZmhArYr9O9huBoHY3/oXispx5LorIX7Sl2CgSQ==",
+          "requires": {
+            "file-uri-to-path": "1.0.0"
+          }
+        }
       }
     },
     "node-schedule": {
@@ -4409,24 +4614,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "sproxydclient": {
-      "version": "github:scality/sproxydclient#45090b76b24ca1d05482bf151ba84ff6178423d1",
-      "from": "github:scality/sproxydclient#45090b7",
-      "dev": true,
-      "requires": {
-        "werelogs": "github:scality/werelogs#f1e9a17b23acf9cd3d6a2ff460db5b47bbc0c512"
-      },
-      "dependencies": {
-        "werelogs": {
-          "version": "github:scality/werelogs#f1e9a17b23acf9cd3d6a2ff460db5b47bbc0c512",
-          "from": "github:scality/werelogs#7.4.0.3",
-          "dev": true,
-          "requires": {
-            "safe-json-stringify": "^1.0.3"
-          }
-        }
-      }
-    },
     "sql-where-parser": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/sql-where-parser/-/sql-where-parser-2.2.1.tgz",
@@ -4801,161 +4988,6 @@
         "os-homedir": "^1.0.0"
       }
     },
-    "utapi": {
-      "version": "github:scality/utapi#f2f1d0c7423ffdec2ad175e3c0e8bcd7aa2ba867",
-      "from": "github:scality/utapi#f2f1d0c",
-      "dev": true,
-      "requires": {
-        "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
-        "async": "^2.0.1",
-        "ioredis": "^2.3.0",
-        "node-schedule": "1.2.0",
-        "vaultclient": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
-        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
-      },
-      "dependencies": {
-        "arsenal": {
-          "version": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
-          "from": "github:scality/Arsenal#67365083",
-          "dev": true,
-          "requires": {
-            "JSONStream": "^1.0.0",
-            "ajv": "4.10.0",
-            "async": "~2.1.5",
-            "debug": "~2.3.3",
-            "diskusage": "^0.2.2",
-            "ioctl": "2.0.0",
-            "ioredis": "2.4.0",
-            "ipaddr.js": "1.2.0",
-            "joi": "^10.6",
-            "level": "~1.6.0",
-            "level-sublevel": "~6.6.1",
-            "node-forge": "^0.7.1",
-            "simple-glob": "^0.1",
-            "socket.io": "~1.7.3",
-            "socket.io-client": "~1.7.3",
-            "utf8": "2.1.2",
-            "uuid": "^3.0.1",
-            "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-            "xml2js": "~0.4.16"
-          },
-          "dependencies": {
-            "async": {
-              "version": "2.1.5",
-              "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
-              "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.14.0"
-              }
-            },
-            "ioredis": {
-              "version": "2.4.0",
-              "resolved": "http://registry.npmjs.org/ioredis/-/ioredis-2.4.0.tgz",
-              "integrity": "sha1-lj97+8huXEDqWGhX4U6/tUgUKog=",
-              "dev": true,
-              "requires": {
-                "bluebird": "^3.3.4",
-                "cluster-key-slot": "^1.0.6",
-                "debug": "^2.2.0",
-                "double-ended-queue": "^2.1.0-0",
-                "flexbuffer": "0.0.6",
-                "lodash": "^4.8.2",
-                "redis-commands": "^1.2.0",
-                "redis-parser": "^1.3.0"
-              }
-            }
-          }
-        },
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": ">= 1.0.0"
-          }
-        },
-        "cron-parser": {
-          "version": "1.1.0",
-          "resolved": "http://registry.npmjs.org/cron-parser/-/cron-parser-1.1.0.tgz",
-          "integrity": "sha1-B1uExFnBVejEgqtNVq/5na5YNS4=",
-          "dev": true
-        },
-        "ioredis": {
-          "version": "2.5.0",
-          "resolved": "http://registry.npmjs.org/ioredis/-/ioredis-2.5.0.tgz",
-          "integrity": "sha1-+2/fChp+CXRhTGe25eETCKjPlbk=",
-          "dev": true,
-          "requires": {
-            "bluebird": "^3.3.4",
-            "cluster-key-slot": "^1.0.6",
-            "debug": "^2.2.0",
-            "double-ended-queue": "^2.1.0-0",
-            "flexbuffer": "0.0.6",
-            "lodash": "^4.8.2",
-            "redis-commands": "^1.2.0",
-            "redis-parser": "^1.3.0"
-          }
-        },
-        "long-timeout": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.0.2.tgz",
-          "integrity": "sha1-82RJuolinROnorJSOk253Wbj/2g=",
-          "dev": true
-        },
-        "node-schedule": {
-          "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/node-schedule/-/node-schedule-1.2.0.tgz",
-          "integrity": "sha1-8D1OvnGwVz4XCN2uCqRdFlhFDPE=",
-          "dev": true,
-          "requires": {
-            "cron-parser": "1.1.0",
-            "long-timeout": "0.0.2"
-          }
-        },
-        "vaultclient": {
-          "version": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
-          "from": "github:scality/vaultclient#fbd9988d",
-          "dev": true,
-          "requires": {
-            "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
-            "commander": "2.9.0",
-            "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-            "xml2js": "0.4.17"
-          },
-          "dependencies": {
-            "xml2js": {
-              "version": "0.4.17",
-              "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-              "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
-              "dev": true,
-              "requires": {
-                "sax": ">=0.6.0",
-                "xmlbuilder": "^4.1.0"
-              }
-            }
-          }
-        },
-        "werelogs": {
-          "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-          "from": "github:scality/werelogs#0ff7ec82",
-          "dev": true,
-          "requires": {
-            "safe-json-stringify": "1.0.3"
-          }
-        },
-        "xmlbuilder": {
-          "version": "4.2.1",
-          "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
-          "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.0.0"
-          }
-        }
-      }
-    },
     "utf-8-validate": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-4.0.2.tgz",
@@ -5033,15 +5065,13 @@
       "version": "github:scality/vaultclient#754b6e1e1121f44bc3719e35b836a9185d6d5e1a",
       "from": "github:scality/vaultclient#754b6e1",
       "requires": {
-        "arsenal": "github:scality/Arsenal#25f991311db1d23816af183db05c0b664fe296e9",
         "commander": "2.9.0",
-        "werelogs": "github:scality/werelogs#f1e9a17b23acf9cd3d6a2ff460db5b47bbc0c512",
         "xml2js": "0.4.17"
       },
       "dependencies": {
         "arsenal": {
-          "version": "github:scality/Arsenal#25f991311db1d23816af183db05c0b664fe296e9",
-          "from": "github:scality/Arsenal#7.4.0.3",
+          "version": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
+          "from": "github:scality/Arsenal#25f991311db1d23816af183db05c0b664fe296e9",
           "requires": {
             "JSONStream": "^1.0.0",
             "ajv": "4.10.0",
@@ -5091,7 +5121,7 @@
         },
         "ioredis": {
           "version": "2.4.0",
-          "resolved": "http://registry.npmjs.org/ioredis/-/ioredis-2.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.4.0.tgz",
           "integrity": "sha1-lj97+8huXEDqWGhX4U6/tUgUKog=",
           "requires": {
             "bluebird": "^3.3.4",
@@ -5105,8 +5135,8 @@
           }
         },
         "werelogs": {
-          "version": "github:scality/werelogs#f1e9a17b23acf9cd3d6a2ff460db5b47bbc0c512",
-          "from": "github:scality/werelogs#7.4.0.3",
+          "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+          "from": "github:scality/werelogs#f1e9a17b23acf9cd3d6a2ff460db5b47bbc0c512",
           "requires": {
             "safe-json-stringify": "^1.0.3"
           }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ioredis": "^3.2.2",
     "joi": "^10.6",
     "node-forge": "^0.7.1",
-    "node-rdkafka": "2.3.1",
+    "node-rdkafka": "2.5.1",
     "node-schedule": "^1.2.0",
     "node-zookeeper-client": "^0.2.2",
     "prom-client": "^10.2.3",


### PR DESCRIPTION
This is essentially to solve an issue with librdkafka.so.1 lookup when
running tests. It's unclear in which situation exactly it arises (it
seems to run OK on the CI for example but fail in other environments)
but bumping the version fixes for me and was the suggestion in
https://github.com/Blizzard/node-rdkafka/issues/474.