### PR TITLE
ft: ZENKO-1283 ingestion pause resume

### DIFF
--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -1,14 +1,21 @@
 const async = require('async');
 const url = require('url');
+const Redis = require('ioredis');
+const schedule = require('node-schedule');
 
 const Logger = require('werelogs').Logger;
 
 const config = require('../../conf/Config');
-const zookeeper = require('../clients/zookeeper');
 const IngestionReader = require('./IngestionReader');
 const MetricsConsumer = require('../MetricsConsumer');
 const MetricsProducer = require('../MetricsProducer');
 const { metricsExtension } = require('../../extensions/ingestion/constants');
+
+const {
+    zookeeperNamespace,
+    zkStatePath,
+    zkStateProperties,
+} = require('../../extensions/ingestion/constants');
 
 class IngestionPopulator {
     /**
@@ -16,6 +23,7 @@ class IngestionPopulator {
      * queues from the metadata log
      *
      * @constructor
+     * @param {node-zookeeper-client.Client} zkClient - zookeeper client
      * @param {Object} zkConfig - zookeeper configuration object
      * @param {String} zkConfig.connectionString - zookeeper
      *   connection string as "host:port[/chroot]"
@@ -39,8 +47,9 @@ class IngestionPopulator {
      * @param {Object} ingestionConfig - ingestion extension configurations
      * @param {Object} s3Config - configuration to connect to S3 Client
      */
-    constructor(zkConfig, kafkaConfig, qpConfig, mConfig, rConfig,
+    constructor(zkClient, zkConfig, kafkaConfig, qpConfig, mConfig, rConfig,
                 ingestionConfig, s3Config) {
+        this.zkClient = zkClient;
         this.zkConfig = zkConfig;
         this.kafkaConfig = kafkaConfig;
         this.qpConfig = qpConfig;
@@ -56,13 +65,17 @@ class IngestionPopulator {
 
         // list of updated log readers, if any
         this.logReadersUpdate = [];
+
         // metrics clients
         this._mProducer = null;
         this._mConsumer = null;
 
-        // active ingestion readers
-        // i.e.: { zenko-bucket-name: new IngestionReader() }
-        this._activeIngestionSources = {};
+        // all ingestion readers (including paused ones)
+        // i.e.: { zenko-bucket-name: IngestionReader() }
+        this._ingestionSources = {};
+        // paused location constraints
+        // i.e.: { location-constraint: null || new schedule() }
+        this._pausedLocations = {};
     }
 
     /**
@@ -93,7 +106,6 @@ class IngestionPopulator {
                 }
                 return next(err);
             }),
-            next => this._setupZookeeper(next),
         ], err => {
             if (err) {
                 this.log.error('error starting up ingestion populator',
@@ -101,6 +113,9 @@ class IngestionPopulator {
                         error: err });
                 return cb(err);
             }
+            // setup redis for pause/resume
+            this._setupRedis(this.rConfig);
+
             return cb();
         });
     }
@@ -114,6 +129,283 @@ class IngestionPopulator {
         // Metrics Producer
         this._mProducer = new MetricsProducer(this.kafkaConfig, this.mConfig);
         this._mProducer.setupProducer(cb);
+    }
+
+    /**
+     * Setup the Redis Subscriber which listens for actions from other processes
+     * (i.e. BackbeatAPI for pause/resume)
+     * @param {Object} redisConfig - redis config
+     * @return {undefined}
+     */
+    _setupRedis(redisConfig) {
+        // redis pub/sub for pause/resume
+        const redis = new Redis(redisConfig);
+        // redis psubscribe and will need to parse location name
+        const { topic } = this.ingestionConfig;
+        const channelPattern = `${topic}-*`;
+        redis.psubscribe(channelPattern, err => {
+            if (err) {
+                this.log.fatal('failed to subscribe to redis channel', {
+                    method: 'IngestionPopulator._setupRedis',
+                    error: err,
+                });
+                process.exit(1);
+            }
+            this._redis = redis;
+        });
+        redis.on('pmessage', (channel, pattern, message) => {
+            const validActions = {
+                pauseService: this._pauseService.bind(this),
+                resumeService: this._resumeService.bind(this),
+                deleteScheduledResumeService:
+                    this._deleteScheduledResumeService.bind(this),
+            };
+
+            let locationConstraint;
+            let parsedMessage;
+            try {
+                // remove topic in front of pattern to get location name
+                locationConstraint = pattern.replace(`${topic}-`, '');
+                parsedMessage = JSON.parse(message);
+            } catch (e) {
+                this.log.error('error parsing redis subscribe message', {
+                    method: 'IngestionPopulator._setupRedis',
+                    error: e,
+                });
+                return;
+            }
+            const { action, date } = parsedMessage;
+            const cmd = validActions[action];
+            if (typeof cmd === 'function') {
+                cmd(locationConstraint, date);
+            }
+        });
+    }
+
+    setPausedLocationState(location, schedule) {
+        // set paused location state for a location without a scheduled resume
+        this._pausedLocations[location] = schedule || null;
+    }
+
+    removePausedLocationState(location) {
+        if (Object.keys(this._pausedLocations).includes(location)) {
+            delete this._pausedLocations[location];
+        }
+    }
+
+    /**
+     * Pause bucket(s) based on given location constraint
+     * @param {String} location - location constraint
+     * @return {undefined}
+     */
+    _pauseService(location) {
+        const enabled = !Object.keys(this._pausedLocations).includes(location);
+        if (enabled) {
+            // if currently resumed/active, attempt to pause
+            this._updateZkStateNode(location, 'paused', true, err => {
+                if (err) {
+                    this.log.trace('error occurred saving state to zookeeper', {
+                        method: 'IngestionPopulator._pauseService',
+                        locationConstraint: location,
+                    });
+                } else {
+                    // remove from this.logReaders
+                    const toPauseReaders = this.logReaders.filter(lr =>
+                        lr.getLocationConstraint() === location);
+                    toPauseReaders.forEach(reader => {
+                        const zenkoBucket = reader.getTargetZenkoBucketName();
+                        this._checkAndRemoveLogReader(zenkoBucket,
+                            this.logReaders);
+                        this.log.info('paused ingestion reader', {
+                            zenkoBucket,
+                            locationConstraint: location,
+                        });
+                    });
+                    this._deleteScheduledResumeService(location);
+                    // add to this._pausedLocations
+                    this.setPausedLocationState(location);
+                }
+            });
+        }
+    }
+
+    /**
+     * Resume bucket(s) based on given location constraint
+     * @param {String} location - location constraint
+     * @param {Date} [date] - optional date object for scheduling resume
+     * @return {undefined}
+     */
+    _resumeService(location, date) {
+        const enabled = !Object.keys(this._pausedLocations).includes(location);
+        const now = new Date();
+
+        if (enabled) {
+            this.log.info(`cannot resume, location ${location} is not paused`);
+            return;
+        }
+
+        if (date && now < new Date(date)) {
+            // if date is in the future, attempt to schedule job
+            this.scheduleResume(location, date);
+            return;
+        }
+        // otherwise, if !date || now >= new Date(date)
+        this._updateZkStateNode(location, 'paused', false, err => {
+            if (err) {
+                this.log.trace('error occurred saving state to zookeeper', {
+                    method: 'IngestionPopulator._resumeService',
+                    locationConstraint: location,
+                });
+                return;
+            }
+            const zenkoBuckets = Object.keys(this._ingestionSources);
+            this._deleteScheduledResumeService(location);
+            zenkoBuckets.forEach(bucket => {
+                const reader = this._ingestionSources[bucket];
+                if (reader.getLocationConstraint() === location) {
+                    // add to this.logReaders
+                    this.logReaders.push(reader);
+                    // remove from this._pausedLocations
+                    this.removePausedLocationState(location);
+                    this.log.info('resumed ingestion reader', {
+                        zenkoBucket: bucket,
+                        locationConstraint: location,
+                    });
+                }
+            });
+        });
+    }
+
+    /**
+     * Delete scheduled resume (if any)
+     * @param {String} location - location constraint
+     * @return {undefined}
+     */
+    _deleteScheduledResumeService(location) {
+        this._updateZkStateNode(location, 'scheduledResume', null, err => {
+            if (err) {
+                this.log.trace('error occurred saving state to zookeeper', {
+                    method: 'IngestionPopulator._deleteScheduledResumeService',
+                    locationConstraint: location,
+                });
+                return;
+            }
+            const schedule = this._pausedLocations[location];
+            if (schedule) {
+                schedule.cancel();
+                this.setPausedLocationState(location);
+                this.log.info('deleted scheduled resume for ingestion reader', {
+                    locationConstraint: location,
+                });
+            }
+        });
+    }
+
+    scheduleResume(location, date) {
+        function triggerResume() {
+            this._updateZkStateNode(location, 'scheduledResume', null, err => {
+                if (err) {
+                    this.log.error('error occurred saving state to zookeeper ' +
+                    'to resume a scheduled resume. Retry again in 1 minute', {
+                        method: 'IngestionPopulator.scheduleResume',
+                        locationConstraint: location,
+                        error: err,
+                    });
+                    // if an error occurs, need to retry
+                    // for now, schedule minute from now
+                    const date = new Date();
+                    date.setMinutes(date.getMinutes() + 1);
+                    const scheduledResume = schedule.scheduleJob(date,
+                        triggerResume.bind(this));
+                    this.setPausedLocationState(location, scheduledResume);
+                } else {
+                    const scheduledResume = this._pausedLocations[location];
+                    if (scheduledResume) {
+                        scheduledResume.cancel();
+                    }
+                    this.setPausedLocationState(location);
+                    this._resumeService(location);
+                }
+            });
+        }
+
+        this._updateZkStateNode(location, 'scheduledResume', date, err => {
+            if (err) {
+                this.log.trace('error occurred saving state to zookeeper', {
+                    method: 'IngestionPopulator.scheduleResume',
+                    locationConstraint: location,
+                });
+                return;
+            }
+            const scheduledResume = schedule.scheduleJob(date,
+                triggerResume.bind(this));
+            this.setPausedLocationState(location, scheduledResume);
+            this.log.info('scheduled ingestion resume', {
+                locationConstraint: location,
+                scheduleTime: date.toString(),
+            });
+        });
+    }
+
+    _getZkLocationNode(location) {
+        return `${zookeeperNamespace}${zkStatePath}/${location}`;
+    }
+
+    /**
+     * Update zookeeper state node for given location
+     * @param {String} location - location constraint (also zk state node)
+     * @param {String} key - key name to store in zk state node
+     * @param {String|Boolean} value - value
+     * @param {Function} cb - callback(error)
+     * @return {undefined}
+     */
+    _updateZkStateNode(location, key, value, cb) {
+        if (!zkStateProperties.includes(key)) {
+            const errorMsg = 'incorrect zookeeper state property given';
+            this.log.error(errorMsg, {
+                method: 'IngestionPopulator._updateZkStateNode',
+            });
+            return cb(new Error(errorMsg));
+        }
+        const path = this._getZkLocationNode(location);
+        return async.waterfall([
+            next => this.zkClient.getData(path, (err, data) => {
+                if (err) {
+                    this.log.error('could not get state from zookeeper', {
+                        method: 'IngestionPopulator._updateZkStateNode',
+                        zookeeperPath: path,
+                        error: err.message,
+                    });
+                    return next(err);
+                }
+                let bufferedData;
+                try {
+                    const state = JSON.parse(data.toString());
+                    // set revised status
+                    state[key] = value;
+                    bufferedData = Buffer.from(JSON.stringify(state));
+                } catch (err) {
+                    this.log.error('could not parse state data from ' +
+                    'zookeeper', {
+                        method: 'IngestionPopulator._updateZkStateNode',
+                        zookeeperPath: path,
+                        error: err,
+                    });
+                    return next(err);
+                }
+                return next(null, bufferedData);
+            }),
+            (data, next) => this.zkClient.setData(path, data, err => {
+                if (err) {
+                    this.log.error('could not save state data in zookeeper', {
+                        method: 'IngestionPopulator._updateZkStateNode',
+                        zookeeperPath: path,
+                        error: err,
+                    });
+                }
+                return next(err);
+            }),
+        ], cb);
     }
 
     /**
@@ -136,27 +428,26 @@ class IngestionPopulator {
         // ]
         const buckets = config.getIngestionBuckets();
 
-        const currentActiveSources = Object.keys(this._activeIngestionSources);
-        buckets.forEach(bucket => {
-            const { zenkoBucket } = bucket;
+        const configuredSources = Object.keys(this._ingestionSources);
+        buckets.forEach(bucketInfo => {
+            const { zenkoBucket } = bucketInfo;
             // if the zenko bucket has already been setup and is already
             // active, stop tracking bucket from `currentActiveSources`
             const isAlreadyActive =
-                currentActiveSources.indexOf(zenkoBucket) >= 0;
+                configuredSources.indexOf(zenkoBucket) >= 0;
             if (isAlreadyActive) {
-                currentActiveSources.splice(
-                    currentActiveSources.indexOf(zenkoBucket), 1);
-            } else if (!currentActiveSources.includes(zenkoBucket)) {
-                // Add new ingestion source
-                const newSourceInfo =
-                    this._getNewSourceInformation(bucket);
-                this.addNewLogSource(newSourceInfo);
+                configuredSources.splice(
+                    configuredSources.indexOf(zenkoBucket), 1);
+                return;
             }
+            // Add new ingestion source
+            const newSourceInfo = this._getNewSourceInformation(bucketInfo);
+            this.addNewLogSource(newSourceInfo);
         });
 
         // Any leftover `currentActiveSources` are no longer active and
         // must be removed.
-        currentActiveSources.forEach(source => {
+        configuredSources.forEach(source => {
             this.closeLogState(source);
         });
     }
@@ -202,6 +493,7 @@ class IngestionPopulator {
 
         const newRaftReader = new IngestionReader({
             zkClient: this.zkClient,
+            ingestionConfig: this.ingestionConfig,
             kafkaConfig: this.kafkaConfig,
             bucketdConfig: source,
             logger: this.log,
@@ -212,28 +504,9 @@ class IngestionPopulator {
         });
 
         // add to active ingestion sources list
-        this._activeIngestionSources[zenkoBucket] = newRaftReader;
+        this._ingestionSources[zenkoBucket] = newRaftReader;
         // add to log readers update list
         this.logReadersUpdate.push(newRaftReader);
-    }
-
-    _setupZookeeper(done) {
-        const populatorZkPath = this.ingestionConfig.zookeeperPath;
-        const zookeeperUrl =
-            `${this.zkConfig.connectionString}${populatorZkPath}`;
-        this.log.info('opening zookeeper connection for persisting ' +
-                      'populator state',
-                      { zookeeperUrl });
-        this.zkClient = zookeeper.createClient(zookeeperUrl, {
-            autoCreateNamespace: this.zkConfig.autoCreateNamespace,
-        });
-        this.zkClient.connect();
-        this.zkClient.once('error', done);
-        this.zkClient.once('ready', () => {
-            // just in case there would be more 'error' events emitted
-            this.zkClient.removeAllListeners('error');
-            done();
-        });
     }
 
     _loadExtension() {
@@ -271,12 +544,29 @@ class IngestionPopulator {
     }
 
     /**
+     * Remove paused ingestion readers from this.logReaders
+     * @return {undefined}
+     */
+    _removePausedReaders() {
+        const locationsToPause = Object.keys(this._pausedLocations);
+        locationsToPause.forEach(location => {
+            // if IngestionReader is a paused location, remove from active
+            // IngestionReader list: this.logReaders
+            this.logReaders.forEach(lr => {
+                if (lr.getLocationConstraint() === location) {
+                    this._checkAndRemoveLogReader(
+                        lr.getTargetZenkoBucketName(), this.logReaders);
+                }
+            });
+        });
+    }
+
+    /**
      * Remove all ingestion sources
      * @return {undefined}
      */
     close() {
-        // TODO: remove/cleanup zk paths
-        Object.keys(this._activeIngestionSources).forEach(source => {
+        Object.keys(this._ingestionSources).forEach(source => {
             this.closeLogState(source);
         });
     }
@@ -288,7 +578,7 @@ class IngestionPopulator {
      */
     closeLogState(key) {
         // TODO: remove/cleanup zk paths
-        delete this._activeIngestionSources[key];
+        delete this._ingestionSources[key];
         this._checkAndRemoveLogReader(key, this.logReaders);
         this._checkAndRemoveLogReader(key, this.logReadersUpdate);
     }
@@ -320,15 +610,18 @@ class IngestionPopulator {
     }
 
     processLogEntries(params, done) {
-        if (this.logReadersUpdate.length >= 1) {
-            return this._setupUpdatedReaders(err => {
-                if (err) {
-                    return done(err);
+        return async.series([
+            next => {
+                if (this.logReadersUpdate.length >= 1) {
+                    return this._setupUpdatedReaders(next);
                 }
-                return this._processLogEntries(params, done);
-            });
-        }
-        return this._processLogEntries(params, done);
+                return process.nextTick(next);
+            },
+            next => {
+                this._removePausedReaders();
+                return this._processLogEntries(params, next);
+            },
+        ], done);
     }
 
     zkStatus() {

--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -69,6 +69,7 @@ class IngestionPopulator {
         // metrics clients
         this._mProducer = null;
         this._mConsumer = null;
+        this._redis = null;
 
         // all ingestion readers (including paused ones)
         // i.e.: { zenko-bucket-name: IngestionReader() }

--- a/lib/queuePopulator/IngestionReader.js
+++ b/lib/queuePopulator/IngestionReader.js
@@ -17,10 +17,11 @@ function _isVersionedLogKey(key) {
 
 class IngestionReader extends LogReader {
     constructor(params) {
-        const { zkClient, kafkaConfig, bucketdConfig, qpConfig,
+        const { zkClient, ingestionConfig, kafkaConfig, bucketdConfig, qpConfig,
             logger, extensions, metricsProducer, s3Config } = params;
         super({ zkClient, kafkaConfig, logConsumer: {}, logId: '',
                 logger, extensions, metricsProducer });
+        this._ingestionConfig = ingestionConfig;
         this.qpConfig = qpConfig;
         this.s3Config = s3Config;
         this.bucketdConfig = bucketdConfig;
@@ -31,7 +32,8 @@ class IngestionReader extends LogReader {
         // zenko bucket to ingest to
         this._targetZenkoBucket = bucketdConfig.name;
 
-        this.zkBasePath = `/${this._targetZenkoBucket}/logState`;
+        const ingestionPath = this._ingestionConfig.zookeeperPath;
+        this.zkBasePath = `${ingestionPath}/${this._targetZenkoBucket}`;
         this.bucketInitPath = `${this.zkBasePath}/init`;
         this.pathToLogOffset = null;
         this.raftId = null;
@@ -77,7 +79,7 @@ class IngestionReader extends LogReader {
                 this.raftId = data;
                 this.logId = `raft_${this.raftId}`;
                 this.pathToLogOffset =
-                    `${this.zkBasePath}/${this.logId}/logOffset`;
+                    `${this.zkBasePath}/logState/${this.logId}/logOffset`;
 
                 return super.setup(done);
             });

--- a/tests/config.json
+++ b/tests/config.json
@@ -45,7 +45,7 @@
                     "port": 7998,
                     "https": false,
                     "type": "scality_s3",
-                    "locationConstraint": "a-zenko-location",
+                    "locationConstraint": "us-east-1",
                     "auth": {
                         "accessKey": "accessKey1",
                         "secretKey": "o7Q9X25qRv9KNYUewzlXAmfUmnOycFT9yTdgfk5IMntV8kEg4+mqEYl3QhAXyrCw22vbxvSzgdtjh+YhcZBIC6BL/AWurIh5MZyktbaSQabM3ZobTGuEet+qjog0I6Dr9tjHhxM1tfcOdN5Hy2lQk9LTW5uj2/7rtF6jLn5E1HLEn25sAAy60qPqMjBt+pQ0l6Y4JQ6dymZFCv/lZluEQ2mCdH0WlfDh4ZLcNC0KslwjQVJA4kPS5ydE88bB5m5BMscvzMeeRWkObHwdxnu6xN/YJqXvsx05NIC/G4ioeKdoQrBfuRvhlU1MhoCB/+yESdbVRLoM1MppEKkxQbQLTw=="
@@ -58,7 +58,7 @@
                     "port": 7998,
                     "https": false,
                     "type": "scality_s3",
-                    "locationConstraint": "a-zenko-location",
+                    "locationConstraint": "us-east-1",
                     "auth": {
                         "accessKey": "accessKey1",
                         "secretKey": "o7Q9X25qRv9KNYUewzlXAmfUmnOycFT9yTdgfk5IMntV8kEg4+mqEYl3QhAXyrCw22vbxvSzgdtjh+YhcZBIC6BL/AWurIh5MZyktbaSQabM3ZobTGuEet+qjog0I6Dr9tjHhxM1tfcOdN5Hy2lQk9LTW5uj2/7rtF6jLn5E1HLEn25sAAy60qPqMjBt+pQ0l6Y4JQ6dymZFCv/lZluEQ2mCdH0WlfDh4ZLcNC0KslwjQVJA4kPS5ydE88bB5m5BMscvzMeeRWkObHwdxnu6xN/YJqXvsx05NIC/G4ioeKdoQrBfuRvhlU1MhoCB/+yESdbVRLoM1MppEKkxQbQLTw=="
@@ -71,7 +71,7 @@
                     "port": 7998,
                     "https": false,
                     "type": "scality_s3",
-                    "locationConstraint": "a-zenko-location",
+                    "locationConstraint": "us-east-1",
                     "auth": {
                         "accessKey": "accessKey1",
                         "secretKey": "o7Q9X25qRv9KNYUewzlXAmfUmnOycFT9yTdgfk5IMntV8kEg4+mqEYl3QhAXyrCw22vbxvSzgdtjh+YhcZBIC6BL/AWurIh5MZyktbaSQabM3ZobTGuEet+qjog0I6Dr9tjHhxM1tfcOdN5Hy2lQk9LTW5uj2/7rtF6jLn5E1HLEn25sAAy60qPqMjBt+pQ0l6Y4JQ6dymZFCv/lZluEQ2mCdH0WlfDh4ZLcNC0KslwjQVJA4kPS5ydE88bB5m5BMscvzMeeRWkObHwdxnu6xN/YJqXvsx05NIC/G4ioeKdoQrBfuRvhlU1MhoCB/+yESdbVRLoM1MppEKkxQbQLTw=="

--- a/tests/functional/ingestion/IngestionReader.js
+++ b/tests/functional/ingestion/IngestionReader.js
@@ -19,6 +19,7 @@ const testConfig = require('../../config.json');
 const { setupS3Mock, emptyAndDeleteVersionedBucket } = require('./S3Mock');
 const zookeeper = require('../../../lib/clients/zookeeper');
 
+const ingestionConfig = testConfig.extensions.ingestion;
 const testPort = testConfig.extensions.ingestion.sources[0].port;
 const mockLogOffset = 2;
 const CONSUMER_TIMEOUT = 25000;

--- a/tests/functional/ingestion/IngestionReader.js
+++ b/tests/functional/ingestion/IngestionReader.js
@@ -19,7 +19,6 @@ const testConfig = require('../../config.json');
 const { setupS3Mock, emptyAndDeleteVersionedBucket } = require('./S3Mock');
 const zookeeper = require('../../../lib/clients/zookeeper');
 
-const ingestionConfig = testConfig.extensions.ingestion;
 const testPort = testConfig.extensions.ingestion.sources[0].port;
 const mockLogOffset = 2;
 const CONSUMER_TIMEOUT = 25000;
@@ -184,6 +183,7 @@ describe('ingestion reader tests with mock', function fD() {
             };
             this.ingestionReader = new IngestionReader({
                 zkClient,
+                ingestionConfig: testConfig.extensions.ingestion,
                 kafkaConfig: testConfig.kafka,
                 bucketdConfig: testConfig.extensions.ingestion.sources[0],
                 qpConfig: testConfig.queuePopulator,
@@ -191,7 +191,6 @@ describe('ingestion reader tests with mock', function fD() {
                 extensions: [ingestionQP],
                 metricsProducer: { publishMetrics: () => {} },
                 s3Config: testConfig.s3,
-                bucket: testConfig.extensions.ingestion.sources[0].bucket,
             });
             this.ingestionReader.setup(() => {
                 async.series([
@@ -319,6 +318,7 @@ describe('ingestion reader tests with mock', function fD() {
         beforeEach(done => {
             this.ingestionReader = new IngestionReader({
                 zkClient,
+                ingestionConfig: testConfig.extensions.ingestion,
                 kafkaConfig: testConfig.kafka,
                 bucketdConfig: sourceConfig,
                 qpConfig: testConfig.queuePopulator,
@@ -326,7 +326,6 @@ describe('ingestion reader tests with mock', function fD() {
                 extensions: [ingestionQP],
                 metricsProducer: { publishMetrics: () => {} },
                 s3Config: testConfig.s3,
-                bucket: sourceConfig.bucket,
             });
             this.ingestionReader.setup(() => {
                 async.series([

--- a/tests/functional/ingestion/pauseResumeState.js
+++ b/tests/functional/ingestion/pauseResumeState.js
@@ -1,0 +1,775 @@
+const assert = require('assert');
+const async = require('async');
+const schedule = require('node-schedule');
+
+const IngestionPopulator =
+    require('../../../lib/queuePopulator/IngestionPopulator');
+const TimeMachine = require('../utils/timeMachine');
+const ZKStateHelper = require('../utils/pauseResumeUtils/zkStateHelper');
+const MockAPI = require('../utils/pauseResumeUtils/mockAPI');
+
+// Configs
+const Config = require('../../../conf/Config');
+const { zookeeperNamespace } =
+    require('../../../extensions/ingestion/constants');
+
+const redisConfig = {
+    host: Config.redis.host,
+    port: Config.redis.port,
+};
+const kafkaConfig = Config.kafka;
+const zkConfig = Config.zookeeper;
+const ingestionConfig = Config.extensions.ingestion;
+const s3Config = Config.s3;
+
+// Constants
+const ZK_TEST_STATE_PATH = `${zookeeperNamespace}/state`;
+
+// Future Date to be used in tests
+const futureDate = new Date();
+futureDate.setHours(futureDate.getHours() + 5);
+
+// test ingestion buckets we should fetch from mongo
+const firstBucket = {
+    // zenko bucket name
+    name: 'zenko-bucket',
+    // zenko storage location
+    locationConstraint: 'ring-location',
+    // s3c bucket name
+    bucketName: 'ring-bucket',
+};
+const secondBucket = {
+    name: 'other-zenko-bucket',
+    locationConstraint: 'other-ring-location',
+    bucketName: 'other-ring-bucket',
+};
+
+// This is passed from initManagement to Config and only represents the data
+// we need in IngestionPopulator
+const existingLocationConstraints = {
+    [firstBucket.locationConstraint]: {
+        details: {
+            accessKey: 'accessKey1',
+            secretKey: 'verySecretKey1',
+            endpoint: 'http://localhost:8000',
+            bucketName: firstBucket.bucketName,
+        },
+        locationType: 'location-scality-ring-s3-v1',
+    },
+    [secondBucket.locationConstraint]: {
+        details: {
+            accessKey: 'accessKey1',
+            secretKey: 'verySecretKey1',
+            endpoint: 'http://localhost:8000',
+            bucketName: secondBucket.bucketName,
+        },
+        locationType: 'location-scality-ring-s3-v1',
+    },
+};
+
+class IngestionPopulatorMock extends IngestionPopulator {
+
+    /* Overwrite setup process */
+
+    open(cb) {
+        super.open(err => {
+            assert.ifError(err);
+
+            const buckets = [firstBucket, secondBucket];
+            Config.setIngestionBuckets(existingLocationConstraints, buckets);
+
+            return cb(err);
+        });
+    }
+
+    _setupMetricsClients(cb) {
+        return cb();
+    }
+
+    /* Getters for testing purposes */
+
+    getIngestionSourceNames() {
+        return Object.keys(this._ingestionSources);
+    }
+
+    getPausedLocations() {
+        return this._pausedLocations;
+    }
+
+    getPausedLocationNames() {
+        return Object.keys(this._pausedLocations);
+    }
+
+    getZkClient() {
+        return this.zkClient;
+    }
+
+    getRedisPubSubClient() {
+        return this._redis;
+    }
+}
+
+/* eslint-disable no-param-reassign */
+function locationConditionalCheck(iPopulator, location, zkPauseState, cFxn,
+done) {
+    const zkClient = iPopulator.getZkClient();
+    const path = `${ZK_TEST_STATE_PATH}/${location}`;
+    async.doWhilst(cb => setTimeout(() => {
+        zkClient.getData(path, (err, data) => {
+            if (err) {
+                return cb(err);
+            }
+            const parsedData = JSON.parse(data);
+            Object.keys(parsedData).forEach(key => {
+                zkPauseState[key] = parsedData[key];
+            });
+            return cb();
+        });
+    }, 1000), cFxn, error => done(error, zkPauseState));
+}
+/* eslint-enable no-param-reassign */
+
+function pauseLocation(iPopulator, location, done) {
+    const state = {};
+    const conditionFxn = () => {
+        const pausedLocations = iPopulator.getPausedLocationNames();
+        return !pausedLocations.includes(location);
+    };
+    locationConditionalCheck(iPopulator, location, state, conditionFxn,
+    (err, zkPauseState) => {
+        if (err) {
+            return done(err);
+        }
+        assert.strictEqual(zkPauseState.paused, true);
+        return done(null, zkPauseState);
+    });
+}
+
+function resumeLocation(iPopulator, location, done) {
+    const state = {};
+    const conditionFxn = () => {
+        const pausedLocations = iPopulator.getPausedLocationNames();
+        return pausedLocations.includes(location);
+    };
+    locationConditionalCheck(iPopulator, location, state, conditionFxn,
+    (err, zkPauseState) => {
+        if (err) {
+            return done(err);
+        }
+        assert.strictEqual(zkPauseState.paused, false);
+        return done(null, zkPauseState);
+    });
+}
+
+function resumeScheduleLocation(iPopulator, location, done) {
+    const state = {};
+    const conditionFxn = () => (state && !state.scheduledResume);
+    locationConditionalCheck(iPopulator, location, state, conditionFxn,
+    (err, zkPauseState) => {
+        if (err) {
+            return done(err);
+        }
+        assert.strictEqual(zkPauseState.paused, true);
+        assert(zkPauseState.scheduledResume);
+        return done(null, zkPauseState);
+    });
+}
+
+function deleteScheduledResumeLocation(iPopulator, location, done) {
+    const state = {};
+    const conditionFxn = () => (state && state.scheduledResume);
+    locationConditionalCheck(iPopulator, location, state, conditionFxn,
+    (err, zkPauseState) => {
+        if (err) {
+            return done(err);
+        }
+        assert.strictEqual(zkPauseState.scheduledResume, null);
+        return done(null, zkPauseState);
+    });
+}
+
+/*
+    Create an initial state where the `firstBucket` location is not paused and
+    `secondBucket` is paused and has a scheduled resume for `futureDate`.
+
+    The IngestionPopulator holds state for all ingestion buckets as:
+        `{ zenko-bucket-name: IngestionReader() }`
+    This object keeps track of all ingestion buckets regardless of state.
+
+    The IngestionPopulator holds state for all paused locations as:
+        `{ location-constraint: null || new schedule }`
+    This object keeps track of all paused ingestion locations.
+*/
+
+describe('Ingestion Pause/Resume', function d() {
+    this.timeout(10000);
+
+    this.mockAPI = new MockAPI(ingestionConfig);
+
+    before(done => {
+        this.zkHelper = new ZKStateHelper(zkConfig, ZK_TEST_STATE_PATH,
+            firstBucket.locationConstraint, secondBucket.locationConstraint,
+            futureDate);
+        this.zkHelper.init(err => {
+            if (err) {
+                return done(err);
+            }
+            const zkClient = this.zkHelper.getClient();
+            this.iPopulator = new IngestionPopulatorMock(zkClient, zkConfig,
+                kafkaConfig, {}, {}, redisConfig, ingestionConfig, s3Config);
+            return done();
+        });
+    });
+
+    beforeEach(done => {
+        this.iPopulator.open(err => {
+            if (err) {
+                return done(err);
+            }
+            const firstLocation = firstBucket.locationConstraint;
+            const secondLocation = secondBucket.locationConstraint;
+            this.iPopulator._resumeService(firstLocation);
+            this.iPopulator._pauseService(secondLocation);
+            this.iPopulator.applyUpdates();
+
+            let pausedList = this.iPopulator.getPausedLocations();
+            return async.whilst(() =>
+                Object.keys(pausedList).includes(firstLocation) ||
+                pausedList[secondLocation] === undefined ||
+                (pausedList[secondLocation] &&
+                 pausedList[secondLocation].constructor.name !== 'Job'),
+            cb => setTimeout(() => {
+                this.iPopulator._resumeService(firstLocation);
+                this.iPopulator._resumeService(secondLocation, futureDate);
+                pausedList = this.iPopulator.getPausedLocations();
+                cb();
+            }, 1000), err => {
+                if (err) {
+                    return done(err);
+                }
+                return setTimeout(done, 2000);
+            });
+        });
+    });
+
+    afterEach(() => {
+        const redisClient = this.iPopulator.getRedisPubSubClient();
+        if (redisClient) {
+            redisClient.quit();
+        }
+    });
+
+    after(() => {
+        this.zkHelper.close();
+    });
+
+    it('should setup initial state', done => {
+        const locations = Object.keys(existingLocationConstraints);
+        const zkClient = this.iPopulator.getZkClient();
+
+        async.each(locations, (l, cb) => {
+            const path = `${ZK_TEST_STATE_PATH}/${l}`;
+            // assert bucket paths are created
+            zkClient.getData(path, (err, data) => {
+                assert.ifError(err);
+
+                const parsedData = JSON.parse(data);
+                if (firstBucket.locationConstraint === l) {
+                    assert.strictEqual(parsedData.paused, false);
+                }
+                if (secondBucket.locationConstraint === l) {
+                    // assert default state
+                    assert.strictEqual(parsedData.paused, true);
+                    // assert default state
+                    assert(parsedData.scheduledResume);
+                }
+                return cb();
+            });
+        }, err => {
+            assert.ifError(err);
+
+            const sourceListNames = this.iPopulator.getIngestionSourceNames();
+            const pausedListNames = this.iPopulator.getPausedLocationNames();
+
+            // ingestion sources holds all IngestionReader instances
+            assert.strictEqual(sourceListNames.length, 2);
+            assert(sourceListNames.includes(firstBucket.name));
+            assert(sourceListNames.includes(secondBucket.name));
+            // paused locations holds all current paused locations and their
+            // schedules (schedule resume), if any
+            assert.strictEqual(pausedListNames.length, 1);
+            assert(pausedListNames.includes(secondBucket.locationConstraint));
+
+            done();
+        });
+    });
+
+    it('should pause an active location', done => {
+        // using first location
+        const zenkoBucket = firstBucket.name;
+        const location = firstBucket.locationConstraint;
+        // send fake api request
+        this.mockAPI.pauseService(location);
+        pauseLocation(this.iPopulator, location, (err, zkPauseState) => {
+            assert.ifError(err);
+
+            const sourceListNames = this.iPopulator.getIngestionSourceNames();
+            const pausedList = this.iPopulator.getPausedLocations();
+            const pausedListNames = this.iPopulator.getPausedLocationNames();
+
+            // should have paused first location with no scheduled resume
+            assert.strictEqual(zkPauseState.paused, true);
+            assert(!zkPauseState.scheduledResume);
+            assert(sourceListNames.includes(zenkoBucket));
+            assert(pausedListNames.includes(location));
+            assert.strictEqual(pausedList[location], null);
+
+            // should not have affected the other location
+            const otherLocation = secondBucket.locationConstraint;
+            assert(sourceListNames.includes(secondBucket.name));
+            assert.strictEqual(
+                pausedList[otherLocation].constructor.name, 'Job');
+            done();
+        });
+    });
+
+    it('should not change state if pausing an already paused location',
+    done => {
+        // using first location
+        const zenkoBucket = firstBucket.name;
+        const location = firstBucket.locationConstraint;
+
+        async.series([
+            // pause
+            next => {
+                this.mockAPI.pauseService(location);
+                pauseLocation(this.iPopulator, location, next);
+            },
+            // then send another pause request and confirm state has not changed
+            next => {
+                this.mockAPI.pauseService(location);
+                // just in case, give some time because we already expect state
+                // to be set as paused. If for some reason, state will change,
+                // we want to give the request time to make that unexpected
+                // change
+                setTimeout(() => {
+                    pauseLocation(this.iPopulator, location, next);
+                }, 2000);
+            },
+        ], (error, zkPauseStates) => {
+            assert.ifError(error);
+
+            const sourceListNames = this.iPopulator.getIngestionSourceNames();
+            const pausedListNames = this.iPopulator.getPausedLocationNames();
+
+            // first location should still be paused
+            assert(sourceListNames.includes(zenkoBucket));
+            assert(pausedListNames.includes(location));
+            // zookeeper state should be the same
+            assert.deepStrictEqual(zkPauseStates[0], zkPauseStates[1]);
+            done();
+        });
+    });
+
+    it('should resume a paused location', done => {
+        // using second location
+        const zenkoBucket = secondBucket.name;
+        const location = secondBucket.locationConstraint;
+
+        // send fake api request
+        this.mockAPI.resumeService(location);
+        resumeLocation(this.iPopulator, location, (err, zkPauseState) => {
+            assert.ifError(err);
+
+            const sourceListNames = this.iPopulator.getIngestionSourceNames();
+            const pausedListNames = this.iPopulator.getPausedLocationNames();
+
+            // should have resumed location
+            assert.strictEqual(zkPauseState.paused, false);
+            assert(sourceListNames.includes(zenkoBucket));
+            assert(!pausedListNames.includes(location));
+
+            // should not have affected other location
+            assert(sourceListNames.includes(secondBucket.name));
+            assert(!pausedListNames.includes(
+                secondBucket.locationConstraint));
+            done();
+        });
+    });
+
+    it('should not change state if resuming an already active location',
+    done => {
+        // using first location
+        const zenkoBucket = firstBucket.name;
+        const location = firstBucket.locationConstraint;
+
+        const sourceListNames = this.iPopulator.getIngestionSourceNames();
+        const pausedListNames = this.iPopulator.getPausedLocationNames();
+
+        // by default, should already be active
+        assert(sourceListNames.includes(zenkoBucket));
+        assert(!pausedListNames.includes(location));
+
+        // send fake api request
+        this.mockAPI.resumeService(location);
+        // just in case, give some time because we already expect state
+        // to be set as not paused. If for some reason, state will change,
+        // we want to give the request time to make that unexpected change
+        setTimeout(() => {
+            resumeLocation(this.iPopulator, location,
+            (err, zkPauseState) => {
+                assert.ifError(err);
+
+                const sourceListNames =
+                    this.iPopulator.getIngestionSourceNames();
+                const pausedListNames =
+                    this.iPopulator.getPausedLocationNames();
+
+                // first location should still be active
+                assert(sourceListNames.includes(zenkoBucket));
+                assert(!pausedListNames.includes(location));
+                // zookeeper state should be the same
+                assert.strictEqual(zkPauseState.paused, false);
+
+                done();
+            });
+        }, 2000);
+    });
+
+    it('should schedule a resume', done => {
+        // using first location
+        const location = firstBucket.locationConstraint;
+
+        // send fake api request
+        this.mockAPI.pauseService(location);
+
+        // first pause and confirm
+        pauseLocation(this.iPopulator, location, error => {
+            assert.ifError(error);
+
+            // send fake api request
+            this.mockAPI.resumeService(location, futureDate);
+            resumeScheduleLocation(this.iPopulator, location,
+            (err, zkPauseState) => {
+                assert.ifError(err);
+
+                const sourceListNames =
+                    this.iPopulator.getIngestionSourceNames();
+                const pausedList = this.iPopulator.getPausedLocations();
+                const pausedListNames =
+                    this.iPopulator.getPausedLocationNames();
+
+                // should still be paused
+                assert.strictEqual(zkPauseState.paused, true);
+                assert(pausedListNames.includes(location));
+                // should have a scheduled date matching futureDate
+                assert(zkPauseState.scheduledResume);
+                assert.strictEqual(futureDate.getTime(),
+                    (new Date(zkPauseState.scheduledResume).getTime()));
+                // should have saved the schedule in memory
+                assert(pausedList[location]);
+                assert.strictEqual(
+                    pausedList[location].constructor.name, 'Job');
+
+                // should not have affected other location
+                const otherLocation = secondBucket.locationConstraint;
+                assert(sourceListNames.includes(secondBucket.name));
+                assert.strictEqual(
+                    pausedList[otherLocation].constructor.name, 'Job');
+
+                done();
+            });
+        });
+    });
+
+    it('should cancel a scheduled resume for a given location', done => {
+        // using second location
+        const location = secondBucket.locationConstraint;
+
+        this.mockAPI.deleteScheduledResumeService(location);
+        deleteScheduledResumeLocation(this.iPopulator, location,
+        (err, zkPauseState) => {
+            assert.ifError(err);
+
+            const pausedList = this.iPopulator.getPausedLocations();
+            const pausedListNames = this.iPopulator.getPausedLocationNames();
+
+            // should still be paused
+            assert.strictEqual(zkPauseState.paused, true);
+            assert(pausedListNames.includes(location));
+            // should no longer have a scheduled date
+            assert.strictEqual(zkPauseState.scheduledResume, null);
+            // should have removed the in-memory scheduled Job
+            assert.strictEqual(pausedList[location], null);
+            done();
+        });
+    });
+
+    it('should not schedule a resume when the location is already active',
+    done => {
+        // using first location
+        const location = firstBucket.locationConstraint;
+
+        // schedule resume
+        this.mockAPI.resumeService(location, futureDate);
+        resumeLocation(this.iPopulator, location, (err, zkPauseState) => {
+            assert.ifError(err);
+
+            const pausedListNames = this.iPopulator.getPausedLocationNames();
+
+            // state should be the same
+            assert.strictEqual(zkPauseState.paused, false);
+            assert(!pausedListNames.includes(location));
+            assert(!zkPauseState.scheduledResume);
+            done();
+        });
+    });
+
+    [
+        // new schedule time is less than current scheduled time
+        {
+            testCase: 'less than',
+            timeChange: -1,
+        },
+        // new schedule time is greater than current scheduled time
+        {
+            testCase: 'greater than',
+            timeChange: 1,
+        },
+    ].forEach(item => {
+        it('should overwrite an existing scheduled resume on new valid ' +
+        `request where new time is ${item.testCase} current scheduled time`,
+        done => {
+            // using first location
+            const location = firstBucket.locationConstraint;
+            const zkClient = this.iPopulator.getZkClient();
+
+            let zkPauseState;
+            async.series([
+                next => {
+                    // pause
+                    this.mockAPI.pauseService(location);
+                    pauseLocation(this.iPopulator, location, next);
+                },
+                next => {
+                    // schedule resume
+                    this.mockAPI.resumeService(location, futureDate);
+                    resumeScheduleLocation(this.iPopulator, location,
+                        next);
+                },
+            ], error => {
+                assert.ifError(error);
+
+                const path = `${ZK_TEST_STATE_PATH}/${location}`;
+                const newScheduledDate = new Date(futureDate);
+                newScheduledDate.setHours(newScheduledDate.getHours() +
+                    item.timeChange);
+
+                // send fake api request
+                this.mockAPI.resumeService(location, newScheduledDate);
+
+                async.doWhilst(cb => setTimeout(() => {
+                    zkClient.getData(path, (err, data) => {
+                        if (err) {
+                            return cb(err);
+                        }
+                        zkPauseState = JSON.parse(data);
+                        return cb();
+                    });
+                }, 1000), () => {
+                    if (zkPauseState && zkPauseState.scheduledResume) {
+                        const zkStateDate =
+                            new Date(zkPauseState.scheduledResume);
+                        return zkStateDate.getTime() !==
+                            newScheduledDate.getTime();
+                    }
+                    return true;
+                }, error => {
+                    assert.ifError(error);
+
+                    const pausedList = this.iPopulator.getPausedLocations();
+                    const pausedListNames =
+                        this.iPopulator.getPausedLocationNames();
+
+                    // should still be paused
+                    assert.strictEqual(zkPauseState.paused, true);
+                    assert(pausedListNames.includes(location));
+                    // should have a different date
+                    assert.strictEqual(
+                        new Date(zkPauseState.scheduledResume).toString(),
+                        newScheduledDate.toString());
+                    // scheduled job should still be saved in-memory
+                    const schedule = pausedList[location];
+                    assert(schedule);
+                    assert.strictEqual(schedule.constructor.name, 'Job');
+                    done();
+                });
+            });
+        });
+    });
+
+    it('should cancel a scheduled resume when the location is manually resumed',
+    done => {
+        // using first location
+        const location = firstBucket.locationConstraint;
+        const zkClient = this.iPopulator.getZkClient();
+        const path = `${ZK_TEST_STATE_PATH}/${location}`;
+
+        return async.series([
+            next => {
+                // pause
+                this.mockAPI.pauseService(location);
+                pauseLocation(this.iPopulator, location, next);
+            },
+            next => {
+                // schedule resume
+                this.mockAPI.resumeService(location, futureDate);
+                resumeScheduleLocation(this.iPopulator, location, next);
+            },
+            next => {
+                // resume
+                this.mockAPI.resumeService(location);
+                resumeLocation(this.iPopulator, location, next);
+            }
+        ], error => {
+            assert.ifError(error);
+
+            // check zookeeper
+            return zkClient.getData(path, (err, data) => {
+                assert.ifError(err);
+
+                const zkPauseState = JSON.parse(data);
+                const pausedListNames =
+                    this.iPopulator.getPausedLocationNames();
+
+                // should not be paused
+                assert.strictEqual(zkPauseState.paused, false);
+                assert(!pausedListNames.includes(location));
+                // scheduled resume job should be cancelled
+                assert.strictEqual(zkPauseState.scheduledResume, null);
+                return done();
+            });
+        });
+    });
+
+    it('should resume a location when a scheduled resume triggers', done => {
+        // install time machine to eventually move time forward
+        const timeMachine = new TimeMachine();
+        timeMachine.install();
+        // hack - for some reason, the scheduled job in QueueProcessor does not
+        // trigger unless I schedule a job here.
+        schedule.scheduleJob(new Date(), () => {});
+
+        // using first location
+        const location = firstBucket.locationConstraint;
+
+        async.series([
+            next => {
+                // pause
+                this.mockAPI.pauseService(location);
+                pauseLocation(this.iPopulator, location, next);
+            },
+            next => {
+                // schedule resume
+                this.mockAPI.resumeService(location, futureDate);
+                resumeScheduleLocation(this.iPopulator, location, next);
+            },
+        ], error => {
+            assert.ifError(error);
+
+            let zkPauseState;
+            const zkClient = this.iPopulator.getZkClient();
+            const path = `${ZK_TEST_STATE_PATH}/${location}`;
+
+            // move time forward past `futureDate`
+            timeMachine.moveTimeForward(6);
+
+            async.doWhilst(cb => setTimeout(() => {
+                zkClient.getData(path, (err, data) => {
+                    if (err) {
+                        return cb(err);
+                    }
+                    zkPauseState = JSON.parse(data);
+                    return cb();
+                });
+            }, 1000), () => zkPauseState.paused !== false,
+            error => {
+                assert.ifError(error);
+
+                const pausedListNames =
+                    this.iPopulator.getPausedLocationNames();
+
+                // location should be active
+                assert.strictEqual(zkPauseState.paused, false);
+                assert(!pausedListNames.includes(location));
+                // location should no longer have scheduled resume
+                assert.strictEqual(zkPauseState.scheduledResume, null);
+
+                timeMachine.uninstall();
+
+                done();
+            });
+        });
+    });
+
+    it('should not trigger a scheduled job that was previously cancelled',
+    done => {
+        // install time machine to eventually move time forward
+        const timeMachine = new TimeMachine();
+        timeMachine.install();
+        // hack - for some reason, the scheduled job in QueueProcessor does not
+        // trigger unless I schedule a job here.
+        schedule.scheduleJob(new Date(), () => {});
+
+        // using first location
+        const location = firstBucket.locationConstraint;
+
+        async.series([
+            next => {
+                // pause
+                this.mockAPI.pauseService(location);
+                pauseLocation(this.iPopulator, location, next);
+            },
+            next => {
+                // schedule resume
+                this.mockAPI.resumeService(location, futureDate);
+                resumeScheduleLocation(this.iPopulator, location, next);
+            },
+            next => {
+                // cancel scheduled resume
+                this.mockAPI.deleteScheduledResumeService(location);
+                deleteScheduledResumeLocation(this.iPopulator, location, next);
+            },
+        ], error => {
+            assert.ifError(error);
+
+            const zkClient = this.iPopulator.getZkClient();
+            const path = `${ZK_TEST_STATE_PATH}/${location}`;
+
+            // move time forward past `futureDate`
+            timeMachine.moveTimeForward(6);
+
+            // just in case, give some time
+            setTimeout(() => {
+                zkClient.getData(path, (err, data) => {
+                    assert.ifError(err);
+
+                    const zkPauseState = JSON.parse(data);
+                    const pausedList = this.iPopulator.getPausedLocations();
+                    const pausedListNames =
+                        this.iPopulator.getPausedLocationNames();
+
+                    // location should not have a scheduled resume
+                    assert(pausedListNames.includes(location));
+                    assert.strictEqual(pausedList[location], null);
+                    // location should still be paused
+                    assert.strictEqual(zkPauseState.paused, true);
+
+                    timeMachine.uninstall();
+
+                    done();
+                });
+            }, 2000);
+        });
+    });
+});

--- a/tests/functional/utils/pauseResumeUtils/mockAPI.js
+++ b/tests/functional/utils/pauseResumeUtils/mockAPI.js
@@ -1,0 +1,64 @@
+const Redis = require('ioredis');
+
+/**
+ * @class MockAPI
+ *
+ * @classdesc mimics an api request sent to service process with pause/resume
+ */
+class MockAPI {
+    /**
+     * @param {Object} config - config object
+     * @param {String} config.topic - service topic
+     */
+    constructor(config) {
+        this._topic = config.topic;
+        this.publisher = new Redis();
+    }
+
+    _sendRequest(site, msg) {
+        const channel = `${this._topic}-${site}`;
+        this.publisher.publish(channel, msg);
+    }
+
+    /**
+     * mock a delete schedule resume call
+     * @param {string} site - site name
+     * @return {undefined}
+     */
+    deleteScheduledResumeService(site) {
+        const message = JSON.stringify({
+            action: 'deleteScheduledResumeService',
+        });
+        this._sendRequest(site, message);
+    }
+
+    /**
+     * mock a resume api call
+     * @param {string} site - site name
+     * @param {Date} [date] - optional date object
+     * @return {undefined}
+     */
+    resumeService(site, date) {
+        const message = {
+            action: 'resumeService',
+        };
+        if (date) {
+            message.date = date;
+        }
+        this._sendRequest(site, JSON.stringify(message));
+    }
+
+    /**
+     * mock a pause api call
+     * @param {string} site - site name
+     * @return {undefined}
+     */
+    pauseService(site) {
+        const message = JSON.stringify({
+            action: 'pauseService',
+        });
+        this._sendRequest(site, message);
+    }
+}
+
+module.exports = MockAPI;

--- a/tests/functional/utils/pauseResumeUtils/zkStateHelper.js
+++ b/tests/functional/utils/pauseResumeUtils/zkStateHelper.js
@@ -1,0 +1,140 @@
+const async = require('async');
+const zookeeper = require('node-zookeeper-client');
+
+const EPHEMERAL_NODE = 1;
+
+/**
+ * @class ZKStateHelper
+ *
+ * @classdesc Helps to create zookeeper state based on the following state:
+ *   - firstSite: not paused and no scheduled resume
+ *   - secondSite: paused with scheduled resume set to `futureDate`
+ */
+class ZKStateHelper {
+    constructor(zkConfig, statePath, firstSite, secondSite, futureDate) {
+        this.zkConfig = zkConfig;
+        this.statePath = statePath;
+        this.futureDate = futureDate;
+
+        this.zkClient = null;
+
+        this.firstPath = `${this.statePath}/${firstSite}`;
+        this.secondPath = `${this.statePath}/${secondSite}`;
+    }
+
+    getClient() {
+        return this.zkClient;
+    }
+
+    get(site, cb) {
+        const path = `${this.statePath}/${site}`;
+        this.zkClient.getData(path, (err, data) => {
+            if (err) {
+                process.stdout.write('Zookeeper test helper error in ' +
+                'ZKStateHelper.get at zkClient.getData');
+                return cb(err);
+            }
+            let state;
+            try {
+                state = JSON.parse(data.toString());
+            } catch (parseErr) {
+                process.stdout.write('Zookeeper test helper error in ' +
+                'ZKStateHelper.get at JSON.parse');
+                return cb(parseErr);
+            }
+            return cb(null, state);
+        });
+    }
+
+    set(site, state, cb) {
+        const data = Buffer.from(state);
+        const path = `${this.statePath}/${site}`;
+        this.zkClient.setData(path, data, cb);
+    }
+
+    /**
+     * Setup initial zookeeper state for pause/resume tests. After each test,
+     * state should be reset to this initial state.
+     * State is setup as such:
+     *   - firstSite: { paused: false }
+     *   - secondSite: { paused: true, scheduledResume: futureDate }
+     * Where futureDate is defined at the top of this test file.
+     * @param {function} cb - callback(err)
+     * @return {undefined}
+     */
+    init(cb) {
+        const { connectionString } = this.zkConfig;
+        this.zkClient = zookeeper.createClient(connectionString);
+        this.zkClient.connect();
+        this.zkClient.once('connected', () => {
+            async.series([
+                next => this.zkClient.mkdirp(this.statePath, err => {
+                    if (err && err.name !== 'NODE_EXISTS') {
+                        return next(err);
+                    }
+                    return next();
+                }),
+                next => {
+                    // emulate first site to be active (not paused)
+                    const data =
+                        Buffer.from(JSON.stringify({ paused: false }));
+                    this.zkClient.create(this.firstPath, data, EPHEMERAL_NODE,
+                        next);
+                },
+                next => {
+                    // emulate second site to be paused
+                    const data = Buffer.from(JSON.stringify({
+                        paused: true,
+                        scheduledResume: this.futureDate.toString(),
+                    }));
+                    this.zkClient.create(this.secondPath, data, EPHEMERAL_NODE,
+                        next);
+                },
+            ], err => {
+                if (err) {
+                    process.stdout.write('Zookeeper test helper error in ' +
+                    'ZKStateHelper.init');
+                    return cb(err);
+                }
+                return cb();
+            });
+        });
+    }
+
+    reset(cb) {
+        // reset state, just overwrite regardless of current state
+        async.parallel([
+            next => {
+                const data = Buffer.from(JSON.stringify({
+                    paused: false,
+                    scheduledResume: null,
+                }));
+                this.zkClient.setData(this.firstPath, data, next);
+            },
+            next => {
+                const data = Buffer.from(JSON.stringify({
+                    paused: true,
+                    scheduledResume: this.futureDate.toString(),
+                }));
+                this.zkClient.setData(this.secondPath, data, next);
+            },
+        ], err => {
+            if (err) {
+                process.stdout.write('Zookeeper test helper error in ' +
+                'ZKStateHelper.reset');
+                return cb(err);
+            }
+            return cb();
+        });
+    }
+
+    close() {
+        if (this.zkClient) {
+            this.zkClient.close();
+            this.zkClient = null;
+        }
+    }
+}
+
+
+module.exports = ZKStateHelper;

--- a/tests/unit/ingestion/IngestionPopulator.js
+++ b/tests/unit/ingestion/IngestionPopulator.js
@@ -79,10 +79,15 @@ class IngestionPopulatorMock extends IngestionPopulator {
         config.setIngestionBuckets(locationConstraints, buckets);
 
         // mock existing active sources
-        this._activeIngestionSources = {
+        this._ingestionSources = {
             [OLD_BUCKET]: {},
             [EXISTING_BUCKET]: {},
         };
+    }
+
+    _setupZkLocationNode(list, cb) {
+        // overwrite and ignore creation of zookeeper nodes
+        return cb();
     }
 
     addNewLogSource(newSource) {


### PR DESCRIPTION
Changes in this PR:
- Add constants file for ingestion
- Add pause/resume for ingestion
- Update pause/resume readme to include RING-OOB
- Add functional tests for pause/resume ingestion

Follows same pattern for zookeeper as replication pause/resume:
`/backbeat/ingestion/state/<location-name>`
