### PR TITLE
cleanup: ZENKO-1420 CRR-agnostic canary in BackbeatConsumer

### DIFF
--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -569,6 +569,7 @@ class QueueProcessor extends EventEmitter {
                     groupId,
                     concurrency: this.repConfig.queueProcessor.concurrency,
                     queueProcessor: this.processKafkaEntry.bind(this),
+                    canary: true,
                 });
                 this._consumer.on('error', () => {
                     if (!consumerReady) {

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -10,7 +10,6 @@ const zookeeperHelper = require('./clients/zookeeper');
 const BackbeatProducer = require('./BackbeatProducer');
 const OffsetLedger = require('./OffsetLedger');
 
-const replicationTopic = require('../conf/Config').extensions.replication.topic;
 // controls the number of messages to process in parallel
 const CONCURRENCY_DEFAULT = 1;
 const CLIENT_ID = 'BackbeatConsumer';
@@ -51,6 +50,9 @@ class BackbeatConsumer extends EventEmitter {
      * @param {boolean} [config.backlogMetrics.intervalS=60] -
      * interval in seconds between iterations of backlog metrics
      * publishing task
+     * @param {boolean} [config.canary=false] - true to send a canary
+     * message to bootstrap partition offsets (useful for pause/resume
+     * functionality to work)
      * @param {boolean} [config.bootstrap=false] - TEST ONLY: true to
      * bootstrap the consumer with test messages until it starts
      * consuming them
@@ -76,6 +78,7 @@ class BackbeatConsumer extends EventEmitter {
                 zkPath: joi.string().required(),
                 intervalS: joi.number().default(60),
             },
+            canary: joi.boolean().default(false),
             bootstrap: joi.boolean().default(false),
         };
         const validConfig = joi.attempt(config, configJoi,
@@ -83,7 +86,7 @@ class BackbeatConsumer extends EventEmitter {
 
         const { zookeeper, kafka, topic, groupId, queueProcessor,
                 fromOffset, concurrency, fetchMaxBytes,
-                backlogMetrics, bootstrap } = validConfig;
+                backlogMetrics, canary, bootstrap } = validConfig;
 
         this._zookeeperEndpoint = zookeeper && zookeeper.connectionString;
         this._kafkaHosts = kafka.hosts;
@@ -95,6 +98,7 @@ class BackbeatConsumer extends EventEmitter {
         this._concurrency = concurrency;
         this._fetchMaxBytes = fetchMaxBytes;
         this._backlogMetrics = backlogMetrics;
+        this._canary = canary;
         this._bootstrap = bootstrap;
         this._offsetLedger = new OffsetLedger();
 
@@ -235,9 +239,11 @@ class BackbeatConsumer extends EventEmitter {
             this._log.debug(`consumer is paused for topic ${this._topic}`);
         }
 
-        this._sendCanary(() => {
-            this.emit('canary');
-        });
+        if (this._canary) {
+            this._sendCanary(() => {
+                this.emit('canary');
+            });
+        }
 
         this._processingQueue = async.queue(
             this._queueProcessor, this._concurrency);
@@ -677,7 +683,9 @@ class BackbeatConsumer extends EventEmitter {
     _waitForAssignment(wait, cb) {
         setTimeout(() => {
             const assignments = this._consumer.assignments();
-            if (assignments.length === 0) {
+            const topicDetails = this._consumer._metadata.topics
+                  .find(topic => topic.name === this._topic);
+            if (assignments.length === 0 || !topicDetails) {
                 if (wait > 50000) {
                     return cb(true);
                 }
@@ -696,10 +704,6 @@ class BackbeatConsumer extends EventEmitter {
      * @return {undefined}
      */
     _sendCanary(cb) {
-        const crrTopic = withTopicPrefix(replicationTopic);
-        if (this._topic !== crrTopic) {
-            return process.nextTick(cb);
-        }
         return this._waitForAssignment(0, err => {
             if (err) {
                 this._log.debug('could not send canary on consumer init, ' +
@@ -709,15 +713,12 @@ class BackbeatConsumer extends EventEmitter {
                 return cb();
             }
             const topicDetails = this._consumer._metadata.topics
-                .find(topic => topic.name === crrTopic);
-            const entries = topicDetails.partitions.map(p => {
-                const contents = '{"canary":true}';
-                return {
-                    key: 'canary',
-                    message: contents,
-                    partition: p.id,
-                };
-            });
+                  .find(topic => topic.name === this._topic);
+            const entries = topicDetails.partitions.map(p => ({
+                key: 'canary',
+                message: '{"canary":true}',
+                partition: p.id,
+            }));
             const producer = new BackbeatProducer({
                 kafka: { hosts: this._kafkaHosts },
                 topic: this._topic,


### PR DESCRIPTION
Rework canary code to be able to specify use of canaries as an option
to BackbeatConsumer constructor rather than hard-coded to CRR
topic. This will be useful to extend canaries to data-mover topic, as
it will also make use of pause/resume functionality it will also
require canaries.