### PR TITLE
ft: move ft_tests to kube worker

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -22,9 +22,8 @@ models:
 
 stages:
   pre-merge:
-    worker: &pod
-      type: kube_pod
-      path: eve/workers/pod.yml
+    worker:
+      type: local
     steps:
     - TriggerStages:
         name: trigger all the tests
@@ -33,10 +32,10 @@ stages:
         - docker-build
   run-tests:
     worker: &workspace
-      type: docker
-      path: eve/workers/unit_and_feature_tests
-      volumes:
-        - '/home/eve/workspace'
+      type: kube_pod
+      path: eve/workers/pod.yml
+      images:
+        aggressor: eve/workers/unit_and_feature_tests
     steps:
       - Git: &git
           name: fetch source
@@ -97,18 +96,14 @@ stages:
             BACKBEAT_CONFIG_FILE: "tests/config.json"
 
   docker-build:
-    worker:
-      type: kube_pod
-      path: eve/workers/pod.yml
+    worker: *workspace
     steps:
       - Git: *git
       - SetProperty: *docker_image_name
       - ShellCommand: *docker_build
 
   post-merge:
-    worker:
-      type: kube_pod
-      path: eve/workers/pod.yml
+    worker: *workspace
     steps:
       - Git: *git
       - ShellCommand: &docker_login

--- a/eve/workers/pod.yml
+++ b/eve/workers/pod.yml
@@ -1,26 +1,45 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "zenko-test-pod"
+  name: "backbeat-test-pod"
 spec:
   activeDeadlineSeconds: 3600
   restartPolicy: Never
   terminationGracePeriodSeconds: 10
   containers:
-  - name: zenko-releng
-    image: zenko/zenko-releng:0.0.6
+  - name: aggressor
+    image: {{ images.aggressor }}
     imagePullPolicy: IfNotPresent
     resources:
       requests:
         cpu: 500m
         memory: 1Gi
       limits:
-        cpu: "1"
-        memory: 2Gi
-    command: ["/bin/sh", "-c", "buildbot-worker create-worker . ${BUILDMASTER}:${BUILDMASTER_PORT} ${WORKERNAME} ${WORKERPASS} && buildbot-worker start --nodaemon"]
+        cpu: "3"
+        memory: 3Gi
     volumeMounts:
     - mountPath: /var/run/docker.sock
       name: docker-socket
+  - name: mongo
+    image: scality/ci-mongo:3.6.8
+    imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 100m
+        memory: 512Mi
+      limits:
+        cpu: 250m
+        memory: 512Mi
+  - name: redis
+    image: redis:alpine
+    imagePullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 250m
+        memory: 512Mi
   volumes:
   - name: docker-socket
     hostPath:

--- a/eve/workers/unit_and_feature_tests/Dockerfile
+++ b/eve/workers/unit_and_feature_tests/Dockerfile
@@ -6,6 +6,7 @@ FROM spotify/kafka
 COPY ./backbeat_packages.list ./buildbot_worker_packages.list /tmp/
 
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - \
+    && curl -fsSL https://get.docker.com | bash - \
     && cat /tmp/*packages.list | xargs apt-get install -y \
     && pip install pip==9.0.1 \
     && rm -rf /var/lib/apt/lists/* \

--- a/eve/workers/unit_and_feature_tests/backbeat_packages.list
+++ b/eve/workers/unit_and_feature_tests/backbeat_packages.list
@@ -1,3 +1,2 @@
 build-essential
 nodejs
-redis-server

--- a/eve/workers/unit_and_feature_tests/supervisor/buildbot_worker.conf
+++ b/eve/workers/unit_and_feature_tests/supervisor/buildbot_worker.conf
@@ -2,8 +2,3 @@
 command=/bin/sh -c 'buildbot-worker create-worker . "%(ENV_BUILDMASTER)s:%(ENV_BUILDMASTER_PORT)s" "%(ENV_WORKERNAME)s" "%(ENV_WORKERPASS)s"  && buildbot-worker start --nodaemon'
 autostart=true
 autorestart=false
-
-[program:redis]
-command=/usr/bin/redis-server
-autostart=true
-autorestart=false


### PR DESCRIPTION
Moves the primary worker to a configurable kube pod that has mongodb to enable ZENKO-1377. Also moves redis into it's own container to parallel cloudserver CI configuration.