### PR TITLE
bugfix: ZENKO-1522 fix CRR on copied MPU object

### DIFF
--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -61,6 +61,7 @@ const joiSchema = {
         groupId: joi.string().required(),
         retry: qpRetryJoi,
         concurrency: joi.number().greater(0).default(10),
+        minMPUSizeMB: joi.number().greater(0).default(20),
     },
     replicationStatusProcessor: {
         groupId: joi.string().required(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -824,8 +824,8 @@
       "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco="
     },
     "arsenal": {
-      "version": "github:scality/Arsenal#d620fef517886b179f2b693679b1dcecc53fb012",
-      "from": "github:scality/Arsenal#d620fef",
+      "version": "github:scality/Arsenal#9fe0ba5c8cd24dad3b6fea8b937e5616a04476bc",
+      "from": "github:scality/Arsenal#9fe0ba5",
       "requires": {
         "JSONStream": "^1.0.0",
         "ajv": "4.10.0",
@@ -833,6 +833,7 @@
         "bson": "2.0.4",
         "debug": "~2.3.3",
         "diskusage": "^0.2.2",
+        "fcntl": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
         "ioctl": "2.0.0",
         "ioredis": "2.4.0",
         "ipaddr.js": "1.2.0",
@@ -846,6 +847,7 @@
         "socket.io-client": "~1.7.3",
         "utf8": "2.1.2",
         "uuid": "^3.0.1",
+        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
         "xml2js": "~0.4.16"
       },
       "dependencies": {
@@ -857,17 +859,9 @@
             "lodash": "^4.14.0"
           }
         },
-        "fcntl": {
-          "version": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
-          "from": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
-          "requires": {
-            "bindings": "^1.1.1",
-            "nan": "^2.3.2"
-          }
-        },
         "ioredis": {
           "version": "2.4.0",
-          "resolved": "http://registry.npmjs.org/ioredis/-/ioredis-2.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.4.0.tgz",
           "integrity": "sha1-lj97+8huXEDqWGhX4U6/tUgUKog=",
           "requires": {
             "bluebird": "^3.3.4",
@@ -882,7 +876,7 @@
         },
         "werelogs": {
           "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-          "from": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+          "from": "github:scality/werelogs#0ff7ec82",
           "requires": {
             "safe-json-stringify": "1.0.3"
           }
@@ -1158,7 +1152,7 @@
     },
     "blob": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
     },
     "bluebird": {
@@ -1190,7 +1184,7 @@
     },
     "bson": {
       "version": "2.0.4",
-      "resolved": "http://registry.npmjs.org/bson/-/bson-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-2.0.4.tgz",
       "integrity": "sha512-e/GPy6CE0xL7MOYYRMIEwPGKF21WNaQdPIpV0YvaQDoR7oc47KUZ8c2P/TlRJVQP8RZ4CEsArGBC1NbkCRvl1w=="
     },
     "bucketclient": {
@@ -1800,7 +1794,7 @@
     },
     "engine.io-parser": {
       "version": "1.3.2",
-      "resolved": "http://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
       "integrity": "sha1-k3sHnwAH0Ik+xW1GyyILjLQ1Igo=",
       "requires": {
         "after": "0.8.2",
@@ -3104,7 +3098,7 @@
     },
     "level-iterator-stream": {
       "version": "1.3.1",
-      "resolved": "http://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
       "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
       "requires": {
         "inherits": "^2.0.1",
@@ -3146,7 +3140,7 @@
       "dependencies": {
         "abstract-leveldown": {
           "version": "0.12.4",
-          "resolved": "http://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
           "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
           "requires": {
             "xtend": "~3.0.0"
@@ -3161,7 +3155,7 @@
         },
         "bl": {
           "version": "0.8.2",
-          "resolved": "http://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
           "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
           "requires": {
             "readable-stream": "~1.0.26"
@@ -3203,7 +3197,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -3214,7 +3208,7 @@
         },
         "semver": {
           "version": "5.1.1",
-          "resolved": "http://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.1.1.tgz",
           "integrity": "sha1-oykqNz5vPgeY2gsgZBuanFvEfhk="
         }
       }
@@ -3233,7 +3227,7 @@
       "dependencies": {
         "bindings": {
           "version": "1.2.1",
-          "resolved": "http://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
           "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
         },
         "nan": {
@@ -3475,7 +3469,7 @@
     },
     "lru-cache": {
       "version": "2.7.3",
-      "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
     },
     "ltgt": {
@@ -3528,9 +3522,9 @@
       "dev": true
     },
     "memory-pager": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.1.0.tgz",
-      "integrity": "sha512-Mf9OHV/Y7h6YWDxTzX/b4ZZ4oh9NSXblQL8dtPCOomOtZciEHxePR78+uHFLLlsk01A6jVHhHsQZZ/WcIPpnzg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
       "optional": true
     },
     "mime": {
@@ -3678,18 +3672,18 @@
       }
     },
     "mongodb": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.9.tgz",
-      "integrity": "sha512-f+Og32wK/ovzVlC1S6Ft7yjVTvNsAOs6pBpDrPd2/3wPO9ijNsQrTNntuECjOSxGZpPVl0aRqgHzF1e9e+KvnQ==",
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.13.tgz",
+      "integrity": "sha512-sz2dhvBZQWf3LRNDhbd30KHVzdjZx9IKC0L+kSZ/gzYquCF5zPOgGqRz6sSCqYZtKP2ekB4nfLxhGtzGHnIKxA==",
       "requires": {
-        "mongodb-core": "3.1.8",
+        "mongodb-core": "3.1.11",
         "safe-buffer": "^5.1.2"
       }
     },
     "mongodb-core": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.8.tgz",
-      "integrity": "sha512-reWCqIRNehyuLaqaz5JMOmh3Xd8JIjNX34o8mnewXLK2Fyt/Ky6BZbU+X0OPzy8qbX+JZrOtnuay7ASCieTYZw==",
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.11.tgz",
+      "integrity": "sha512-rD2US2s5qk/ckbiiGFHeu+yKYDXdJ1G87F6CG3YdaZpzdOm5zpoAZd/EKbPmFO6cQZ+XVXBXBJ660sSI0gc6qg==",
       "requires": {
         "bson": "^1.1.0",
         "require_optional": "^1.0.1",
@@ -4190,7 +4184,7 @@
     },
     "readable-stream": {
       "version": "1.1.14",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -4461,7 +4455,7 @@
       "dependencies": {
         "lodash": {
           "version": "2.4.2",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
           "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
         }
       }
@@ -4529,7 +4523,7 @@
     },
     "socket.io-parser": {
       "version": "2.3.1",
-      "resolved": "http://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
       "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
       "requires": {
         "component-emitter": "1.1.2",
@@ -4540,7 +4534,7 @@
       "dependencies": {
         "debug": {
           "version": "2.2.0",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
           "requires": {
             "ms": "0.7.1"
@@ -4548,7 +4542,7 @@
         },
         "ms": {
           "version": "0.7.1",
-          "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
           "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
         }
       }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/scality/backbeat#readme",
   "dependencies": {
-    "arsenal": "scality/Arsenal#d620fef",
+    "arsenal": "scality/Arsenal#9fe0ba5",
     "async": "^2.3.0",
     "aws-sdk": "2.147.0",
     "backo": "^1.1.0",


### PR DESCRIPTION
Change the logic to ignore the 'MPU' flag set in replicationInfo.content array (it may not always be set), instead rely on the object size and if a MPU or not based on its content-md5 metadata attribute containing a dash.

Note: the copy code lacks integrity checking now, this would need a
rework but it's out of scope of this fix.