### PR TITLE
ft: ZENKO-1531 reset replication/acl info on ingested objects

### DIFF
--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -196,6 +196,38 @@ class MongoQueueProcessor {
         entry.setLocation(editLocations);
     }
 
+    _updateReplicationInfo(entry) {
+        // TODO: Rely on ObjectMD to set this
+        // defaults
+        const replicationInfo = {
+            status: '',
+            backends: [],
+            content: [],
+            destination: '',
+            storageClass: '',
+            role: '',
+            storageType: '',
+            dataStoreVersionId: '',
+            isNFS: null,
+        };
+
+        entry.setReplicationInfo(replicationInfo);
+    }
+
+    _updateAcl(entry) {
+        // TODO: Rely on ObjectMD to set this
+        // defaults
+        const aclInfo = {
+            Canned: 'private',
+            FULL_CONTROL: [],
+            WRITE_ACP: [],
+            READ: [],
+            READ_ACP: [],
+        };
+
+        entry.setAcl(aclInfo);
+    }
+
     /**
      * Process a delete object entry
      * @param {DeleteOpQueueEntry} sourceEntry - delete object entry
@@ -241,6 +273,8 @@ class MongoQueueProcessor {
         this._updateOwnerMD(sourceEntry, bucketInfo);
         this._updateObjectDataStoreName(sourceEntry, location);
         this._updateLocations(sourceEntry, location);
+        this._updateReplicationInfo(sourceEntry);
+        this._updateAcl(sourceEntry);
 
         const objVal = sourceEntry.getValue();
         // Always call putObject with version params undefined so

--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -154,13 +154,13 @@ class MongoQueueProcessor {
     /**
      * Update ingested entry metadata fields: owner-id, owner-display-name
      * @param {ObjectQueueEntry} entry - object queue entry object
-     * @param {object} ownerInfo - owner details
+     * @param {BucketInfo} bucketInfo - bucket info object
      * @return {undefined}
      */
-    _updateOwnerMD(entry, ownerInfo) {
+    _updateOwnerMD(entry, bucketInfo) {
         // zenko bucket owner information is being set on ingested md
-        entry.setOwnerDisplayName(ownerInfo.ownerDisplayName);
-        entry.setOwnerId(ownerInfo.ownerId);
+        entry.setOwnerDisplayName(bucketInfo.getOwnerDisplayName());
+        entry.setOwnerId(bucketInfo.getOwner());
     }
 
     /**
@@ -228,17 +228,17 @@ class MongoQueueProcessor {
      * Process an object entry
      * @param {ObjectQueueEntry} sourceEntry - object metadata entry
      * @param {string} location - zenko storage location name
-     * @param {object} ownerInfo - owner details
+     * @param {BucketInfo} bucketInfo - bucket info object
      * @param {function} done - callback(error)
      * @return {undefined}
      */
-    _processObjectQueueEntry(sourceEntry, location, ownerInfo, done) {
+    _processObjectQueueEntry(sourceEntry, location, bucketInfo, done) {
         const bucket = sourceEntry.getBucket();
         // always use versioned key so putting full version state to mongo
         const key = sourceEntry.getObjectVersionedKey();
 
         // update necessary metadata fields before saving to Zenko MongoDB
-        this._updateOwnerMD(sourceEntry, ownerInfo);
+        this._updateOwnerMD(sourceEntry, bucketInfo);
         this._updateObjectDataStoreName(sourceEntry, location);
         this._updateLocations(sourceEntry, location);
 
@@ -294,7 +294,7 @@ class MongoQueueProcessor {
         const bucketName = sourceEntry.getBucket();
         return async.series([
             next => this._mongoClient.getBucketAttributes(bucketName,
-                this.logger, (err, data) => {
+                this.logger, (err, bucketInfo) => {
                     if (err) {
                         this.logger.error('error getting bucket owner ' +
                         'details', {
@@ -303,11 +303,7 @@ class MongoQueueProcessor {
                         });
                         return done(err);
                     }
-                    const ownerInfo = {
-                        ownerId: data._owner,
-                        ownerDisplayName: data._ownerDisplayName,
-                    };
-                    return next(null, ownerInfo);
+                    return next(null, bucketInfo);
                 }),
             next => this._s3Client.getBucketLocation({ Bucket: bucketName },
                 (err, data) => {
@@ -326,7 +322,7 @@ class MongoQueueProcessor {
             if (err) {
                 return done(err);
             }
-            const ownerInfo = results[0];
+            const bucketInfo = results[0];
             const location = results[1];
             // if entry is for another site, simply skip/ignore
             if (this.site !== location) {
@@ -338,7 +334,7 @@ class MongoQueueProcessor {
             }
             if (sourceEntry instanceof ObjectQueueEntry) {
                 return this._processObjectQueueEntry(sourceEntry, location,
-                    ownerInfo, done);
+                    bucketInfo, done);
             }
             this.logger.warn('skipping unknown source entry',
                             { entry: sourceEntry.getLogInfo() });


### PR DESCRIPTION
Acl and replication info are fields that might be set in S3C world that won't be relevant to us in Zenko world

Changes in this PR:
- Refactor mongo processor to use public methods defined on BucketInfo instance we fetch from mongo
- reset acl and replication info to default empty values (to be later addressed with Zenko bucket info)