### PR TITLE
bugfix: ZENKO-1553 Add check for config deletion

### DIFF
--- a/lib/management/getWorkflowUpdates.js
+++ b/lib/management/getWorkflowUpdates.js
@@ -62,6 +62,9 @@ function getWorkflowUpdates(configuredWorkflows, currentWorkflows) {
     Object.keys(configuredWorkflows).forEach(bucketName => {
         const currentBucketWorkflows = currentWorkflows[bucketName];
         const configuredBucketWorkflows = configuredWorkflows[bucketName];
+        if (!configuredBucketWorkflows) {
+            return undefined;
+        }
         if (!currentBucketWorkflows) {
             if (configuredBucketWorkflows.length > 0) {
                 workflowUpdates[bucketName] = {


### PR DESCRIPTION
When deleting the last bucket lifecycle configuration a TypeError occurs and the pod is restarted. This adds the necessary check to prevent that behavior.