### PR TITLE
feature: ZENKO-1420 data mover service

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -101,6 +101,7 @@
                 }
             },
             "topic": "backbeat-replication",
+            "dataMoverTopic": "backbeat-data-mover",
             "replicationStatusTopic": "backbeat-replication-status",
             "replicationFailedTopic": "backbeat-replication-failed",
             "monitorReplicationFailures": true,

--- a/docs/data-mover.md
+++ b/docs/data-mover.md
@@ -1,0 +1,78 @@
+# Data Mover Service
+
+## OVERVIEW
+
+The data mover service can copy object data as a service.
+
+It consumes action messages from a kafka topic ("backbeat-data-mover"
+by default), and optionally returns the action outcome in another
+kafka topic, which name can be set in the action message.
+
+Each action message type defines the type of copy we want, described
+below. The recommended way to pass action messages and receive results
+is to use the lib/models/ActionQueueEntry class to create instances of
+actions that can be manipulated, but it's not mandatory as messages
+can be created and parsed directly to/from JSON format.
+
+Attributes in parenthesis are optional.
+
+## COPY LOCATION ACTION
+
+The "copy location" action copies a zenko object to a new location.
+
+### Action message format
+
+This is the format of "copy location" actions that the data mover
+expects:
+
+```
+{
+    "action": "copyLocation",
+    ("actionId": "uuid-xyz",)
+    "target": {
+        "bucket": "bucketName",
+        "key": "objectKey",
+        "contentMd5": "0123456789abcdef0123456789abcdef",
+        ("version": "versionNumber"),
+    },
+    "toLocation": "zenkoLocationName",
+    ("resultsTopic": "results-kafka-topic-name"),
+    ("context": { /* user-defined context fields */ },)
+}
+```
+
+### Action result format
+
+This is the format of "copy location" responses that the data mover
+will send to the results topic if set, with all original action
+message fields preserved:
+
+```
+{
+    "action": "copyLocation",
+    ("actionId": "uuid-xyz",)
+    "target": {
+        "bucket": "bucketName",
+        "key": "objectKey",
+        ("version": "versionNumber")
+    },
+    "toLocation": "zenkoLocationName",
+    ("resultsTopic": "results-kafka-topic-name",)
+    ("context": { /* user-defined context fields */ },)
+
+    "status": "success|error",
+    // if status is "success":
+    ("results": {
+        "location": [{
+            // location-specific info (key, dataStoreVersionId etc.)
+        }]
+    }),
+    // if status is "error":
+    ("error": {
+        "code": xxx // original error.code, usually HTTP error code
+        "message": "ErrorType" // original error.message, usually
+                               // arsenal error type
+        "description": "lengthy description", // original error.description
+    })
+}
+```

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -52,6 +52,7 @@ const joiSchema = {
         bootstrapList: bootstrapListJoi,
     },
     topic: joi.string().required(),
+    dataMoverTopic: joi.string().required(),
     replicationStatusTopic: joi.string().required(),
     monitorReplicationFailures: joi.boolean().default(true),
     replicationFailedTopic: joi.string().required(),

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -21,10 +21,12 @@ const getLocationsFromStorageClass =
     require('../utils/getLocationsFromStorageClass');
 const ReplicateObject = require('../tasks/ReplicateObject');
 const MultipleBackendTask = require('../tasks/MultipleBackendTask');
+const CopyLocationTask = require('../tasks/CopyLocationTask');
 const EchoBucket = require('../tasks/EchoBucket');
 
 const ObjectQueueEntry = require('../../../lib/models/ObjectQueueEntry');
 const BucketQueueEntry = require('../../../lib/models/BucketQueueEntry');
+const ActionQueueEntry = require('../../../lib/models/ActionQueueEntry');
 const MetricsProducer = require('../../../lib/MetricsProducer');
 
 const {
@@ -106,6 +108,7 @@ class QueueProcessor extends EventEmitter {
         this.destAdminVaultConfigured = false;
         this.replicationStatusProducer = null;
         this._consumer = null;
+        this._dataMoverConsumer = null;
         this._mProducer = null;
         this.site = site;
         this.mConfig = mConfig;
@@ -264,6 +267,33 @@ class QueueProcessor extends EventEmitter {
         });
     }
 
+    _createConsumer(topic, queueProcessorFunc, options) {
+        let consumerReady = false;
+        const groupId =
+              `${this.repConfig.queueProcessor.groupId}-${this.site}`;
+        const consumer = new BackbeatConsumer({
+            kafka: { hosts: this.kafkaConfig.hosts },
+            topic,
+            groupId,
+            concurrency: this.repConfig.queueProcessor.concurrency,
+            queueProcessor: queueProcessorFunc,
+            canary: true,
+        });
+        consumer.on('error', () => {
+            if (!consumerReady) {
+                this.logger.fatal('queue processor failed to start a ' +
+                                  'backbeat consumer');
+                process.exit(1);
+            }
+        });
+        consumer.on('ready', () => {
+            consumerReady = true;
+            const paused = options && options.paused;
+            consumer.subscribe(paused);
+        });
+        return consumer;
+    }
+
     _setupEcho() {
         if (!this.sourceAdminVaultConfigured) {
             throw new Error('echo mode not properly configured: missing ' +
@@ -344,6 +374,7 @@ class QueueProcessor extends EventEmitter {
                     });
                 } else {
                     this._consumer.pause(this.site);
+                    this._dataMoverConsumer.pause(this.site);
                     this.logger.info('paused replication for location: ' +
                         `${this.site}`);
                     this._deleteScheduledResumeService();
@@ -378,6 +409,7 @@ class QueueProcessor extends EventEmitter {
                     });
                 } else {
                     this._consumer.resume(this.site);
+                    this._dataMoverConsumer.resume(this.site);
                     this.logger.info('resumed replication for location: ' +
                         `${this.site}`);
                     this._deleteScheduledResumeService();
@@ -524,6 +556,9 @@ class QueueProcessor extends EventEmitter {
             logger: this.logger,
             site: this.site,
             consumer: this._consumer,
+            dataMoverConsumer: this._dataMoverConsumer,
+            backbeatClient: this.backbeatClient,
+            backbeatMetadataProxy: this.backbeatMetadataProxy,
         };
     }
 
@@ -543,52 +578,45 @@ class QueueProcessor extends EventEmitter {
      */
     start(options) {
         this._mProducer = new MetricsProducer(this.kafkaConfig, this.mConfig);
-        return this._mProducer.setupProducer(err => {
-            if (err) {
-                this.logger.info('error setting up metrics producer',
-                                 { error: err.message });
-                process.exit(1);
-            }
-            return this._setupProducer(err => {
-                let consumerReady = false;
+        return async.parallel([
+            done => this._mProducer.setupProducer(err => {
+                if (err) {
+                    this.logger.info('error setting up metrics producer',
+                                     { error: err.message });
+                    process.exit(1);
+                }
+                return done();
+            }),
+            done => this._setupProducer(err => {
                 if (err) {
                     this.logger.info('error setting up kafka producer',
                                      { error: err.message });
                     process.exit(1);
                 }
+                return done();
+            }),
+            done => {
                 if (options && options.disableConsumer) {
-                    this.emit('ready');
-                    return undefined;
+                    return done();
                 }
-                const groupId =
-                    `${this.repConfig.queueProcessor.groupId}-${this.site}`;
-                this._consumer = new BackbeatConsumer({
-                    kafka: { hosts: this.kafkaConfig.hosts },
-                    topic: this.repConfig.topic,
-                    groupId,
-                    concurrency: this.repConfig.queueProcessor.concurrency,
-                    queueProcessor: this.processKafkaEntry.bind(this),
-                    canary: true,
-                });
-                this._consumer.on('error', () => {
-                    if (!consumerReady) {
-                        this.logger.fatal('queue processor failed to start a ' +
-                                       'backbeat consumer');
-                        process.exit(1);
-                    }
-                });
-                this._consumer.on('ready', () => {
-                    consumerReady = true;
-                    const paused = options && options.paused;
-                    this._consumer.subscribe(paused);
-                });
-                this._consumer.on('canary', () => {
-                    this.logger.info('queue processor is ready to consume ' +
-                                     'replication entries');
-                    this.emit('ready');
-                });
-                return undefined;
-            });
+                this._consumer = this._createConsumer(
+                    this.repConfig.topic,
+                    this.processReplicationEntry.bind(this), options);
+                return this._consumer.once('canary', done);
+            },
+            done  => {
+                if (options && options.disableConsumer) {
+                    return done();
+                }
+                this._dataMoverConsumer = this._createConsumer(
+                    this.repConfig.dataMoverTopic,
+                    this.processDataMoverEntry.bind(this), options);
+                return this._dataMoverConsumer.once('canary', done);
+            },
+        ], () => {
+            this.logger.info('queue processor is ready to consume ' +
+                             'replication entries');
+            this.emit('ready');
         });
     }
 
@@ -620,16 +648,26 @@ class QueueProcessor extends EventEmitter {
      * @return {undefined}
      */
     stop(done) {
-        if (!this.replicationStatusProducer) {
-            return setImmediate(done);
-        }
-        return this.replicationStatusProducer.close(() => {
-            if (this._consumer) {
-                this._consumer.close(done);
-            } else {
-                done();
-            }
-        });
+        async.series([
+            next => {
+                if (this.replicationStatusProducer) {
+                    return this.replicationStatusProducer.close(next);
+                }
+                return next();
+            },
+            next => {
+                if (this._consumer) {
+                    return this._consumer.close(next);
+                }
+                return next();
+            },
+            next => {
+                if (this._dataMoverConsumer) {
+                    return this._dataMoverConsumer.close(next);
+                }
+                return next();
+            },
+        ], done);
     }
 
     /**
@@ -642,10 +680,10 @@ class QueueProcessor extends EventEmitter {
      * @param {function} done - callback function
      * @return {undefined}
      */
-    processKafkaEntry(kafkaEntry, done) {
+    processReplicationEntry(kafkaEntry, done) {
         const sourceEntry = QueueEntry.createFromKafkaEntry(kafkaEntry);
         if (sourceEntry.error) {
-            this.logger.error('error processing source entry',
+            this.logger.error('error processing replication entry',
                               { error: sourceEntry.error });
             return process.nextTick(() => done(errors.InternalError));
         }
@@ -675,15 +713,64 @@ class QueueProcessor extends EventEmitter {
             }
         }
         if (task) {
-            this.logger.debug('source entry is being pushed',
+            this.logger.debug('replication entry is being pushed',
               { entry: sourceEntry.getLogInfo() });
             return this.taskScheduler.push({ task, entry: sourceEntry,
                                              kafkaEntry },
                                            sourceEntry.getCanonicalKey(),
                                            done);
         }
-        this.logger.debug('skip source entry',
+        this.logger.debug('skip replication entry',
                           { entry: sourceEntry.getLogInfo() });
+        return process.nextTick(done);
+    }
+
+    /**
+     * Process an action entry from the data mover topic
+     *
+     * @param {object} kafkaEntry - action entry generated by client services
+     * @param {string} kafkaEntry.key - kafka entry key
+     * @param {string} kafkaEntry.value - kafka entry value
+     * @param {function} done - callback function
+     * @return {undefined}
+     */
+    processDataMoverEntry(kafkaEntry, done) {
+        const actionEntry = ActionQueueEntry.createFromKafkaEntry(kafkaEntry);
+        if (actionEntry.error) {
+            this.logger.error('error processing source entry',
+                              { error: actionEntry.error,
+                                entry: kafkaEntry.value });
+            return process.nextTick(() => done(errors.InternalError));
+        }
+        if (actionEntry.skip) {
+            // skip message, noop
+            return process.nextTick(done);
+        }
+        let task;
+        let canonicalKey;
+        if (actionEntry.getActionType() === 'copyLocation') {
+            if (actionEntry.getAttribute('toLocation') === this.site) {
+                task = new CopyLocationTask(this);
+                const { bucket, key } = actionEntry.getAttribute('target');
+                canonicalKey = `${bucket}/${key}`;
+            }
+        } else {
+            this.logger.warn('skipping unsupported action type', {
+                method: 'QueueProcessor.processDataMoverEntry',
+                entry: actionEntry.getLogInfo(),
+            });
+        }
+        if (task) {
+            this.logger.debug('data mover entry is being pushed', {
+                entry: actionEntry.getLogInfo(),
+            });
+            return this.taskScheduler.push({ task, entry: actionEntry,
+                                             kafkaEntry },
+                                           canonicalKey, done);
+        }
+        this.logger.debug('skip data mover entry', {
+            entry: actionEntry.getLogInfo(),
+        });
         return process.nextTick(done);
     }
 

--- a/extensions/replication/tasks/CopyLocationTask.js
+++ b/extensions/replication/tasks/CopyLocationTask.js
@@ -1,0 +1,792 @@
+const async = require('async');
+const uuid = require('uuid/v4');
+
+const { errors, jsutil, models } = require('arsenal');
+const { ObjectMD } = models;
+
+const BackbeatMetadataProxy = require('../../../lib/BackbeatMetadataProxy');
+const BackbeatClient = require('../../../lib/clients/BackbeatClient');
+const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
+const { attachReqUids } = require('../../../lib/clients/utils');
+const { getAccountCredentials } =
+          require('../../../lib/credentials/AccountCredentials');
+const RoleCredentials =
+          require('../../../lib/credentials/RoleCredentials');
+const { metricsExtension, metricsTypeQueued, metricsTypeCompleted } =
+    require('../constants');
+
+const MPU_CONC_LIMIT = 10;
+const MPU_GCP_MAX_PARTS = 1024;
+
+function _getExtMetrics(site, bytes, actionEntry) {
+    const extMetrics = {};
+    extMetrics[site] = {
+        bytes,
+        bucketName: actionEntry.getAttribute('target.bucket'),
+        objectKey: actionEntry.getAttribute('target.key'),
+        versionId: actionEntry.getAttribute('target.version'),
+    };
+    return extMetrics;
+}
+
+class CopyLocationTask extends BackbeatTask {
+
+    _getReplicationEndpointType() {
+        const replicationEndpoint = this.destConfig.bootstrapList
+            .find(endpoint => endpoint.site === this.site);
+        return replicationEndpoint.type;
+    }
+
+    constructor(qp) {
+        const qpState = qp.getStateVars();
+        super();
+        Object.assign(this, qpState);
+        this.destType = null;
+        if (this.destConfig && this.destConfig.bootstrapList) {
+            this.destType = this._getReplicationEndpointType();
+            const retryParams =
+                  this.repConfig.queueProcessor.retry[this.destType];
+            if (retryParams) {
+                this.retryParams = retryParams;
+            }
+        }
+    }
+
+    _validateActionCredentials(actionEntry) {
+        const authConfig = this.sourceConfig.auth;
+        if (authConfig.type === 'role') {
+            return actionEntry.getAttribute(
+                'auth.roleArn', { required: true }) !== undefined;
+        }
+        return true;
+    }
+
+    _createCredentials(actionEntry, log) {
+        const authConfig = this.sourceConfig.auth;
+        const accountCredentials = getAccountCredentials(authConfig, log);
+        if (accountCredentials) {
+            return accountCredentials;
+        }
+        const vaultclient = this.vaultclientCache.getClient('source:s3');
+        const actionAuth = actionEntry.getAttribute('auth');
+        return new RoleCredentials(
+            vaultclient, 'replication', actionAuth.roleArn, log);
+    }
+
+    _setupClients(actionEntry, log) {
+        const s3Credentials = this._createCredentials(actionEntry, log);
+        // Disable retries, use our own retry policy (mandatory for
+        // putObject route in order to fetch data again from source).
+        const { transport, s3, auth } = this.sourceConfig;
+        this.backbeatClient = new BackbeatClient({
+            endpoint: `${transport}://${s3.host}:${s3.port}`,
+            credentials: s3Credentials,
+            sslEnabled: transport === 'https',
+            httpOptions: { agent: this.sourceHTTPAgent, timeout: 0 },
+            maxRetries: 0,
+        });
+        this.backbeatMetadataProxy = new BackbeatMetadataProxy(
+            `${transport}://${s3.host}:${s3.port}`, auth, this.sourceHTTPAgent);
+        this.backbeatMetadataProxy
+            .setSourceRole(actionEntry.getAttribute('auth.roleArn'))
+            .setSourceClient(log);
+    }
+
+    processQueueEntry(actionEntry, kafkaEntry, done) {
+        const log = this.logger.newRequestLogger();
+        actionEntry.addLoggedAttributes({
+            bucketName: 'target.bucket',
+            objectKey: 'target.key',
+            versionId: 'target.version',
+            copyToLocation: 'toLocation',
+        });
+        log.debug('action execution starts', actionEntry.getLogInfo());
+        return async.waterfall([
+            next => {
+                if (!this._validateActionCredentials(actionEntry)) {
+                    return next(errors.AccessDenied);
+                }
+                this._setupClients(actionEntry, log);
+                return next();
+            },
+            next => this._getSourceMD(actionEntry, log, (err, objMD) => {
+                if (err && err.code === 'ObjNotFound') {
+                    // The object was deleted before entry is processed, we
+                    // can safely skip this entry.
+                    return next(errors.ObjNotFound);
+                }
+                if (err) {
+                    return next(err);
+                }
+                return next(null, objMD);
+            }),
+            (objMD, next) => {
+                const err = this._checkObjectState(actionEntry, objMD);
+                if (err) {
+                    return next(err);
+                }
+                // Do a multipart upload when either the size is above
+                // a threshold or the source object is itself a MPU.
+                //
+                // FIXME: object ETag for MPUs is an aggregate from
+                // each part's ETag, which does not allow the current
+                // implementation to check the data integrity when
+                // doing ranged PUTs. Also in the current
+                // implementation we are forced to send an ETag for a
+                // multiple backend putObject(), which only matches if
+                // the object is not a MPU, so we cannot use this
+                // route for MPUs as-is without recomputing a new
+                // checksum, which is not the case today (hence the
+                // MPU check below).
+                if (objMD.getContentLength() / 1000000 >=
+                    this.repConfig.queueProcessor.minMPUSizeMB ||
+                    objMD.isMultipartUpload()) {
+                    return this._getAndPutMultipartUpload(actionEntry, objMD,
+                        log, next);
+                }
+                return this._getAndPutObject(actionEntry, objMD, log, next);
+            },
+        ], err => this._publishCopyLocationStatus(
+            err, actionEntry, kafkaEntry, log, done));
+    }
+
+    _getSourceMD(actionEntry, log, cb) {
+        const { bucket, key, version } = actionEntry.getAttribute('target');
+        const params = {
+            bucket,
+            objectKey: key,
+            versionId: version,
+        };
+        return this.backbeatMetadataProxy.getMetadata(
+        params, log, (err, blob) => {
+            if (err) {
+                log.error('error getting metadata blob from S3', Object.assign({
+                    method: 'CopyLocationTask._getSourceMD',
+                    error: err,
+                }, actionEntry.getLogInfo()));
+                return cb(err);
+            }
+            const res = ObjectMD.createFromBlob(blob.Body);
+            if (res.error) {
+                log.error('error parsing metadata blob', Object.assign({
+                    error: res.error,
+                    method: 'CopyLocationTask._getSourceMD',
+                }, actionEntry.getLogInfo()));
+                return cb(errors.InternalError.
+                    customizeDescription('error parsing metadata blob'));
+            }
+            return cb(null, res.result);
+        });
+    }
+
+    _getAndPutObject(actionEntry, objMD, log, cb) {
+        const objectLogger = this.logger.newRequestLogger(log.getUids());
+        const extMetrics = _getExtMetrics(this.site,
+            objMD.getContentLength(), actionEntry);
+        this.mProducer.publishMetrics(extMetrics,
+            metricsTypeQueued, metricsExtension, () => {});
+        this.retry({
+            actionDesc: 'stream object data',
+            logFields: { entry: actionEntry.getLogInfo() },
+            actionFunc: done => this._getAndPutObjectOnce(
+                actionEntry, objMD, objectLogger, done),
+            shouldRetryFunc: err => err.retryable,
+            log: objectLogger,
+        }, cb);
+    }
+
+    _getAndPutObjectOnce(actionEntry, objMD, log, done) {
+        log.debug('getting object data', actionEntry.getLogInfo());
+        const doneOnce = jsutil.once(done);
+        const size = objMD.getContentLength();
+        let incomingMsg = null;
+        if (size !== 0) {
+            const { bucket, key, version } = actionEntry.getAttribute('target');
+            const sourceReq = this.backbeatClient.getObject({
+                Bucket: bucket,
+                Key: key,
+                VersionId: version,
+                LocationConstraint: objMD.getDataStoreName(),
+            });
+            attachReqUids(sourceReq, log);
+            sourceReq.on('error', err => {
+                // eslint-disable-next-line no-param-reassign
+                if (err.statusCode === 404) {
+                    log.error('the source object was not found', Object.assign({
+                        method: 'CopyLocationTask._getAndPutObjectOnce',
+                        peer: this.sourceConfig.s3,
+                        error: err.message,
+                        httpStatus: err.statusCode,
+                    }, actionEntry.getLogInfo()));
+                    return doneOnce(err);
+                }
+                log.error('an error occurred on getObject from S3',
+                    Object.assign({
+                        method: 'CopyLocationTask._getAndPutObjectOnce',
+                        peer: this.sourceConfig.s3,
+                        error: err.message,
+                        httpStatus: err.statusCode,
+                    }, actionEntry.getLogInfo()));
+                return doneOnce(err);
+            });
+            incomingMsg = sourceReq.createReadStream();
+            incomingMsg.on('error', err => {
+                if (err.statusCode === 404) {
+                    log.error('the source object was not found', Object.assign({
+                        method: 'CopyLocationTask._getAndPutObjectOnce',
+                        peer: this.sourceConfig.s3,
+                        error: err.message,
+                        httpStatus: err.statusCode,
+                    }, actionEntry.getLogInfo()));
+                    return doneOnce(errors.ObjNotFound);
+                }
+                log.error('an error occurred when streaming data from S3',
+                    Object.assign({
+                        method: 'CopyLocationTask._getAndPutObjectOnce',
+                        peer: this.sourceConfig.s3,
+                        error: err.message,
+                    }, actionEntry.getLogInfo()));
+                return doneOnce(err);
+            });
+            log.debug('putting data', actionEntry.getLogInfo());
+        }
+        return this._sendMultipleBackendPutObject(
+            actionEntry, objMD, size, incomingMsg, log, doneOnce);
+    }
+
+    /**
+     * Send the put object request to Cloudserver.
+     * @param {ActionQueueEntry} actionEntry - the action entry
+     * @param {ObjectMD} objMD - metadata object
+     * @param {Number} size - The size of object to stream
+     * @param {Readable} incomingMsg - The stream of data to put
+     * @param {Werelogs} log - The logger instance
+     * @param {Function} cb - The callback to call
+     * @return {undefined}
+     */
+    _sendMultipleBackendPutObject(actionEntry, objMD, size,
+        incomingMsg, log, cb) {
+        const { bucket, key, version } = actionEntry.getAttribute('target');
+        const destReq = this.backbeatClient.multipleBackendPutObject({
+            Bucket: bucket,
+            Key: key,
+            CanonicalID: objMD.getOwnerId(),
+            ContentLength: size,
+            ContentMD5: objMD.getContentMd5(),
+            StorageType: this.destType,
+            StorageClass: this.site,
+            VersionId: version,
+            UserMetaData: objMD.getUserMetadata(),
+            ContentType: objMD.getContentType() || undefined,
+            CacheControl: objMD.getCacheControl() || undefined,
+            ContentDisposition:
+                objMD.getContentDisposition() || undefined,
+            ContentEncoding: objMD.getContentEncoding() || undefined,
+            Body: incomingMsg,
+        });
+        attachReqUids(destReq, log);
+        return destReq.send((err, data) => {
+            if (err) {
+                log.error('an error occurred on putObject to S3',
+                Object.assign({
+                    method: 'CopyLocationTask._sendMultipleBackendPutObject',
+                    error: err.message,
+                }, actionEntry.getLogInfo()));
+                return cb(err);
+            }
+            actionEntry.setSuccess({
+                location: data.location,
+            });
+            const extMetrics = _getExtMetrics(this.site, size, actionEntry);
+            this.mProducer.publishMetrics(extMetrics,
+                metricsTypeCompleted, metricsExtension, () => {});
+            return cb(null, data);
+        });
+    }
+
+    /**
+     * This is a retry wrapper for calling _getRangeAndPutMPUPartOnce.
+     * @param {ActionQueueEntry} actionEntry - the action entry
+     * @param {ObjectMD} objMD - metadata object
+     * @param {String} range - The range to get an object with
+     * @param {Number} partNumber - The part number for the current part
+     * @param {String} uploadId - The upload ID of the initiated MPU
+     * @param {Werelogs} log - The logger instance
+     * @param {Function} cb - The callback to call
+     * @return {undefined}
+     */
+    _getRangeAndPutMPUPart(actionEntry, objMD, range, partNumber, uploadId,
+        log, cb) {
+        this.retry({
+            actionDesc: 'stream part data',
+            logFields: { entry: actionEntry.getLogInfo() },
+            actionFunc: done => this._getRangeAndPutMPUPartOnce(
+                actionEntry, objMD, range, partNumber, uploadId, log, done),
+            shouldRetryFunc: err => err.retryable,
+            log,
+        }, cb);
+    }
+
+    /**
+     * Get the ranged object, calculate the data's size, then put the part.
+     * @param {ActionQueueEntry} actionEntry - the action entry
+     * @param {ObjectMD} objMD - metadata object
+     * @param {Object} [range] - The range to get an object with
+     * @param {Number} range.start - The start byte range
+     * @param {Number} range.end - The end byte range
+     * @param {Number} partNumber - The part number for the current part
+     * @param {String} uploadId - The upload ID of the initiated MPU
+     * @param {Werelogs} log - The logger instance
+     * @param {Function} done - The callback to call
+     * @return {undefined}
+     */
+    _getRangeAndPutMPUPartOnce(actionEntry, objMD, range, partNumber,
+        uploadId, log, done) {
+        log.debug('getting object range', Object.assign({
+            range,
+        }, actionEntry.getLogInfo()));
+        // A 0-byte object has no range, otherwise range is inclusive.
+        const size = range ? range.end - range.start + 1 : 0;
+        let sourceReq = null;
+        const { bucket, key, version } = actionEntry.getAttribute('target');
+        if (size !== 0) {
+            sourceReq = this.backbeatClient.getObject({
+                Bucket: bucket,
+                Key: key,
+                VersionId: version,
+                // A 0-byte part has no range.
+                Range: range && `bytes=${range.start}-${range.end}`,
+                LocationConstraint: objMD.getDataStoreName(),
+            });
+        }
+        return this._putMPUPart(actionEntry, objMD, sourceReq, size,
+            uploadId, partNumber, log, done);
+    }
+
+    /**
+     * Wrapper for aborting an MPU which uses exponential backoff retry.
+     * @param {ActionQueueEntry} actionEntry - the action entry
+     * @param {ObjectMD} objMD - metadata object
+     * @param {String} uploadId - The MPU upload ID to abort
+     * @param {Werelogs} log - The logger instance
+     * @param {Function} cb - The callback to call
+     * @return {undefined}
+     */
+    _multipleBackendAbortMPU(actionEntry, objMD, uploadId, log, cb) {
+        this.retry({
+            actionDesc: 'abort multipart upload',
+            logFields: { entry: actionEntry.getLogInfo() },
+            actionFunc: done => this._multipleBackendAbortMPUOnce(
+                actionEntry, objMD, uploadId, log, done),
+            shouldRetryFunc: err => err.retryable,
+            log,
+        }, cb);
+    }
+
+    /**
+     * Attempt to abort the given MPU on the source. Used when an
+     * operation performed in the process of replicating a multipart
+     * upload fails.
+     *
+     * @param {ActionQueueEntry} actionEntry - the action entry
+     * @param {ObjectMD} objMD - metadata object
+     * @param {String} uploadId - The MPU upload ID to abort
+     * @param {Werelogs} log - The logger instance
+     * @param {Function} cb - The callback to call
+     * @return {undefined}
+     */
+    _multipleBackendAbortMPUOnce(actionEntry, objMD, uploadId, log, cb) {
+        log.debug('aborting multipart upload', Object.assign({
+            uploadId,
+        }, actionEntry.getLogInfo()));
+        const { bucket, key } = actionEntry.getAttribute('target');
+        const destReq = this.backbeatClient.multipleBackendAbortMPU({
+            Bucket: bucket,
+            Key: key,
+            StorageType: this.destType,
+            StorageClass: this.site,
+            UploadId: uploadId,
+        });
+        attachReqUids(destReq, log);
+        return destReq.send(err => {
+            if (err) {
+                log.error('an error occurred aborting multipart upload', {
+                    method: 'CopyLocationTask._multipleBackendAbortMPUOnce',
+                    error: err.message,
+                }, actionEntry.getLogInfo());
+                return cb(err);
+            }
+            return cb();
+        });
+    }
+
+   /**
+    * Perform a multipart upload.
+     * @param {ActionQueueEntry} actionEntry - the action entry
+     * @param {ObjectMD} objMD - metadata object
+    * @param {String} uploadId - The upload ID of the initiated MPU
+    * @param {Stream} data - The incoming message of the get request
+    * @param {Werelogs} log - The logger instance
+    * @param {Function} doneOnce - The callback to call
+    * @return {undefined}
+    */
+    _completeMPU(actionEntry, objMD, uploadId, data, log, doneOnce) {
+        const { bucket, key, version } = actionEntry.getAttribute('target');
+        const destReq = this.backbeatClient.multipleBackendCompleteMPU({
+            Bucket: bucket,
+            Key: key,
+            StorageType: this.destType,
+            StorageClass: this.site,
+            VersionId: version,
+            UserMetaData: objMD.getUserMetadata(),
+            ContentType: objMD.getContentType(),
+            CacheControl: objMD.getCacheControl() || undefined,
+            ContentDisposition: objMD.getContentDisposition() ||
+                undefined,
+            ContentEncoding: objMD.getContentEncoding() ||
+                undefined,
+            UploadId: uploadId,
+            Body: JSON.stringify(data),
+        });
+        attachReqUids(destReq, log);
+        return destReq.send((err, data) => {
+            if (err) {
+                log.error('an error occurred on completing MPU to S3',
+                Object.assign({
+                    method: 'CopyLocationTask._completeMPU',
+                    error: err.message,
+                }, actionEntry.getLogInfo()));
+                // Attempt to abort the MPU, but pass the error from
+                // multipleBackendCompleteMPU because that operation's result
+                // should determine the replication's success or failure.
+                return this._multipleBackendAbortMPU(
+                    actionEntry, objMD, uploadId, log, () => doneOnce(err));
+            }
+            actionEntry.setSuccess({
+                location: data.location,
+            });
+            return doneOnce();
+        });
+    }
+
+    /**
+     * Get the ranged object, calculate the data's size, then put the part.
+     * @param {ActionQueueEntry} actionEntry - the action entry
+     * @param {ObjectMD} objMD - metadata object
+     * @param {AWS.Request} sourceReq - The source request for getting data
+     * @param {Number} size - The size of the content
+     * @param {String} uploadId - The upload ID of the initiated MPU
+     * @param {Number} partNumber - The part number of the part
+     * @param {Werelogs} log - The logger instance
+     * @param {Function} cb - The callback to call
+     * @return {undefined}
+     */
+    _putMPUPart(actionEntry, objMD, sourceReq, size, uploadId, partNumber,
+                log, cb) {
+        const doneOnce = jsutil.once(cb);
+        let incomingMsg = null;
+        if (sourceReq) {
+            attachReqUids(sourceReq, log);
+            sourceReq.on('error', err => {
+                if (err.statusCode === 404) {
+                    return doneOnce(err);
+                }
+                log.error('an error occurred on getObject from S3',
+                Object.assign({
+                    method: 'CopyLocationTask._putMPUPart',
+                    error: err.message,
+                    httpStatus: err.statusCode,
+                }, actionEntry.getLogInfo()));
+                return doneOnce(err);
+            });
+            incomingMsg = sourceReq.createReadStream();
+            incomingMsg.on('error', err => {
+                if (err.statusCode === 404) {
+                    return doneOnce(errors.ObjNotFound);
+                }
+                log.error('an error occurred when streaming data from S3',
+                Object.assign({
+                    method: 'CopyLocationTask._putMPUPart',
+                    error: err.message,
+                }, actionEntry.getLogInfo()));
+                return doneOnce(err);
+            });
+            log.debug('putting data', actionEntry.getLogInfo());
+        }
+
+        const { bucket, key } = actionEntry.getAttribute('target');
+        const destReq = this.backbeatClient.multipleBackendPutMPUPart({
+            Bucket: bucket,
+            Key: key,
+            ContentLength: size,
+            StorageType: this.destType,
+            StorageClass: this.site,
+            PartNumber: partNumber,
+            UploadId: uploadId,
+            Body: incomingMsg,
+        });
+        attachReqUids(destReq, log);
+        return destReq.send((err, data) => {
+            if (err) {
+                log.error('an error occurred on putting MPU part to S3',
+                Object.assign({
+                    method: 'CopyLocationTask._putMPUPart',
+                    error: err.message,
+                }, actionEntry.getLogInfo()));
+                return doneOnce(err);
+            }
+            const extMetrics = _getExtMetrics(this.site, size, actionEntry);
+            this.mProducer.publishMetrics(extMetrics,
+                metricsTypeCompleted, metricsExtension, () => {});
+            return doneOnce(null, data);
+        });
+    }
+
+    _getAndPutMultipartUpload(actionEntry, objMD, log, cb) {
+        this.retry({
+            actionDesc: 'stream MPU data',
+            logFields: { entry: actionEntry.getLogInfo() },
+            actionFunc: done => this._getAndPutMultipartUploadOnce(
+                actionEntry, objMD, log, done),
+            shouldRetryFunc: err => err.retryable,
+            log,
+        }, cb);
+    }
+
+    _initiateMPU(actionEntry, objMD, log, cb) {
+        // If using Azure backend, create a unique ID to use as the block ID.
+        if (this._getReplicationEndpointType() === 'azure') {
+            const uploadId = uuid().replace(/-/g, '');
+            return setImmediate(() => cb(null, uploadId));
+        }
+        const { bucket, key, version } = actionEntry.getAttribute('target');
+        const destReq = this.backbeatClient.multipleBackendInitiateMPU({
+            Bucket: bucket,
+            Key: key,
+            StorageType: this.destType,
+            StorageClass: this.site,
+            VersionId: version,
+            UserMetaData: objMD.getUserMetadata(),
+            ContentType: objMD.getContentType() || undefined,
+            CacheControl: objMD.getCacheControl() || undefined,
+            ContentDisposition:
+                objMD.getContentDisposition() || undefined,
+            ContentEncoding: objMD.getContentEncoding() || undefined,
+        });
+        attachReqUids(destReq, log);
+        return destReq.send((err, data) => {
+            if (err) {
+                log.error('an error occurred on initating MPU to S3',
+                Object.assign({
+                    method: 'CopyLocationTask._initiateMPU',
+                    error: err.message,
+                }, actionEntry.getLogInfo()));
+                return cb(err);
+            }
+            return cb(null, data.uploadId);
+        });
+    }
+
+    /**
+     * Get a byte range size for an object of the given content length, such
+     * that the range count does not exceed 1024 elements (i.e.
+     * MPU_GCP_MAX_PARTS).
+     * @param {Number} contentLen - The content length of the whole object
+     * @return {Number} The range size to use
+     */
+    _getGCPRangeSize(contentLen) {
+        let rangeSize = this._getRangeSize(contentLen);
+        if (contentLen / rangeSize > MPU_GCP_MAX_PARTS) {
+            const pow =
+                Math.pow(2, Math.ceil(Math.log(contentLen) / Math.log(2)));
+            rangeSize = Math.ceil(pow / MPU_GCP_MAX_PARTS);
+        }
+        return rangeSize;
+    }
+
+    /**
+     * Get a byte range size for an object of the given content length, such
+     * that the range size sums to the content length when multiplied by a value
+     * between 1 and 10000. This has the effect of creating MPU parts of the
+     * given range size. This method also optimizes for the subsequent range
+     * requests by returning a range size that is an interval of MB or GB.
+     * @param {Number} contentLen - The content length of the whole object
+     * @return {Number} The range size to use
+     */
+    _getRangeSize(contentLen) {
+        let rangeSize = (1024 * 1024) * 16; // Default 16MB part size.
+        if (contentLen <= rangeSize) {
+            return contentLen;
+        }
+        // Target creation of an MPU that is between a 2 and 1000 parts.
+        while (contentLen / rangeSize > 1000) {
+            // When given a very large object we want to allow use of up to 10K
+            // parts, so we limit the part size to 512MB here.
+            if (rangeSize >= (1024 * 1024) * 512) {
+                break;
+            }
+            rangeSize *= 2;
+        }
+        // If the object is large enough to exceed 10K parts of 512MB, then at
+        // this point we need to increase the part size such that the largest
+        // object size of 5TB can be accounted for.
+        while (contentLen / rangeSize > 10000) {
+            rangeSize *= 2;
+        }
+        return rangeSize;
+    }
+
+    /**
+     * Get byte ranges for an object of the given content length, such that the
+     * range count does not exceed 1024 parts if replicating to GCP or does not
+     * exceed 10000 parts otherwise.
+     * @param {Number} contentLen - The content length of the whole object
+     * @param {Boolean} isGCP - Whether the object is being replicated to GCP
+     * @return {Array} The array of byte ranges.
+     */
+    _getRanges(contentLen, isGCP) {
+        if (contentLen === 0) {
+            // 0-byte object has no range. However we still want to put a single
+            // part so the range in the subsequent GET request is undefined.
+            return [null];
+        }
+        const size = isGCP ?
+            this._getGCPRangeSize(contentLen) : this._getRangeSize(contentLen);
+        const ranges = [];
+        let start = 0;
+        let end = 0;
+        while (end < contentLen - 1) {
+            end = start + size - 1;
+            if (end < contentLen - 1) {
+                ranges.push({ start, end });
+                start = end + 1;
+            }
+        }
+        ranges.push({ start, end: contentLen - 1 });
+        return ranges;
+    }
+
+    /**
+     * Perform a multipart upload using ranged get object requests.
+     * @param {ActionQueueEntry} actionEntry - the action entry
+     * @param {ObjectMD} objMD - metadata object
+     * @param {String} uploadId - The upload ID of the initiated MPU
+     * @param {Werelogs} log - The logger instance
+     * @param {Function} cb - The callback to call
+     * @return {undefined}
+     */
+    _completeRangedMPU(actionEntry, objMD, uploadId, log, cb) {
+        const isGCP = this._getReplicationEndpointType() === 'gcp';
+        const isAzure = this._getReplicationEndpointType() === 'azure';
+        const ranges = this._getRanges(objMD.getContentLength(), isGCP);
+        return async.timesLimit(ranges.length, MPU_CONC_LIMIT, (n, next) =>
+            this._getRangeAndPutMPUPart(actionEntry, objMD, ranges[n],
+                n + 1, uploadId, log, (err, data) => {
+                    if (err) {
+                        return next(err);
+                    }
+                    const res = {
+                        PartNumber: [data.partNumber],
+                        ETag: [data.ETag],
+                        Size: [ranges[n].end - ranges[n].start + 1],
+                    };
+                    if (isAzure) {
+                        res.NumberSubParts = [data.numberSubParts];
+                    }
+                    return next(null, res);
+                }),
+            (err, data) => {
+                if (err) {
+                    log.error('an error occurred on putting MPU part to S3',
+                    Object.assign({
+                        method: 'CopyLocationTask._completeRangedMPU',
+                        error: err.message,
+                    }, actionEntry.getLogInfo()));
+                    // Attempt to abort the MPU, but pass an error from
+                    // multipleBackendPutMPUPart because that operation's result
+                    // should determine the replication's success or failure.
+                    return this._multipleBackendAbortMPU(
+                        actionEntry, objMD, uploadId, log, () => cb(err));
+                }
+                return this._completeMPU(actionEntry, objMD, uploadId, data,
+                    log, cb);
+            });
+    }
+
+    /**
+     * Send the initiate MPU request and then complete the MPU.
+     * @param {ActionQueueEntry} actionEntry - the action entry
+     * @param {ObjectMD} objMD - metadata object
+     * @param {Werelogs} log - The logger instance
+     * @param {Function} cb - The callback to call
+     * @return {undefined}
+     */
+    _getAndPutMultipartUploadOnce(actionEntry, objMD, log, cb) {
+        return this._initiateMPU(actionEntry, objMD, log, (err, uploadId) => {
+            if (err) {
+                return cb(err);
+            }
+            const extMetrics = _getExtMetrics(this.site,
+                objMD.getContentLength(), actionEntry);
+            this.mProducer.publishMetrics(extMetrics, metricsTypeQueued,
+                metricsExtension, () => {});
+            return this._completeRangedMPU(actionEntry, objMD,
+                uploadId, log, cb);
+        });
+    }
+
+    /**
+     * Get the source object metadata and ensure the latest object MD5 hash is
+     * the same as in the action entry.
+     * @param {ActionQueueEntry} actionEntry - the action entry
+     * @param {ObjectMD} objMD - metadata object
+
+     * @return {null|Error} - null if the check passes, or an error
+     * object of type InvalidObjectState describing the check failure.
+     */
+    _checkObjectState(actionEntry, objMD) {
+        const eTag = actionEntry.getAttribute('target.eTag');
+        if (eTag) {
+            const strippedETag = eTag.slice(1, -1);
+            if (objMD.getContentMd5() !== strippedETag) {
+                // The object was overwritten with new contents since
+                // the action was initiated
+                return errors.InvalidObjectState.customizeDescription(
+                    'object contents have changed');
+            }
+        }
+        return null;
+    }
+
+    _publishCopyLocationStatus(err, actionEntry, kafkaEntry, log, done) {
+        if (err && !actionEntry.getError()) {
+            actionEntry.setError(err);
+        }
+        log.info('action execution ended', actionEntry.getLogInfo());
+        if (!actionEntry.getResultsTopic()) {
+            // no result requested, we may commit immediately
+            return process.nextTick(() => done(null, { committable: true }));
+        }
+        this.replicationStatusProducer.sendToTopic(
+            actionEntry.getResultsTopic(),
+            [{ message: actionEntry.toKafkaMessage() }], deliveryErr => {
+                if (deliveryErr) {
+                    log.error('error in entry delivery to results topic',
+                    Object.assign({
+                        method: 'CopyLocationTask._publishCopyLocationStatus',
+                        topic: actionEntry.getResultsTopic(),
+                        error: deliveryErr.message,
+                    }, actionEntry.getLogInfo()));
+                }
+                // Commit whether there was an error or not delivering
+                // the message to allow progress of the consumer, as
+                // best effort measure when there are errors.
+                if (this.dataMoverConsumer) {
+                    this.dataMoverConsumer.onEntryCommittable(kafkaEntry);
+                }
+            });
+        return process.nextTick(() => done(null, { committable: false }));
+    }
+}
+
+module.exports = CopyLocationTask;

--- a/lib/BackbeatMetadataProxy.js
+++ b/lib/BackbeatMetadataProxy.js
@@ -35,9 +35,8 @@ class BackbeatMetadataProxy extends BackbeatTask {
             return accountCredentials;
         }
         const vaultclient = this.vaultclientCache.getClient('source:s3');
-        const extension = 'replication';
         const role = this.sourceRole;
-        return new RoleCredentials(vaultclient, extension, role, log);
+        return new RoleCredentials(vaultclient, 'replication', role, log);
     }
 
     /**
@@ -192,6 +191,7 @@ class BackbeatMetadataProxy extends BackbeatTask {
 
     setSourceRole(sourceRole) {
         this.sourceRole = sourceRole;
+        return this;
     }
 
     setSourceClient(log) {

--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -152,6 +152,12 @@
                 "members": {
                     "versionId": {
                         "type": "string"
+                    },
+                    "location": {
+                        "type": "list",
+                        "member": {
+                            "shape": "LocationMDObj"
+                        }
                     }
                 }
             }
@@ -441,6 +447,12 @@
                 "members": {
                     "versionId": {
                         "type": "string"
+                    },
+                    "location": {
+                        "type": "list",
+                        "member": {
+                            "shape": "LocationMDObj"
+                        }
                     }
                 }
             }

--- a/lib/models/ActionQueueEntry.js
+++ b/lib/models/ActionQueueEntry.js
@@ -1,5 +1,7 @@
 const uuid = require('uuid/v4');
 
+const errors = require('arsenal').errors;
+
 /**
  * @class
  * @classdesc Generic convenience class used to ask a remote service
@@ -143,16 +145,26 @@ class ActionQueueEntry {
      * @param {string} attributePath - path to the attribute to get -
      * it can be a simple attribute name, or a dot-separated path to a
      * nested attribute
+     * @param {object} [options] - options object
+     * @param {boolean} [options.required=false] - if true and the
+     * attribute is not found, set the action error to
+     * "errors.MissingParameter" if no previous error has been already
+     * set.
      * @return {object|undefined} - attribute value, or {undefined} if
      * the attribute or any of its parents do not exist
      */
-    getAttribute(attributePath) {
+    getAttribute(attributePath, options = {}) {
         const attrPathElems = attributePath.split('.');
         let attr = this._actionAttributes;
         for (let i = 0; i < attrPathElems.length; ++i) {
             const attrPathElem = attrPathElems[i];
             attr = attr[attrPathElem];
             if (attr === undefined) {
+                if (options.required && !this.getError()) {
+                    this.setError(errors.MissingParameter.customizeDescription(
+                        `missing required attribute "${attributePath}" ` +
+                            'in action message'));
+                }
                 return undefined;
             }
         }

--- a/tests/config.json
+++ b/tests/config.json
@@ -107,6 +107,7 @@
                 }
             },
             "topic": "backbeat-replication",
+            "dataMoverTopic": "backbeat-data-mover",
             "replicationStatusTopic": "backbeat-replication-status",
             "replicationFailedTopic": "backbeat-replication-failed",
             "queueProcessor": {

--- a/tests/unit/lib/models/ActionQueueEntry.spec.js
+++ b/tests/unit/lib/models/ActionQueueEntry.spec.js
@@ -43,6 +43,17 @@ describe('ActionQueueEntry', () => {
             entry.getAttribute('details'), { roundTrip: true });
     });
 
+    it('should set an error when retrieving an unset attribute and ' +
+    '"required" option is set', () => {
+        const entry = ActionQueueEntry.create('sendPigeon')
+              .setAttribute('toCountry', 'Finland');
+        assert.strictEqual(
+            entry.getAttribute('cost', { required: true }), undefined);
+        assert(entry.getError());
+        assert.strictEqual(entry.getError().code, 400);
+        assert.strictEqual(entry.getError().message, 'MissingParameter');
+    });
+
     it('should return specified logged attributes from getLogInfo()', () => {
         const entry = ActionQueueEntry.create('sendPigeon')
               .setAttribute('toCountry', 'Finland')


### PR DESCRIPTION
Create a new task type inside the queue processor to copy data between
locations.

It relies on ActionQueueEntry class to marshall/unmarshall requests
and responses to/from the backbeat-data-mover topic.

The current version does not allow choosing the key of the new object,
as it is chosen by the multiple backend code that executes the copy,
but it fits the need for transition policies.

**Note for reviews**: it may look daunting, but a large part of the logic of CopyLocationTask is derived from MultipleBackendTask, with argument passing changed to use action objects and return action results. I though it was hard and risky enough to factorize the code that I preferred to split it into different tasks instead, in a future version we could get rid of MultipleBackendTask in favor of CopyLocationTask (copy as a service approach).

Functionally depends on https://github.com/scality/cloudserver/pull/1719.