### PR TITLE
rf: ZENKO-1566 api route parser map datapoint keys

### DIFF
--- a/extensions/ingestion/constants.js
+++ b/extensions/ingestion/constants.js
@@ -7,6 +7,7 @@ const constants = {
         testIsOn ? '/backbeattest/ingestion' : '/backbeat/ingestion',
     zkStatePath: '/state',
     zkStateProperties: ['paused', 'scheduledResume'],
+    redisKeys: {},
 };
 
 module.exports = constants;

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -21,11 +21,12 @@ const { getSortedSetKey, getSortedSetMember } =
 const monitoringClient = require('../clients/monitoringHandler').client;
 
 const {
-    redisKeys,
+    redisKeys: crrRedisKeys,
     zookeeperNamespace: zookeeperReplicationNamespace,
     zkStatePath: zkReplicationStatePath,
 } = require('../../extensions/replication/constants');
 const {
+    redisKeys: ingestionRedisKeys,
     zookeeperNamespace: zookeeperIngestionNamespace,
     zkStatePath: zkIngestionStatePath,
 } = require('../../extensions/ingestion/constants');
@@ -141,6 +142,22 @@ class BackbeatAPI {
     }
 
     /**
+     * Maps the data points to their respective redis keys
+     * @param {String} service - service name, i.e. 'crr', 'ingestion'
+     * @param {Array} dataPoints - array of strings
+     * @return {Array} array of redis keys
+     */
+    _getRedisKeySchemas(service, dataPoints) {
+        if (service === 'ingestion') {
+            return dataPoints.map(dp => ingestionRedisKeys[dp]);
+        }
+        if (service === 'crr') {
+            return dataPoints.map(dp => crrRedisKeys[dp]);
+        }
+        return [];
+    }
+
+    /**
      * Find valid route from list of routes defined in Arsenal backbeat routes
      * Sets the matched route on the BackbeatRequest object with possible
      * extra properties.
@@ -154,7 +171,7 @@ class BackbeatAPI {
         const addKeys = {};
 
         this._updateConfigSites();
-        const routes = getRoutesFn(redisKeys, {
+        const routes = getRoutesFn({
             crr: this._crrSites,
             ingestion: this._ingestionSites,
         });
@@ -271,9 +288,28 @@ class BackbeatAPI {
             addKeys.versionId = rDetails.versionId;
         }
 
+        const expectedRoute = filteredRoutes[0];
+        // convert dataPoint to relevant redis keys
+        if (expectedRoute.dataPoints) {
+            const dataPointKeys = this._getRedisKeySchemas(rDetails.extension,
+                expectedRoute.dataPoints);
+            if (dataPointKeys.length === 0) {
+                // this would be a developer error, either wrong redis key map
+                // or missing constants in redis keys, so return InternalError
+                this._logger.error('error getting metrics redis keys', {
+                    path: bbRequest.getRoute(),
+                    dataPoints: expectedRoute.dataPoints,
+                    extension: rDetails.extension,
+                });
+                return errors.InternalError.customizeDescription(
+                    `error for ${bbRequest.getRoute()}, check error logs`);
+            }
+            expectedRoute.dataPoints = dataPointKeys;
+        }
+
         // Matching route found. Set on request object so we do not have to
         // re-match later
-        const matchedRoute = Object.assign({}, filteredRoutes[0], addKeys);
+        const matchedRoute = Object.assign({}, expectedRoute, addKeys);
         bbRequest.setMatchedRoute(matchedRoute);
 
         return null;
@@ -581,8 +617,8 @@ class BackbeatAPI {
                 });
                 return cb(err);
             }
-            const opsPendingKey = `${site}:${redisKeys.opsPending}`;
-            const bytesPendingkey = `${site}:${redisKeys.bytesPending}`;
+            const opsPendingKey = `${site}:${crrRedisKeys.opsPending}`;
+            const bytesPendingkey = `${site}:${crrRedisKeys.bytesPending}`;
             const bytes = queueEntry.getContentLength();
             this._statsClient.incrementKey(opsPendingKey, 1);
             this._statsClient.incrementKey(bytesPendingkey, bytes);
@@ -752,8 +788,8 @@ class BackbeatAPI {
                 }
                 const contentLength = queueEntry.getContentLength();
                 const site = entry.getSite();
-                const opsPendingKey = `${site}:${redisKeys.opsPending}`;
-                const bytesPendingkey = `${site}:${redisKeys.bytesPending}`;
+                const opsPendingKey = `${site}:${crrRedisKeys.opsPending}`;
+                const bytesPendingkey = `${site}:${crrRedisKeys.bytesPending}`;
                 // decrement key as a duplicate failure object key was found.
                 // If removing a duplicate failure object key, we also need to
                 // normalize pending metrics by decrementing
@@ -773,7 +809,7 @@ class BackbeatAPI {
      * @return {undefined}
      */
     getFailedMetrics(details, cb, data) {
-        const { failedCRR } = redisKeys;
+        const { failedCRR } = crrRedisKeys;
         const sites = details.site === 'all' ?
             this._crrSites : [details.site];
         const hourTimestamps = this._statsClient.getSortedSetHours(Date.now());

--- a/package-lock.json
+++ b/package-lock.json
@@ -2112,8 +2112,8 @@
       "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
     },
     "arsenal": {
-      "version": "github:scality/Arsenal#d44c2f123e4079e2fa64883e06b3768b3bfba627",
-      "from": "github:scality/Arsenal#d44c2f1",
+      "version": "github:scality/Arsenal#0213bcfd25076ba40bf5b295950066f8be9463ae",
+      "from": "github:scality/Arsenal#0213bcf",
       "requires": {
         "JSONStream": "^1.0.0",
         "ajv": "4.10.0",
@@ -6662,10 +6662,13 @@
     "sproxydclient": {
       "version": "github:scality/sproxydclient#45090b76b24ca1d05482bf151ba84ff6178423d1",
       "from": "github:scality/sproxydclient#45090b7",
+      "requires": {
+        "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2"
+      },
       "dependencies": {
         "werelogs": {
           "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
-          "from": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+          "from": "github:scality/werelogs#7.4.0.3",
           "requires": {
             "safe-json-stringify": "^1.0.3"
           }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/scality/backbeat#readme",
   "dependencies": {
     "JSONStream": "^1.3.5",
-    "arsenal": "github:scality/Arsenal#d44c2f1",
+    "arsenal": "github:scality/Arsenal#0213bcf",
     "async": "^2.3.0",
     "aws-sdk": "2.147.0",
     "backo": "^1.1.0",


### PR DESCRIPTION
Goes with https://github.com/scality/Arsenal/pull/757

Rather than passing redis keys to route function defined in
Arsenal, we fetch the data point identifiers for a given
route from Arsenal and then map those to the redis keys
we want for a given service.