### PR TITLE
ft: ZENKO-1566 add ingestion metrics routes

### DIFF
--- a/extensions/ingestion/constants.js
+++ b/extensions/ingestion/constants.js
@@ -7,7 +7,13 @@ const constants = {
         testIsOn ? '/backbeattest/ingestion' : '/backbeat/ingestion',
     zkStatePath: '/state',
     zkStateProperties: ['paused', 'scheduledResume'],
-    redisKeys: {},
+    redisKeys: {
+        opsDone: testIsOn ? 'test:bb:opsdone' : 'bb:ingestion:opsdone',
+        bytesDone: testIsOn ? 'test:bb:bytesdone' : 'bb:ingestion:bytesdone',
+        opsPending: testIsOn ? 'test:bb:opspending' : 'bb:ingestion:opspending',
+        bytesPending: testIsOn ?
+            'test:bb:bytespending' : 'bb:ingestion:bytespending',
+    },
 };
 
 module.exports = constants;

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -104,11 +104,23 @@ class BackbeatAPI {
             _getMaxUptime: metrics._getMaxUptime,
             getBacklog: metrics.getBacklog,
             getCompletions: metrics.getCompletions,
+            _sendCompletionsResponseReplication:
+                metrics._sendCompletionsResponseReplication,
+            _sendCompletionsResponseIngestion:
+                metrics._sendCompletionsResponseIngestion,
             getObjectThroughput: metrics.getObjectThroughput,
             getObjectProgress: metrics.getObjectProgress,
             getThroughput: metrics.getThroughput,
+            _sendThroughputResponseReplication:
+                metrics._sendThroughputResponseReplication,
+            _sendThroughputResponseIngestion:
+                metrics._sendThroughputResponseIngestion,
             getAllMetrics: metrics.getAllMetrics,
             getPending: metrics.getPending,
+            _sendPendingResponseReplication:
+                metrics._sendPendingResponseReplication,
+            _sendPendingResponseIngestion:
+                metrics._sendPendingResponseIngestion,
         });
     }
 
@@ -223,6 +235,10 @@ class BackbeatAPI {
             return isMatchingMethod && isMatchingExtension && isMatchingLevel;
         });
 
+        // if rDetails has an extension property, i.e. 'crr', 'ingestion'
+        if (rDetails.extension) {
+            addKeys.service = rDetails.extension;
+        }
         // if rDetails has a category property. Currently only metrics
         if (rDetails.category) {
             filteredRoutes = filteredRoutes.filter(r =>
@@ -256,8 +272,6 @@ class BackbeatAPI {
                 // currently only pause/resume (for both crr and ingestion)
                 filteredRoutes = filteredRoutes.filter(r =>
                     rDetails.status === r.type);
-                // save type of service
-                addKeys.service = rDetails.extension;
                 if (rDetails.schedule) {
                     addKeys.schedule = rDetails.schedule;
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2112,8 +2112,8 @@
       "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
     },
     "arsenal": {
-      "version": "github:scality/Arsenal#0213bcfd25076ba40bf5b295950066f8be9463ae",
-      "from": "github:scality/Arsenal#0213bcf",
+      "version": "github:scality/Arsenal#a8e0a30918a8904974d2e6b09020a3ee270dc095",
+      "from": "github:scality/Arsenal#a8e0a30",
       "requires": {
         "JSONStream": "^1.0.0",
         "ajv": "4.10.0",
@@ -6662,13 +6662,10 @@
     "sproxydclient": {
       "version": "github:scality/sproxydclient#45090b76b24ca1d05482bf151ba84ff6178423d1",
       "from": "github:scality/sproxydclient#45090b7",
-      "requires": {
-        "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2"
-      },
       "dependencies": {
         "werelogs": {
           "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
-          "from": "github:scality/werelogs#7.4.0.3",
+          "from": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
           "requires": {
             "safe-json-stringify": "^1.0.3"
           }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/scality/backbeat#readme",
   "dependencies": {
     "JSONStream": "^1.3.5",
-    "arsenal": "github:scality/Arsenal#0213bcf",
+    "arsenal": "github:scality/Arsenal#a8e0a30",
     "async": "^2.3.0",
     "aws-sdk": "2.147.0",
     "backo": "^1.1.0",

--- a/tests/functional/api/routes.js
+++ b/tests/functional/api/routes.js
@@ -307,6 +307,7 @@ describe('API routes', () => {
             // general wrong paths
             '/',
             '/metrics/crr/all',
+            '/metrics/ingestion/all',
             '/_/metrics',
             '/_/metrics/backlog',
             // wrong category field
@@ -318,6 +319,8 @@ describe('API routes', () => {
             '/_/metrics/c/all',
             '/_/metrics/c/all/backlog',
             '/_/metrics/crrr/all',
+            '/_/metrics/ingestio/all',
+            '/_/metrics/ingestionn/all',
             // wrong site field
             // wrong type field
             '/_/metrics/crr/all/backlo',
@@ -329,6 +332,10 @@ describe('API routes', () => {
             '/_/metrics/crr/all/pendin',
             '/_/metrics/crr/all/pendings',
             `/_/metrics/crr/${site1}/progresss`,
+            // ingestion service does not support these paths/metrics
+            '/_/metrics/ingestion/all',
+            '/_/metrics/ingestion/all/backlog',
+            '/_/metrics/ingestion/all/failures',
             // given bucket without object key
             `/_/metrics/crr/${site1}/progress/bucket`,
             `/_/metrics/crr/${site1}/progress/bucket/`,
@@ -409,6 +416,20 @@ describe('API routes', () => {
         });
 
         it('should get the right data for route: ' +
+        '/_/metrics/ingestion/all/completions', done => {
+            getRequest('/_/metrics/ingestion/all/completions', (err, res) => {
+                assert.ifError(err);
+
+                const key = Object.keys(res)[0];
+                // Completions count = OPS_DONE
+                assert.equal(res[key].results.count, 750);
+                // Should not include bytes
+                assert(!res[key].results.size);
+                done();
+            });
+        });
+
+        it('should get the right data for route: ' +
         `/_/metrics/crr/${site1}/failures`, done => {
             getRequest(`/_/metrics/crr/${site1}/failures`, (err, res) => {
                 assert.ifError(err);
@@ -459,19 +480,6 @@ describe('API routes', () => {
         });
 
         it('should get the right data for route: ' +
-        `/_/metrics/crr/${site1}/throughput`, done => {
-            getRequest(`/_/metrics/crr/${site1}/throughput`, (err, res) => {
-                assert.ifError(err);
-                const key = Object.keys(res)[0];
-                // Throughput count = OPS_DONE / EXPIRY
-                assert.equal(res[key].results.count, 0.5);
-                // Throughput bytes = BYTES_DONE / EXPIRY
-                assert.equal(res[key].results.size, 1.14);
-                done();
-            });
-        });
-
-        it('should get the right data for route: ' +
         '/_/metrics/crr/all/throughput', done => {
             getRequest('/_/metrics/crr/all/throughput', (err, res) => {
                 assert.ifError(err);
@@ -480,6 +488,19 @@ describe('API routes', () => {
                 assert.equal(res[key].results.count, 0.83);
                 // Throughput bytes = BYTES_DONE / EXPIRY
                 assert.equal(res[key].results.size, 3.22);
+                done();
+            });
+        });
+
+        it('should get the right data for route: ' +
+        '/_/metrics/ingestion/all/throughput', done => {
+            getRequest('/_/metrics/ingestion/all/throughput', (err, res) => {
+                assert.ifError(err);
+                const key = Object.keys(res)[0];
+                // Throughput count = OPS_DONE / EXPIRY
+                assert.equal(res[key].results.count, 0.83);
+                // Should not include bytes
+                assert(!res[key].results.size);
                 done();
             });
         });
@@ -502,6 +523,18 @@ describe('API routes', () => {
                 const key = Object.keys(res)[0];
                 assert.equal(res[key].results.count, 4);
                 assert.equal(res[key].results.size, 2048);
+                done();
+            });
+        });
+
+        it('should get the right data for route: ' +
+        '/_/metrics/ingestion/all/pending', done => {
+            getRequest('/_/metrics/ingestion/all/pending', (err, res) => {
+                assert.ifError(err);
+                const key = Object.keys(res)[0];
+                assert.equal(res[key].results.count, 4);
+                // Should not include bytes
+                assert(!res[key].results.size);
                 done();
             });
         });

--- a/tests/unit/api/BackbeatAPI.spec.js
+++ b/tests/unit/api/BackbeatAPI.spec.js
@@ -26,6 +26,13 @@ describe('BackbeatAPI', () => {
         { url: '/_/metrics/crr/all/completions', method: 'GET' },
         { url: '/_/metrics/crr/all/failures', method: 'GET' },
         { url: '/_/metrics/crr/all/throughput', method: 'GET' },
+        { url: '/_/metrics/ingestion/all/completions', method: 'GET' },
+        { url: `/_/metrics/ingestion/${ingestSite}/completions`,
+            method: 'GET' },
+        { url: '/_/metrics/ingestion/all/throughput', method: 'GET' },
+        { url: `/_/metrics/ingestion/${ingestSite}/throughput`, method: 'GET' },
+        { url: '/_/metrics/ingestion/all/pending', method: 'GET' },
+        { url: `/_/metrics/ingestion/${ingestSite}/pending`, method: 'GET' },
         { url: '/_/monitoring/metrics', method: 'GET' },
         { url: '/_/crr/failed/mybucket/mykey?versionId=test-myvId',
             method: 'GET' },
@@ -74,6 +81,10 @@ describe('BackbeatAPI', () => {
         { url: '/_/metrics/crr/all/fail', method: 'GET' },
         { url: '/_/invalid/crr/all', method: 'GET' },
         { url: '/_/metrics/pause/all', method: 'GET' },
+        // unavailable routes for given service
+        { url: '/_/metrics/ingestion/all', method: 'GET' },
+        { url: '/_/metrics/ingestion/all/backlog', method: 'GET' },
+        { url: '/_/metrics/ingestion/all/failures', method: 'GET' },
         // invalid http verb
         { url: '/_/healthcheck', method: 'POST' },
         { url: '/_/monitoring/metrics', method: 'POST' },
@@ -85,7 +96,17 @@ describe('BackbeatAPI', () => {
             '?versionId=test-myvId', method: 'GET' },
         { url: '/_/metrics/crr/unknown-site/progress/mybucket/mykey' +
             '?versionId=test-myvId', method: 'GET' },
+        { url: '/_/metrics/ingestion/all/throughput', method: 'POST' },
+        { url: `/_/metrics/ingestion/${site}/completions`, method: 'POST' },
+        { url: `/_/metrics/ingestion/${site}/pending`, method: 'POST' },
         // invalid site for given service
+        { url: `/_/ingestion/pause/${site}`, method: 'POST' },
+        { url: `/_/ingestion/resume/${site}`, method: 'POST' },
+        { url: `/_/ingestion/status/${site}`, method: 'GET' },
+        // invalid site for given service
+        { url: `/_/crr/pause/${ingestSite}`, method: 'POST' },
+        { url: `/_/crr/resume/${ingestSite}`, method: 'POST' },
+        { url: `/_/crr/status/${ingestSite}`, method: 'GET' },
         { url: `/_/ingestion/pause/${site}`, method: 'POST' },
         { url: `/_/ingestion/resume/${site}`, method: 'POST' },
         { url: `/_/ingestion/status/${site}`, method: 'GET' },
@@ -115,7 +136,7 @@ describe('BackbeatAPI', () => {
             ]);
         };
 
-        bbapi.getThroughput('', (err, data) => {
+        bbapi.getThroughput({ service: 'crr' }, (err, data) => {
             assert.ifError(err);
 
             assert(data.throughput);


### PR DESCRIPTION
Goes with https://github.com/scality/Arsenal/pull/758

Add ingestion metric routes: throughput, completions, pending

I need to refactor backbeat api.. 😢 