### PR TITLE
feature: ZENKO-1520 transition policies metrics

### DIFF
--- a/extensions/replication/ReplicationMetric.js
+++ b/extensions/replication/ReplicationMetric.js
@@ -1,0 +1,80 @@
+const { Logger } = require('werelogs');
+
+const MetricsModel = require('../../lib/models/MetricsModel');
+
+class ReplicationMetric {
+    constructor() {
+        this._log = new Logger('ReplicationMetric');
+    }
+
+    withProducer(producer) {
+        this._producer = producer;
+        return this;
+    }
+
+    withSite(site) {
+        this._site = site;
+        return this;
+    }
+
+    withObjectSize(objectSize) {
+        this._objectSize = objectSize;
+        return this;
+    }
+
+    /**
+     * Setter for an instance of ActionQueueEntry.
+     * @param {ActionQueueEntry} entry - The entry to publish a metric for
+     * @return {ReplicationMetric} - The current instance
+     */
+    withEntry(entry) {
+        this._entry = entry;
+        return this;
+    }
+
+    withMetricType(type) {
+        this._metricsType = type;
+        return this;
+    }
+
+    withExtension(extension) {
+        this._extension = extension;
+        return this;
+    }
+
+    _isLifecycleAction() {
+        const { origin } = this._entry.getContext();
+        return origin !== undefined && origin === 'lifecycle';
+    }
+
+    _createProducerMessage() {
+        const { bucket, key, version } = this._entry.getAttribute('target');
+        const metricsModel = new MetricsModel()
+            .withBytes(this._objectSize)
+            .withExtension(this._extension)
+            .withMetricType(this._metricsType)
+            .withSite(this._site)
+            .withBucketName(bucket)
+            .withObjectKey(key)
+            .withVersionId(version);
+        return metricsModel.serialize();
+    }
+
+    publish() {
+        // Lifecycle metrics not yet implemented.
+        if (this._isLifecycleAction()) {
+            return undefined;
+        }
+        const message = this._createProducerMessage();
+        return this._producer.send([{ message }], err => {
+            if (err) {
+                this._log.error('error publishing metric', Object.assign({
+                    error: err,
+                    metricsType: this._metricsType,
+                }, this._entry.getLogInfo()));
+            }
+        });
+    }
+}
+
+module.exports = ReplicationMetric;

--- a/lib/MetricsProducer.js
+++ b/lib/MetricsProducer.js
@@ -37,6 +37,10 @@ class MetricsProducer {
         });
     }
 
+    getProducer() {
+        return this._producer;
+    }
+
     /**
      * @param {Object} extMetrics - an object where keys are all sites for a
      *   given extension and values are the metrics for the site

--- a/lib/models/MetricsModel.js
+++ b/lib/models/MetricsModel.js
@@ -26,6 +26,46 @@ class MetricsModel {
         this._versionId = versionId;
     }
 
+    withOps(ops) {
+        this._ops = ops;
+        return this;
+    }
+
+    withBytes(bytes) {
+        this._bytes = bytes;
+        return this;
+    }
+
+    withExtension(extension) {
+        this._extension = extension;
+        return this;
+    }
+
+    withMetricType(type) {
+        this._type = type;
+        return this;
+    }
+
+    withSite(site) {
+        this._site = site;
+        return this;
+    }
+
+    withBucketName(bucketName) {
+        this._bucketName = bucketName;
+        return this;
+    }
+
+    withObjectKey(objectKey) {
+        this._objectKey = objectKey;
+        return this;
+    }
+
+    withVersionId(versionId) {
+        this._versionId = versionId;
+        return this;
+    }
+
     serialize() {
         return JSON.stringify({
             timestamp: this._timestamp,

--- a/tests/unit/ReplicationMetric.js
+++ b/tests/unit/ReplicationMetric.js
@@ -1,0 +1,89 @@
+const assert = require('assert');
+
+const ReplicationMetric =
+    require('../../extensions/replication/ReplicationMetric');
+const ActionQueueEntry = require('../../lib/models/ActionQueueEntry');
+
+const mock = {
+    bytes: 1,
+    extension: 'a',
+    type: 'b',
+    site: 'c',
+    bucketName: 'd',
+    objectKey: 'e',
+    versionId: 'f',
+};
+
+describe('ReplicationMetric', () => {
+    let entry;
+    let metric;
+    let sentMessages;
+
+    function setEntry() {
+        entry = ActionQueueEntry
+            .create()
+            .setAttribute('target', {
+                bucket: mock.bucketName,
+                key: mock.objectKey,
+                version: mock.versionId,
+            });
+    }
+
+    function setReplicationMetric() {
+        const producer = {
+            send: messages => {
+                messages.forEach(message => sentMessages.push(message));
+            }
+        };
+        metric = new ReplicationMetric()
+            .withProducer(producer)
+            .withEntry(entry)
+            .withSite(mock.site)
+            .withObjectSize(mock.bytes)
+            .withMetricType(mock.type)
+            .withExtension(mock.extension);
+    }
+
+    beforeEach(() => {
+        setEntry();
+        setReplicationMetric();
+        sentMessages = [];
+    });
+
+    it('::_createProducerMessage should create a message', () => {
+        const data = JSON.parse(metric._createProducerMessage());
+        Object.keys(mock)
+            .forEach(key => assert.strictEqual(data[key], mock[key]));
+    });
+
+    it('::_isLifecycleAction should return false by default', () => {
+        metric.withEntry(entry);
+        assert.strictEqual(metric._isLifecycleAction(), false);
+    });
+
+    it('::_isLifecycleAction should return true when origin is lifecycle',
+        () => {
+            entry.setAttribute('contextInfo', {
+                origin: 'lifecycle',
+            });
+            metric.withEntry(entry);
+            assert.strictEqual(metric._isLifecycleAction(), true);
+        });
+
+    it('::publish should not send data to topic if lifecycle task', () => {
+        entry.setAttribute('contextInfo', {
+            origin: 'lifecycle',
+        });
+        metric.withEntry(entry);
+        metric.publish();
+        assert.strictEqual(sentMessages.length, 0);
+    });
+
+    it('::publish should send data to topic', () => {
+        metric.publish();
+        assert.strictEqual(sentMessages.length, 1);
+        const data = JSON.parse(sentMessages[0].message);
+        Object.keys(mock)
+            .forEach(key => assert.strictEqual(data[key], mock[key]));
+    });
+});

--- a/tests/unit/lib/models/MetricsModel.js
+++ b/tests/unit/lib/models/MetricsModel.js
@@ -1,0 +1,52 @@
+const assert = require('assert');
+
+const MetricsModel = require('../../../../lib/models/MetricsModel');
+
+const mock = {
+    ops: 1,
+    bytes: 1,
+    extension: 'a',
+    type: 'b',
+    site: 'c',
+    bucketName: 'd',
+    objectKey: 'e',
+    versionId: 'f',
+};
+
+describe('MetricsModel', () => {
+    it('should set a timestamp when instantiated', () => {
+        const metrics = new MetricsModel();
+        const data = JSON.parse(metrics.serialize());
+        assert(data.timestamp);
+    });
+
+    it('should serialize data when values passed to constructor', () => {
+        const metrics = new MetricsModel(
+            mock.ops,
+            mock.bytes,
+            mock.extension,
+            mock.type,
+            mock.site,
+            mock.bucketName,
+            mock.objectKey,
+            mock.versionId);
+        const data = JSON.parse(metrics.serialize());
+        Object.keys(mock)
+            .forEach(key => assert.strictEqual(data[key], mock[key]));
+    });
+
+    it('should serialize data when values passed to setters', () => {
+        const metrics = new MetricsModel()
+            .withOps(mock.ops)
+            .withBytes(mock.bytes)
+            .withExtension(mock.extension)
+            .withMetricType(mock.type)
+            .withSite(mock.site)
+            .withBucketName(mock.bucketName)
+            .withObjectKey(mock.objectKey)
+            .withVersionId(mock.versionId);
+        const data = JSON.parse(metrics.serialize());
+        Object.keys(mock)
+            .forEach(key => assert.strictEqual(data[key], mock[key]));
+    });
+});


### PR DESCRIPTION
Introduce a metric handler specifically for action entries. This behaves the same as the current metrics producer but does not process metrics during a lifecycle task, thereby preventing replication metrics pollution.