### PR TITLE
feature: ZENKO-1387 filter transition entries

### DIFF
--- a/extensions/replication/utils/ReplicationTaskScheduler.js
+++ b/extensions/replication/utils/ReplicationTaskScheduler.js
@@ -1,24 +1,58 @@
 const async = require('async');
 
+const ObjectQueueEntry = require('../../../lib/models/ObjectQueueEntry');
+const ActionQueueEntry = require('../../../lib/models/ActionQueueEntry');
+
 /**
- * Schedule replication tasks for replicated buckets, by ensuring that
- * all updates to the same object are serialized
-*/
+ * Schedule replication tasks by ensuring that all updates to the same object
+ * are serialized. Any etnries that are duplicates (i.e. they have the same
+ * key, version, and content MD5) are skipped.
+ */
 class ReplicationTaskScheduler {
     constructor(processingFunc) {
         this._processingFunc = processingFunc;
         this._runningTasksByMasterKey = {};
+        this._runningTasks = {};
+    }
+
+    _getTaskKey(ctx) {
+        const { entry } = ctx;
+        if (entry instanceof ObjectQueueEntry) {
+            const key = entry.getCanonicalKey();
+            const version = entry.getVersionId();
+            const contentMd5 = entry.getContentMd5();
+            return `${key}:${version || ''}:${contentMd5}`;
+        }
+        if (entry instanceof ActionQueueEntry) {
+            const { key, version, contentMd5 } = entry.getAttribute('target');
+            return `${key}:${version || ''}:${contentMd5}`;
+        }
+        return undefined;
+    }
+
+    _getNewMasterKeyQueue(ctx, masterKey) {
+        const queue = async.queue(this._processingFunc);
+        queue.drain = () => delete this._runningTasksByMasterKey[masterKey];
+        this._runningTasksByMasterKey[masterKey] = queue;
+        return queue;
+    }
+
+    _getMasterKeyQueue(ctx, masterKey) {
+        const queue = this._runningTasksByMasterKey[masterKey];
+        return queue || this._getNewMasterKeyQueue(ctx, masterKey);
     }
 
     push(ctx, masterKey, done) {
-        let queue = this._runningTasksByMasterKey[masterKey];
-        if (queue === undefined) {
-            queue = async.queue(this._processingFunc);
-            queue.drain =
-                () => delete this._runningTasksByMasterKey[masterKey];
-            this._runningTasksByMasterKey[masterKey] = queue;
+        const taskKey = this._getTaskKey(ctx);
+        if (taskKey === undefined || this._runningTasks[taskKey]) {
+            return done();
         }
-        queue.push(ctx, done);
+        this._runningTasks[taskKey] = true;
+        const queue = this._getMasterKeyQueue(ctx, masterKey);
+        return queue.push(ctx, () => {
+            delete this._runningTasks[taskKey];
+            done();
+        });
     }
 }
 


### PR DESCRIPTION
Prevent processing of duplicate lifecycle tasks. E.g. in the scenario where an object from a previous cron task has not finished the transition, the same object should not be queued again (unless the source data has been overwritten).