### PR TITLE
rf: ZENKO-1566 adjust metrics consumer

### DIFF
--- a/extensions/ingestion/constants.js
+++ b/extensions/ingestion/constants.js
@@ -7,6 +7,7 @@ const constants = {
         testIsOn ? '/backbeattest/ingestion' : '/backbeat/ingestion',
     zkStatePath: '/state',
     zkStateProperties: ['paused', 'scheduledResume'],
+    metricsExtension: 'ingestion',
     redisKeys: {
         opsDone: testIsOn ? 'test:bb:opsdone' : 'bb:ingestion:opsdone',
         bytesDone: testIsOn ? 'test:bb:bytesdone' : 'bb:ingestion:bytesdone',

--- a/lib/MetricsConsumer.js
+++ b/lib/MetricsConsumer.js
@@ -2,9 +2,17 @@
 
 const Logger = require('werelogs').Logger;
 const { RedisClient, StatsModel } = require('arsenal').metrics;
+const errors = require('arsenal').errors;
 
 const BackbeatConsumer = require('./BackbeatConsumer');
-const redisKeys = require('../extensions/replication/constants').redisKeys;
+const {
+    redisKeys: crrRedisKeys,
+    metricsExtension: crrExtension,
+} = require('../extensions/replication/constants');
+const {
+    redisKeys: ingestionRedisKeys,
+    metricsExtension: ingestionExtension,
+} = require('../extensions/ingestion/constants');
 
 // StatsClient constant defaults for site metrics
 const INTERVAL = 300; // 5 minutes;
@@ -25,10 +33,12 @@ class MetricsConsumer {
      * @param {object} kafkaConfig - kafka configurations
      * @param {string} kafkaConfig.hosts - kafka hosts
      *   as "host:port[/chroot]"
+     * @param {string} id - identifier used for filtering metrics entries
      */
-    constructor(rConfig, mConfig, kafkaConfig) {
+    constructor(rConfig, mConfig, kafkaConfig, id) {
         this.mConfig = mConfig;
         this.kafkaConfig = kafkaConfig;
+        this._id = id;
 
         this.logger = new Logger('Backbeat:MetricsConsumer');
         const redisClient = new RedisClient(rConfig, this.logger);
@@ -40,7 +50,7 @@ class MetricsConsumer {
         const consumer = new BackbeatConsumer({
             kafka: { hosts: this.kafkaConfig.hosts },
             topic: this.mConfig.topic,
-            groupId: 'backbeat-metrics-group',
+            groupId: `backbeat-metrics-group-${this._id}`,
             concurrency: CONCURRENCY,
             queueProcessor: this.processKafkaEntry.bind(this),
             fetchMaxBytes: CONSUMER_FETCH_MAX_BYTES,
@@ -58,43 +68,76 @@ class MetricsConsumer {
         });
     }
 
+    _getRedisKeys(extension) {
+        switch (extension) {
+            case crrExtension: return crrRedisKeys;
+            case ingestionExtension: return ingestionRedisKeys;
+            default:
+                throw errors.InternalError.customizeDescription(
+                    `${extension} is not a valid extension`);
+        }
+    }
+
     _sendSiteLevelRequests(data) {
-        const { type, site, ops, bytes } = data;
+        const { type, site, ops, bytes, extension } = data;
+        let redisKeys;
+        try {
+            redisKeys = this._getRedisKeys(extension);
+        } catch (err) {
+            return this.logger.error('error consuming metric entry', {
+                method: 'MetricsConsumer._sendSiteLevelRequests',
+                site,
+                type,
+            });
+        }
         if (type === 'completed') {
-            this._statsClient
-                .decrementKey(`${site}:${redisKeys.opsPending}`, ops);
-            this._statsClient
-                .decrementKey(`${site}:${redisKeys.bytesPending}`, bytes);
-            this._sendRequest(`${site}:${redisKeys.opsDone}`, ops);
-            this._sendRequest(`${site}:${redisKeys.bytesDone}`, bytes);
+            // Pending metrics
+            this._sendRequest('decrementKey', site, redisKeys, 'opsPending',
+                ops);
+            this._sendRequest('decrementKey', site, redisKeys, 'bytesPending',
+                bytes);
+            // Other metrics
+            this._sendRequest('reportNewRequest', site, redisKeys, 'opsDone',
+                ops);
+            this._sendRequest('reportNewRequest', site, redisKeys, 'bytesDone',
+                bytes);
         } else if (type === 'failed') {
-            this._statsClient
-                .decrementKey(`${site}:${redisKeys.opsPending}`, ops);
-            this._statsClient
-                .decrementKey(`${site}:${redisKeys.bytesPending}`, bytes);
-            this._sendRequest(`${site}:${redisKeys.opsFail}`, ops);
-            this._sendRequest(`${site}:${redisKeys.bytesFail}`, bytes);
+            // Pending metrics
+            this._sendRequest('decrementKey', site, redisKeys, 'opsPending',
+                ops);
+            this._sendRequest('decrementKey', site, redisKeys, 'bytesPending',
+                bytes);
+            // Other metrics
+            this._sendRequest('reportNewRequest', site, redisKeys, 'opsFail',
+                ops);
+            this._sendRequest('reportNewRequest', site, redisKeys, 'bytesFail',
+                bytes);
         } else if (type === 'queued') {
-            this._statsClient
-                .incrementKey(`${site}:${redisKeys.opsPending}`, ops);
-            this._statsClient
-                .incrementKey(`${site}:${redisKeys.bytesPending}`, bytes);
-            this._sendRequest(`${site}:${redisKeys.ops}`, ops);
-            this._sendRequest(`${site}:${redisKeys.bytes}`, bytes);
+            // Pending metrics
+            this._sendRequest('incrementKey', site, redisKeys, 'opsPending',
+                ops);
+            this._sendRequest('incrementKey', site, redisKeys, 'bytesPending',
+                bytes);
+            // Other metrics
+            this._sendRequest('reportNewRequest', site, redisKeys, 'ops', ops);
+            this._sendRequest('reportNewRequest', site, redisKeys, 'bytes',
+                bytes);
         }
         return undefined;
     }
 
     _sendObjectLevelRequests(data) {
-        const { type, site, bytes, bucketName, objectKey, versionId } = data;
+        const { type, site, bytes, extension,
+                bucketName, objectKey, versionId } = data;
+        const redisKeys = this._getRedisKeys(extension);
         if (type === 'completed') {
             const key = `${site}:${bucketName}:${objectKey}:` +
                 `${versionId}:${redisKeys.objectBytesDone}`;
-            this._sendRequest(key, bytes);
+            this._sendObjectRequest(key, bytes);
         } else if (type === 'queued') {
             const key = `${site}:${bucketName}:${objectKey}:` +
                 `${versionId}:${redisKeys.objectBytes}`;
-            this._sendRequest(key, bytes);
+            this._sendObjectRequest(key, bytes);
         }
         return undefined;
     }
@@ -121,6 +164,10 @@ class MetricsConsumer {
                 type: 'processed'
             }
         */
+        // filter metric entries by service, i.e. 'crr', 'ingestion'
+        if (this._id !== data.extension) {
+            return done();
+        }
         const operationTypes = ['completed', 'failed', 'queued'];
         const isValidType = operationTypes.includes(data.type);
         if (!isValidType) {
@@ -141,7 +188,14 @@ class MetricsConsumer {
         return done();
     }
 
-    _sendRequest(key, value) {
+    _sendRequest(action, site, redisKeys, keyType, value) {
+        if (redisKeys[keyType]) {
+            this._statsClient[action](`${site}:${redisKeys[keyType]}`,
+                value || 0);
+        }
+    }
+
+    _sendObjectRequest(key, value) {
         this._statsClient.reportNewRequest(key, value);
     }
 }

--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -8,6 +8,7 @@ const zookeeper = require('../clients/zookeeper');
 const IngestionReader = require('./IngestionReader');
 const MetricsProducer = require('../MetricsProducer');
 const MetricsConsumer = require('../MetricsConsumer');
+const { metricsExtension } = require('../../extensions/ingestion/constants');
 
 class IngestionPopulator {
     /**
@@ -107,7 +108,7 @@ class IngestionPopulator {
     _setupMetricsClients(cb) {
         // Metrics Consumer
         this._mConsumer = new MetricsConsumer(this.rConfig, this.mConfig,
-            this.kafkaConfig);
+            this.kafkaConfig, metricsExtension);
         this._mConsumer.start();
 
         // Metrics Producer

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -11,6 +11,7 @@ const MetricsConsumer = require('../MetricsConsumer');
 const FailedCRRConsumer =
     require('../../extensions/replication/failedCRR/FailedCRRConsumer');
 const MongoLogReader = require('./MongoLogReader');
+const { metricsExtension } = require('../../extensions/replication/constants');
 
 class QueuePopulator {
     /**
@@ -118,7 +119,7 @@ class QueuePopulator {
     _setupMetricsClients(cb) {
         // Metrics Consumer
         this._mConsumer = new MetricsConsumer(this.rConfig,
-            this.mConfig, this.kafkaConfig);
+            this.mConfig, this.kafkaConfig, metricsExtension);
         this._mConsumer.start();
 
         // Metrics Producer


### PR DESCRIPTION
The reason for a few of the changes here is to adapt to adding ingestion populator metrics. This means that metric entries need to be filtered by their given populator. The filter is done on each MetricsConsumer, and each MetricsConsumer is created by each QueuePopulator.

Helper method for reporting site-level metrics to StatsClient was adjusted to first check if the Redis key exists for the given populator and then check if the value is a non zero to avoid reporting empty metrics.

Plan is to add another MetricsConsumer on IngestionPopulator that reports pending metrics.