### PR TITLE
bugfix: ZENKO-1582 check ETag before updating md on transition

### DIFF
--- a/extensions/lifecycle/tasks/LifecycleDeleteObjectTask.js
+++ b/extensions/lifecycle/tasks/LifecycleDeleteObjectTask.js
@@ -9,12 +9,12 @@ class LifecycleDeleteObjectTask extends BackbeatTask {
      * Process a lifecycle object entry
      *
      * @constructor
-     * @param {QueueProcessor} qp - queue processor instance
+     * @param {LifecycleObjectProcessor} proc - object processor instance
      */
-    constructor(qp) {
-        const qpState = qp.getStateVars();
+    constructor(proc) {
+        const procState = proc.getStateVars();
         super();
-        Object.assign(this, qpState);
+        Object.assign(this, procState);
     }
 
     _checkDate(entry, log, done) {

--- a/tests/unit/lifecycle/LifecycleUpdateTransitionTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleUpdateTransitionTask.spec.js
@@ -1,0 +1,140 @@
+const assert = require('assert');
+const werelogs = require('werelogs');
+
+const { ObjectMD } = require('arsenal').models;
+const ActionQueueEntry = require('../../../lib/models/ActionQueueEntry');
+const LifecycleUpdateTransitionTask = require(
+    '../../../extensions/lifecycle/tasks/LifecycleUpdateTransitionTask');
+
+class GarbageCollectorProducerMock {
+    constructor() {
+        this.receivedEntry = null;
+    }
+
+    publishActionEntry(gcEntry, done) {
+        this.receivedEntry = gcEntry;
+        return done();
+    }
+
+    getReceivedEntry() {
+        return this.receivedEntry;
+    }
+}
+
+
+class BackbeatClientMock {
+    constructor() {
+        this.mdObj = null;
+        this.receivedMd = null;
+    }
+
+    setMdObj(mdObj) {
+        this.mdObj = mdObj;
+    }
+
+    getMetadata(params, log, cb) {
+        return cb(null, { Body: this.mdObj.getSerialized() });
+    }
+
+    putMetadata(params, log, cb) {
+        this.receivedMd = JSON.parse(params.mdBlob);
+        return cb();
+    }
+
+    getReceivedMd() {
+        return this.receivedMd;
+    }
+}
+
+class LifecycleObjectProcessorMock {
+    constructor(backbeatClient, gcProducer) {
+        this.backbeatClient = backbeatClient;
+        this.gcProducer = gcProducer;
+        this.logger = new werelogs.Logger('test:LifecycleUpdateTransitionTask');
+    }
+
+    getStateVars() {
+        return {
+            backbeatClient: this.backbeatClient,
+            gcProducer: this.gcProducer,
+            logger: this.logger,
+        };
+    }
+}
+
+describe('LifecycleUpdateTransitionTask', () => {
+    let backbeatClient;
+    let gcProducer;
+    let objectProcessor;
+    let mdObj;
+    let actionEntry;
+    let oldLocation;
+    let newLocation;
+    let task;
+    beforeEach(() => {
+        oldLocation = [{
+            key: 'oldLocationKey',
+            size: 10,
+            start: 0,
+            dataStoreName: 'oldLocationName',
+            dataStoreType: 'aws_s3',
+            dataStoreETag: 'oldETag',
+            dataStoreVersionId: 'oldVersionId',
+        }];
+        newLocation = [{
+            key: 'newLocationKey',
+            size: 20,
+            start: 0,
+            dataStoreName: 'newLocationName',
+            dataStoreType: 'gcp',
+            dataStoreETag: 'newETag',
+            dataStoreVersionId: 'newVersionId',
+        }];
+
+        backbeatClient = new BackbeatClientMock();
+        gcProducer = new GarbageCollectorProducerMock();
+        objectProcessor = new LifecycleObjectProcessorMock(
+            backbeatClient, gcProducer);
+        mdObj = new ObjectMD();
+        mdObj.setLocation(oldLocation)
+            .setContentMd5('1ccc7006b902a4d30ec26e9ddcf759d8');
+        backbeatClient.setMdObj(mdObj);
+        actionEntry = ActionQueueEntry.create('copyLocation')
+            .setAttribute('target', {
+                bucket: 'somebucket',
+                key: 'somekey',
+                eTag: '"1ccc7006b902a4d30ec26e9ddcf759d8"',
+            })
+            .setSuccess({ location: newLocation });
+        task = new LifecycleUpdateTransitionTask(objectProcessor);
+    });
+
+    it('should transition location in metadata', done => {
+        task.processActionEntry(actionEntry, err => {
+            assert.ifError(err);
+            const receivedMd = backbeatClient.getReceivedMd();
+            assert.deepStrictEqual(receivedMd.location, newLocation);
+            const receivedGcEntry = gcProducer.getReceivedEntry();
+            assert.strictEqual(receivedGcEntry.getActionType(), 'deleteData');
+            assert.deepStrictEqual(
+                receivedGcEntry.getAttribute('target.locations'), oldLocation);
+            done();
+        });
+    });
+
+    it('should not transition location in metadata and should GC new ' +
+    'location if eTag does not match', done => {
+        actionEntry.setAttribute('target.eTag',
+                                 '"6713e7cf89b6b16d5abf11d1fabac587"');
+        task.processActionEntry(actionEntry, err => {
+            assert.ifError(err);
+            const receivedMd = backbeatClient.getReceivedMd();
+            assert.strictEqual(receivedMd, null);
+            const receivedGcEntry = gcProducer.getReceivedEntry();
+            assert.strictEqual(receivedGcEntry.getActionType(), 'deleteData');
+            assert.deepStrictEqual(
+                receivedGcEntry.getAttribute('target.locations'), newLocation);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
If ETag does not match between transition action and object metadata,
skip update and garbage-collect the new location. This is to cover the
race condition that exists on non-versioned source bucket if a user
modifies the object while it is being transitioned, that would lead to
losing the latest write if updating the metadata anyway.

Add basic unit test coverage for object processor.