### PR TITLE
ft: ZENKO-1566 ingestion metrics producer/consumer

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -50,6 +50,7 @@
                     "port": 8000,
                     "https": false,
                     "type": "scality_s3",
+                    "locationConstraint": "a-zenko-location",
                     "auth": {
                         "accessKey": "myAccessKey",
                         "secretKey": "myEncryptedSecretKey"

--- a/extensions/ingestion/IngestionQueuePopulator.js
+++ b/extensions/ingestion/IngestionQueuePopulator.js
@@ -24,6 +24,37 @@ class IngestionQueuePopulator extends QueuePopulatorExtension {
         this.publish(this.config.topic,
                      `${entry.bucket}/${entry.key}`,
                      JSON.stringify(entry));
+
+        this._incrementMetrics(entry.bucket);
+    }
+
+    /**
+     * Get currently stored metrics for given bucket and reset its counter
+     * @param {String} bucket - zenko bucket name
+     * @return {Integer} metrics accumulated since last called
+     */
+    getAndResetMetrics(bucket) {
+        const tempStore = this._metricsStore[bucket];
+        if (tempStore === undefined) {
+            return undefined;
+        }
+        this._metricsStore[bucket] = {};
+        return tempStore;
+    }
+
+    /**
+     * Set or accumulate metrics based on bucket
+     * @param {String} bucket - Zenko bucket name
+     * @return {undefined}
+     */
+    _incrementMetrics(bucket) {
+        if (!this._metricsStore[bucket]) {
+            this._metricsStore[bucket] = {
+                ops: 1,
+            };
+        } else {
+            this._metricsStore[bucket].ops++;
+        }
     }
 }
 

--- a/extensions/ingestion/constants.js
+++ b/extensions/ingestion/constants.js
@@ -8,6 +8,8 @@ const constants = {
     zkStatePath: '/state',
     zkStateProperties: ['paused', 'scheduledResume'],
     metricsExtension: 'ingestion',
+    metricsTypeQueued: 'queued',
+    metricsTypeCompleted: 'completed',
     redisKeys: {
         opsDone: testIsOn ? 'test:bb:opsdone' : 'bb:ingestion:opsdone',
         bytesDone: testIsOn ? 'test:bb:bytesdone' : 'bb:ingestion:bytesdone',

--- a/extensions/mongoProcessor/mongoProcessorTask.js
+++ b/extensions/mongoProcessor/mongoProcessorTask.js
@@ -9,6 +9,7 @@ const { initManagement } = require('../../lib/management/index');
 
 const kafkaConfig = config.kafka;
 const s3Config = config.s3;
+const mConfig = config.metrics;
 const mongoProcessorConfig = config.extensions.mongoProcessor;
 // TODO: consider whether we would want a separate mongo config
 // for the consumer side
@@ -40,7 +41,7 @@ function updateProcessors(bootstrapList) {
             // add new processor, site is new and requires setup
             const mqp = new MongoQueueProcessor(kafkaConfig, s3Config,
                 mongoProcessorConfig, mongoClientConfig,
-                ingestionServiceAuth, site);
+                ingestionServiceAuth, mConfig, site);
             mqp.start();
             activeProcessors[site] = mqp;
         }
@@ -61,7 +62,7 @@ function loadProcessors() {
     siteNames.forEach(site => {
         const mqp = new MongoQueueProcessor(kafkaConfig, s3Config,
             mongoProcessorConfig, mongoClientConfig,
-            ingestionServiceAuth, site);
+            ingestionServiceAuth, mConfig, site);
         mqp.start();
         activeProcessors[site] = mqp;
     });

--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -6,8 +6,8 @@ const Logger = require('werelogs').Logger;
 const config = require('../../conf/Config');
 const zookeeper = require('../clients/zookeeper');
 const IngestionReader = require('./IngestionReader');
-const MetricsProducer = require('../MetricsProducer');
 const MetricsConsumer = require('../MetricsConsumer');
+const MetricsProducer = require('../MetricsProducer');
 const { metricsExtension } = require('../../extensions/ingestion/constants');
 
 class IngestionPopulator {
@@ -170,7 +170,7 @@ class IngestionPopulator {
     _getNewSourceInformation(ingestionInfo) {
         const {
             accessKey, secretKey, endpoint, locationType,
-            bucketName, zenkoBucket,
+            bucketName, zenkoBucket, locationConstraint,
         } = ingestionInfo;
 
         const urlObject = url.parse(endpoint);
@@ -187,6 +187,7 @@ class IngestionPopulator {
             port: parseInt(urlObject.port, 10) || 80,
             https: urlObject.protocol.startsWith('https'),
             type: locationType,
+            locationConstraint,
             auth,
         };
     }

--- a/lib/queuePopulator/IngestionReader.js
+++ b/lib/queuePopulator/IngestionReader.js
@@ -6,6 +6,10 @@ const VID_SEP = require('arsenal').versioning.VersioningConstants
 const IngestionProducer = require('./IngestionProducer');
 const LogReader = require('./LogReader');
 const { decryptLocationSecret } = require('../management/index');
+const {
+    metricsExtension,
+    metricsTypeQueued
+} = require('../../extensions/ingestion/constants');
 
 function _isVersionedLogKey(key) {
     return key.split(VID_SEP)[1] !== undefined;
@@ -374,7 +378,13 @@ class IngestionReader extends LogReader {
                 batchState.publishedEntries[topic] = topicEntries;
                 return done();
             });
-        }, done);
+        }, err => {
+            if (err) {
+                return done(err);
+            }
+            this._publishMetrics();
+            return done();
+        });
     }
 
     _processSaveLogOffset(batchState, done) {
@@ -395,12 +405,28 @@ class IngestionReader extends LogReader {
         ], done);
     }
 
+    _publishMetrics() {
+        // Ingestion extensions is a single IngestionQueuePopulatorExt
+        const extension = this._extensions[0];
+        const location = this.getLocationConstraint();
+        const metric = extension.getAndResetMetrics(this._targetZenkoBucket);
+        if (metric && metric.ops > 0) {
+            const value = { [location]: metric };
+            this._mProducer.publishMetrics(value, metricsTypeQueued,
+                metricsExtension, () => {});
+        }
+    }
+
     getLogInfo() {
         return { raftId: this.raftId };
     }
 
     getTargetZenkoBucketName() {
         return this._targetZenkoBucket;
+    }
+
+    getLocationConstraint() {
+        return this.bucketdConfig.locationConstraint;
     }
 }
 

--- a/tests/config.json
+++ b/tests/config.json
@@ -45,6 +45,7 @@
                     "port": 7998,
                     "https": false,
                     "type": "scality_s3",
+                    "locationConstraint": "a-zenko-location",
                     "auth": {
                         "accessKey": "accessKey1",
                         "secretKey": "o7Q9X25qRv9KNYUewzlXAmfUmnOycFT9yTdgfk5IMntV8kEg4+mqEYl3QhAXyrCw22vbxvSzgdtjh+YhcZBIC6BL/AWurIh5MZyktbaSQabM3ZobTGuEet+qjog0I6Dr9tjHhxM1tfcOdN5Hy2lQk9LTW5uj2/7rtF6jLn5E1HLEn25sAAy60qPqMjBt+pQ0l6Y4JQ6dymZFCv/lZluEQ2mCdH0WlfDh4ZLcNC0KslwjQVJA4kPS5ydE88bB5m5BMscvzMeeRWkObHwdxnu6xN/YJqXvsx05NIC/G4ioeKdoQrBfuRvhlU1MhoCB/+yESdbVRLoM1MppEKkxQbQLTw=="
@@ -57,6 +58,7 @@
                     "port": 7998,
                     "https": false,
                     "type": "scality_s3",
+                    "locationConstraint": "a-zenko-location",
                     "auth": {
                         "accessKey": "accessKey1",
                         "secretKey": "o7Q9X25qRv9KNYUewzlXAmfUmnOycFT9yTdgfk5IMntV8kEg4+mqEYl3QhAXyrCw22vbxvSzgdtjh+YhcZBIC6BL/AWurIh5MZyktbaSQabM3ZobTGuEet+qjog0I6Dr9tjHhxM1tfcOdN5Hy2lQk9LTW5uj2/7rtF6jLn5E1HLEn25sAAy60qPqMjBt+pQ0l6Y4JQ6dymZFCv/lZluEQ2mCdH0WlfDh4ZLcNC0KslwjQVJA4kPS5ydE88bB5m5BMscvzMeeRWkObHwdxnu6xN/YJqXvsx05NIC/G4ioeKdoQrBfuRvhlU1MhoCB/+yESdbVRLoM1MppEKkxQbQLTw=="
@@ -69,6 +71,7 @@
                     "port": 7998,
                     "https": false,
                     "type": "scality_s3",
+                    "locationConstraint": "a-zenko-location",
                     "auth": {
                         "accessKey": "accessKey1",
                         "secretKey": "o7Q9X25qRv9KNYUewzlXAmfUmnOycFT9yTdgfk5IMntV8kEg4+mqEYl3QhAXyrCw22vbxvSzgdtjh+YhcZBIC6BL/AWurIh5MZyktbaSQabM3ZobTGuEet+qjog0I6Dr9tjHhxM1tfcOdN5Hy2lQk9LTW5uj2/7rtF6jLn5E1HLEn25sAAy60qPqMjBt+pQ0l6Y4JQ6dymZFCv/lZluEQ2mCdH0WlfDh4ZLcNC0KslwjQVJA4kPS5ydE88bB5m5BMscvzMeeRWkObHwdxnu6xN/YJqXvsx05NIC/G4ioeKdoQrBfuRvhlU1MhoCB/+yESdbVRLoM1MppEKkxQbQLTw=="

--- a/tests/functional/ingestion/IngestionReader.js
+++ b/tests/functional/ingestion/IngestionReader.js
@@ -188,6 +188,7 @@ describe('ingestion reader tests with mock', function fD() {
                 qpConfig: testConfig.queuePopulator,
                 logger: dummyLogger,
                 extensions: [ingestionQP],
+                metricsProducer: { publishMetrics: () => {} },
                 s3Config: testConfig.s3,
                 bucket: testConfig.extensions.ingestion.sources[0].bucket,
             });
@@ -322,6 +323,7 @@ describe('ingestion reader tests with mock', function fD() {
                 qpConfig: testConfig.queuePopulator,
                 logger: dummyLogger,
                 extensions: [ingestionQP],
+                metricsProducer: { publishMetrics: () => {} },
                 s3Config: testConfig.s3,
                 bucket: sourceConfig.bucket,
             });


### PR DESCRIPTION
Relies on https://github.com/scality/backbeat/pull/645

This PR introduces metrics data accumulation used for completions, throughput, and pending metrics. A metrics producer exists on both IngestionPopulator and MongoQueueProcessor. A metrics consumer exists on IngestionPopulator.

Ingestion needs to overwrite `QueuePopulatorExtension` methods `getAndResetMetrics` and `_incrementMetrics` to only report ops and to avoid reporting to `monitoringClient`.

