### PR TITLE
bugfix: ZENKO-1582 skip update if new location == old location

### DIFF
--- a/tests/unit/lifecycle/LifecycleUpdateTransitionTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleUpdateTransitionTask.spec.js
@@ -137,4 +137,17 @@ describe('LifecycleUpdateTransitionTask', () => {
             done();
         });
     });
+
+    it('should not update metadata nor GC anything if location does not change',
+    done => {
+        mdObj.setLocation(newLocation);
+        task.processActionEntry(actionEntry, err => {
+            assert.ifError(err);
+            const receivedMd = backbeatClient.getReceivedMd();
+            assert.strictEqual(receivedMd, null);
+            const receivedGcEntry = gcProducer.getReceivedEntry();
+            assert.strictEqual(receivedGcEntry, null);
+            done();
+        });
+    });
 });


### PR DESCRIPTION
It's possible to get duplicate updates, not always because of kafka
delivering duplicate messages, but also if a duplicate copy occurred
(possible even if we reduced the risk by deduplicating in the queue
processor).

In such case we need to skip the GC of the location otherwise we lose
the valid data.

Note that it's normally more likely to happen if the target is non-versioned (e.g. Azure bucket). But it also covers duplicate cases that may happen with versioned targets as well.