### PR TITLE
ft: ZENKO-1441 allow updating ingestion locations

### DIFF
--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -411,9 +411,10 @@ class IngestionPopulator {
 
     /**
      * Apply updates when ingestion buckets are updated in Config
+     * @param {Function} cb - callback(error)
      * @return {undefined}
      */
-    applyUpdates() {
+    applyUpdates(cb) {
         // Example buckets param object:
         // [
         //      {
@@ -430,36 +431,47 @@ class IngestionPopulator {
         const buckets = config.getIngestionBuckets();
 
         const configuredSources = Object.keys(this._ingestionSources);
-        buckets.forEach(bucketInfo => {
-            const { zenkoBucket } = bucketInfo;
+        return async.each(buckets, (bucket, next) => {
+            const { zenkoBucket } = bucket;
             // if the zenko bucket has already been setup and is already
             // active, stop tracking bucket from `currentActiveSources`
             const isAlreadyActive =
                 configuredSources.indexOf(zenkoBucket) >= 0;
             if (isAlreadyActive) {
+                // Get ingestion source information
+                const sourceInfo = this._getSourceInformation(bucket);
+                // remove from currentActiveSources
                 configuredSources.splice(
                     configuredSources.indexOf(zenkoBucket), 1);
-                return;
+                // check/refresh the IngestionReader if any changes
+                return this._ingestionSources[zenkoBucket].refresh(
+                    sourceInfo, next);
             }
-            // Add new ingestion source
-            const newSourceInfo = this._getNewSourceInformation(bucketInfo);
-            this.addNewLogSource(newSourceInfo);
-        });
 
-        // Any leftover `currentActiveSources` are no longer active and
-        // must be removed.
-        configuredSources.forEach(source => {
-            this.closeLogState(source);
+            // Get ingestion source information
+            const sourceInfo = this._getSourceInformation(bucket);
+            this.addNewLogSource(sourceInfo);
+            return next();
+        }, err => {
+            if (err) {
+                return cb(err);
+            }
+            // Any leftover `currentActiveSources` are no longer active and
+            // must be removed.
+            configuredSources.forEach(source => {
+                this.closeLogState(source);
+            });
+            return cb();
         });
     }
 
     /**
-     * Get necessary information for setting up a new IngestionReader and form
-     * as single object
+     * Get necessary information for setting up a new IngestionReader or
+     * updating an existing IngestionReader
      * @param {Object} ingestionInfo - ingestion bucket/location info
      * @return {Object} new source config details
      */
-    _getNewSourceInformation(ingestionInfo) {
+    _getSourceInformation(ingestionInfo) {
         const {
             accessKey, secretKey, endpoint, locationType,
             bucketName, zenkoBucket, locationConstraint,

--- a/lib/queuePopulator/IngestionReader.js
+++ b/lib/queuePopulator/IngestionReader.js
@@ -419,6 +419,47 @@ class IngestionReader extends LogReader {
         }
     }
 
+
+    /**
+     * Bucket configs have user editable fields: credentials, endpoint
+     * This method will detect if a change has occurred. If a change occurred,
+     * update relevant instance variables and reinstantiate any clients
+     * affected by the change.
+     * @param {Object} sourceInfo - latest bucketdConfig information
+     * @param {Function} done - callback(error)
+     * @return {undefined}
+     */
+    refresh(sourceInfo, done) {
+        const bucketdConfig = this._getEditableFields(this.bucketdConfig);
+        const latestBucketdConfig = this._getEditableFields(sourceInfo);
+        const updated = bucketdConfig !== latestBucketdConfig;
+
+        if (updated) {
+            // update instance variables
+            this.bucketdConfig = sourceInfo;
+            // update clients
+            return this._setupIngestionProducer(done);
+        }
+        return done();
+    }
+
+    /**
+     * Helper method to fetch an bucketdConfig object of only editable fields
+     * following a specific format.
+     * Editable fields: auth.accessKey, auth.secretKey, host, port, https
+     * @param {Object} info - bucketdConfig information
+     * @return {String} editableInfo as a string
+     */
+    _getEditableFields(info) {
+        return JSON.stringify({
+            accessKey: info.auth && info.auth.accessKey,
+            secretKey: info.auth && info.auth.secretKey,
+            host: info.host,
+            port: info.port,
+            https: info.https,
+        });
+    }
+
     getLogInfo() {
         return { raftId: this.raftId };
     }

--- a/tests/functional/ingestion/pauseResumeState.js
+++ b/tests/functional/ingestion/pauseResumeState.js
@@ -222,16 +222,19 @@ describe('Ingestion Pause/Resume', function d() {
     });
 
     beforeEach(done => {
-        this.iPopulator.open(err => {
+        const firstLocation = firstBucket.locationConstraint;
+        const secondLocation = secondBucket.locationConstraint;
+        async.series([
+            next => this.iPopulator.open(next),
+            next => {
+                this.iPopulator._resumeService(firstLocation);
+                this.iPopulator._pauseService(secondLocation);
+                return this.iPopulator.applyUpdates(next);
+            },
+        ], err => {
             if (err) {
                 return done(err);
             }
-            const firstLocation = firstBucket.locationConstraint;
-            const secondLocation = secondBucket.locationConstraint;
-            this.iPopulator._resumeService(firstLocation);
-            this.iPopulator._pauseService(secondLocation);
-            this.iPopulator.applyUpdates();
-
             let pausedList = this.iPopulator.getPausedLocations();
             return async.whilst(() =>
                 Object.keys(pausedList).includes(firstLocation) ||


### PR DESCRIPTION
Sits on top of https://github.com/scality/backbeat/pull/617

If changes to a storage location are made on an s3c ingestion location, we should detect these changes and apply them.

Changes in this PR:
- Add a method to check existing IngestionReaders'
  bucketdConfig information for any changes. If an
  update occurred, we want to update relevant, impacted
  instance variables and re-create IngestionProducer clients
- Update tests to check if updates are fetched properly