### PR TITLE
bf: ZENKO-1593 queue object pending metric

### DIFF
--- a/extensions/replication/tasks/MultipleBackendTask.js
+++ b/extensions/replication/tasks/MultipleBackendTask.js
@@ -665,6 +665,10 @@ class MultipleBackendTask extends ReplicateObject {
 
     _getAndPutObject(sourceEntry, log, cb) {
         const partLogger = this.logger.newRequestLogger(log.getUids());
+        const extMetrics = getExtMetrics(this.site,
+            sourceEntry.getContentLength(), sourceEntry);
+        this.mProducer.publishMetrics(extMetrics, metricsTypeQueued,
+            metricsExtension, () => {});
         this.retry({
             actionDesc: 'stream object data',
             logFields: { entry: sourceEntry.getLogInfo() },


### PR DESCRIPTION
For put object replication (non-mpu) operation, queue the pending object metric stat before proceeding with replication.

Passing e2e here:
https://eve.devsca.com/github/scality/zenko/#/builders/2/builds/2213
Image uses latest dev/8.1 w/ this fix 👍 

TODO: Add metrics population tests and metrics consumer tests :/ sorry