### PR TITLE
INTEGRATION [PR#652 > development/8.1] bf: ZENKO-1593 queue object pending metric

### DIFF
--- a/extensions/replication/tasks/MultipleBackendTask.js
+++ b/extensions/replication/tasks/MultipleBackendTask.js
@@ -514,6 +514,10 @@ class MultipleBackendTask extends ReplicateObject {
 
     _getAndPutObject(sourceEntry, destEntry, log, cb) {
         const partLogger = this.logger.newRequestLogger(log.getUids());
+        const extMetrics = getExtMetrics(this.site,
+            sourceEntry.getContentLength(), sourceEntry);
+        this.mProducer.publishMetrics(extMetrics, metricsTypeQueued,
+            metricsExtension, () => {});
         this.retry({
             actionDesc: 'stream object data',
             logFields: { entry: sourceEntry.getLogInfo() },


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #652.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/ZENKO-1593-objectMonitorMetricFix`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/ZENKO-1593-objectMonitorMetricFix
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/ZENKO-1593-objectMonitorMetricFix
```

Please always comment pull request #652 instead of this one.