### PR TITLE
bf: ZENKO-1605 null version object md fetch

### DIFF
--- a/lib/queuePopulator/IngestionProducer.js
+++ b/lib/queuePopulator/IngestionProducer.js
@@ -340,35 +340,44 @@ class IngestionProducer {
         if (versionList.length === 0) {
             return done();
         }
-
         const objectMDList = [];
         return async.eachLimit(versionList, 10, (version, cb) => {
             const { Key, VersionId, IsLatest } = version;
-            const objectKey = `${Key}${VID_SEP}${decode(VersionId)}`;
+            // version id from s3 listing are strings
+            const isNullVersion = VersionId === 'null';
+            let objectKey;
+            if (isNullVersion) {
+                objectKey = Key;
+            } else {
+                objectKey = `${Key}${VID_SEP}${decode(VersionId)}`;
+            }
+            async.waterfall([
+                next => this._getObjectMetadata(bucket, objectKey, next),
+                (entry, next) => {
+                    // if null version and nullVersionId defined
+                    let nullVersionId;
+                    if (entry.res && entry.res.nullVersionId) {
+                        nullVersionId = entry.res.nullVersionId;
+                    }
 
-            const req = this._ringReader.getObjectMetadata({
-                Bucket: bucket,
-                Key: objectKey,
-            });
-            attachReqUids(req, this.requestLogger);
-            req.send((err, data) => {
+                    if (isNullVersion && nullVersionId) {
+                        const nullVersionKey =
+                            `${objectKey}${VID_SEP}${nullVersionId}`;
+                        return this._getObjectMetadata(bucket, nullVersionKey,
+                            next);
+                    }
+                    return next(null, entry);
+                },
+            ], (err, entry) => {
                 if (err) {
-                    this.log.error('error getting metadata for object', {
-                        method: 'IngestionProducer._getBucketObjectsMetadata',
-                        error: err
-                    });
                     return cb(err);
                 }
-                const objectEntry = {
-                    res: data,
-                    objectKey,
-                    bucketName: bucket,
-                };
-                objectMDList.push(objectEntry);
-                if (IsLatest) {
-                    // duplicate the entry w/out the version id in the object
-                    // key to represent the master key
-                    objectMDList.push(Object.assign({}, objectEntry, {
+                objectMDList.push(entry);
+                // if IsLatest null version, it represents master
+                if (IsLatest && !isNullVersion) {
+                    // duplicate the entry w/out the version id in the
+                    // object key to represent the master key
+                    objectMDList.push(Object.assign({}, entry, {
                         // key name w/out version id
                         objectKey: Key,
                     }));
@@ -380,6 +389,31 @@ class IngestionProducer {
                 return done(err);
             }
             return this._createAndPushEntry(objectMDList, done);
+        });
+    }
+
+    _getObjectMetadata(bucket, key, done) {
+        const req = this._ringReader.getObjectMetadata({
+            Bucket: bucket,
+            Key: key,
+        });
+        attachReqUids(req, this.requestLogger);
+        req.send((err, data) => {
+            if (err) {
+                this.log.error('error getting metadata for object', {
+                    method: 'IngestionProducer._getObjectMetadata',
+                    bucket,
+                    key,
+                    error: err
+                });
+                return done(err);
+            }
+            const objectEntry = {
+                res: data,
+                objectKey: key,
+                bucketName: bucket,
+            };
+            return done(null, objectEntry);
         });
     }
 


### PR DESCRIPTION
When fetching object metadata for oob-ring, do not specify
the version id field. Instead fetch master which should have
`nullVersionId` defined with the null version id. Make
another request to get the null version specific object md.

In IngestionProducer._getBucketObjectsMetadata, master keys were
duplicated to emulate the additional metadata log entry to update
master. This should not occur for IsLatest null versions.