### PR TITLE
rf: ZENKO-1608 error handling ingestion populator

### DIFF
--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -302,10 +302,21 @@ class IngestionPopulator {
     }
 
     _processLogEntries(params, done) {
-        return async.map(
-            this.logReaders,
-            (logReader, cb) => logReader.processLogEntries(params, cb),
-            done);
+        return async.eachLimit(this.logReaders, 10,
+            (logReader, cb) => {
+                logReader.processLogEntries(params, error => {
+                    if (error) {
+                        this.log.warn('error processing log entries', {
+                            error,
+                            zenkoBucket: logReader.getTargetZenkoBucketName(),
+                            location: logReader.getLocationConstraint(),
+                        });
+                    }
+                    // do not escalate error to avoid crashing pod
+                    // instead retry on next cron
+                    return cb();
+                });
+            }, done);
     }
 
     processLogEntries(params, done) {


### PR DESCRIPTION
Avoid crashing pod when errors are raised from
IngestionReader. We can give a warning log for a given
location and continue processing other ingestion locations.