### PR TITLE
ft: ZENKO-1448 ingestion location cleanup

### DIFF
--- a/bin/ingestion.js
+++ b/bin/ingestion.js
@@ -329,7 +329,14 @@ zkClient.once('ready', () => {
 
 process.on('SIGTERM', () => {
     log.info('received SIGTERM, exiting');
-    ingestionPopulator.close();
     scheduler.cancel();
-    process.exit(0);
+    ingestionPopulator.close(error => {
+        if (error) {
+            log.error('failed to exit properly', {
+                error,
+            });
+            process.exit(1);
+        }
+        process.exit(0);
+    });
 });

--- a/bin/queuePopulator.js
+++ b/bin/queuePopulator.js
@@ -90,7 +90,13 @@ async.waterfall([
 
 process.on('SIGTERM', () => {
     log.info('received SIGTERM, exiting');
-    queuePopulator.close(() => {
+    queuePopulator.close(error => {
+        if (error) {
+            log.error('failed to exit properly', {
+                error,
+            });
+            process.exit(1);
+        }
         process.exit(0);
     });
 });

--- a/extensions/mongoProcessor/mongoProcessorTask.js
+++ b/extensions/mongoProcessor/mongoProcessorTask.js
@@ -1,5 +1,6 @@
 'use strict'; // eslint-disable-line
 
+const async = require('async');
 const werelogs = require('werelogs');
 const { HealthProbeServer } = require('arsenal').network.probe;
 
@@ -101,3 +102,19 @@ function loadManagementDatabase() {
 }
 
 loadManagementDatabase();
+
+process.on('SIGTERM', () => {
+    log.info('received SIGTERM, exiting');
+    const sites = Object.keys(activeProcessors);
+    async.each(sites,
+               (site, done) => activeProcessors[site].stop(done),
+               error => {
+                   if (error) {
+                       log.error('failed to exit properly', {
+                           error,
+                       });
+                       process.exit(1);
+                   }
+                   process.exit(0);
+               });
+});

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -651,20 +651,58 @@ class QueueProcessor extends EventEmitter {
         async.series([
             next => {
                 if (this.replicationStatusProducer) {
+                    this.logger.debug('closing replication status producer', {
+                        method: 'QueueProcessor.stop',
+                        site: this.site,
+                    });
                     return this.replicationStatusProducer.close(next);
                 }
+                this.logger.debug('no replication status producer to close', {
+                    method: 'QueueProcessor.stop',
+                    site: this.site,
+                });
                 return next();
             },
             next => {
                 if (this._consumer) {
+                    this.logger.debug('closing kafka consumer', {
+                        method: 'QueueProcessor.stop',
+                        site: this.site,
+                    });
                     return this._consumer.close(next);
                 }
+                this.logger.debug('no kafka consumer to close', {
+                    method: 'QueueProcessor.stop',
+                    site: this.site,
+                });
                 return next();
             },
             next => {
                 if (this._dataMoverConsumer) {
+                    this.logger.debug('closing data mover consumer', {
+                        method: 'QueueProcessor.stop',
+                        site: this.site,
+                    });
                     return this._dataMoverConsumer.close(next);
                 }
+                this.logger.debug('no data mover consumer to close', {
+                    method: 'QueueProcessor.stop',
+                    site: this.site,
+                });
+                return next();
+            },
+            next => {
+                if (this._mProducer) {
+                    this.logger.debug('closing metrics producer', {
+                        method: 'QueueProcessor.stop',
+                        site: this.site,
+                    });
+                    return this._mProducer.close(next);
+                }
+                this.logger.debug('no metrics producer to close', {
+                    method: 'QueueProcessor.stop',
+                    site: this.site,
+                });
                 return next();
             },
         ], done);

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -256,3 +256,19 @@ zkClient.once('ready', () => {
         return initAndStart(zkClient);
     });
 });
+
+process.on('SIGTERM', () => {
+    log.info('received SIGTERM, exiting');
+    const sites = Object.keys(activeQProcessors);
+    async.each(sites,
+               (site, done) => activeQProcessors[site].stop(done),
+               error => {
+                   if (error) {
+                       log.error('failed to exit properly', {
+                           error,
+                       });
+                       process.exit(1);
+                   }
+                   process.exit(0);
+               });
+});

--- a/extensions/replication/replicationStatusProcessor/task.js
+++ b/extensions/replication/replicationStatusProcessor/task.js
@@ -51,3 +51,16 @@ function initAndStart() {
 }
 
 initAndStart();
+
+process.on('SIGTERM', () => {
+    logger.info('received SIGTERM, exiting');
+    replicationStatusProcessor.stop(error => {
+        if (error) {
+            logger.error('failed to exit properly', {
+                error,
+            });
+            process.exit(1);
+        }
+        process.exit(0);
+    });
+});

--- a/lib/MetricsConsumer.js
+++ b/lib/MetricsConsumer.js
@@ -40,6 +40,8 @@ class MetricsConsumer {
         this.kafkaConfig = kafkaConfig;
         this._id = id;
 
+        this._consumer = null;
+
         this.logger = new Logger('Backbeat:MetricsConsumer');
         const redisClient = new RedisClient(rConfig, this.logger);
         this._statsClient = new StatsModel(redisClient, INTERVAL, EXPIRY);
@@ -64,6 +66,7 @@ class MetricsConsumer {
         consumer.on('ready', () => {
             consumerReady = true;
             consumer.subscribe();
+            this._consumer = consumer;
             this.logger.info('metrics processor is ready to consume entries');
         });
     }
@@ -197,6 +200,10 @@ class MetricsConsumer {
 
     _sendObjectRequest(key, value) {
         this._statsClient.reportNewRequest(key, value);
+    }
+
+    close(cb) {
+        this._consumer.close(cb);
     }
 }
 

--- a/lib/MetricsProducer.js
+++ b/lib/MetricsProducer.js
@@ -67,6 +67,10 @@ class MetricsProducer {
             });
         }, cb);
     }
+
+    close(cb) {
+        this._producer.close(cb);
+    }
 }
 
 module.exports = MetricsProducer;

--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -575,17 +575,48 @@ class IngestionPopulator {
     }
 
     /**
-     * Remove all ingestion sources
+     * Close IngestionPopulator and does not remove ZooKeeper state
+     * @param {Function} done - callback(error)
      * @return {undefined}
      */
-    close() {
-        Object.keys(this._ingestionSources).forEach(source => {
-            this.closeLogState(source);
-        });
+    close(done) {
+        async.series([
+            next => {
+                const buckets = Object.keys(this._ingestionSources);
+                async.each(buckets,
+                           (bucket, cb) =>
+                                this._ingestionSources[bucket].close(cb),
+                           next);
+            },
+            next => {
+                if (this._mProducer) {
+                    this.log.debug('closing metrics producer', {
+                        method: 'IngestionPopulator.close',
+                    });
+                    return this._mProducer.close(next);
+                }
+                this.log.debug('no metrics producer to close', {
+                    method: 'IngestionPopulator.close',
+                });
+                return next();
+            },
+            next => {
+                if (this._mConsumer) {
+                    this.log.debug('closing metrics consumer', {
+                        method: 'IngestionPopulator.close',
+                    });
+                    return this._mConsumer.close(next);
+                }
+                this.log.debug('no metrics consumer to close', {
+                    method: 'IngestionPopulator.close',
+                });
+                return next();
+            },
+        ], done);
     }
 
     /**
-     * Remove an inactive IngestionReader
+     * Remove an IngestionReader and remove state in ZooKeeper
      * @param {String} key - source key (zenko bucket name)
      * @return {undefined}
      */

--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -457,11 +457,10 @@ class IngestionPopulator {
                 return cb(err);
             }
             // Any leftover `currentActiveSources` are no longer active and
-            // must be removed.
-            configuredSources.forEach(source => {
-                this.closeLogState(source);
-            });
-            return cb();
+            // must be removed (including zookeeper state)
+            return async.each(configuredSources,
+                              this._closeLogState.bind(this),
+                              cb);
         });
     }
 
@@ -618,21 +617,49 @@ class IngestionPopulator {
     /**
      * Remove an IngestionReader and remove state in ZooKeeper
      * @param {String} key - source key (zenko bucket name)
+     * @param {Function} done - callback(error)
      * @return {undefined}
      */
-    closeLogState(key) {
-        // TODO: remove/cleanup zk paths
-        delete this._ingestionSources[key];
-        this._checkAndRemoveLogReader(key, this.logReaders);
-        this._checkAndRemoveLogReader(key, this.logReadersUpdate);
+    _closeLogState(key, done) {
+        if (this._checkAndRemoveLogReader(key, this.logReadersUpdate)) {
+            // if removed from `this.logReadersUpdate`, zookeeper setup has not
+            // been performed yet
+            this.log.debug('removed ingestion reader from logReadersUpdate', {
+                method: 'IngestionPopulator._closeLogState',
+                bucket: key,
+            });
+            delete this._ingestionSources[key];
+            return done();
+        }
+        if (this._checkAndRemoveLogReader(key, this.logReaders)) {
+            // if removed from `this.logReaders`, we must cleanup zookeeper
+            // state for this bucket
+            this.log.debug('removed ingestion reader from logReaders', {
+                method: 'IngestionPopulator._closeLogState',
+                bucket: key,
+            });
+            delete this._ingestionSources[key];
+            const path = `${this.ingestionConfig.zookeeperPath}/${key}`;
+            return this.zkClient.removeRecur(path, done);
+        }
+        return done();
     }
 
+    /**
+     * Helper method to check an array of logReaders to remove a given bucket
+     * name.
+     * @param {String} name - bucket name
+     * @param {Array} list - list of logReaders
+     * @return {Boolean} true if something was removed from given list
+     */
     _checkAndRemoveLogReader(name, list) {
         const index = list.findIndex(lr =>
             lr.getTargetZenkoBucketName() === name);
         if (index !== -1) {
             list.splice(index, 1);
+            return true;
         }
+        return false;
     }
 
     _processLogEntries(params, done) {

--- a/lib/queuePopulator/IngestionReader.js
+++ b/lib/queuePopulator/IngestionReader.js
@@ -471,6 +471,21 @@ class IngestionReader extends LogReader {
     getLocationConstraint() {
         return this.bucketdConfig.locationConstraint;
     }
+
+    close(done) {
+        // i.e. this._producers = { topic: new BackbeatProducer() }
+        const topics = Object.keys(this._producers);
+        async.each(topics,
+                   (topic, next) => {
+                       this.logger.debug('closing backbeat producer', {
+                           method: 'IngestionReader.close',
+                           topic,
+                           zenkoBucket: this._targetZenkoBucket,
+                       });
+                       return this._producers[topic].close(next);
+                   },
+                   done);
+    }
 }
 
 module.exports = IngestionReader;

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -143,7 +143,33 @@ class QueuePopulator {
      * @return {undefined}
      */
     close(cb) {
-        return this._closeLogState(cb);
+        async.series([
+            next => this._closeLogState(next),
+            next => {
+                if (this._mProducer) {
+                    this.log.debug('closing metrics producer', {
+                        method: 'QueuePopulator.close',
+                    });
+                    return this._mProducer.close(next);
+                }
+                this.log.debug('no metrics producer to close', {
+                    method: 'QueuePopulator.close',
+                });
+                return next();
+            },
+            next => {
+                if (this._mConsumer) {
+                    this.log.debug('closing metrics consumer', {
+                        method: 'QueuePopulator.close',
+                    });
+                    return this._mConsumer.close(next);
+                }
+                this.log.debug('no metrics consumer to close', {
+                    method: 'QueuePopulator.close',
+                });
+                return next();
+            },
+        ], cb);
     }
 
     _setupLogSources() {
@@ -287,6 +313,9 @@ class QueuePopulator {
 
     _closeLogState(done) {
         if (this.raftIdDispatcher !== undefined) {
+            this.log.debug('closing provision dispatcher', {
+                method: 'QueuePopulator._closeLogState',
+            });
             return this.raftIdDispatcher.unsubscribe(done);
         }
         return process.nextTick(done);

--- a/tests/unit/ingestion/IngestionPopulator.js
+++ b/tests/unit/ingestion/IngestionPopulator.js
@@ -173,8 +173,9 @@ class IngestionPopulatorMock extends IngestionPopulator {
         this._added.push(newSource);
     }
 
-    closeLogState(source) {
+    _closeLogState(source, cb) {
         this._removed.push(source);
+        return cb();
     }
 }
 


### PR DESCRIPTION
Sits on top of https://github.com/scality/backbeat/pull/650

When a user removes an ingestion bucket, we should cleanup the bucket path in zookeeper.
In zookeeper, the path is prefixed like: `/ingestion/<bucket>`
This path has nodes that hold information about the snapshot phase and log offset

From a user perspective, in order for a cleanup to occur, they would need to remove all object versions from their Zenko bucket. This will remove object versions from their s3c bucket as well. Then, they can remove the Zenko bucket. The cleanup will occur after deletion of Zenko bucket and before we try and call `processLogEntries` for that given ingestion bucket.