### PR TITLE
feature: ZENKO-1585 configure replication group id

### DIFF
--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -8,6 +8,7 @@ const logSourcesJoi = joi.string().valid('bucketd', 'mongo', 'ingestion',
     'dmd');
 
 const joiSchema = {
+    replicationGroupId: joi.string().length(7).required(),
     zookeeper: {
         connectionString: joi.string().required(),
         autoCreateNamespace: joi.boolean().default(false),

--- a/conf/config.json
+++ b/conf/config.json
@@ -10,6 +10,7 @@
         "host": "127.0.0.1",
         "port": 8000
     },
+    "replicationGroupId": "RG001  ",
     "queuePopulator": {
         "cronRule": "*/5 * * * * *",
         "batchMaxRead": 10000,

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -264,6 +264,10 @@ if [[ "$EXTENSIONS_INGESTION_AUTH_ACCOUNT" ]]; then
     JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .extensions.ingestion.auth.account=\"$EXTENSIONS_INGESTION_AUTH_ACCOUNT\""
 fi
 
+if [[ "$REPLICATION_GROUP_ID" ]] ; then
+    JQ_FILTERS_CONFIG="$JQ_FILTERS_CONFIG | .replicationGroupId=\"$REPLICATION_GROUP_ID\""
+fi
+
 if [[ $JQ_FILTERS_CONFIG != "." ]]; then
     jq "$JQ_FILTERS_CONFIG" conf/config.json > conf/config.json.tmp
     mv conf/config.json.tmp conf/config.json

--- a/tests/config.json
+++ b/tests/config.json
@@ -10,6 +10,7 @@
         "host": "127.0.0.1",
         "port": 8000
     },
+    "replicationGroupId": "RG001  ",
     "queuePopulator": {
         "cronRule": "*/5 * * * * *",
         "batchMaxRead": 10000,


### PR DESCRIPTION
Replication group id is used in the calculation of version ids for objects
on buckets that have versioning enabled. It has many benefits including avoiding
collisions in an active-active scenario, identifying distinct entries from an
instance etc.
This allows commit allows configuring a custom replication group id for an instance,
ensuring that the version ids generated by the instance are unique.