### PR TITLE
bf: ZENKO-1605 fix null version obj md fetches

### DIFF
--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -1063,32 +1063,6 @@
                 "shape": "ObjectMDListResponse"
             }
         },
-        "GetObjectMetadata": {
-            "http": {
-                "method": "GET",
-                "requestUri": "/_/metadata/default/bucket/{Bucket}/{Key+}"
-            },
-            "input": {
-                "type": "structure",
-                "required": [
-                    "Bucket",
-                    "Key"
-                ],
-                "members": {
-                    "Bucket": {
-                        "location": "uri",
-                        "locationName": "Bucket"
-                    },
-                    "Key": {
-                        "location": "uri",
-                        "locationName": "Key"
-                    }
-                }
-            },
-            "output": {
-                "shape": "ObjectMetadataObject"
-            }
-        },
         "GetBucketCseq": {
             "http": {
                 "method": "GET",
@@ -1350,44 +1324,6 @@
                 }
             }
         },
-        "ReplicationInfoObj": {
-            "type": "structure",
-            "members": {
-                "status": {
-                    "type": "string"
-                },
-                "backends": {
-                    "type": "list",
-                    "members": {
-                        "type": "string"
-                    }
-                },
-                "content": {
-                    "type": "list",
-                    "members": {
-                        "type": "string"
-                    }
-                },
-                "destination": {
-                    "type": "string"
-                },
-                "storageClass": {
-                    "type": "string"
-                },
-                "role": {
-                    "type": "string"
-                },
-                "storageType": {
-                    "type": "string"
-                },
-                "dataStoreVersionId": {
-                    "type": "string"
-                },
-                "isNFS": {
-                    "type": "boolean"
-                }
-            }
-        },
         "LocationMDObj": {
             "type": "structure",
             "members": {
@@ -1458,100 +1394,6 @@
                             }
                         }
                     }
-                }
-            }
-        },
-        "ObjectMetadataObject": {
-            "type": "structure",
-            "members": {
-                "owner-display-name": {
-                    "type": "string"
-                },
-                "owner-id": {
-                    "type": "string"
-                },
-                "cache-control": {
-                    "type": "string"
-                },
-                "content-disposition": {
-                    "type": "string"
-                },
-                "content-encoding": {
-                    "type": "string"
-                },
-                "expires": {
-                    "type": "string"
-                },
-                "content-length": {
-                    "type": "integer"
-                },
-                "content-type": {
-                    "type": "string"
-                },
-                "content-md5": {
-                    "type": "string"
-                },
-                "x-amz-version-id": {
-                    "type": "string"
-                },
-                "x-amz-server-version-id": {
-                    "type": "string"
-                },
-                "x-amz-storage-class": {
-                    "type": "string"
-                },
-                "x-amz-server-side-encryption": {
-                    "type": "string"
-                },
-                "x-amz-server-side-encryption-aws-kms-key-id": {
-                    "type": "string"
-                },
-                "x-amz-server-side-encryption-customer-algorithm": {
-                    "type": "string"
-                },
-                "x-amz-website-redirect-location": {
-                    "type": "string"
-                },
-                "acl": {
-                    "shape": "AclObj"
-                },
-                "key": {
-                    "type": "string"
-                },
-                "location": {
-                    "type": "list",
-                    "member": {
-                        "shape": "LocationMDObj"
-                    }
-                },
-                "isNull": {
-                    "type": "boolean"
-                },
-                "nullVersionId": {
-                    "type": "string"
-                },
-                "isDeleteMarker": {
-                    "type": "boolean"
-                },
-                "tags": {
-                    "type": "map",
-                    "key": {},
-                    "value": {}
-                },
-                "replicationInfo": {
-                    "shape": "ReplicationInfoObj"
-                },
-                "dataStoreName": {
-                    "type": "string"
-                },
-                "last-modified": {
-                    "type": "string"
-                },
-                "md-model-version": {
-                    "type": "integer"
-                },
-                "versionId": {
-                    "type": "string"
                 }
             }
         }

--- a/lib/queuePopulator/IngestionProducer.js
+++ b/lib/queuePopulator/IngestionProducer.js
@@ -7,7 +7,7 @@ const stream = require('stream');
 const Logger = require('werelogs').Logger;
 const { constants, errors } = require('arsenal');
 
-const { decode } = require('arsenal').versioning.VersionID;
+const ObjectMD = require('arsenal').models.ObjectMD;
 const VID_SEP = require('arsenal').versioning.VersioningConstants
           .VersionId.Separator;
 
@@ -340,34 +340,32 @@ class IngestionProducer {
         if (versionList.length === 0) {
             return done();
         }
-
         const objectMDList = [];
         return async.eachLimit(versionList, 10, (version, cb) => {
             const { Key, VersionId, IsLatest } = version;
-            const objectKey = `${Key}${VID_SEP}${decode(VersionId)}`;
+            // version id from s3 listing are strings
+            const isNullVersion = VersionId === 'null';
 
-            const req = this._ringReader.getObjectMetadata({
-                Bucket: bucket,
-                Key: objectKey,
-            });
-            attachReqUids(req, this.requestLogger);
-            req.send((err, data) => {
+            return this._getObjectMetadata(bucket, Key, VersionId,
+            (err, entry) => {
                 if (err) {
-                    this.log.error('error getting metadata for object', {
-                        method: 'IngestionProducer._getBucketObjectsMetadata',
-                        error: err
-                    });
                     return cb(err);
                 }
+                const decodedVersionId = entry.getVersionId();
+                let objectKey = Key;
+                if (decodedVersionId) {
+                    objectKey += `${VID_SEP}${decodedVersionId}`;
+                }
                 const objectEntry = {
-                    res: data,
+                    res: entry.getValue(),
                     objectKey,
                     bucketName: bucket,
                 };
                 objectMDList.push(objectEntry);
-                if (IsLatest) {
-                    // duplicate the entry w/out the version id in the object
-                    // key to represent the master key
+                // if IsLatest null version, it represents master
+                if (IsLatest && !isNullVersion) {
+                    // duplicate the entry w/out the version id in the
+                    // object key to represent the master key
                     objectMDList.push(Object.assign({}, objectEntry, {
                         // key name w/out version id
                         objectKey: Key,
@@ -380,6 +378,37 @@ class IngestionProducer {
                 return done(err);
             }
             return this._createAndPushEntry(objectMDList, done);
+        });
+    }
+
+    _getObjectMetadata(bucket, key, versionId, done) {
+        const req = this._ringReader.getMetadata({
+            Bucket: bucket,
+            Key: key,
+            VersionId: versionId,
+        });
+        attachReqUids(req, this.requestLogger);
+        req.send((err, blob) => {
+            if (err) {
+                this.log.error('error getting metadata for object', {
+                    method: 'IngestionProducer._getObjectMetadata',
+                    bucket,
+                    key,
+                    versionId,
+                    error: err
+                });
+                return done(err);
+            }
+            const res = ObjectMD.createFromBlob(blob.Body);
+            if (res.error) {
+                this.log.error('error parsing metadata blob', {
+                    error: res.error,
+                    method: 'IngestionProducer._getObjectMetadata',
+                });
+                return done(errors.InternalError.
+                    customizeDescription('error parsing metadata blob'));
+            }
+            return done(null, res.result);
         });
     }
 

--- a/tests/functional/lib/BackbeatClient.js
+++ b/tests/functional/lib/BackbeatClient.js
@@ -127,13 +127,15 @@ describe('BackbeatClient unit tests with mock server', () => {
     });
 
     it('should get object metadata', done => {
-        const destReq = backbeatClient.getObjectMetadata({
+        const destReq = backbeatClient.getMetadata({
             Bucket: bucketName,
             Key: objectName,
         });
         return destReq.send((err, data) => {
             assert.ifError(err);
-            assert.deepStrictEqual(data, expectedObjectMD);
+            assert(data.Body);
+            const dataValue = JSON.parse(data.Body);
+            assert.deepStrictEqual(dataValue, expectedObjectMD);
             return done();
         });
     });

--- a/tests/functional/utils/mockRes.json
+++ b/tests/functional/utils/mockRes.json
@@ -1,23 +1,23 @@
 {
     "GET": {
         "responses": {
-            "/_/metadata/default/bucket/bucket1/object1": {
+            "/_/backbeat/metadata/bucket1/object1": {
                 "resType": "objectMD",
                 "name": "object1"
             },
-            "/_/metadata/default/bucket/bucket2/zerobyteobject": {
+            "/_/backbeat/metadata/bucket2/zerobyteobject": {
                 "resType": "objectMD",
                 "name": "zerobyteobject"
             },
-            "/_/metadata/default/bucket/bucket2/%E4%86%A9%E9%88%81%E6%AB%A8%E3%9F%94%E7%BD%B3": {
+            "/_/backbeat/metadata/bucket2/%E4%86%A9%E9%88%81%E6%AB%A8%E3%9F%94%E7%BD%B3": {
                 "resType": "objectMD",
                 "name": "䆩鈁櫨㟔罳"
             },
-            "/_/metadata/default/bucket/bucket2/taggedobject": {
+            "/_/backbeat/metadata/bucket2/taggedobject": {
                 "resType": "objectMD",
                 "name": "taggedobject"
             },
-            "/_/metadata/default/bucket/bucket2/versionedobject": {
+            "/_/backbeat/metadata/bucket2/versionedobject": {
                 "resType": "objectMD",
                 "name": "versionedobject"
             },


### PR DESCRIPTION
Use the existing BackbeatClient `getMetadata` call vs `getObjectMetadata`.

The `getMetadata` route allows us to pass encoded version id's as a query param.
This solves a few issues for us:
- We no longer need to send a decoded version id as part of the url path
- Passing decoded version id in the path caused issues with nginx where it would see a null value in the url and fail
- For null versions, we fetch master which contains the null version id.

For null versions during snapshot phase, if the null version is the latest version, it is its own master key, so we send the single entry. If the null version is not the latest version, the master key contains a field called `nullVersionId` that holds the null versions version-id. In this case, we send both master and null version entries.