### PR TITLE
bugfix: ZENKO-1583 Non-versioned cloud transition

### DIFF
--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -812,6 +812,7 @@ class LifecycleTask extends BackbeatTask {
      * @param {string} params.objectKey - The object key name
      * @param {string} params.encodedVersionId - The object encoded version ID
      * @param {string} params.eTag - The object data ETag
+     * @param {string} params.lastModified - The last modified date of object
      * @param {string} params.site - The site name to transition the object to
      * @param {Werelogs.Logger} log - Logger object
      * @return {undefined}
@@ -828,7 +829,9 @@ class LifecycleTask extends BackbeatTask {
               .setAttribute('target.key', params.objectKey)
               .setAttribute('target.version', params.encodedVersionId)
               .setAttribute('target.eTag', params.eTag)
+              .setAttribute('target.lastModified', params.lastModified)
               .setAttribute('toLocation', params.site);
+
         this._sendDataMoverAction(entry, err => {
             if (err) {
                 log.error('could not send transition entry for consumption',
@@ -1024,6 +1027,7 @@ class LifecycleTask extends BackbeatTask {
                     bucket: bucketData.target.bucket,
                     objectKey: obj.Key,
                     eTag: obj.ETag,
+                    lastModified: obj.LastModified,
                     site: rules.Transition.StorageClass,
                 }, log);
                 return done();


### PR DESCRIPTION
**Summary**
This change helps prevent the deletion of overwritten data on a non-versioned source during transition.

**Details**
In the action entry for a transition, set the `LastModified` value that was retrieved during the lifecycle processing task. Then, before garbage collecting the source object, perform an additional check that the object has not been modified.