### PR TITLE
bugfix: ZENKO-1583 Add if-unmodified-since check

### DIFF
--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -2,7 +2,9 @@
 
 const async = require('async');
 const { errors } = require('arsenal');
+const ObjectMD = require('arsenal').models.ObjectMD;
 
+const config = require('../../../conf/Config');
 const { attachReqUids } = require('../../../lib/clients/utils');
 const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
 const ActionQueueEntry = require('../../../lib/models/ActionQueueEntry');
@@ -57,14 +59,29 @@ class LifecycleTask extends BackbeatTask {
     /**
      * Send entry to the data mover topic
      * @param {ActionQueueEntry} entry - The action entry to send to the topic
+     * @param {Logger.newRequestLogger} log - logger object
      * @param {Function} cb - The callback to call
      * @return {undefined}
      */
-    _sendDataMoverAction(entry, cb) {
+    _sendDataMoverAction(entry, log, cb) {
         const { bucket, key } = entry.getAttribute('target');
         const entries = [{ key: `${bucket}/${key}`,
                            message: entry.toKafkaMessage() }];
-        this.producer.sendToTopic(this.dataMoverTopic, entries, cb);
+        this.producer.sendToTopic(this.dataMoverTopic, entries, err => {
+            if (err) {
+                log.error('could not send entry for consumption',
+                    Object.assign({
+                        method: 'LifecycleTask._sendDataMoverAction',
+                        error: err,
+                    }, entry.getLogInfo()));
+                return cb(err);
+            }
+            log.debug('sent entry for consumption',
+                Object.assign({
+                    method: 'LifecycleTask._sendDataMoverAction',
+                }, entry.getLogInfo()));
+            return cb();
+        });
     }
 
     /**
@@ -802,6 +819,76 @@ class LifecycleTask extends BackbeatTask {
         return false;
     }
 
+    _getObjectMD(params, log, cb) {
+        this.backbeatMetadataProxy.getMetadata(params, log, (err, blob) => {
+            if (err) {
+                log.error('failed to get object metadata', {
+                    method: 'LifecycleTask._getObjectMD',
+                    error: err,
+                    bucket: params.bucket,
+                    objectKey: params.objectKey,
+                });
+                return cb(err);
+            }
+            const { error, result } = ObjectMD.createFromBlob(blob.Body);
+            if (error) {
+                const msg = 'error parsing metadata blob';
+                return cb(errors.InternalError.customizeDescription(msg));
+            }
+            return cb(null, result);
+        });
+    }
+
+    _canUnconditionallyGarbageCollect(objectMD) {
+        const sourceEndpoint = config.getBootstrapList()
+            .find(endpoint => endpoint.site === objectMD.getDataStoreName());
+        // Is it a local data source?
+        if (!sourceEndpoint) {
+            return true;
+        }
+        // Is the public cloud data source versioned?
+        if (objectMD.getDataStoreVersionId()) {
+            return true;
+        }
+        return false;
+    }
+
+    _getTransitionActionEntry(params, objectMD, log, cb) {
+        const entry = ActionQueueEntry.create('copyLocation')
+            .setResultsTopic(this.objectTasksTopic)
+            .addContext({
+                origin: 'lifecycle',
+                ruleType: 'transition',
+                reqId: log.getSerializedUids(),
+            })
+            .setAttribute('target', {
+                bucket: params.bucket,
+                key: params.objectKey,
+                version: params.encodedVersionId,
+                eTag: params.eTag,
+                lastModified: params.lastModified,
+            })
+            .setAttribute('toLocation', params.site);
+
+        if (this._canUnconditionallyGarbageCollect(objectMD)) {
+            return cb(null, entry);
+        }
+        const locations = objectMD.getLocation();
+        return this._headLocation(params, locations, log,
+            (err, lastModified) => {
+                if (err) {
+                    return cb(err);
+                }
+                entry.setAttribute('source', {
+                    bucket: params.bucket,
+                    objectKey: params.objectKey,
+                    storageClass: objectMD.getDataStoreName(),
+                    lastModified,
+                });
+                return cb(null, entry);
+        });
+    }
+
     /**
      * Gets the transition entry and sends it to the data mover topic,
      * then gathers the result in the object tasks topic for execution
@@ -818,31 +905,21 @@ class LifecycleTask extends BackbeatTask {
      * @return {undefined}
      */
     _applyTransitionRule(params, log) {
-        const entry = ActionQueueEntry.create('copyLocation')
-              .setResultsTopic(this.objectTasksTopic)
-              .addContext({
-                  origin: 'lifecycle',
-                  ruleType: 'transition',
-                  reqId: log.getSerializedUids(),
-              })
-              .setAttribute('target.bucket', params.bucket)
-              .setAttribute('target.key', params.objectKey)
-              .setAttribute('target.version', params.encodedVersionId)
-              .setAttribute('target.eTag', params.eTag)
-              .setAttribute('target.lastModified', params.lastModified)
-              .setAttribute('toLocation', params.site);
-
-        this._sendDataMoverAction(entry, err => {
+        async.waterfall([
+            next =>
+                this._getObjectMD(params, log, next),
+            (objectMD, next) =>
+                this._getTransitionActionEntry(params, objectMD, log, next),
+            (entry, next) =>
+                this._sendDataMoverAction(entry, log, next),
+        ], err => {
             if (err) {
-                log.error('could not send transition entry for consumption',
-                          Object.assign({
-                              method: 'LifecycleTask._applyTransitionRule',
-                              error: err,
-                          }, entry.getLogInfo()));
+                log.error('could not apply transition rule', {
+                    method: 'LifecycleTask._applyTransitionRule',
+                    error: err,
+                });
             }
-            log.debug('sent transition entry for consumption', Object.assign({
-                method: 'LifecycleTask._applyTransitionRule',
-            }, entry.getLogInfo()));
+            log.debug('transition rule applied');
         });
     }
 
@@ -976,6 +1053,22 @@ class LifecycleTask extends BackbeatTask {
                 }
             });
         }
+    }
+
+    _headLocation(params, locations, log, cb) {
+        const headLocationParams = {
+            bucket: params.bucket,
+            objectKey: params.objectKey,
+            locations,
+        };
+        this.backbeatMetadataProxy.headLocation(
+            headLocationParams, log, (err, data) => {
+                if (err) {
+                    log.error('error getting head response from CloudServer');
+                    return cb(err);
+                }
+                return cb(null, data.lastModified);
+            });
     }
 
     /**
@@ -1235,13 +1328,18 @@ class LifecycleTask extends BackbeatTask {
      * @param {string} [bucketData.details.objectName] - used specifically for
      *   handling versioned buckets
      * @param {AWS.S3} s3target - s3 instance
+     * @param {BackbeatMetadataProxy} backbeatMetadataProxy - The metadata proxy
      * @param {function} done - callback(error)
      * @return {undefined}
      */
-    processBucketEntry(bucketLCRules, bucketData, s3target, done) {
+    processBucketEntry(bucketLCRules, bucketData, s3target,
+    backbeatMetadataProxy, done) {
         const log = this.log.newRequestLogger();
         this.s3target = s3target;
-
+        this.backbeatMetadataProxy = backbeatMetadataProxy;
+        if (!this.backbeatMetadataProxy) {
+            return process.nextTick(done);
+        }
         if (!this.s3target) {
             return process.nextTick(done);
         }

--- a/extensions/lifecycle/tasks/LifecycleUpdateTransitionTask.js
+++ b/extensions/lifecycle/tasks/LifecycleUpdateTransitionTask.js
@@ -94,6 +94,8 @@ class LifecycleUpdateTransitionTask extends BackbeatTask {
                   versionId: version,
                   eTag,
               })
+              .setAttribute('source', entry.getAttribute('source'))
+              .setAttribute('serviceName', 'lifecycle-transition')
               .setAttribute('target.locations', locations);
         this.gcProducer.publishActionEntry(gcEntry);
         return process.nextTick(done);

--- a/lib/BackbeatMetadataProxy.js
+++ b/lib/BackbeatMetadataProxy.js
@@ -105,6 +105,59 @@ class BackbeatMetadataProxy extends BackbeatTask {
         });
     }
 
+    headLocation(params, log, cb) {
+        this.retry({
+            actionDesc: 'head object location from source',
+            logFields: {
+                bucket: params.bucket,
+                objectKey: params.objectKey
+            },
+            actionFunc: done => this._headLocationOnce(params, log, done),
+            shouldRetryFunc: err => err.retryable,
+            log,
+        }, cb);
+    }
+
+    _headLocationOnce(params, log, cb) {
+        const { bucket, objectKey, locations } = params;
+        log.debug('heading object location', {
+            where: 'source',
+            bucket, objectKey, locations,
+            method: 'BackbeatMetadataProxy._headLocationOnce',
+        });
+        const cbOnce = jsutil.once(cb);
+        const req = this.backbeatSource.multipleBackendHeadObject({
+            Bucket: bucket,
+            Key: objectKey,
+            Locations: JSON.stringify([{
+                dataStoreName: locations[0].dataStoreName,
+                key: locations[0].key,
+            }]),
+        });
+        attachReqUids(req, log);
+        req.send((err, data) => {
+            if (err) {
+                // eslint-disable-next-line no-param-reassign
+                err.origin = 'source';
+                if (err.ObjNotFound || err.code === 'ObjNotFound') {
+                    return cbOnce(err);
+                }
+                log.error(
+                    'an error occurred during head object location request', {
+                    method: 'BackbeatMetadataProxy._headLocationOnce',
+                    origin: 'source',
+                    endpoint: this._s3Endpoint,
+                    error: err,
+                    errMsg: err.message,
+                    errCode: err.code,
+                    errStack: err.stack,
+                });
+                return cbOnce(err);
+            }
+            return cbOnce(null, data);
+        });
+    }
+
     /**
      * Retrieve raw object metadata in JSON from MongoDB
      *

--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -206,6 +206,53 @@
                 }
             }
         },
+        "MultipleBackendHeadObject": {
+            "http": {
+                "method": "GET",
+                "requestUri": "/_/backbeat/multiplebackendmetadata/{Bucket}/{Key+}"
+            },
+            "input": {
+                "type": "structure",
+                "required": [
+                    "Bucket",
+                    "Key",
+                    "Locations"
+                ],
+                "members": {
+                    "Bucket": {
+                        "location": "uri",
+                        "locationName": "Bucket"
+                    },
+                    "Key": {
+                        "location": "uri",
+                        "locationName": "Key"
+                    },
+                    "Locations": {
+                        "location": "header",
+                        "locationName": "X-Scal-Locations",
+                        "type": "string",
+                        "member": {
+                            "type": "structure",
+                            "required": [
+                                "key",
+                                "dataStoreName"
+                            ],
+                            "member": {
+                                "shape": "LocationMDObj"
+                            }
+                        }
+                    }
+                }
+            },
+            "output": {
+                "type": "structure",
+                "members": {
+                    "lastModified": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "MultipleBackendPutMPUPart": {
             "http": {
                 "method": "PUT",
@@ -897,13 +944,34 @@
         "BatchDelete": {
             "http": {
                 "method": "POST",
-                "requestUri": "/_/backbeat/batchdelete"
+                "requestUri": "/_/backbeat/batchdelete/{Bucket}/{Key+}"
             },
             "input": {
                 "type": "structure",
                 "required": [
                 ],
                 "members": {
+                    "Bucket": {
+                        "location": "uri",
+                        "locationName": "Bucket"
+                    },
+                    "Key": {
+                        "location": "uri",
+                        "locationName": "Key"
+                    },
+                    "IfUnmodifiedSince": {
+                        "location": "header",
+                        "locationName": "If-Unmodified-Since",
+                        "type": "string"
+                    },
+                    "StorageClass": {
+                        "location": "header",
+                        "locationName": "X-Scal-Storage-Class"
+                    },
+                    "Tags": {
+                        "location": "header",
+                        "locationName": "X-Scal-Tags"
+                    },
                     "ContentType": {
                         "location": "header",
                         "locationName": "X-Scal-Content-Type"

--- a/tests/functional/lifecycle/LifecycleTask.js
+++ b/tests/functional/lifecycle/LifecycleTask.js
@@ -8,12 +8,26 @@ const LifecycleTask = require('../../../extensions/lifecycle' +
     '/tasks/LifecycleTask');
 const Rule = require('../../utils/Rule');
 const testConfig = require('../../config.json');
+const { objectMD } = require('../utils/MetadataMock');
 
 const S3 = AWS.S3;
 const s3config = {
     endpoint: `http://${testConfig.s3.host}:${testConfig.s3.port}`,
     s3ForcePathStyle: true,
     credentials: new AWS.Credentials('accessKey1', 'verySecretKey1'),
+};
+
+const backbeatMetadataProxyMock = {
+    headObject: (headObjectParams, log, cb) => {
+        cb(null, {
+            lastModified: 'Thu, 28 Mar 2019 21:33:15 GMT',
+        });
+    },
+    getMetadata: (params, log, cb) => {
+        cb(null, {
+            Body: JSON.stringify(objectMD.object1),
+        });
+    },
 };
 
 /*
@@ -389,7 +403,7 @@ class LifecycleBucketProcessorMock {
 function wrapProcessBucketEntry(bucketLCRules, bucketEntry,
 s3mock, params, cb) {
     params.lcTask.processBucketEntry(bucketLCRules, bucketEntry,
-    s3mock, err => {
+    s3mock, backbeatMetadataProxyMock, err => {
         assert.ifError(err);
         const entries = params.lcp.getEntries();
 

--- a/tests/unit/gc/GarbageCollector.spec.js
+++ b/tests/unit/gc/GarbageCollector.spec.js
@@ -39,7 +39,8 @@ describe('garbage collector', () => {
                 if (expectBatchDeleteLocations === null) {
                     assert.fail('did not expect a batch delete request');
                 }
-                assert.strictEqual(req.url, '/_/backbeat/batchdelete');
+                assert.strictEqual(req.url,
+                    '/_/backbeat/batchdelete/{Bucket}/{Key+}');
                 const buffers = [];
                 req.on('data', data => {
                     buffers.push(data);


### PR DESCRIPTION
Functional tests forthcoming.

High-level description:

* Use the multiplebackend backbeat metadata route to fetch a cloud object `LastModified` value.
* Add conditional batch delete support using `IfUnmodifiedSince` logic.

The `IfUnmodifiedSince` value will only be sent by the backbeat garbage collector if the source object is on a non-versioned public cloud. If the object has changed since the transition was initiated, we do nothing. If it has not changed, we set a tag on the object (the tag key-value is sent by the garbage collector) indicating that the object has transitioned to a new location and should be deleted. Note: we do not carry out the delete operation ourselves due to a race condition which could result in lost data.