### PR TITLE
bugfix: ZENKO-1583 Check LastModified for versions

### DIFF
--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -1137,6 +1137,7 @@ class LifecycleTask extends BackbeatTask {
                 bucket: bucketData.target.bucket,
                 objectKey: version.Key,
                 eTag: version.ETag,
+                lastModified: version.LastModified,
                 site: rules.Transition.StorageClass,
                 encodedVersionId: undefined,
             }, log);

--- a/extensions/lifecycle/tasks/LifecycleUpdateTransitionTask.js
+++ b/extensions/lifecycle/tasks/LifecycleUpdateTransitionTask.js
@@ -100,6 +100,9 @@ class LifecycleUpdateTransitionTask extends BackbeatTask {
 
     _wasObjectModified(entry, objMD, log) {
         const { lastModified } = entry.getAttribute('target');
+        if (!lastModified) {
+            return false;
+        }
         const objectWasModified = lastModified !== objMD.getLastModified();
         if (objectWasModified) {
             log.info('object LastModified date changed during lifecycle ' +

--- a/tests/unit/lifecycle/LifecycleUpdateTransitionTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleUpdateTransitionTask.spec.js
@@ -168,4 +168,24 @@ describe('LifecycleUpdateTransitionTask', () => {
             done();
         });
     });
+
+    it('should transition location in metadata if LastModified is not ' +
+    'provided as a check', done => {
+        actionEntry.setAttribute('target', {
+            bucket: 'somebucket',
+            key: 'somekey',
+            eTag: '"1ccc7006b902a4d30ec26e9ddcf759d8"',
+            lastModified: undefined,
+        });
+        task.processActionEntry(actionEntry, err => {
+            assert.ifError(err);
+            const receivedMd = backbeatClient.getReceivedMd();
+            assert.deepStrictEqual(receivedMd.location, newLocation);
+            const receivedGcEntry = gcProducer.getReceivedEntry();
+            assert.strictEqual(receivedGcEntry.getActionType(), 'deleteData');
+            assert.deepStrictEqual(
+                receivedGcEntry.getAttribute('target.locations'), oldLocation);
+            done();
+        });
+    });
 });


### PR DESCRIPTION
For versioned transitions, we also need to pass the `lastModified` value for our lifecycle updating check. Also, for safety, we should not perform the check if it is not provided in the target attributes.