### PR TITLE
bf: ZENKO-1683 ingestion location pause state fix

### DIFF
--- a/bin/ingestion.js
+++ b/bin/ingestion.js
@@ -190,7 +190,6 @@ function setupZkLocationNode(zkClient, location, done) {
             });
             return done(err);
         }
-        ingestionPopulator.setPausedLocationState(location);
         return done();
     });
 }


### PR DESCRIPTION
Initial pause state for a new ingestion location is set as
paused only in-mem causing us to miss the init snapshot.