### PR TITLE
bugfix: ZENKO-1684 do not wait for GC message delivery

### DIFF
--- a/extensions/gc/GarbageCollectorProducer.js
+++ b/extensions/gc/GarbageCollectorProducer.js
@@ -50,10 +50,9 @@ class GarbageCollectorProducer {
      * @param {string} dataLocations[].dataStoreName - data location
      *   constraint name
      * @param {number} dataLocations[].size - object size in bytes
-     * @param {Function} cb - The callback function
      * @return {undefined}
      */
-    publishDeleteDataEntry(dataLocations, cb) {
+    publishDeleteDataEntry(dataLocations) {
         this._producer.send([{ message: JSON.stringify({
             action: 'deleteData',
             target: {
@@ -70,7 +69,6 @@ class GarbageCollectorProducer {
                     method: 'GarbageCollectorProducer.publishDeleteDataEntry',
                 });
             }
-            return cb(err);
         });
     }
 }

--- a/extensions/replication/tasks/UpdateReplicationStatus.js
+++ b/extensions/replication/tasks/UpdateReplicationStatus.js
@@ -158,8 +158,8 @@ class UpdateReplicationStatus extends BackbeatTask {
                     === 'COMPLETED') {
                     // schedule garbage-collection of transient data
                     // locations array
-                    return this.gcProducer.publishDeleteDataEntry(
-                        updatedSourceEntry.getReducedLocations(), done);
+                    this.gcProducer.publishDeleteDataEntry(
+                        updatedSourceEntry.getReducedLocations());
                 }
                 return done();
             });


### PR DESCRIPTION
In replication status update tasks with transient source (8.0+) and in
lifecycle transition update (8.1+ only), do not wait until the GC
acknowledges the delivery of the messages to return a status.

There's no need to wait and it slows down considerably the processing,
as delivery takes about 2 seconds to acknowledge a message, so with 10
workers it limits processing to 5 messages per second.

**Note for reviewers**

The integration branch on 8.1 is subtly different than the base 8.0 branch, please review it as well if you can.
