### PR TITLE
INTEGRATION [PR#668 > development/8.1] bugfix: ZENKO-1684 do not wait for GC message delivery

### DIFF
--- a/extensions/gc/GarbageCollectorProducer.js
+++ b/extensions/gc/GarbageCollectorProducer.js
@@ -50,10 +50,9 @@ class GarbageCollectorProducer {
      * @param {string} dataLocations[].dataStoreName - data location
      *   constraint name
      * @param {number} dataLocations[].size - object size in bytes
-     * @param {Function} cb - The callback function
      * @return {undefined}
      */
-    publishDeleteDataEntry(dataLocations, cb) {
+    publishDeleteDataEntry(dataLocations) {
         this._producer.send([{ message: JSON.stringify({
             action: 'deleteData',
             target: {
@@ -70,7 +69,6 @@ class GarbageCollectorProducer {
                     method: 'GarbageCollectorProducer.publishDeleteDataEntry',
                 });
             }
-            return cb(err);
         });
     }
 }

--- a/extensions/gc/GarbageCollectorProducer.js
+++ b/extensions/gc/GarbageCollectorProducer.js
@@ -56,10 +56,9 @@ class GarbageCollectorProducer {
      *   cloud backends
      * @param {ActionQueueEntry} entry - the action entry to send to
      * the GC service
-     * @param {Function} cb - The callback function
      * @return {undefined}
      */
-    publishActionEntry(entry, cb) {
+    publishActionEntry(entry) {
         this._producer.send([{ message: entry.toKafkaMessage() }], err => {
             if (err) {
                 this._log.error('error publishing GC.deleteData entry', {
@@ -67,7 +66,6 @@ class GarbageCollectorProducer {
                     method: 'GarbageCollectorProducer.publishActionEntry',
                 });
             }
-            return cb(err);
         });
     }
 }

--- a/extensions/lifecycle/tasks/LifecycleUpdateTransitionTask.js
+++ b/extensions/lifecycle/tasks/LifecycleUpdateTransitionTask.js
@@ -95,7 +95,8 @@ class LifecycleUpdateTransitionTask extends BackbeatTask {
                   eTag,
               })
               .setAttribute('target.locations', locations);
-        this.gcProducer.publishActionEntry(gcEntry, done);
+        this.gcProducer.publishActionEntry(gcEntry);
+        return process.nextTick(done);
     }
 
     _wasObjectModified(entry, objMD, log) {

--- a/extensions/replication/tasks/UpdateReplicationStatus.js
+++ b/extensions/replication/tasks/UpdateReplicationStatus.js
@@ -186,7 +186,7 @@ class UpdateReplicationStatus extends BackbeatTask {
                   })
                   .addContext(entry.getLogInfo())
                   .setAttribute('target.locations', locations);
-            return this.gcProducer.publishActionEntry(gcEntry, cb);
+            this.gcProducer.publishActionEntry(gcEntry);
         }
         return cb();
     }

--- a/extensions/replication/tasks/UpdateReplicationStatus.js
+++ b/extensions/replication/tasks/UpdateReplicationStatus.js
@@ -158,8 +158,8 @@ class UpdateReplicationStatus extends BackbeatTask {
                     === 'COMPLETED') {
                     // schedule garbage-collection of transient data
                     // locations array
-                    return this.gcProducer.publishDeleteDataEntry(
-                        updatedSourceEntry.getReducedLocations(), done);
+                    this.gcProducer.publishDeleteDataEntry(
+                        updatedSourceEntry.getReducedLocations());
                 }
                 return done();
             });

--- a/tests/unit/gc/GarbageCollectorProducer.spec.js
+++ b/tests/unit/gc/GarbageCollectorProducer.spec.js
@@ -66,11 +66,9 @@ describe('garbage collector producer', () => {
                     locations: testSpec.dataLocations,
                 },
             });
-            gcProducer.publishActionEntry(action, err => {
-                assert.ifError(err);
-                assert(kafkaProducerMock.hasProcessedExpectedMessage());
-                done();
-            });
+            gcProducer.publishActionEntry(action);
+            assert(kafkaProducerMock.hasProcessedExpectedMessage());
+            done();
         });
     });
 });

--- a/tests/unit/lifecycle/LifecycleUpdateTransitionTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleUpdateTransitionTask.spec.js
@@ -11,9 +11,8 @@ class GarbageCollectorProducerMock {
         this.receivedEntry = null;
     }
 
-    publishActionEntry(gcEntry, done) {
+    publishActionEntry(gcEntry) {
         this.receivedEntry = gcEntry;
-        return done();
     }
 
     getReceivedEntry() {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #668.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/ZENKO-1684-doNotWaitGCMessageDelivery`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/ZENKO-1684-doNotWaitGCMessageDelivery
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/ZENKO-1684-doNotWaitGCMessageDelivery
```

Please always comment pull request #668 instead of this one.