### PR TITLE
bf: ZENKO-1587 fix ingestion pending metrics

### DIFF
--- a/extensions/ingestion/IngestionQueuePopulator.js
+++ b/extensions/ingestion/IngestionQueuePopulator.js
@@ -49,7 +49,7 @@ class IngestionQueuePopulator extends QueuePopulatorExtension {
         if (tempStore === undefined) {
             return undefined;
         }
-        this._metricsStore[bucket] = {};
+        this._metricsStore[bucket] = { ops: 0 };
         return tempStore;
     }
 

--- a/extensions/ingestion/constants.js
+++ b/extensions/ingestion/constants.js
@@ -10,6 +10,7 @@ const constants = {
     metricsExtension: 'ingestion',
     metricsTypeQueued: 'queued',
     metricsTypeCompleted: 'completed',
+    metricsTypePendingOnly: 'pendingOnly',
     redisKeys: {
         opsDone: testIsOn ? 'test:bb:opsdone' : 'bb:ingestion:opsdone',
         bytesDone: testIsOn ? 'test:bb:bytesdone' : 'bb:ingestion:bytesdone',

--- a/lib/MetricsConsumer.js
+++ b/lib/MetricsConsumer.js
@@ -47,6 +47,16 @@ class MetricsConsumer {
         this._statsClient = new StatsModel(redisClient, INTERVAL, EXPIRY);
     }
 
+    /**
+     * List of valid "type" field values for metric kafka entries
+     * @param {string} type - type to check
+     * @return {boolean} true if type is a valid metric type
+     */
+    static isValidMetricType(type) {
+        const validTypes = ['completed', 'failed', 'queued', 'pendingOnly'];
+        return validTypes.includes(type);
+    }
+
     start() {
         let consumerReady = false;
         const consumer = new BackbeatConsumer({
@@ -81,6 +91,25 @@ class MetricsConsumer {
         }
     }
 
+    _reportPending(site, redisKeys, ops, bytes) {
+        if (ops > 0) {
+            this._sendRequest('incrementKey', site, redisKeys, 'opsPending',
+                ops);
+        }
+        if (ops < 0) {
+            this._sendRequest('decrementKey', site, redisKeys, 'opsPending',
+                Math.abs(ops));
+        }
+        if (bytes > 0) {
+            this._sendRequest('incrementKey', site, redisKeys, 'bytesPending',
+                bytes);
+        }
+        if (bytes < 0) {
+            this._sendRequest('decrementKey', site, redisKeys, 'bytesPending',
+                Math.abs(bytes));
+        }
+    }
+
     _sendSiteLevelRequests(data) {
         const { type, site, ops, bytes, extension } = data;
         let redisKeys;
@@ -95,10 +124,7 @@ class MetricsConsumer {
         }
         if (type === 'completed') {
             // Pending metrics
-            this._sendRequest('decrementKey', site, redisKeys, 'opsPending',
-                ops);
-            this._sendRequest('decrementKey', site, redisKeys, 'bytesPending',
-                bytes);
+            this._reportPending(site, redisKeys, -ops, -bytes);
             // Other metrics
             this._sendRequest('reportNewRequest', site, redisKeys, 'opsDone',
                 ops);
@@ -106,10 +132,7 @@ class MetricsConsumer {
                 bytes);
         } else if (type === 'failed') {
             // Pending metrics
-            this._sendRequest('decrementKey', site, redisKeys, 'opsPending',
-                ops);
-            this._sendRequest('decrementKey', site, redisKeys, 'bytesPending',
-                bytes);
+            this._reportPending(site, redisKeys, -ops, -bytes);
             // Other metrics
             this._sendRequest('reportNewRequest', site, redisKeys, 'opsFail',
                 ops);
@@ -117,14 +140,13 @@ class MetricsConsumer {
                 bytes);
         } else if (type === 'queued') {
             // Pending metrics
-            this._sendRequest('incrementKey', site, redisKeys, 'opsPending',
-                ops);
-            this._sendRequest('incrementKey', site, redisKeys, 'bytesPending',
-                bytes);
+            this._reportPending(site, redisKeys, ops, bytes);
             // Other metrics
             this._sendRequest('reportNewRequest', site, redisKeys, 'ops', ops);
             this._sendRequest('reportNewRequest', site, redisKeys, 'bytes',
                 bytes);
+        } else if (type === 'pendingOnly') {
+            this._reportPending(site, redisKeys, ops, bytes);
         }
         return undefined;
     }
@@ -164,15 +186,14 @@ class MetricsConsumer {
                 ops: 5,
                 bytes: 195,
                 extension: 'crr',
-                type: 'processed'
+                type: 'queued'
             }
         */
         // filter metric entries by service, i.e. 'crr', 'ingestion'
         if (this._id !== data.extension) {
             return done();
         }
-        const operationTypes = ['completed', 'failed', 'queued'];
-        const isValidType = operationTypes.includes(data.type);
+        const isValidType = MetricsConsumer.isValidMetricType(data.type);
         if (!isValidType) {
             log.error('unknown type field encountered in metrics consumer', {
                 method: 'MetricsConsumer.processKafkaEntry',


### PR DESCRIPTION
Changes in this PR:
- MongoQueueProcessor normalize pending method to decrement
  pending in cases of skipped entries or errors
- extend MetricsConsumer to handle these pending
  normalizations (currently only added pending decrements as
  I don't see a need for pending increments. But increments
  will be needed in replication)