### PR TITLE
bf: ZENKO-1629 ingestion repInfo md only updates

### DIFF
--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -22,6 +22,7 @@ const { getAccountCredentials } =
 const MetricsProducer = require('../../lib/MetricsProducer');
 const { metricsExtension, metricsTypeCompleted, metricsTypePendingOnly } =
     require('../ingestion/constants');
+const getContentType = require('./utils/contentTypeHelper');
 
 // TODO - ADD PREFIX BASED ON SOURCE
 // april 6, 2018
@@ -209,19 +210,15 @@ class MongoQueueProcessor {
         ], done);
     }
 
-    _getDataContent(entry) {
-        const contentLength = entry.getContentLength();
-        if (contentLength > 0) {
-            return ['DATA', 'METADATA'];
-        } else {
-            return ['METADATA'];
-        }
-    }
-
     _getZenkoObjectMetadata(entry, done) {
         const bucket = entry.getBucket();
         const key = entry.getObjectKey();
-        const params = { versionId: entry.getVersionId() };
+        const params = {};
+        // if not master and is not null version
+        if (!isMasterKey(entry.getObjectVersionedKey()) &&
+            entry.getVersionId()) {
+            params.versionId = entry.getVersionId();
+        }
 
         this._mongoClient.getObject(bucket, key, params, this.logger,
         (err, data) => {
@@ -238,6 +235,24 @@ class MongoQueueProcessor {
             }
             return done(null, data);
         });
+    }
+
+    /**
+     * get dataStoreVersionId, if exists
+     * @param {Object} objMd - object md fetched from mongo
+     * @param {String} site - storage location name
+     * @return {String} dataStoreVersionId
+     */
+    _getDataStoreVersionId(objMd, site) {
+        let dataStoreVersionId = '';
+        if (objMd.replicationInfo && objMd.replicationInfo.backends) {
+            const backend = objMd.replicationInfo.backends
+                                                 .find(l => l.site === site);
+            if (backend && backend.dataStoreVersionId) {
+                dataStoreVersionId = backend.dataStoreVersionId;
+            }
+        }
+        return dataStoreVersionId;
     }
 
     /**
@@ -302,9 +317,10 @@ class MongoQueueProcessor {
      * @param {ObjectQueueEntry} entry - object queue entry object
      * @param {BucketInfo} bucketInfo - bucket info object
      * @param {Array} content - replication info content field
+     * @param {Object|undefined} zenkoObjMd - metadata fetched from mongo
      * @return {undefined}
      */
-    _updateReplicationInfo(entry, bucketInfo, content) {
+    _updateReplicationInfo(entry, bucketInfo, content, zenkoObjMd) {
         const bucketRepInfo = bucketInfo.getReplicationConfiguration();
 
         // reset first before attempting any other updates
@@ -332,10 +348,15 @@ class MongoQueueProcessor {
                     if (location && replicationBackends[location.type]) {
                         storageTypes.push(location.type);
                     }
+                    let dataStoreVersionId = '';
+                    if (zenkoObjMd) {
+                        dataStoreVersionId = this._getDataStoreVersionId(
+                            zenkoObjMd, storageClassName);
+                    }
                     backends.push({
                         site: storageClassName,
                         status: 'PENDING',
-                        dataStoreVersionId: '',
+                        dataStoreVersionId,
                     });
                 });
 
@@ -416,27 +437,26 @@ class MongoQueueProcessor {
                 });
                 return done(err);
             }
-            // identify duplicate entry if the object key w/ version id already
-            // exists in mongo and the current entry is not a master key
-            if (zenkoObjMd && !isMasterKey(key)) {
+
+            const content = getContentType(sourceEntry, zenkoObjMd);
+            if (content.length === 0) {
                 this._normalizePendingMetric(location);
                 this.logger.debug('skipping duplicate entry', {
                     method: 'MongoQueueProcessor._processObjectQueueEntry',
                     entry: sourceEntry.getLogInfo(),
                     location,
                 });
-                return process.nextTick(done);
+                // identified as duplicate entry, do not store in mongo
+                return done();
             }
-            // TODO: for md-only updates, content will need to be checked
-            //   based off previous entries
-            const content = this._getDataContent(sourceEntry);
 
             // update necessary metadata fields before saving to Zenko MongoDB
             this._updateOwnerMD(sourceEntry, bucketInfo);
             this._updateObjectDataStoreName(sourceEntry, location);
             this._updateLocations(sourceEntry, location);
             this._updateAcl(sourceEntry);
-            this._updateReplicationInfo(sourceEntry, bucketInfo, content);
+            this._updateReplicationInfo(sourceEntry, bucketInfo, content,
+                zenkoObjMd);
 
             const objVal = sourceEntry.getValue();
             // Always call putObject with version params undefined so

--- a/extensions/mongoProcessor/utils/contentTypeHelper.js
+++ b/extensions/mongoProcessor/utils/contentTypeHelper.js
@@ -1,0 +1,82 @@
+'use strict'; // eslint-disable-line
+
+function _getDataContent(entry) {
+    const contentLength = entry.getContentLength();
+    if (contentLength > 0) {
+        return ['DATA', 'METADATA'];
+    }
+    return ['METADATA'];
+}
+
+function _getMPUTagContent(entry) {
+    if (entry.isMultipartUpload()) {
+        return ['MPU'];
+    }
+    return [];
+}
+
+/**
+ * compares object tags between Zenko object and kafka object entry to see
+ * if entry contains a object tagging change (for replication Content field)
+ * @param {ObjectQueueEntry} entry - object metadata entry from Kafka entry
+ * @param {Object} zenkoObjMd - Zenko object metadata currently in Mongo
+ * @return {undefined}
+ */
+function _getObjectTagContent(entry, zenkoObjMd) {
+    const kafkaEntryTags = entry.getTags();
+    const zenkoTags = zenkoObjMd.tags;
+    const kafkaTagLength = Object.keys(kafkaEntryTags).length;
+    const zenkoTagLength = Object.keys(zenkoTags).length;
+
+    // if tagging does not exist on past entry vs present entry, identify as
+    // duplicate entry
+    if (kafkaTagLength === 0 && zenkoTagLength === 0) {
+        return [];
+    }
+    // When comparing `kafkaEntryTags` and `zenkoTags`
+    // Cases for PUT_TAGGING:
+    // - If tag length matches and any key values differ
+    // - If kafka entry tags exist and zenko object tags do not
+    // - If tag length differ
+    // Cases for DELETE_TAGGING:
+    // - If zenko object tags exist and kafka entry tags do not
+    if (kafkaTagLength === zenkoTagLength) {
+        const hasChanged = Object.keys(kafkaEntryTags).some(tag =>
+            kafkaEntryTags[tag] !== zenkoTags[tag]
+        );
+        if (hasChanged) {
+            return ['METADATA', 'PUT_TAGGING'];
+        }
+    }
+    // Check delete tags before checking next conditional given tag
+    // length difference check.
+    if (kafkaTagLength === 0 && zenkoTagLength !== 0) {
+        return ['METADATA', 'DELETE_TAGGING'];
+    }
+    if ((kafkaTagLength !== 0 && zenkoTagLength === 0) ||
+         kafkaTagLength !== zenkoTagLength) {
+        return ['METADATA', 'PUT_TAGGING'];
+    }
+    return [];
+}
+
+/**
+ * Get the replicationInfo Content field for a newly ingested object entry
+ * @param {ObjectQueueEntry} entry - object queue entry object
+ * @param {Object|undefined} zenkoObjMd - object metadata currently saved in
+ *    mongo. Can be undefined if this entry has never been ingested before
+ * @return {Array} array of ReplicationInfo Content Type
+ */
+function getContentType(entry, zenkoObjMd) {
+    // if object already exists in mongo, only check for md-only updates.
+    if (zenkoObjMd) {
+        return _getObjectTagContent(entry, zenkoObjMd);
+    }
+    // object does not exist in mongo or is a master key entry
+    const content = [];
+    content.push(..._getDataContent(entry));
+    content.push(..._getMPUTagContent(entry));
+    return content;
+}
+
+module.exports = getContentType;


### PR DESCRIPTION
Identify md-only (i.e. PUT/DELETE tagging) updates for
setting the ReplicationInfo "Content" field. This is
necessary for replication-enabled ingestion buckets
in order to replicate md-only updates.

Idea is to fetch metadata from mongo and make comparisons
between the new entry and existing entry in mongo. If entry
does not exist in mongo, this is a newly ingested entry.
If entry exists in mongo, we only compare tagging between
the two entries as that is the only field we care about.