### PR TITLE
bugfix: ZENKO-1606 MPU tagging during replication

### DIFF
--- a/extensions/replication/tasks/CopyLocationTask.js
+++ b/extensions/replication/tasks/CopyLocationTask.js
@@ -444,6 +444,7 @@ class CopyLocationTask extends BackbeatTask {
             ContentEncoding: objMD.getContentEncoding() ||
                 undefined,
             UploadId: uploadId,
+            Tags: JSON.stringify(objMD.getTags()),
             Body: JSON.stringify(data),
         });
         attachReqUids(destReq, log);
@@ -572,6 +573,7 @@ class CopyLocationTask extends BackbeatTask {
             ContentDisposition:
                 objMD.getContentDisposition() || undefined,
             ContentEncoding: objMD.getContentEncoding() || undefined,
+            Tags: JSON.stringify(objMD.getTags()),
         });
         attachReqUids(destReq, log);
         return destReq.send((err, data) => {

--- a/extensions/replication/tasks/MultipleBackendTask.js
+++ b/extensions/replication/tasks/MultipleBackendTask.js
@@ -303,6 +303,7 @@ class MultipleBackendTask extends ReplicateObject {
             ContentEncoding: sourceEntry.getContentEncoding() ||
                 undefined,
             UploadId: uploadId,
+            Tags: JSON.stringify(sourceEntry.getTags()),
             Body: JSON.stringify(data),
         });
         attachReqUids(destReq, log);
@@ -440,6 +441,7 @@ class MultipleBackendTask extends ReplicateObject {
             ContentDisposition:
                 sourceEntry.getContentDisposition() || undefined,
             ContentEncoding: sourceEntry.getContentEncoding() || undefined,
+            Tags: JSON.stringify(sourceEntry.getTags()),
         });
         attachReqUids(destReq, log);
         return destReq.send((err, data) => {

--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -375,6 +375,10 @@
                         "location": "header",
                         "locationName": "X-Scal-Content-Encoding"
                     },
+                    "Tags": {
+                        "location": "header",
+                        "locationName": "X-Scal-Tags"
+                    },
                     "Body": {
                         "type": "blob"
                     }
@@ -486,6 +490,10 @@
                     "UploadId": {
                         "location": "header",
                         "locationName": "X-Scal-Upload-Id"
+                    },
+                    "Tags": {
+                        "location": "header",
+                        "locationName": "X-Scal-Tags"
                     },
                     "Body": {
                         "type": "blob"

--- a/tests/utils/mockEntries.js
+++ b/tests/utils/mockEntries.js
@@ -11,6 +11,7 @@ const sourceEntry = {
     getContentDisposition: () => {},
     getContentEncoding: () => {},
     getReplicationIsNFS: () => {},
+    getTags: () => {},
 };
 
 module.exports = { sourceEntry };


### PR DESCRIPTION
Send any object tags to the route backbeat during an MPU operation.

Depends on:
* https://github.com/scality/cloudserver/pull/1779
* https://github.com/scality/Arsenal/pull/773