### PR TITLE
bf: ZENKO-1718 ingestion master version

### DIFF
--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -8,7 +8,7 @@ const { replicationBackends, emptyFileMd5 } = require('arsenal').constants;
 const MongoClient = require('arsenal').storage
     .metadata.mongoclient.MongoClientInterface;
 const ObjectMD = require('arsenal').models.ObjectMD;
-const { isMasterKey } = require('arsenal/lib/versioning/Version');
+const { encode } = require('arsenal').versioning.VersionID;
 
 const Config = require('../../conf/Config');
 const BackbeatConsumer = require('../../lib/BackbeatConsumer');
@@ -184,9 +184,7 @@ class MongoQueueProcessor {
         const bucket = entry.getBucket();
         const key = entry.getObjectKey();
         const params = {};
-        // if not master and is not null version
-        if (!isMasterKey(entry.getObjectVersionedKey()) &&
-            entry.getVersionId()) {
+        if (entry.getVersionId()) {
             params.versionId = entry.getVersionId();
         }
 
@@ -256,11 +254,12 @@ class MongoQueueProcessor {
      */
     _updateLocations(entry, zenkoLocation) {
         const locations = entry.getLocation();
+        // if version id is undefined, we have a single null object.
+        // To hold reference to this null object, we need to encode "null"
+        // as its dataStoreVersionId
+        const dataStoreVersionId = entry.getVersionId() ?
+            entry.getEncodedVersionId() : encode('null');
         if (!locations || locations.length === 0) {
-            // if version id is defined and this is not a null version
-            const dataStoreVersionId =
-                (entry.getVersionId() && !entry.getIsNull()) ?
-                    entry.getEncodedVersionId() : '';
             const editLocation = [{
                 key: entry.getObjectKey(),
                 size: 0,
@@ -277,9 +276,8 @@ class MongoQueueProcessor {
                     key: entry.getObjectKey(),
                     dataStoreName: zenkoLocation,
                     dataStoreType: 'aws_s3',
+                    dataStoreVersionId,
                 };
-                newValues.dataStoreVersionId = entry.getVersionId() ?
-                    entry.getEncodedVersionId() : '';
                 return Object.assign({}, location, newValues);
             });
             entry.setLocation(editLocations);
@@ -412,8 +410,7 @@ class MongoQueueProcessor {
      */
     _processObjectQueueEntry(log, sourceEntry, location, bucketInfo, done) {
         const bucket = sourceEntry.getBucket();
-        // always use versioned key so putting full version state to mongo
-        const key = sourceEntry.getObjectVersionedKey();
+        const key = sourceEntry.getObjectKey();
 
         this._getZenkoObjectMetadata(log, sourceEntry, bucketInfo,
         (err, zenkoObjMd) => {
@@ -448,19 +445,28 @@ class MongoQueueProcessor {
                 zenkoObjMd);
 
             const objVal = sourceEntry.getValue();
-            // Always call putObject with version params undefined so
-            // that mongoClient will use putObjectNoVer which just puts
-            // the object without further manipulation/actions.
-            // S3 takes care of the versioning logic so consuming the queue
-            // is sufficient to replay the version logic in the consumer.
-            return this._mongoClient.putObject(bucket, key, objVal, undefined,
-                log, err => {
+            const params = {};
+            if (sourceEntry.getVersionId()) {
+                params.versionId = sourceEntry.getVersionId();
+                params.usePHD = true;
+            }
+
+            // For single null versions, their version id is undefined
+            // and isNull is undefined. Always call putObject with version
+            // params undefined so that mongoClient will use putObjectNoVer
+            // which just puts the object without further manipulation/actions.
+            // For all other entries, we specify `usePHD` and `versionId` in
+            // params to putObject to use putObjectVerCase4. We rely on
+            // internal logic in mongoClient for handling master version ops.
+            return this._mongoClient.putObject(bucket, key, objVal, params,
+                this.logger, err => {
                     if (err) {
                         this._normalizePendingMetric(location);
                         log.end().error('error putting object metadata ' +
                         'to mongo', {
                             bucket,
                             key,
+                            versionId: sourceEntry.getEncodedVersionId(),
                             error: err.message,
                             location,
                         });

--- a/tests/functional/ingestion/IngestionReader.js
+++ b/tests/functional/ingestion/IngestionReader.js
@@ -62,8 +62,8 @@ function setZookeeperInitState(ingestionReader, cb) {
 }
 
 function checkEntryInQueue(kafkaEntries, expectedEntries, done) {
-    // 2 entries per object - 1 with version key and 1 with master key
-    assert.strictEqual(kafkaEntries.length, expectedEntries.length * 2);
+    // 2 entries per object, but the master key is filtered
+    assert.strictEqual(kafkaEntries.length, expectedEntries.length);
 
     const retrievedEntries = kafkaEntries.map(entry => JSON.parse(entry.value));
 
@@ -84,7 +84,7 @@ function checkEntryInQueue(kafkaEntries, expectedEntries, done) {
                     assert.strictEqual(JSON.stringify(entryValue[key]),
                                        JSON.stringify(kafkaValue[key]));
                 } else if (key !== 'md-model-version') {
-                   // ignore model version, but compare all other fields
+                    // ignore model version, but compare all other fields
                     assert.strictEqual(entryValue[key], kafkaValue[key]);
                 }
             });


### PR DESCRIPTION
Goes with https://github.com/scality/Arsenal/pull/774

Avoid handling of master version entries. Rely on pre-existing logic for handling this for us.

There are these single null versions that look like master keys. To create these, you create object(s) in a non-versioned bucket, then enable versioning on bucket, and try and ingest these null version objects. Their obj md specifies no "isNull" and they have no internal version id (the one we default for null versions in suspended buckets). I mention these in in-line comments usually as "single null versions"

Changes in this PR:
- Filter master keys on populator
- Update arsenal, and use `putObjectVerCase4`
- Always set `dataStoreVersionId` in the `locations` array on object md.
     - null version objects with no internal version id (single null versions). We encode the string "null" and save to mongo so we can reference these null versions from Zenko.


Note: moved out MongoQueueProcessor fxnl tests to own PR
