### PR TITLE
bugfix: ZENKO-1729 Use if..else for error logging

### DIFF
--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -918,8 +918,14 @@ class LifecycleTask extends BackbeatTask {
                     method: 'LifecycleTask._applyTransitionRule',
                     error: err,
                 });
+            } else {
+                log.debug('transition rule applied', {
+                    method: 'LifecycleTask._applyTransitionRule',
+                    bucket: params.bucket,
+                    key: params.objectKey,
+                    site: params.site,
+                });
             }
-            log.debug('transition rule applied');
         });
     }
 


### PR DESCRIPTION
During the error condition, we shouldn't log both the error message and success debug message.