### PR TITLE
bf: ZENKO-1585 retro propagation filter for s3c ingestion

### DIFF
--- a/conf/Config.js
+++ b/conf/Config.js
@@ -5,6 +5,7 @@ const { EventEmitter } = require('events');
 const fs = require('fs');
 const path = require('path');
 const joi = require('joi');
+const crypto = require('crypto');
 
 const extensions = require('../extensions');
 const backbeatConfigJoi = require('./config.joi.js');
@@ -212,6 +213,16 @@ class Config extends EventEmitter {
 
     getIsTransientLocation(locationName) {
         return this.transientLocations[locationName] || false;
+    }
+
+    getPublicInstanceId() {
+        return this.publicInstanceId;
+    }
+
+    setPublicInstanceId(instanceId) {
+        this.publicInstanceId = crypto.createHash('sha256')
+                                .update(instanceId)
+                                .digest('hex');
     }
 }
 

--- a/extensions/ingestion/IngestionQueuePopulator.js
+++ b/extensions/ingestion/IngestionQueuePopulator.js
@@ -8,6 +8,7 @@ class IngestionQueuePopulator extends QueuePopulatorExtension {
     constructor(params) {
         super(params);
         this.config = params.config;
+        this._instanceId = params.instanceId;
     }
 
     // called by _processLogEntry in lib/queuePopulator/LogReader.js
@@ -22,54 +23,8 @@ class IngestionQueuePopulator extends QueuePopulatorExtension {
             this.log.trace('skipping entry because missing bucket name');
             return;
         }
-        if (entry.value) {
-            const metadataVal = JSON.parse(entry.value);
-            // Filter out bucket metadata entries
-            // If `attributes` key exists in metadata, this is a nested bucket
-            // metadata entry for s3c buckets
-            if (metadataVal.mdBucketModelVersion ||
-                metadataVal.attributes) {
-                return;
-            }
-            if (entry.type === 'put') {
-                const queueEntry = new ObjectQueueEntry(entry.bucket,
-                                                        entry.key,
-                                                        metadataVal);
-                const sanityCheckRes = queueEntry.checkSanity();
-                if (sanityCheckRes) {
-                    this.log.trace('entry malformed', {
-                        method: 'IngestionQueuePopulator.filter',
-                        bucket: entry.bucket,
-                        key: entry.key,
-                        type: entry.type,
-                    });
-                    return;
-                }
-                // Retro-propagation is where S3C ingestion will re-ingest an
-                // object whose request originated from Zenko.
-                // Filter these entries indicated by user metadata field
-                // defined by constants.zenkoIDHeader
-                const userMD = queueEntry.getUserMetadata();
-                let existingIDHeader;
-                if (userMD) {
-                    try {
-                        const metaHeaders = JSON.parse(userMD);
-                        existingIDHeader = metaHeaders[zenkoIDHeader];
-                    } catch (err) {
-                        this.log.trace('malformed user metadata', {
-                            method: 'IngestionQueuePopulator.filter',
-                            bucket: entry.bucket,
-                            key: entry.key,
-                            type: entry.type,
-                        });
-                        return;
-                    }
-                    if (existingIDHeader && existingIDHeader === 'zenko') {
-                        this.log.trace('skipping retro-propagated entry');
-                        return;
-                    }
-                }
-            }
+        if (entry.value && this._filterValueOp(entry)) {
+            return;
         }
 
         this.log.debug('publishing entry',
@@ -79,6 +34,85 @@ class IngestionQueuePopulator extends QueuePopulatorExtension {
                      JSON.stringify(entry));
 
         this._incrementMetrics(entry.bucket);
+    }
+
+    _filterValueOp(entry) {
+        const metadataVal = JSON.parse(entry.value);
+        if (this._isBucketEntry(metadataVal)) {
+            this.log.trace('skipping bucket entry');
+            return true;
+        }
+        if (entry.type === 'put') {
+            const queueEntry = new ObjectQueueEntry(entry.bucket,
+                                                    entry.key,
+                                                    metadataVal);
+            const sanityCheckRes = queueEntry.checkSanity();
+            if (sanityCheckRes) {
+                this.log.trace('entry malformed', {
+                    method: 'IngestionQueuePopulator.filter',
+                    error: sanityCheckRes.message,
+                    bucket: entry.bucket,
+                    key: entry.key,
+                    type: entry.type,
+                });
+                return true;
+            }
+            if (this._isRetroPropagationEntry(queueEntry)) {
+                this.log.trace('skipping retro-propagated entry');
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Filter out bucket metadata entries from S3C Raft logs
+     * @param {Object} metadataVal - entry metadata value
+     * @return {Boolean} true if we should filter entry
+     */
+    _isBucketEntry(metadataVal) {
+        // If `attributes` key exists in metadata, this is a nested bucket
+        // metadata entry for s3c buckets
+        if (metadataVal.mdBucketModelVersion ||
+            metadataVal.attributes) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Retro-propagation is where S3C ingestion will re-ingest an object whose
+     * request originated from Zenko. Filter these entries indicated by user
+     * metadata field defined by constants.zenkoIDHeader
+     * @param {ObjectQueueEntry} entry - object queue entry instance
+     * @return {Boolean} true if we should filter entry
+     */
+    _isRetroPropagationEntry(entry) {
+        const userMD = entry.getUserMetadata();
+        let existingIDHeader;
+        if (userMD) {
+            try {
+                const metaHeaders = JSON.parse(userMD);
+                existingIDHeader = metaHeaders[zenkoIDHeader];
+            } catch (err) {
+                this.log.trace('malformed user metadata', {
+                    method: 'IngestionQueuePopulator.filter',
+                    bucket: entry.bucket,
+                    key: entry.key,
+                    type: entry.type,
+                });
+                return true;
+            }
+            // if user metadata field of `constants.zenkoIDHeader`
+            // exists and value is either 'zenko' (for delete markers)
+            // or matches given hashed instance id
+            if (existingIDHeader && (existingIDHeader === 'zenko' ||
+                existingIDHeader === this._instanceId)) {
+                this.log.trace('skipping retro-propagated entry');
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/lib/management/patchConfiguration.js
+++ b/lib/management/patchConfiguration.js
@@ -68,6 +68,8 @@ logger, cb) {
                     overlayVersion >= conf.version) {
                     return process.nextTick(next);
                 }
+                // save instance id
+                config.setPublicInstanceId(conf.instanceId);
                 return updateLocations(conf, logger, cb);
             }
         ], cb);

--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -531,6 +531,7 @@ class IngestionPopulator {
         const ext = new index.queuePopulatorExtension({
             config: this.ingestionConfig,
             logger: this.log,
+            instanceId: config.getPublicInstanceId(),
         });
         ext.setZkConfig(this.zkConfig);
         this._extension = ext;

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,14 +60,11 @@
       "from": "github:scality/cloudserver#d47b71d",
       "dev": true,
       "requires": {
-        "arsenal": "github:scality/arsenal#699890d2d7badd4981bcb7f7ad4a5aaf98cef01c",
         "async": "~2.5.0",
         "aws-sdk": "2.28.0",
         "azure-storage": "^2.1.0",
         "backo": "^1.1.0",
-        "bucketclient": "github:scality/bucketclient#5aa99d7b25fdfb5a42b787cce7710cdec8ac78f0",
         "bufferutil": "^3.0.5",
-        "cdmiclient": "github:scality/cdmiclient#8f0c2e6331dfa905bfe269fb4e1558d65ca0b866",
         "commander": "^2.9.0",
         "diskusage": "0.2.4",
         "google-auto-auth": "^0.9.1",
@@ -79,14 +76,10 @@
         "npm-run-all": "~4.0.2",
         "prom-client": "^10.2.3",
         "request": "^2.81.0",
-        "sproxydclient": "github:scality/sproxydclient#45090b76b24ca1d05482bf151ba84ff6178423d1",
         "sql-where-parser": "~2.2.1",
-        "utapi": "github:scality/utapi#f2f1d0c7423ffdec2ad175e3c0e8bcd7aa2ba867",
         "utf-8-validate": "^4.0.2",
         "utf8": "~2.1.1",
         "uuid": "^3.0.1",
-        "vaultclient": "github:scality/vaultclient#754b6e1e1121f44bc3719e35b836a9185d6d5e1a",
-        "werelogs": "github:scality/werelogs#74b121bef4068645e307da143749e61ef416a4c3",
         "ws": "^5.1.0",
         "xml2js": "~0.4.16"
       },
@@ -95,7 +88,6 @@
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
           "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
-          "dev": true,
           "requires": {
             "xtend": "~4.0.0"
           }
@@ -104,7 +96,6 @@
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
-          "dev": true,
           "requires": {
             "mime-types": "~2.1.11",
             "negotiator": "0.6.1"
@@ -113,13 +104,11 @@
         "arraybuffer.slice": {
           "version": "0.0.6",
           "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
-          "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco=",
-          "dev": true
+          "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco="
         },
         "arsenal": {
           "version": "github:scality/arsenal#699890d2d7badd4981bcb7f7ad4a5aaf98cef01c",
-          "from": "github:scality/arsenal#699890d",
-          "dev": true,
+          "from": "github:scality/arsenal#699890d2d7badd4981bcb7f7ad4a5aaf98cef01c",
           "requires": {
             "JSONStream": "^1.0.0",
             "ajv": "4.10.0",
@@ -149,7 +138,6 @@
               "version": "2.6.2",
               "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
               "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
-              "dev": true,
               "requires": {
                 "lodash": "^4.17.11"
               }
@@ -158,7 +146,6 @@
               "version": "1.1.1",
               "resolved": "https://registry.npmjs.org/diskusage/-/diskusage-1.1.1.tgz",
               "integrity": "sha512-YI5PJXdZEe1QfVGx+n0IFbxXYj2cwV/PrQKZKvBKjA///EHNoeM1dJafBYPsfAn9yrb+BDhHSoZ1FDrgs1kqaQ==",
-              "dev": true,
               "requires": {
                 "es6-promise": "^4.2.5",
                 "nan": "^2.11.1"
@@ -168,7 +155,6 @@
               "version": "3.2.3",
               "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.2.3.tgz",
               "integrity": "sha512-jw8UyPsq4QleZ9z+t/pIVy3L++51vKdaJ2Q/XXeYxk/3cnKioAH8H6f5tkkDivrQL4PUgUOHe9uZzkpRFH1XtQ==",
-              "dev": true,
               "requires": {
                 "mongodb-core": "^3.2.3",
                 "safe-buffer": "^5.1.2"
@@ -177,13 +163,11 @@
             "utf8": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-              "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
-              "dev": true
+              "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
             },
             "werelogs": {
               "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
               "from": "github:scality/werelogs#0ff7ec82",
-              "dev": true,
               "requires": {
                 "safe-json-stringify": "1.0.3"
               }
@@ -194,7 +178,6 @@
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
           "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
-          "dev": true,
           "requires": {
             "lodash": "^4.14.0"
           }
@@ -237,13 +220,11 @@
         "blob": {
           "version": "0.0.4",
           "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-          "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
-          "dev": true
+          "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
         },
         "bucketclient": {
           "version": "github:scality/bucketclient#5aa99d7b25fdfb5a42b787cce7710cdec8ac78f0",
-          "from": "github:scality/bucketclient#5aa99d7",
-          "dev": true,
+          "from": "github:scality/bucketclient#5aa99d7b25fdfb5a42b787cce7710cdec8ac78f0",
           "requires": {
             "arsenal": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
             "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2"
@@ -252,7 +233,6 @@
             "arsenal": {
               "version": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
               "from": "github:scality/Arsenal#7.4.0.3",
-              "dev": true,
               "requires": {
                 "JSONStream": "^1.0.0",
                 "ajv": "4.10.0",
@@ -278,7 +258,6 @@
                 "werelogs": {
                   "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
                   "from": "github:scality/werelogs#hotfix/7.4.0",
-                  "dev": true,
                   "requires": {
                     "safe-json-stringify": "^1.0.3"
                   }
@@ -289,7 +268,6 @@
               "version": "2.1.5",
               "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
               "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
-              "dev": true,
               "requires": {
                 "lodash": "^4.14.0"
               }
@@ -297,29 +275,38 @@
             "component-emitter": {
               "version": "1.2.1",
               "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-              "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-              "dev": true
+              "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
             },
             "debug": {
               "version": "2.3.3",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
               "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-              "dev": true,
               "requires": {
                 "ms": "0.7.2"
+              }
+            },
+            "double-ended-queue": {
+              "version": "2.1.0-0",
+              "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+              "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+            },
+            "has-binary": {
+              "version": "0.1.7",
+              "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+              "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
+              "requires": {
+                "isarray": "0.0.1"
               }
             },
             "hoek": {
               "version": "4.2.1",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-              "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
-              "dev": true
+              "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
             },
             "ioctl": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ioctl/-/ioctl-2.0.0.tgz",
               "integrity": "sha1-Kqy9c+tv+a0B/fPswzkO5XeBEA4=",
-              "dev": true,
               "optional": true,
               "requires": {
                 "bindings": "^1.1.1",
@@ -330,7 +317,6 @@
               "version": "2.4.0",
               "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.4.0.tgz",
               "integrity": "sha1-lj97+8huXEDqWGhX4U6/tUgUKog=",
-              "dev": true,
               "requires": {
                 "bluebird": "^3.3.4",
                 "cluster-key-slot": "^1.0.6",
@@ -345,20 +331,17 @@
             "ipaddr.js": {
               "version": "1.2.0",
               "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz",
-              "integrity": "sha1-irpJyRknmVhb3WQ+DMtQ6K53e6Q=",
-              "dev": true
+              "integrity": "sha1-irpJyRknmVhb3WQ+DMtQ6K53e6Q="
             },
             "isemail": {
               "version": "2.2.1",
               "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
-              "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=",
-              "dev": true
+              "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
             },
             "joi": {
               "version": "10.6.0",
               "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
               "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
-              "dev": true,
               "requires": {
                 "hoek": "4.x.x",
                 "isemail": "2.x.x",
@@ -370,7 +353,6 @@
               "version": "1.6.0",
               "resolved": "https://registry.npmjs.org/level/-/level-1.6.0.tgz",
               "integrity": "sha1-P8uukWOgkWaLjsep79HS/u8eZiE=",
-              "dev": true,
               "requires": {
                 "level-packager": "~1.2.0",
                 "leveldown": "~1.6.0"
@@ -379,20 +361,17 @@
             "ms": {
               "version": "0.7.2",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-              "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-              "dev": true
+              "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
             },
             "redis-parser": {
               "version": "1.3.0",
               "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-1.3.0.tgz",
-              "integrity": "sha1-gG6+e7+3005NfB6e8oLvz60EEmo=",
-              "dev": true
+              "integrity": "sha1-gG6+e7+3005NfB6e8oLvz60EEmo="
             },
             "simple-glob": {
               "version": "0.1.1",
               "resolved": "https://registry.npmjs.org/simple-glob/-/simple-glob-0.1.1.tgz",
               "integrity": "sha1-KCv6AS1yBmQ99h00xrueTOP9dxQ=",
-              "dev": true,
               "requires": {
                 "glob": "~3.2.8",
                 "lodash": "~2.4.1",
@@ -402,8 +381,7 @@
                 "lodash": {
                   "version": "2.4.2",
                   "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-                  "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-                  "dev": true
+                  "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
                 }
               }
             },
@@ -411,7 +389,6 @@
               "version": "1.7.4",
               "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.4.tgz",
               "integrity": "sha1-L37O3DORvy1cc+KR/iM+bjTU3QA=",
-              "dev": true,
               "requires": {
                 "debug": "2.3.3",
                 "engine.io": "~1.8.4",
@@ -426,7 +403,6 @@
               "version": "1.7.4",
               "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.4.tgz",
               "integrity": "sha1-7J+CA1btme9tNX8HVtZIcXvdQoE=",
-              "dev": true,
               "requires": {
                 "backo2": "1.0.2",
                 "component-bind": "1.0.0",
@@ -445,7 +421,6 @@
               "version": "2.0.2",
               "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
               "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
-              "dev": true,
               "requires": {
                 "hoek": "4.x.x"
               }
@@ -453,9 +428,243 @@
             "werelogs": {
               "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
               "from": "github:scality/werelogs#7.4.0.3",
-              "dev": true,
               "requires": {
                 "safe-json-stringify": "^1.0.3"
+              }
+            }
+          }
+        },
+        "cdmiclient": {
+          "version": "github:scality/cdmiclient#8f0c2e6331dfa905bfe269fb4e1558d65ca0b866",
+          "from": "github:scality/cdmiclient#8f0c2e6331dfa905bfe269fb4e1558d65ca0b866",
+          "requires": {
+            "arsenal": "github:scality/Arsenal#2ff9cf866de3d0f69da2317ed82c6b968129988d",
+            "async": "~1.4.2",
+            "werelogs": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46"
+          },
+          "dependencies": {
+            "arsenal": {
+              "version": "github:scality/Arsenal#2ff9cf866de3d0f69da2317ed82c6b968129988d",
+              "from": "github:scality/Arsenal#development/8.0",
+              "requires": {
+                "JSONStream": "^1.0.0",
+                "ajv": "4.10.0",
+                "async": "~2.1.5",
+                "bson": "2.0.4",
+                "debug": "~2.3.3",
+                "diskusage": "^0.2.2",
+                "fcntl": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
+                "ioctl": "2.0.0",
+                "ioredis": "2.4.0",
+                "ipaddr.js": "1.2.0",
+                "joi": "^10.6",
+                "level": "~1.6.0",
+                "level-sublevel": "~6.6.1",
+                "mongodb": "^3.0.1",
+                "node-forge": "^0.7.1",
+                "simple-glob": "^0.1",
+                "socket.io": "~1.7.3",
+                "socket.io-client": "~1.7.3",
+                "utf8": "2.1.2",
+                "uuid": "^3.0.1",
+                "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+                "xml2js": "~0.4.16"
+              },
+              "dependencies": {
+                "async": {
+                  "version": "2.1.5",
+                  "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+                  "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+                  "requires": {
+                    "lodash": "^4.14.0"
+                  }
+                },
+                "werelogs": {
+                  "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+                  "from": "github:scality/werelogs#0ff7ec82",
+                  "requires": {
+                    "safe-json-stringify": "1.0.3"
+                  }
+                }
+              }
+            },
+            "async": {
+              "version": "1.4.2",
+              "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
+              "integrity": "sha1-bJ7csRztTw3S8tQNsNSaEJwIiqs="
+            },
+            "bson": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/bson/-/bson-2.0.4.tgz",
+              "integrity": "sha512-e/GPy6CE0xL7MOYYRMIEwPGKF21WNaQdPIpV0YvaQDoR7oc47KUZ8c2P/TlRJVQP8RZ4CEsArGBC1NbkCRvl1w=="
+            },
+            "component-emitter": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+              "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+            },
+            "debug": {
+              "version": "2.3.3",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+              "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+              "requires": {
+                "ms": "0.7.2"
+              }
+            },
+            "double-ended-queue": {
+              "version": "2.1.0-0",
+              "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+              "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+            },
+            "has-binary": {
+              "version": "0.1.7",
+              "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+              "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
+              "requires": {
+                "isarray": "0.0.1"
+              }
+            },
+            "hoek": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+              "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+            },
+            "ioctl": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ioctl/-/ioctl-2.0.0.tgz",
+              "integrity": "sha1-Kqy9c+tv+a0B/fPswzkO5XeBEA4=",
+              "optional": true,
+              "requires": {
+                "bindings": "^1.1.1",
+                "nan": "^2.3.2"
+              }
+            },
+            "ioredis": {
+              "version": "2.4.0",
+              "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.4.0.tgz",
+              "integrity": "sha1-lj97+8huXEDqWGhX4U6/tUgUKog=",
+              "requires": {
+                "bluebird": "^3.3.4",
+                "cluster-key-slot": "^1.0.6",
+                "debug": "^2.2.0",
+                "double-ended-queue": "^2.1.0-0",
+                "flexbuffer": "0.0.6",
+                "lodash": "^4.8.2",
+                "redis-commands": "^1.2.0",
+                "redis-parser": "^1.3.0"
+              }
+            },
+            "ipaddr.js": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz",
+              "integrity": "sha1-irpJyRknmVhb3WQ+DMtQ6K53e6Q="
+            },
+            "isemail": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+              "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
+            },
+            "joi": {
+              "version": "10.6.0",
+              "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
+              "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+              "requires": {
+                "hoek": "4.x.x",
+                "isemail": "2.x.x",
+                "items": "2.x.x",
+                "topo": "2.x.x"
+              }
+            },
+            "level": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/level/-/level-1.6.0.tgz",
+              "integrity": "sha1-P8uukWOgkWaLjsep79HS/u8eZiE=",
+              "requires": {
+                "level-packager": "~1.2.0",
+                "leveldown": "~1.6.0"
+              }
+            },
+            "mongodb": {
+              "version": "3.2.3",
+              "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.2.3.tgz",
+              "integrity": "sha512-jw8UyPsq4QleZ9z+t/pIVy3L++51vKdaJ2Q/XXeYxk/3cnKioAH8H6f5tkkDivrQL4PUgUOHe9uZzkpRFH1XtQ==",
+              "requires": {
+                "mongodb-core": "^3.2.3",
+                "safe-buffer": "^5.1.2"
+              }
+            },
+            "ms": {
+              "version": "0.7.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+              "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+            },
+            "redis-parser": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-1.3.0.tgz",
+              "integrity": "sha1-gG6+e7+3005NfB6e8oLvz60EEmo="
+            },
+            "simple-glob": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/simple-glob/-/simple-glob-0.1.1.tgz",
+              "integrity": "sha1-KCv6AS1yBmQ99h00xrueTOP9dxQ=",
+              "requires": {
+                "glob": "~3.2.8",
+                "lodash": "~2.4.1",
+                "minimatch": "~0.2.14"
+              },
+              "dependencies": {
+                "lodash": {
+                  "version": "2.4.2",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+                  "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+                }
+              }
+            },
+            "socket.io": {
+              "version": "1.7.4",
+              "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.4.tgz",
+              "integrity": "sha1-L37O3DORvy1cc+KR/iM+bjTU3QA=",
+              "requires": {
+                "debug": "2.3.3",
+                "engine.io": "~1.8.4",
+                "has-binary": "0.1.7",
+                "object-assign": "4.1.0",
+                "socket.io-adapter": "0.5.0",
+                "socket.io-client": "1.7.4",
+                "socket.io-parser": "2.3.1"
+              }
+            },
+            "socket.io-client": {
+              "version": "1.7.4",
+              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.4.tgz",
+              "integrity": "sha1-7J+CA1btme9tNX8HVtZIcXvdQoE=",
+              "requires": {
+                "backo2": "1.0.2",
+                "component-bind": "1.0.0",
+                "component-emitter": "1.2.1",
+                "debug": "2.3.3",
+                "engine.io-client": "~1.8.4",
+                "has-binary": "0.1.7",
+                "indexof": "0.0.1",
+                "object-component": "0.0.3",
+                "parseuri": "0.0.5",
+                "socket.io-parser": "2.3.1",
+                "to-array": "0.1.4"
+              }
+            },
+            "topo": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+              "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+              "requires": {
+                "hoek": "4.x.x"
+              }
+            },
+            "werelogs": {
+              "version": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46",
+              "from": "github:scality/werelogs#development/8.0",
+              "requires": {
+                "safe-json-stringify": "1.0.3"
               }
             }
           }
@@ -463,14 +672,17 @@
         "component-emitter": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-          "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM=",
-          "dev": true
+          "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM="
+        },
+        "cron-parser": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-1.1.0.tgz",
+          "integrity": "sha1-B1uExFnBVejEgqtNVq/5na5YNS4="
         },
         "deferred-leveldown": {
           "version": "1.2.2",
           "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
           "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
-          "dev": true,
           "requires": {
             "abstract-leveldown": "~2.6.0"
           }
@@ -479,7 +691,6 @@
           "version": "0.2.4",
           "resolved": "https://registry.npmjs.org/diskusage/-/diskusage-0.2.4.tgz",
           "integrity": "sha512-XCLBopqnV6FUG/DdphILleiubqVERvF1ZRqkvOIiPQeMlU6Im1nvlsYqLUosgmRz1UQOXcwuO0vgqASl7DNg+w==",
-          "dev": true,
           "requires": {
             "nan": "^2.5.0"
           }
@@ -488,7 +699,6 @@
           "version": "1.8.5",
           "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.5.tgz",
           "integrity": "sha512-j1DWIcktw4hRwrv6nWx++5nFH2X64x16MAG2P0Lmi5Dvdfi3I+Jhc7JKJIdAmDJa+5aZ/imHV7dWRPy2Cqjh3A==",
-          "dev": true,
           "requires": {
             "accepts": "1.3.3",
             "base64id": "1.0.0",
@@ -502,7 +712,6 @@
               "version": "2.3.3",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
               "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-              "dev": true,
               "requires": {
                 "ms": "0.7.2"
               }
@@ -510,17 +719,27 @@
             "ms": {
               "version": "0.7.2",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-              "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-              "dev": true
+              "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
             },
             "ws": {
               "version": "1.1.5",
               "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
               "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
-              "dev": true,
               "requires": {
                 "options": ">=0.0.5",
                 "ultron": "1.0.x"
+              },
+              "dependencies": {
+                "options": {
+                  "version": "0.0.6",
+                  "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+                  "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+                },
+                "ultron": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+                  "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+                }
               }
             }
           }
@@ -529,7 +748,6 @@
           "version": "1.8.5",
           "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.5.tgz",
           "integrity": "sha512-AYTgHyeVUPitsseqjoedjhYJapNVoSPShbZ+tEUX9/73jgZ/Z3sUlJf9oYgdEBBdVhupUpUqSxH0kBCXlQnmZg==",
-          "dev": true,
           "requires": {
             "component-emitter": "1.2.1",
             "component-inherit": "0.0.3",
@@ -548,14 +766,12 @@
             "component-emitter": {
               "version": "1.2.1",
               "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-              "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-              "dev": true
+              "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
             },
             "debug": {
               "version": "2.3.3",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
               "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-              "dev": true,
               "requires": {
                 "ms": "0.7.2"
               }
@@ -563,17 +779,35 @@
             "ms": {
               "version": "0.7.2",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-              "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-              "dev": true
+              "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+            },
+            "parsejson": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
+              "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
+              "requires": {
+                "better-assert": "~1.0.0"
+              }
             },
             "ws": {
               "version": "1.1.5",
               "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
               "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
-              "dev": true,
               "requires": {
                 "options": ">=0.0.5",
                 "ultron": "1.0.x"
+              },
+              "dependencies": {
+                "options": {
+                  "version": "0.0.6",
+                  "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+                  "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+                },
+                "ultron": {
+                  "version": "1.0.2",
+                  "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+                  "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+                }
               }
             }
           }
@@ -582,7 +816,6 @@
           "version": "1.3.2",
           "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
           "integrity": "sha1-k3sHnwAH0Ik+xW1GyyILjLQ1Igo=",
-          "dev": true,
           "requires": {
             "after": "0.8.2",
             "arraybuffer.slice": "0.0.6",
@@ -590,19 +823,32 @@
             "blob": "0.0.4",
             "has-binary": "0.1.7",
             "wtf-8": "1.0.0"
+          },
+          "dependencies": {
+            "has-binary": {
+              "version": "0.1.7",
+              "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+              "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
+              "requires": {
+                "isarray": "0.0.1"
+              }
+            },
+            "wtf-8": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
+              "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo="
+            }
           }
         },
         "expand-template": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
-          "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg==",
-          "dev": true
+          "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg=="
         },
         "glob": {
           "version": "3.2.11",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-          "dev": true,
           "requires": {
             "inherits": "2",
             "minimatch": "0.3"
@@ -612,10 +858,21 @@
               "version": "0.3.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-              "dev": true,
               "requires": {
                 "lru-cache": "2",
                 "sigmund": "~1.0.0"
+              },
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.7.3",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+                  "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+                }
               }
             }
           }
@@ -624,7 +881,6 @@
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.2.0.tgz",
           "integrity": "sha512-PdxZGNJBfPiR2RI6DkqmiacL1+ML3gaqEiaC5QXWQt9eSTlGj+BwDCct0s8irn1ed8GyzAHTzcjvU9fmnl6D7A==",
-          "dev": true,
           "requires": {
             "cluster-key-slot": "^1.0.6",
             "debug": "^3.1.0",
@@ -642,7 +898,6 @@
               "version": "3.2.6",
               "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
               "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-              "dev": true,
               "requires": {
                 "ms": "^2.1.1"
               }
@@ -652,14 +907,12 @@
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "joi": {
           "version": "14.3.1",
           "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.1.tgz",
           "integrity": "sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==",
-          "dev": true,
           "requires": {
             "hoek": "6.x.x",
             "isemail": "3.x.x",
@@ -669,14 +922,12 @@
         "level-codec": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-          "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
-          "dev": true
+          "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ=="
         },
         "level-errors": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
           "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
-          "dev": true,
           "requires": {
             "errno": "~0.1.1"
           }
@@ -685,7 +936,6 @@
           "version": "1.3.1",
           "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
           "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
-          "dev": true,
           "requires": {
             "inherits": "^2.0.1",
             "level-errors": "^1.0.3",
@@ -697,7 +947,6 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-1.2.1.tgz",
           "integrity": "sha1-Bn/t/Qcrf+PGvsYIDAy9SmsuEfQ=",
-          "dev": true,
           "requires": {
             "levelup": "~1.3.0"
           }
@@ -706,7 +955,6 @@
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.6.0.tgz",
           "integrity": "sha1-5uyQbSmVqL/9AkmfOelZiM0rIw8=",
-          "dev": true,
           "requires": {
             "abstract-leveldown": "~2.6.1",
             "bindings": "~1.2.1",
@@ -718,14 +966,12 @@
             "bindings": {
               "version": "1.2.1",
               "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-              "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=",
-              "dev": true
+              "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
             },
             "nan": {
               "version": "2.5.1",
               "resolved": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz",
-              "integrity": "sha1-1bAWkSUzJql6K77p5hxV2NYDUeI=",
-              "dev": true
+              "integrity": "sha1-1bAWkSUzJql6K77p5hxV2NYDUeI="
             }
           }
         },
@@ -733,7 +979,6 @@
           "version": "1.3.9",
           "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
           "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
-          "dev": true,
           "requires": {
             "deferred-leveldown": "~1.2.1",
             "level-codec": "~7.0.0",
@@ -744,14 +989,30 @@
             "xtend": "~4.0.0"
           }
         },
+        "long-timeout": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.0.2.tgz",
+          "integrity": "sha1-82RJuolinROnorJSOk253Wbj/2g="
+        },
         "minimatch": {
           "version": "0.2.14",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-          "dev": true,
           "requires": {
             "lru-cache": "2",
             "sigmund": "~1.0.0"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.7.3",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+              "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+            },
+            "sigmund": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+              "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+            }
           }
         },
         "mongodb": {
@@ -822,8 +1083,16 @@
         "negotiator": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-          "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-          "dev": true
+          "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+        },
+        "node-schedule": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-1.2.0.tgz",
+          "integrity": "sha1-8D1OvnGwVz4XCN2uCqRdFlhFDPE=",
+          "requires": {
+            "cron-parser": "1.1.0",
+            "long-timeout": "0.0.2"
+          }
         },
         "node-uuid": {
           "version": "1.4.8",
@@ -834,14 +1103,12 @@
         "object-assign": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
-          "dev": true
+          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
         },
         "prebuild-install": {
           "version": "2.5.3",
           "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
           "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
-          "dev": true,
           "requires": {
             "detect-libc": "^1.0.3",
             "expand-template": "^1.0.2",
@@ -864,7 +1131,6 @@
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.1",
@@ -875,26 +1141,22 @@
         "safe-json-stringify": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
-          "integrity": "sha1-PLZxdmCghtB8tb2bemh1vPZ70F4=",
-          "dev": true
+          "integrity": "sha1-PLZxdmCghtB8tb2bemh1vPZ70F4="
         },
         "sax": {
           "version": "1.1.5",
           "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.5.tgz",
-          "integrity": "sha1-HaUKjQDN7NWUBWWfX/hTSf53N0M=",
-          "dev": true
+          "integrity": "sha1-HaUKjQDN7NWUBWWfX/hTSf53N0M="
         },
         "semver": {
           "version": "5.4.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-          "dev": true
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
         },
         "socket.io-adapter": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
           "integrity": "sha1-y21LuL7IHhB4uZZ3+c7QBGBmu4s=",
-          "dev": true,
           "requires": {
             "debug": "2.3.3",
             "socket.io-parser": "2.3.1"
@@ -904,7 +1166,6 @@
               "version": "2.3.3",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
               "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-              "dev": true,
               "requires": {
                 "ms": "0.7.2"
               }
@@ -912,8 +1173,7 @@
             "ms": {
               "version": "0.7.2",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-              "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-              "dev": true
+              "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
             }
           }
         },
@@ -921,7 +1181,6 @@
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
           "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
-          "dev": true,
           "requires": {
             "component-emitter": "1.1.2",
             "debug": "2.2.0",
@@ -933,7 +1192,6 @@
               "version": "2.2.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-              "dev": true,
               "requires": {
                 "ms": "0.7.1"
               }
@@ -941,16 +1199,537 @@
             "ms": {
               "version": "0.7.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-              "dev": true
+              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+            }
+          }
+        },
+        "sproxydclient": {
+          "version": "github:scality/sproxydclient#45090b76b24ca1d05482bf151ba84ff6178423d1",
+          "from": "github:scality/sproxydclient#45090b76b24ca1d05482bf151ba84ff6178423d1",
+          "requires": {
+            "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2"
+          },
+          "dependencies": {
+            "werelogs": {
+              "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+              "from": "github:scality/werelogs#7.4.0.3",
+              "requires": {
+                "safe-json-stringify": "^1.0.3"
+              }
+            }
+          }
+        },
+        "utapi": {
+          "version": "github:scality/utapi#f2f1d0c7423ffdec2ad175e3c0e8bcd7aa2ba867",
+          "from": "github:scality/utapi#f2f1d0c7423ffdec2ad175e3c0e8bcd7aa2ba867",
+          "requires": {
+            "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
+            "async": "^2.0.1",
+            "ioredis": "^2.3.0",
+            "node-schedule": "1.2.0",
+            "vaultclient": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
+            "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
+          },
+          "dependencies": {
+            "arsenal": {
+              "version": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
+              "from": "github:scality/Arsenal#67365083",
+              "requires": {
+                "JSONStream": "^1.0.0",
+                "ajv": "4.10.0",
+                "async": "~2.1.5",
+                "debug": "~2.3.3",
+                "diskusage": "^0.2.2",
+                "ioctl": "2.0.0",
+                "ioredis": "2.4.0",
+                "ipaddr.js": "1.2.0",
+                "joi": "^10.6",
+                "level": "~1.6.0",
+                "level-sublevel": "~6.6.1",
+                "node-forge": "^0.7.1",
+                "simple-glob": "^0.1",
+                "socket.io": "~1.7.3",
+                "socket.io-client": "~1.7.3",
+                "utf8": "2.1.2",
+                "uuid": "^3.0.1",
+                "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+                "xml2js": "~0.4.16"
+              },
+              "dependencies": {
+                "async": {
+                  "version": "2.1.5",
+                  "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+                  "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+                  "requires": {
+                    "lodash": "^4.14.0"
+                  }
+                },
+                "ioredis": {
+                  "version": "2.4.0",
+                  "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.4.0.tgz",
+                  "integrity": "sha1-lj97+8huXEDqWGhX4U6/tUgUKog=",
+                  "requires": {
+                    "bluebird": "^3.3.4",
+                    "cluster-key-slot": "^1.0.6",
+                    "debug": "^2.2.0",
+                    "double-ended-queue": "^2.1.0-0",
+                    "flexbuffer": "0.0.6",
+                    "lodash": "^4.8.2",
+                    "redis-commands": "^1.2.0",
+                    "redis-parser": "^1.3.0"
+                  }
+                }
+              }
+            },
+            "commander": {
+              "version": "2.9.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+              "requires": {
+                "graceful-readlink": ">= 1.0.0"
+              }
+            },
+            "component-emitter": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+              "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+            },
+            "debug": {
+              "version": "2.3.3",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+              "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+              "requires": {
+                "ms": "0.7.2"
+              }
+            },
+            "double-ended-queue": {
+              "version": "2.1.0-0",
+              "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+              "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+            },
+            "has-binary": {
+              "version": "0.1.7",
+              "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+              "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
+              "requires": {
+                "isarray": "0.0.1"
+              }
+            },
+            "hoek": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+              "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+            },
+            "ioctl": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ioctl/-/ioctl-2.0.0.tgz",
+              "integrity": "sha1-Kqy9c+tv+a0B/fPswzkO5XeBEA4=",
+              "optional": true,
+              "requires": {
+                "bindings": "^1.1.1",
+                "nan": "^2.3.2"
+              }
+            },
+            "ioredis": {
+              "version": "2.5.0",
+              "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.5.0.tgz",
+              "integrity": "sha1-+2/fChp+CXRhTGe25eETCKjPlbk=",
+              "requires": {
+                "bluebird": "^3.3.4",
+                "cluster-key-slot": "^1.0.6",
+                "debug": "^2.2.0",
+                "double-ended-queue": "^2.1.0-0",
+                "flexbuffer": "0.0.6",
+                "lodash": "^4.8.2",
+                "redis-commands": "^1.2.0",
+                "redis-parser": "^1.3.0"
+              }
+            },
+            "ipaddr.js": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz",
+              "integrity": "sha1-irpJyRknmVhb3WQ+DMtQ6K53e6Q="
+            },
+            "isemail": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+              "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
+            },
+            "joi": {
+              "version": "10.6.0",
+              "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
+              "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+              "requires": {
+                "hoek": "4.x.x",
+                "isemail": "2.x.x",
+                "items": "2.x.x",
+                "topo": "2.x.x"
+              }
+            },
+            "level": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/level/-/level-1.6.0.tgz",
+              "integrity": "sha1-P8uukWOgkWaLjsep79HS/u8eZiE=",
+              "requires": {
+                "level-packager": "~1.2.0",
+                "leveldown": "~1.6.0"
+              }
+            },
+            "ms": {
+              "version": "0.7.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+              "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+            },
+            "redis-parser": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-1.3.0.tgz",
+              "integrity": "sha1-gG6+e7+3005NfB6e8oLvz60EEmo="
+            },
+            "simple-glob": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/simple-glob/-/simple-glob-0.1.1.tgz",
+              "integrity": "sha1-KCv6AS1yBmQ99h00xrueTOP9dxQ=",
+              "requires": {
+                "glob": "~3.2.8",
+                "lodash": "~2.4.1",
+                "minimatch": "~0.2.14"
+              },
+              "dependencies": {
+                "lodash": {
+                  "version": "2.4.2",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+                  "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+                }
+              }
+            },
+            "socket.io": {
+              "version": "1.7.4",
+              "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.4.tgz",
+              "integrity": "sha1-L37O3DORvy1cc+KR/iM+bjTU3QA=",
+              "requires": {
+                "debug": "2.3.3",
+                "engine.io": "~1.8.4",
+                "has-binary": "0.1.7",
+                "object-assign": "4.1.0",
+                "socket.io-adapter": "0.5.0",
+                "socket.io-client": "1.7.4",
+                "socket.io-parser": "2.3.1"
+              }
+            },
+            "socket.io-client": {
+              "version": "1.7.4",
+              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.4.tgz",
+              "integrity": "sha1-7J+CA1btme9tNX8HVtZIcXvdQoE=",
+              "requires": {
+                "backo2": "1.0.2",
+                "component-bind": "1.0.0",
+                "component-emitter": "1.2.1",
+                "debug": "2.3.3",
+                "engine.io-client": "~1.8.4",
+                "has-binary": "0.1.7",
+                "indexof": "0.0.1",
+                "object-component": "0.0.3",
+                "parseuri": "0.0.5",
+                "socket.io-parser": "2.3.1",
+                "to-array": "0.1.4"
+              }
+            },
+            "topo": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+              "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+              "requires": {
+                "hoek": "4.x.x"
+              }
+            },
+            "vaultclient": {
+              "version": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
+              "from": "github:scality/vaultclient#fbd9988d",
+              "requires": {
+                "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
+                "commander": "2.9.0",
+                "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+                "xml2js": "0.4.17"
+              },
+              "dependencies": {
+                "xml2js": {
+                  "version": "0.4.17",
+                  "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+                  "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+                  "requires": {
+                    "sax": ">=0.6.0",
+                    "xmlbuilder": "^4.1.0"
+                  }
+                }
+              }
+            },
+            "werelogs": {
+              "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+              "from": "github:scality/werelogs#0ff7ec82",
+              "requires": {
+                "safe-json-stringify": "1.0.3"
+              }
+            },
+            "xmlbuilder": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+              "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+              "requires": {
+                "lodash": "^4.0.0"
+              }
             }
           }
         },
         "utf8": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
-          "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY=",
-          "dev": true
+          "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY="
+        },
+        "vaultclient": {
+          "version": "github:scality/vaultclient#754b6e1e1121f44bc3719e35b836a9185d6d5e1a",
+          "from": "github:scality/vaultclient#754b6e1e1121f44bc3719e35b836a9185d6d5e1a",
+          "requires": {
+            "arsenal": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
+            "commander": "2.9.0",
+            "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+            "xml2js": "0.4.17"
+          },
+          "dependencies": {
+            "arsenal": {
+              "version": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
+              "from": "github:scality/Arsenal#7.4.0.3",
+              "requires": {
+                "JSONStream": "^1.0.0",
+                "ajv": "4.10.0",
+                "async": "~2.1.5",
+                "debug": "~2.3.3",
+                "diskusage": "^0.2.2",
+                "ioctl": "2.0.0",
+                "ioredis": "2.4.0",
+                "ipaddr.js": "1.2.0",
+                "joi": "^10.6",
+                "level": "~1.6.0",
+                "level-sublevel": "~6.6.1",
+                "node-forge": "^0.7.1",
+                "simple-glob": "^0.1",
+                "socket.io": "~1.7.3",
+                "socket.io-client": "~1.7.3",
+                "utf8": "2.1.2",
+                "uuid": "^3.0.1",
+                "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+                "xml2js": "~0.4.16"
+              },
+              "dependencies": {
+                "werelogs": {
+                  "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+                  "from": "github:scality/werelogs#hotfix/7.4.0",
+                  "requires": {
+                    "safe-json-stringify": "^1.0.3"
+                  }
+                }
+              }
+            },
+            "async": {
+              "version": "2.1.5",
+              "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+              "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+              "requires": {
+                "lodash": "^4.14.0"
+              }
+            },
+            "commander": {
+              "version": "2.9.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+              "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+              "requires": {
+                "graceful-readlink": ">= 1.0.0"
+              }
+            },
+            "component-emitter": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+              "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+            },
+            "debug": {
+              "version": "2.3.3",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+              "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+              "requires": {
+                "ms": "0.7.2"
+              }
+            },
+            "double-ended-queue": {
+              "version": "2.1.0-0",
+              "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+              "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+            },
+            "has-binary": {
+              "version": "0.1.7",
+              "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+              "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
+              "requires": {
+                "isarray": "0.0.1"
+              }
+            },
+            "hoek": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+              "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+            },
+            "ioctl": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/ioctl/-/ioctl-2.0.0.tgz",
+              "integrity": "sha1-Kqy9c+tv+a0B/fPswzkO5XeBEA4=",
+              "optional": true,
+              "requires": {
+                "bindings": "^1.1.1",
+                "nan": "^2.3.2"
+              }
+            },
+            "ioredis": {
+              "version": "2.4.0",
+              "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.4.0.tgz",
+              "integrity": "sha1-lj97+8huXEDqWGhX4U6/tUgUKog=",
+              "requires": {
+                "bluebird": "^3.3.4",
+                "cluster-key-slot": "^1.0.6",
+                "debug": "^2.2.0",
+                "double-ended-queue": "^2.1.0-0",
+                "flexbuffer": "0.0.6",
+                "lodash": "^4.8.2",
+                "redis-commands": "^1.2.0",
+                "redis-parser": "^1.3.0"
+              }
+            },
+            "ipaddr.js": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz",
+              "integrity": "sha1-irpJyRknmVhb3WQ+DMtQ6K53e6Q="
+            },
+            "isemail": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+              "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY="
+            },
+            "joi": {
+              "version": "10.6.0",
+              "resolved": "https://registry.npmjs.org/joi/-/joi-10.6.0.tgz",
+              "integrity": "sha512-hBF3LcqyAid+9X/pwg+eXjD2QBZI5eXnBFJYaAkH4SK3mp9QSRiiQnDYlmlz5pccMvnLcJRS4whhDOTCkmsAdQ==",
+              "requires": {
+                "hoek": "4.x.x",
+                "isemail": "2.x.x",
+                "items": "2.x.x",
+                "topo": "2.x.x"
+              }
+            },
+            "level": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/level/-/level-1.6.0.tgz",
+              "integrity": "sha1-P8uukWOgkWaLjsep79HS/u8eZiE=",
+              "requires": {
+                "level-packager": "~1.2.0",
+                "leveldown": "~1.6.0"
+              }
+            },
+            "ms": {
+              "version": "0.7.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+              "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U="
+            },
+            "redis-parser": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-1.3.0.tgz",
+              "integrity": "sha1-gG6+e7+3005NfB6e8oLvz60EEmo="
+            },
+            "simple-glob": {
+              "version": "0.1.1",
+              "resolved": "https://registry.npmjs.org/simple-glob/-/simple-glob-0.1.1.tgz",
+              "integrity": "sha1-KCv6AS1yBmQ99h00xrueTOP9dxQ=",
+              "requires": {
+                "glob": "~3.2.8",
+                "lodash": "~2.4.1",
+                "minimatch": "~0.2.14"
+              },
+              "dependencies": {
+                "lodash": {
+                  "version": "2.4.2",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+                  "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+                }
+              }
+            },
+            "socket.io": {
+              "version": "1.7.4",
+              "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.4.tgz",
+              "integrity": "sha1-L37O3DORvy1cc+KR/iM+bjTU3QA=",
+              "requires": {
+                "debug": "2.3.3",
+                "engine.io": "~1.8.4",
+                "has-binary": "0.1.7",
+                "object-assign": "4.1.0",
+                "socket.io-adapter": "0.5.0",
+                "socket.io-client": "1.7.4",
+                "socket.io-parser": "2.3.1"
+              }
+            },
+            "socket.io-client": {
+              "version": "1.7.4",
+              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.4.tgz",
+              "integrity": "sha1-7J+CA1btme9tNX8HVtZIcXvdQoE=",
+              "requires": {
+                "backo2": "1.0.2",
+                "component-bind": "1.0.0",
+                "component-emitter": "1.2.1",
+                "debug": "2.3.3",
+                "engine.io-client": "~1.8.4",
+                "has-binary": "0.1.7",
+                "indexof": "0.0.1",
+                "object-component": "0.0.3",
+                "parseuri": "0.0.5",
+                "socket.io-parser": "2.3.1",
+                "to-array": "0.1.4"
+              }
+            },
+            "topo": {
+              "version": "2.0.2",
+              "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+              "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+              "requires": {
+                "hoek": "4.x.x"
+              }
+            },
+            "werelogs": {
+              "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
+              "from": "github:scality/werelogs#7.4.0.3",
+              "requires": {
+                "safe-json-stringify": "^1.0.3"
+              }
+            },
+            "xml2js": {
+              "version": "0.4.17",
+              "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
+              "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
+              "requires": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "^4.1.0"
+              }
+            },
+            "xmlbuilder": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-4.2.1.tgz",
+              "integrity": "sha1-qlijBBoGb5DqoWwvU4n/GfP0YaU=",
+              "requires": {
+                "lodash": "^4.0.0"
+              }
+            }
+          }
+        },
+        "werelogs": {
+          "version": "github:scality/werelogs#74b121bef4068645e307da143749e61ef416a4c3",
+          "from": "github:scality/werelogs#74b121bef4068645e307da143749e61ef416a4c3",
+          "requires": {
+            "safe-json-stringify": "^1.0.3"
+          }
         },
         "ws": {
           "version": "5.2.2",
@@ -981,8 +1760,7 @@
         "xmlhttprequest-ssl": {
           "version": "1.5.3",
           "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
-          "integrity": "sha1-GFqIjATspGw+QHDZn3tJ3jUomS0=",
-          "dev": true
+          "integrity": "sha1-GFqIjATspGw+QHDZn3tJ3jUomS0="
         }
       }
     },
@@ -1129,8 +1907,8 @@
       "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
     },
     "arsenal": {
-      "version": "github:scality/Arsenal#886110138adf2410984a0b1189cdea1c324e8536",
-      "from": "github:scality/Arsenal#8861101",
+      "version": "github:scality/Arsenal#7dd4dca7e5d3ae0810cd529197e5f4d3e1211270",
+      "from": "github:scality/Arsenal#7dd4dca",
       "requires": {
         "JSONStream": "^1.0.0",
         "ajv": "4.10.0",
@@ -1142,6 +1920,7 @@
         "debug": "~4.1.0",
         "diskusage": "^1.0.0",
         "fcntl": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
+        "hdclient": "github:scality/hdclient#5145e04e5ed33e85106765b1caa90cd245ef482b",
         "https-proxy-agent": "^2.2.0",
         "ioctl": "2.0.1",
         "ioredis": "4.2.0",
@@ -1523,10 +2302,6 @@
     "bucketclient": {
       "version": "github:scality/bucketclient#520d164d264ac74b920a9d517bd4e08f3ff71473",
       "from": "github:scality/bucketclient#520d164",
-      "requires": {
-        "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
-        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
-      },
       "dependencies": {
         "abstract-leveldown": {
           "version": "2.6.3",
@@ -1552,7 +2327,7 @@
         },
         "arsenal": {
           "version": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
-          "from": "github:scality/Arsenal#67365083",
+          "from": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
           "requires": {
             "JSONStream": "^1.0.0",
             "ajv": "4.10.0",
@@ -1573,6 +2348,15 @@
             "uuid": "^3.0.1",
             "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
             "xml2js": "~0.4.16"
+          },
+          "dependencies": {
+            "werelogs": {
+              "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
+              "from": "github:scality/werelogs#0ff7ec82",
+              "requires": {
+                "safe-json-stringify": "1.0.3"
+              }
+            }
           }
         },
         "async": {
@@ -1653,6 +2437,14 @@
               "version": "1.2.1",
               "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
               "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+            },
+            "parsejson": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
+              "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
+              "requires": {
+                "better-assert": "~1.0.0"
+              }
             }
           }
         },
@@ -1667,6 +2459,21 @@
             "blob": "0.0.4",
             "has-binary": "0.1.7",
             "wtf-8": "1.0.0"
+          },
+          "dependencies": {
+            "has-binary": {
+              "version": "0.1.7",
+              "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+              "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
+              "requires": {
+                "isarray": "0.0.1"
+              }
+            },
+            "wtf-8": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
+              "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo="
+            }
           }
         },
         "expand-template": {
@@ -1683,6 +2490,11 @@
             "minimatch": "0.3"
           },
           "dependencies": {
+            "lru-cache": {
+              "version": "2.7.3",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+              "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+            },
             "minimatch": {
               "version": "0.3.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
@@ -1691,6 +2503,11 @@
                 "lru-cache": "2",
                 "sigmund": "~1.0.0"
               }
+            },
+            "sigmund": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+              "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
             }
           }
         },
@@ -1717,6 +2534,13 @@
             "lodash": "^4.8.2",
             "redis-commands": "^1.2.0",
             "redis-parser": "^1.3.0"
+          },
+          "dependencies": {
+            "double-ended-queue": {
+              "version": "2.1.0-0",
+              "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+              "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+            }
           }
         },
         "ipaddr.js": {
@@ -1815,6 +2639,18 @@
           "requires": {
             "lru-cache": "2",
             "sigmund": "~1.0.0"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.7.3",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+              "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+            },
+            "sigmund": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+              "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+            }
           }
         },
         "ms": {
@@ -1909,6 +2745,16 @@
             "socket.io-adapter": "0.5.0",
             "socket.io-client": "1.7.4",
             "socket.io-parser": "2.3.1"
+          },
+          "dependencies": {
+            "has-binary": {
+              "version": "0.1.7",
+              "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+              "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
+              "requires": {
+                "isarray": "0.0.1"
+              }
+            }
           }
         },
         "socket.io-adapter": {
@@ -1942,6 +2788,14 @@
               "version": "1.2.1",
               "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
               "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+            },
+            "has-binary": {
+              "version": "0.1.7",
+              "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+              "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
+              "requires": {
+                "isarray": "0.0.1"
+              }
             }
           }
         },
@@ -1978,7 +2832,7 @@
         },
         "werelogs": {
           "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-          "from": "github:scality/werelogs#0ff7ec82",
+          "from": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
           "requires": {
             "safe-json-stringify": "1.0.3"
           }
@@ -1990,6 +2844,18 @@
           "requires": {
             "options": ">=0.0.5",
             "ultron": "1.0.x"
+          },
+          "dependencies": {
+            "options": {
+              "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+              "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+            },
+            "ultron": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+              "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+            }
           }
         },
         "xmlhttprequest-ssl": {
@@ -2126,600 +2992,6 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "cdmiclient": {
-      "version": "github:scality/cdmiclient#8f0c2e6331dfa905bfe269fb4e1558d65ca0b866",
-      "from": "github:scality/cdmiclient#8f0c2e6",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "arsenal": "github:scality/Arsenal#2ff9cf866de3d0f69da2317ed82c6b968129988d",
-        "async": "~1.4.2",
-        "werelogs": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-          "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
-          "dev": true,
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        },
-        "accepts": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-          "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "mime-types": "~2.1.11",
-            "negotiator": "0.6.1"
-          }
-        },
-        "arraybuffer.slice": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
-          "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco=",
-          "dev": true
-        },
-        "arsenal": {
-          "version": "github:scality/Arsenal#2ff9cf866de3d0f69da2317ed82c6b968129988d",
-          "from": "github:scality/Arsenal#development/8.0",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "JSONStream": "^1.0.0",
-            "ajv": "4.10.0",
-            "async": "~2.1.5",
-            "bson": "2.0.4",
-            "debug": "~2.3.3",
-            "diskusage": "^0.2.2",
-            "fcntl": "github:scality/node-fcntl#9108603d8881d7762dcadfde1db927a1653dfda5",
-            "ioctl": "2.0.0",
-            "ioredis": "2.4.0",
-            "ipaddr.js": "1.2.0",
-            "joi": "^10.6",
-            "level": "~1.6.0",
-            "level-sublevel": "~6.6.1",
-            "mongodb": "^3.0.1",
-            "node-forge": "^0.7.1",
-            "simple-glob": "^0.1",
-            "socket.io": "~1.7.3",
-            "socket.io-client": "~1.7.3",
-            "utf8": "2.1.2",
-            "uuid": "^3.0.1",
-            "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-            "xml2js": "~0.4.16"
-          },
-          "dependencies": {
-            "async": {
-              "version": "2.1.5",
-              "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
-              "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "lodash": "^4.14.0"
-              }
-            },
-            "werelogs": {
-              "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-              "from": "github:scality/werelogs#0ff7ec82",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "safe-json-stringify": "1.0.3"
-              }
-            }
-          }
-        },
-        "async": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.4.2.tgz",
-          "integrity": "sha1-bJ7csRztTw3S8tQNsNSaEJwIiqs=",
-          "dev": true,
-          "optional": true
-        },
-        "blob": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-          "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
-          "dev": true
-        },
-        "bson": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-2.0.4.tgz",
-          "integrity": "sha512-e/GPy6CE0xL7MOYYRMIEwPGKF21WNaQdPIpV0YvaQDoR7oc47KUZ8c2P/TlRJVQP8RZ4CEsArGBC1NbkCRvl1w==",
-          "dev": true,
-          "optional": true
-        },
-        "component-emitter": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-          "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
-        },
-        "deferred-leveldown": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-          "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abstract-leveldown": "~2.6.0"
-          }
-        },
-        "diskusage": {
-          "version": "0.2.6",
-          "resolved": "https://registry.npmjs.org/diskusage/-/diskusage-0.2.6.tgz",
-          "integrity": "sha512-zjXy+rKg52XYNDOBXcIKwNevgP+6rvOSNx8OAX0N7o0BFdEl5sBL8UhuwSi3j5BS0Sd+9Lb6YuCSR00gZi4KQw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "nan": "^2.11.1"
-          }
-        },
-        "engine.io": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.5.tgz",
-          "integrity": "sha512-j1DWIcktw4hRwrv6nWx++5nFH2X64x16MAG2P0Lmi5Dvdfi3I+Jhc7JKJIdAmDJa+5aZ/imHV7dWRPy2Cqjh3A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "accepts": "1.3.3",
-            "base64id": "1.0.0",
-            "cookie": "0.3.1",
-            "debug": "2.3.3",
-            "engine.io-parser": "1.3.2",
-            "ws": "~1.1.5"
-          }
-        },
-        "engine.io-client": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.5.tgz",
-          "integrity": "sha512-AYTgHyeVUPitsseqjoedjhYJapNVoSPShbZ+tEUX9/73jgZ/Z3sUlJf9oYgdEBBdVhupUpUqSxH0kBCXlQnmZg==",
-          "dev": true,
-          "requires": {
-            "component-emitter": "1.2.1",
-            "component-inherit": "0.0.3",
-            "debug": "2.3.3",
-            "engine.io-parser": "1.3.2",
-            "has-cors": "1.1.0",
-            "indexof": "0.0.1",
-            "parsejson": "0.0.3",
-            "parseqs": "0.0.5",
-            "parseuri": "0.0.5",
-            "ws": "~1.1.5",
-            "xmlhttprequest-ssl": "1.5.3",
-            "yeast": "0.1.2"
-          },
-          "dependencies": {
-            "component-emitter": {
-              "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-              "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-              "dev": true
-            }
-          }
-        },
-        "engine.io-parser": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
-          "integrity": "sha1-k3sHnwAH0Ik+xW1GyyILjLQ1Igo=",
-          "dev": true,
-          "requires": {
-            "after": "0.8.2",
-            "arraybuffer.slice": "0.0.6",
-            "base64-arraybuffer": "0.1.5",
-            "blob": "0.0.4",
-            "has-binary": "0.1.7",
-            "wtf-8": "1.0.0"
-          }
-        },
-        "expand-template": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
-          "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg==",
-          "dev": true,
-          "optional": true
-        },
-        "glob": {
-          "version": "3.2.11",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "inherits": "2",
-            "minimatch": "0.3"
-          },
-          "dependencies": {
-            "minimatch": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-              "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "lru-cache": "2",
-                "sigmund": "~1.0.0"
-              }
-            }
-          }
-        },
-        "ioctl": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ioctl/-/ioctl-2.0.0.tgz",
-          "integrity": "sha1-Kqy9c+tv+a0B/fPswzkO5XeBEA4=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "bindings": "^1.1.1",
-            "nan": "^2.3.2"
-          }
-        },
-        "ioredis": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.4.0.tgz",
-          "integrity": "sha1-lj97+8huXEDqWGhX4U6/tUgUKog=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "bluebird": "^3.3.4",
-            "cluster-key-slot": "^1.0.6",
-            "debug": "^2.2.0",
-            "double-ended-queue": "^2.1.0-0",
-            "flexbuffer": "0.0.6",
-            "lodash": "^4.8.2",
-            "redis-commands": "^1.2.0",
-            "redis-parser": "^1.3.0"
-          }
-        },
-        "ipaddr.js": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz",
-          "integrity": "sha1-irpJyRknmVhb3WQ+DMtQ6K53e6Q=",
-          "dev": true,
-          "optional": true
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "level": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/level/-/level-1.6.0.tgz",
-          "integrity": "sha1-P8uukWOgkWaLjsep79HS/u8eZiE=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "level-packager": "~1.2.0",
-            "leveldown": "~1.6.0"
-          }
-        },
-        "level-codec": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-          "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
-          "dev": true,
-          "optional": true
-        },
-        "level-errors": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-          "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
-          "dev": true,
-          "requires": {
-            "errno": "~0.1.1"
-          }
-        },
-        "level-iterator-stream": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-          "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "inherits": "^2.0.1",
-            "level-errors": "^1.0.3",
-            "readable-stream": "^1.0.33",
-            "xtend": "^4.0.0"
-          }
-        },
-        "level-packager": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-1.2.1.tgz",
-          "integrity": "sha1-Bn/t/Qcrf+PGvsYIDAy9SmsuEfQ=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "levelup": "~1.3.0"
-          }
-        },
-        "leveldown": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.6.0.tgz",
-          "integrity": "sha1-5uyQbSmVqL/9AkmfOelZiM0rIw8=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abstract-leveldown": "~2.6.1",
-            "bindings": "~1.2.1",
-            "fast-future": "~1.0.2",
-            "nan": "~2.5.1",
-            "prebuild-install": "^2.1.0"
-          },
-          "dependencies": {
-            "bindings": {
-              "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-              "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=",
-              "dev": true,
-              "optional": true
-            },
-            "nan": {
-              "version": "2.5.1",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz",
-              "integrity": "sha1-1bAWkSUzJql6K77p5hxV2NYDUeI=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "levelup": {
-          "version": "1.3.9",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-          "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deferred-leveldown": "~1.2.1",
-            "level-codec": "~7.0.0",
-            "level-errors": "~1.0.3",
-            "level-iterator-stream": "~1.3.0",
-            "prr": "~1.0.1",
-            "semver": "~5.4.1",
-            "xtend": "~4.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "0.2.14",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
-          }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-          "dev": true
-        },
-        "negotiator": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-          "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-          "dev": true,
-          "optional": true
-        },
-        "object-assign": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
-          "dev": true,
-          "optional": true
-        },
-        "prebuild-install": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
-          "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "^1.0.3",
-            "expand-template": "^1.0.2",
-            "github-from-package": "0.0.0",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "node-abi": "^2.2.0",
-            "noop-logger": "^0.1.1",
-            "npmlog": "^4.0.1",
-            "os-homedir": "^1.0.1",
-            "pump": "^2.0.1",
-            "rc": "^1.1.6",
-            "simple-get": "^2.7.0",
-            "tar-fs": "^1.13.0",
-            "tunnel-agent": "^0.6.0",
-            "which-pm-runs": "^1.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "redis-parser": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-1.3.0.tgz",
-          "integrity": "sha1-gG6+e7+3005NfB6e8oLvz60EEmo=",
-          "dev": true,
-          "optional": true
-        },
-        "safe-json-stringify": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
-          "integrity": "sha1-PLZxdmCghtB8tb2bemh1vPZ70F4=",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-          "dev": true,
-          "optional": true
-        },
-        "simple-glob": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/simple-glob/-/simple-glob-0.1.1.tgz",
-          "integrity": "sha1-KCv6AS1yBmQ99h00xrueTOP9dxQ=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "glob": "~3.2.8",
-            "lodash": "~2.4.1",
-            "minimatch": "~0.2.14"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "socket.io": {
-          "version": "1.7.4",
-          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.4.tgz",
-          "integrity": "sha1-L37O3DORvy1cc+KR/iM+bjTU3QA=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.3.3",
-            "engine.io": "~1.8.4",
-            "has-binary": "0.1.7",
-            "object-assign": "4.1.0",
-            "socket.io-adapter": "0.5.0",
-            "socket.io-client": "1.7.4",
-            "socket.io-parser": "2.3.1"
-          }
-        },
-        "socket.io-adapter": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
-          "integrity": "sha1-y21LuL7IHhB4uZZ3+c7QBGBmu4s=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.3.3",
-            "socket.io-parser": "2.3.1"
-          }
-        },
-        "socket.io-client": {
-          "version": "1.7.4",
-          "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.4.tgz",
-          "integrity": "sha1-7J+CA1btme9tNX8HVtZIcXvdQoE=",
-          "dev": true,
-          "requires": {
-            "backo2": "1.0.2",
-            "component-bind": "1.0.0",
-            "component-emitter": "1.2.1",
-            "debug": "2.3.3",
-            "engine.io-client": "~1.8.4",
-            "has-binary": "0.1.7",
-            "indexof": "0.0.1",
-            "object-component": "0.0.3",
-            "parseuri": "0.0.5",
-            "socket.io-parser": "2.3.1",
-            "to-array": "0.1.4"
-          },
-          "dependencies": {
-            "component-emitter": {
-              "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-              "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-              "dev": true
-            }
-          }
-        },
-        "socket.io-parser": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
-          "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
-          "dev": true,
-          "requires": {
-            "component-emitter": "1.1.2",
-            "debug": "2.2.0",
-            "isarray": "0.0.1",
-            "json3": "3.3.2"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-              "dev": true,
-              "requires": {
-                "ms": "0.7.1"
-              }
-            },
-            "ms": {
-              "version": "0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-              "dev": true
-            }
-          }
-        },
-        "utf8": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
-          "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY=",
-          "dev": true,
-          "optional": true
-        },
-        "werelogs": {
-          "version": "github:scality/werelogs#1a6e052fb2bdfb1c4f6bb9467dc814e79abf6e46",
-          "from": "github:scality/werelogs#development/8.0",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-json-stringify": "1.0.3"
-          }
-        },
-        "ws": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
-          "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
-          "dev": true,
-          "requires": {
-            "options": ">=0.0.5",
-            "ultron": "1.0.x"
-          }
-        },
-        "xmlhttprequest-ssl": {
-          "version": "1.5.3",
-          "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
-          "integrity": "sha1-GFqIjATspGw+QHDZn3tJ3jUomS0=",
-          "dev": true
-        }
-      }
     },
     "chalk": {
       "version": "1.1.3",
@@ -2985,11 +3257,6 @@
       "requires": {
         "esutils": "^2.0.2"
       }
-    },
-    "double-ended-queue": {
-      "version": "2.1.0-0",
-      "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
     },
     "duplexer": {
       "version": "0.1.1",
@@ -3937,21 +4204,6 @@
         "ansi-regex": "^2.0.0"
       }
     },
-    "has-binary": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
-      "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
-      "requires": {
-        "isarray": "0.0.1"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-        }
-      }
-    },
     "has-binary2": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
@@ -3996,6 +4248,22 @@
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "hdclient": {
+      "version": "github:scality/hdclient#5145e04e5ed33e85106765b1caa90cd245ef482b",
+      "from": "github:scality/hdclient#5145e04e5ed33e85106765b1caa90cd245ef482b",
+      "requires": {
+        "werelogs": "github:scality/werelogs#bc034589ebf7810d6e6d61932f94327976de6eef"
+      },
+      "dependencies": {
+        "werelogs": {
+          "version": "github:scality/werelogs#bc034589ebf7810d6e6d61932f94327976de6eef",
+          "from": "github:scality/werelogs#GA7.2.0.5",
+          "requires": {
+            "safe-json-stringify": "^1.0.3"
+          }
+        }
       }
     },
     "he": {
@@ -4981,11 +5249,6 @@
       "resolved": "https://registry.npmjs.org/looper/-/looper-2.0.0.tgz",
       "integrity": "sha1-Zs0Md0rz1P7axTeU90LbVtqPCew="
     },
-    "lru-cache": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
-    },
     "ltgt": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.1.3.tgz",
@@ -5444,11 +5707,6 @@
         "wordwrap": "~1.0.0"
       }
     },
-    "options": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
-      "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
-    },
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -5500,14 +5758,6 @@
       "dev": true,
       "requires": {
         "error-ex": "^1.2.0"
-      }
-    },
-    "parsejson": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
-      "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
-      "requires": {
-        "better-assert": "~1.0.0"
       }
     },
     "parseqs": {
@@ -5713,9 +5963,9 @@
       "integrity": "sha1-Xy867UethpGfAbEqLpnW8b13ZYE="
     },
     "pull-stream": {
-      "version": "3.6.9",
-      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.9.tgz",
-      "integrity": "sha512-hJn4POeBrkttshdNl0AoSCVjMVSuBwuHocMerUdoZ2+oIUzrWHFTwJMlbHND7OiKLVgvz6TFj8ZUVywUMXccbw=="
+      "version": "3.6.11",
+      "resolved": "https://registry.npmjs.org/pull-stream/-/pull-stream-3.6.11.tgz",
+      "integrity": "sha512-43brwtqO0OSltctKbW1mgzzKH4TNE8egkW+Y4BFzlDWiG2Ayl7VKr4SeuoKacfgPfUWcSwcPlHsf40BEqNR32A=="
     },
     "pull-window": {
       "version": "2.1.4",
@@ -5983,11 +6233,6 @@
         "jsonify": "~0.0.0"
       }
     },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
-    },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -6195,13 +6440,10 @@
     "sproxydclient": {
       "version": "github:scality/sproxydclient#45090b76b24ca1d05482bf151ba84ff6178423d1",
       "from": "github:scality/sproxydclient#45090b7",
-      "requires": {
-        "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2"
-      },
       "dependencies": {
         "werelogs": {
           "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
-          "from": "github:scality/werelogs#7.4.0.3",
+          "from": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
           "requires": {
             "safe-json-stringify": "^1.0.3"
           }
@@ -6558,11 +6800,6 @@
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
     },
-    "ultron": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
-      "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
-    },
     "underscore": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
@@ -6590,614 +6827,6 @@
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
-      }
-    },
-    "utapi": {
-      "version": "github:scality/utapi#f2f1d0c7423ffdec2ad175e3c0e8bcd7aa2ba867",
-      "from": "github:scality/utapi#f2f1d0c",
-      "dev": true,
-      "requires": {
-        "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
-        "async": "^2.0.1",
-        "ioredis": "^2.3.0",
-        "node-schedule": "1.2.0",
-        "vaultclient": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
-        "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
-          "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
-          "dev": true,
-          "requires": {
-            "xtend": "~4.0.0"
-          }
-        },
-        "accepts": {
-          "version": "1.3.3",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-          "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
-          "dev": true,
-          "requires": {
-            "mime-types": "~2.1.11",
-            "negotiator": "0.6.1"
-          }
-        },
-        "arraybuffer.slice": {
-          "version": "0.0.6",
-          "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
-          "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco=",
-          "dev": true
-        },
-        "arsenal": {
-          "version": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
-          "from": "github:scality/Arsenal#67365083",
-          "dev": true,
-          "requires": {
-            "JSONStream": "^1.0.0",
-            "ajv": "4.10.0",
-            "async": "~2.1.5",
-            "debug": "~2.3.3",
-            "diskusage": "^0.2.2",
-            "ioctl": "2.0.0",
-            "ioredis": "2.4.0",
-            "ipaddr.js": "1.2.0",
-            "joi": "^10.6",
-            "level": "~1.6.0",
-            "level-sublevel": "~6.6.1",
-            "node-forge": "^0.7.1",
-            "simple-glob": "^0.1",
-            "socket.io": "~1.7.3",
-            "socket.io-client": "~1.7.3",
-            "utf8": "2.1.2",
-            "uuid": "^3.0.1",
-            "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-            "xml2js": "~0.4.16"
-          },
-          "dependencies": {
-            "async": {
-              "version": "2.1.5",
-              "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
-              "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
-              "dev": true,
-              "requires": {
-                "lodash": "^4.14.0"
-              }
-            },
-            "ioredis": {
-              "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.4.0.tgz",
-              "integrity": "sha1-lj97+8huXEDqWGhX4U6/tUgUKog=",
-              "dev": true,
-              "requires": {
-                "bluebird": "^3.3.4",
-                "cluster-key-slot": "^1.0.6",
-                "debug": "^2.2.0",
-                "double-ended-queue": "^2.1.0-0",
-                "flexbuffer": "0.0.6",
-                "lodash": "^4.8.2",
-                "redis-commands": "^1.2.0",
-                "redis-parser": "^1.3.0"
-              }
-            }
-          }
-        },
-        "blob": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
-          "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
-          "dev": true
-        },
-        "commander": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-          "dev": true,
-          "requires": {
-            "graceful-readlink": ">= 1.0.0"
-          }
-        },
-        "component-emitter": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
-          "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM=",
-          "dev": true
-        },
-        "cron-parser": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-1.1.0.tgz",
-          "integrity": "sha1-B1uExFnBVejEgqtNVq/5na5YNS4=",
-          "dev": true
-        },
-        "debug": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
-          "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.2"
-          }
-        },
-        "deferred-leveldown": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
-          "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
-          "dev": true,
-          "requires": {
-            "abstract-leveldown": "~2.6.0"
-          }
-        },
-        "diskusage": {
-          "version": "0.2.6",
-          "resolved": "https://registry.npmjs.org/diskusage/-/diskusage-0.2.6.tgz",
-          "integrity": "sha512-zjXy+rKg52XYNDOBXcIKwNevgP+6rvOSNx8OAX0N7o0BFdEl5sBL8UhuwSi3j5BS0Sd+9Lb6YuCSR00gZi4KQw==",
-          "dev": true,
-          "requires": {
-            "nan": "^2.11.1"
-          }
-        },
-        "engine.io": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.5.tgz",
-          "integrity": "sha512-j1DWIcktw4hRwrv6nWx++5nFH2X64x16MAG2P0Lmi5Dvdfi3I+Jhc7JKJIdAmDJa+5aZ/imHV7dWRPy2Cqjh3A==",
-          "dev": true,
-          "requires": {
-            "accepts": "1.3.3",
-            "base64id": "1.0.0",
-            "cookie": "0.3.1",
-            "debug": "2.3.3",
-            "engine.io-parser": "1.3.2",
-            "ws": "~1.1.5"
-          }
-        },
-        "engine.io-client": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.5.tgz",
-          "integrity": "sha512-AYTgHyeVUPitsseqjoedjhYJapNVoSPShbZ+tEUX9/73jgZ/Z3sUlJf9oYgdEBBdVhupUpUqSxH0kBCXlQnmZg==",
-          "dev": true,
-          "requires": {
-            "component-emitter": "1.2.1",
-            "component-inherit": "0.0.3",
-            "debug": "2.3.3",
-            "engine.io-parser": "1.3.2",
-            "has-cors": "1.1.0",
-            "indexof": "0.0.1",
-            "parsejson": "0.0.3",
-            "parseqs": "0.0.5",
-            "parseuri": "0.0.5",
-            "ws": "~1.1.5",
-            "xmlhttprequest-ssl": "1.5.3",
-            "yeast": "0.1.2"
-          },
-          "dependencies": {
-            "component-emitter": {
-              "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-              "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-              "dev": true
-            }
-          }
-        },
-        "engine.io-parser": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
-          "integrity": "sha1-k3sHnwAH0Ik+xW1GyyILjLQ1Igo=",
-          "dev": true,
-          "requires": {
-            "after": "0.8.2",
-            "arraybuffer.slice": "0.0.6",
-            "base64-arraybuffer": "0.1.5",
-            "blob": "0.0.4",
-            "has-binary": "0.1.7",
-            "wtf-8": "1.0.0"
-          }
-        },
-        "expand-template": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
-          "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg==",
-          "dev": true
-        },
-        "glob": {
-          "version": "3.2.11",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-          "dev": true,
-          "requires": {
-            "inherits": "2",
-            "minimatch": "0.3"
-          },
-          "dependencies": {
-            "minimatch": {
-              "version": "0.3.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-              "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-              "dev": true,
-              "requires": {
-                "lru-cache": "2",
-                "sigmund": "~1.0.0"
-              }
-            }
-          }
-        },
-        "ioctl": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ioctl/-/ioctl-2.0.0.tgz",
-          "integrity": "sha1-Kqy9c+tv+a0B/fPswzkO5XeBEA4=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "bindings": "^1.1.1",
-            "nan": "^2.3.2"
-          }
-        },
-        "ioredis": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-2.5.0.tgz",
-          "integrity": "sha1-+2/fChp+CXRhTGe25eETCKjPlbk=",
-          "dev": true,
-          "requires": {
-            "bluebird": "^3.3.4",
-            "cluster-key-slot": "^1.0.6",
-            "debug": "^2.2.0",
-            "double-ended-queue": "^2.1.0-0",
-            "flexbuffer": "0.0.6",
-            "lodash": "^4.8.2",
-            "redis-commands": "^1.2.0",
-            "redis-parser": "^1.3.0"
-          }
-        },
-        "ipaddr.js": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz",
-          "integrity": "sha1-irpJyRknmVhb3WQ+DMtQ6K53e6Q=",
-          "dev": true
-        },
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "level": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/level/-/level-1.6.0.tgz",
-          "integrity": "sha1-P8uukWOgkWaLjsep79HS/u8eZiE=",
-          "dev": true,
-          "requires": {
-            "level-packager": "~1.2.0",
-            "leveldown": "~1.6.0"
-          }
-        },
-        "level-codec": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
-          "integrity": "sha512-Ua/R9B9r3RasXdRmOtd+t9TCOEIIlts+TN/7XTT2unhDaL6sJn83S3rUyljbr6lVtw49N3/yA0HHjpV6Kzb2aQ==",
-          "dev": true
-        },
-        "level-errors": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
-          "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
-          "dev": true,
-          "requires": {
-            "errno": "~0.1.1"
-          }
-        },
-        "level-iterator-stream": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
-          "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.1",
-            "level-errors": "^1.0.3",
-            "readable-stream": "^1.0.33",
-            "xtend": "^4.0.0"
-          }
-        },
-        "level-packager": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-1.2.1.tgz",
-          "integrity": "sha1-Bn/t/Qcrf+PGvsYIDAy9SmsuEfQ=",
-          "dev": true,
-          "requires": {
-            "levelup": "~1.3.0"
-          }
-        },
-        "leveldown": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.6.0.tgz",
-          "integrity": "sha1-5uyQbSmVqL/9AkmfOelZiM0rIw8=",
-          "dev": true,
-          "requires": {
-            "abstract-leveldown": "~2.6.1",
-            "bindings": "~1.2.1",
-            "fast-future": "~1.0.2",
-            "nan": "~2.5.1",
-            "prebuild-install": "^2.1.0"
-          },
-          "dependencies": {
-            "bindings": {
-              "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
-              "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE=",
-              "dev": true
-            },
-            "nan": {
-              "version": "2.5.1",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz",
-              "integrity": "sha1-1bAWkSUzJql6K77p5hxV2NYDUeI=",
-              "dev": true
-            }
-          }
-        },
-        "levelup": {
-          "version": "1.3.9",
-          "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
-          "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
-          "dev": true,
-          "requires": {
-            "deferred-leveldown": "~1.2.1",
-            "level-codec": "~7.0.0",
-            "level-errors": "~1.0.3",
-            "level-iterator-stream": "~1.3.0",
-            "prr": "~1.0.1",
-            "semver": "~5.4.1",
-            "xtend": "~4.0.0"
-          }
-        },
-        "long-timeout": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/long-timeout/-/long-timeout-0.0.2.tgz",
-          "integrity": "sha1-82RJuolinROnorJSOk253Wbj/2g=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "0.2.14",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2",
-            "sigmund": "~1.0.0"
-          }
-        },
-        "ms": {
-          "version": "0.7.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
-          "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
-          "dev": true
-        },
-        "negotiator": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-          "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-          "dev": true
-        },
-        "node-schedule": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/node-schedule/-/node-schedule-1.2.0.tgz",
-          "integrity": "sha1-8D1OvnGwVz4XCN2uCqRdFlhFDPE=",
-          "dev": true,
-          "requires": {
-            "cron-parser": "1.1.0",
-            "long-timeout": "0.0.2"
-          }
-        },
-        "object-assign": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
-          "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
-          "dev": true
-        },
-        "prebuild-install": {
-          "version": "2.5.3",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
-          "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
-          "dev": true,
-          "requires": {
-            "detect-libc": "^1.0.3",
-            "expand-template": "^1.0.2",
-            "github-from-package": "0.0.0",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "node-abi": "^2.2.0",
-            "noop-logger": "^0.1.1",
-            "npmlog": "^4.0.1",
-            "os-homedir": "^1.0.1",
-            "pump": "^2.0.1",
-            "rc": "^1.1.6",
-            "simple-get": "^2.7.0",
-            "tar-fs": "^1.13.0",
-            "tunnel-agent": "^0.6.0",
-            "which-pm-runs": "^1.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "redis-parser": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-1.3.0.tgz",
-          "integrity": "sha1-gG6+e7+3005NfB6e8oLvz60EEmo=",
-          "dev": true
-        },
-        "safe-json-stringify": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
-          "integrity": "sha1-PLZxdmCghtB8tb2bemh1vPZ70F4=",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
-          "dev": true
-        },
-        "simple-glob": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/simple-glob/-/simple-glob-0.1.1.tgz",
-          "integrity": "sha1-KCv6AS1yBmQ99h00xrueTOP9dxQ=",
-          "dev": true,
-          "requires": {
-            "glob": "~3.2.8",
-            "lodash": "~2.4.1",
-            "minimatch": "~0.2.14"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
-              "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=",
-              "dev": true
-            }
-          }
-        },
-        "socket.io": {
-          "version": "1.7.4",
-          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.4.tgz",
-          "integrity": "sha1-L37O3DORvy1cc+KR/iM+bjTU3QA=",
-          "dev": true,
-          "requires": {
-            "debug": "2.3.3",
-            "engine.io": "~1.8.4",
-            "has-binary": "0.1.7",
-            "object-assign": "4.1.0",
-            "socket.io-adapter": "0.5.0",
-            "socket.io-client": "1.7.4",
-            "socket.io-parser": "2.3.1"
-          }
-        },
-        "socket.io-adapter": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
-          "integrity": "sha1-y21LuL7IHhB4uZZ3+c7QBGBmu4s=",
-          "dev": true,
-          "requires": {
-            "debug": "2.3.3",
-            "socket.io-parser": "2.3.1"
-          }
-        },
-        "socket.io-client": {
-          "version": "1.7.4",
-          "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.4.tgz",
-          "integrity": "sha1-7J+CA1btme9tNX8HVtZIcXvdQoE=",
-          "dev": true,
-          "requires": {
-            "backo2": "1.0.2",
-            "component-bind": "1.0.0",
-            "component-emitter": "1.2.1",
-            "debug": "2.3.3",
-            "engine.io-client": "~1.8.4",
-            "has-binary": "0.1.7",
-            "indexof": "0.0.1",
-            "object-component": "0.0.3",
-            "parseuri": "0.0.5",
-            "socket.io-parser": "2.3.1",
-            "to-array": "0.1.4"
-          },
-          "dependencies": {
-            "component-emitter": {
-              "version": "1.2.1",
-              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-              "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
-              "dev": true
-            }
-          }
-        },
-        "socket.io-parser": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
-          "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
-          "dev": true,
-          "requires": {
-            "component-emitter": "1.1.2",
-            "debug": "2.2.0",
-            "isarray": "0.0.1",
-            "json3": "3.3.2"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-              "dev": true,
-              "requires": {
-                "ms": "0.7.1"
-              }
-            },
-            "ms": {
-              "version": "0.7.1",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-              "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-              "dev": true
-            }
-          }
-        },
-        "utf8": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
-          "integrity": "sha1-H6DZJw6b6FDZsFAn9jUZv0ZFfZY=",
-          "dev": true
-        },
-        "vaultclient": {
-          "version": "github:scality/vaultclient#fbd9988dcc2559ac68d4f1c1aea95e0db57f7d0c",
-          "from": "github:scality/vaultclient#fbd9988d",
-          "dev": true,
-          "requires": {
-            "arsenal": "github:scality/Arsenal#6736508364ed537a8851838ba56cf147234c7bd8",
-            "commander": "2.9.0",
-            "werelogs": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-            "xml2js": "0.4.17"
-          },
-          "dependencies": {
-            "xml2js": {
-              "version": "0.4.17",
-              "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.17.tgz",
-              "integrity": "sha1-F76T6q4/O3eTWceVtBlwWogX6Gg=",
-              "dev": true,
-              "requires": {
-                "sax": ">=0.6.0",
-                "xmlbuilder": "^4.1.0"
-              }
-            }
-          }
-        },
-        "werelogs": {
-          "version": "github:scality/werelogs#0ff7ec82f0deb1e472d8285fb7cc9ebde72c5f61",
-          "from": "github:scality/werelogs#0ff7ec82",
-          "dev": true,
-          "requires": {
-            "safe-json-stringify": "1.0.3"
-          }
-        },
-        "ws": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.5.tgz",
-          "integrity": "sha512-o3KqipXNUdS7wpQzBHSe180lBGO60SoK0yVo3CYJgb2MkobuWuBX6dhkYP5ORCLd55y+SaflMOV5fqAB53ux4w==",
-          "dev": true,
-          "requires": {
-            "options": ">=0.0.5",
-            "ultron": "1.0.x"
-          }
-        },
-        "xmlhttprequest-ssl": {
-          "version": "1.5.3",
-          "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
-          "integrity": "sha1-GFqIjATspGw+QHDZn3tJ3jUomS0=",
-          "dev": true
-        }
       }
     },
     "utf-8-validate": {
@@ -7288,9 +6917,7 @@
       "version": "github:scality/vaultclient#754b6e1e1121f44bc3719e35b836a9185d6d5e1a",
       "from": "github:scality/vaultclient#754b6e1",
       "requires": {
-        "arsenal": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
         "commander": "2.9.0",
-        "werelogs": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
         "xml2js": "0.4.17"
       },
       "dependencies": {
@@ -7318,7 +6945,7 @@
         },
         "arsenal": {
           "version": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
-          "from": "github:scality/Arsenal#7.4.0.3",
+          "from": "github:scality/Arsenal#bd1bac6b56e01c65320eb315b26221db5adb4b38",
           "requires": {
             "JSONStream": "^1.0.0",
             "ajv": "4.10.0",
@@ -7436,6 +7063,14 @@
               "version": "1.2.1",
               "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
               "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+            },
+            "parsejson": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
+              "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
+              "requires": {
+                "better-assert": "~1.0.0"
+              }
             }
           }
         },
@@ -7450,6 +7085,21 @@
             "blob": "0.0.4",
             "has-binary": "0.1.7",
             "wtf-8": "1.0.0"
+          },
+          "dependencies": {
+            "has-binary": {
+              "version": "0.1.7",
+              "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+              "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
+              "requires": {
+                "isarray": "0.0.1"
+              }
+            },
+            "wtf-8": {
+              "version": "1.0.0",
+              "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
+              "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo="
+            }
           }
         },
         "expand-template": {
@@ -7466,6 +7116,11 @@
             "minimatch": "0.3"
           },
           "dependencies": {
+            "lru-cache": {
+              "version": "2.7.3",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+              "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+            },
             "minimatch": {
               "version": "0.3.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
@@ -7474,6 +7129,11 @@
                 "lru-cache": "2",
                 "sigmund": "~1.0.0"
               }
+            },
+            "sigmund": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+              "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
             }
           }
         },
@@ -7500,6 +7160,13 @@
             "lodash": "^4.8.2",
             "redis-commands": "^1.2.0",
             "redis-parser": "^1.3.0"
+          },
+          "dependencies": {
+            "double-ended-queue": {
+              "version": "2.1.0-0",
+              "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
+              "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw="
+            }
           }
         },
         "ipaddr.js": {
@@ -7598,6 +7265,18 @@
           "requires": {
             "lru-cache": "2",
             "sigmund": "~1.0.0"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.7.3",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+              "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI="
+            },
+            "sigmund": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+              "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
+            }
           }
         },
         "ms": {
@@ -7687,6 +7366,16 @@
             "socket.io-adapter": "0.5.0",
             "socket.io-client": "1.7.4",
             "socket.io-parser": "2.3.1"
+          },
+          "dependencies": {
+            "has-binary": {
+              "version": "0.1.7",
+              "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+              "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
+              "requires": {
+                "isarray": "0.0.1"
+              }
+            }
           }
         },
         "socket.io-adapter": {
@@ -7720,6 +7409,14 @@
               "version": "1.2.1",
               "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
               "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+            },
+            "has-binary": {
+              "version": "0.1.7",
+              "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+              "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
+              "requires": {
+                "isarray": "0.0.1"
+              }
             }
           }
         },
@@ -7756,7 +7453,7 @@
         },
         "werelogs": {
           "version": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
-          "from": "github:scality/werelogs#7.4.0.3",
+          "from": "github:scality/werelogs#a5605431dfd5927fe74871a737b14fcdbbe9b0c2",
           "requires": {
             "safe-json-stringify": "^1.0.3"
           }
@@ -7768,6 +7465,18 @@
           "requires": {
             "options": ">=0.0.5",
             "ultron": "1.0.x"
+          },
+          "dependencies": {
+            "options": {
+              "version": "0.0.6",
+              "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+              "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8="
+            },
+            "ultron": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+              "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po="
+            }
           }
         },
         "xml2js": {
@@ -7852,11 +7561,6 @@
       "requires": {
         "async-limiter": "~1.0.0"
       }
-    },
-    "wtf-8": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
-      "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo="
     },
     "xml2js": {
       "version": "0.4.19",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/scality/backbeat#readme",
   "dependencies": {
     "JSONStream": "^1.3.5",
-    "arsenal": "github:scality/Arsenal#8861101",
+    "arsenal": "github:scality/Arsenal#7dd4dca",
     "async": "^2.3.0",
     "aws-sdk": "2.147.0",
     "backo": "^1.1.0",

--- a/tests/functional/ingestion/IngestionReader.js
+++ b/tests/functional/ingestion/IngestionReader.js
@@ -83,7 +83,7 @@ function checkEntryInQueue(kafkaEntries, expectedEntries, done) {
                 if (typeof entryValue[key] === 'object') {
                     assert.strictEqual(JSON.stringify(entryValue[key]),
                                        JSON.stringify(kafkaValue[key]));
-               } else if (key !== 'md-model-version') {
+                } else if (key !== 'md-model-version') {
                    // ignore model version, but compare all other fields
                     assert.strictEqual(entryValue[key], kafkaValue[key]);
                 }

--- a/tests/unit/management/patchConfiguration.js
+++ b/tests/unit/management/patchConfiguration.js
@@ -51,6 +51,7 @@ const configOverlay = {
             locationType: 'location-azure-v1',
         },
     },
+    instanceId: 'hello-zenko',
 };
 
 function createBucketMDObject(bucketName, locationName, ingestion) {


### PR DESCRIPTION
Retro-propagation bug fix.

Filter any ingestion entry that has user metadata header "x-amz-meta-zenko-instance-id" defined.
If a hashed instance id is defined, compare to the current Zenko deployment instance id and only
filter if it matches with current deployment