### PR TITLE
bf: ZENKO-1746 ingestion negative pending metrics

### DIFF
--- a/lib/api/Metrics.js
+++ b/lib/api/Metrics.js
@@ -550,7 +550,7 @@ class Metrics {
 
     _sendPendingResponseIngestion(ops, cb) {
         const results = {
-            count: ops,
+            count: ops < 0 ? 0 : ops,
         };
         const response = {
             pending: {


### PR DESCRIPTION
It is possible for ingestion consumers to consume entries
before the populator's batch of entries are reported.

The populator will batch and send entries to kafka broker.
Consumers will process as they come, and will typically
experience some lag and queue of entries based on load.
Pending metrics on populator are only produced to the
metrics client once the entire batch has sent (for a given
IngestionReader). Since consumers have already started
working on processing entries, they will report pending
completion metrics (subtract from pending), which will
show as negative to the user.

Suggested fix is to keep metrics reporting as is, but on
api, report a 0 even if internally we are negative.