### PR TITLE
bf: ZENKO-1770 fix ingestion reader test

### DIFF
--- a/tests/functional/ingestion/IngestionReader.js
+++ b/tests/functional/ingestion/IngestionReader.js
@@ -83,7 +83,8 @@ function checkEntryInQueue(kafkaEntries, expectedEntries, done) {
                 if (typeof entryValue[key] === 'object') {
                     assert.strictEqual(JSON.stringify(entryValue[key]),
                                        JSON.stringify(kafkaValue[key]));
-                } else {
+               } else if (key !== 'md-model-version') {
+                   // ignore model version, but compare all other fields
                     assert.strictEqual(entryValue[key], kafkaValue[key]);
                 }
             });


### PR DESCRIPTION
A deep compare is made between kafka entry and expected
entry. The object MD field 'md-model-version' can and will
change in the future, so we should ignore comparing this
field.