### PR TITLE
feature: ZENKO-1520 expose data mover metrics

### DIFF
--- a/extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor.js
+++ b/extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor.js
@@ -103,7 +103,6 @@ class LifecycleBucketProcessor {
             s3Auth: this._lcConfig.auth,
             bucketTasksTopic: this._lcConfig.bucketTasksTopic,
             objectTasksTopic: this._lcConfig.objectTasksTopic,
-            dataMoverTopic: this._repConfig.dataMoverTopic,
             kafkaBacklogMetrics: this._kafkaBacklogMetrics,
             log: this._log,
         };

--- a/extensions/replication/ReplicationAPI.js
+++ b/extensions/replication/ReplicationAPI.js
@@ -1,0 +1,100 @@
+const config = require('../../conf/Config');
+
+const ActionQueueEntry = require('../../lib/models/ActionQueueEntry');
+const ReplicationMetrics = require('./ReplicationMetrics');
+
+let { dataMoverTopic } = config.extensions.replication;
+
+class ReplicationAPI {
+    /**
+     * Create an action to copy an object's data to a new location.
+     *
+     * Pass the returned object to
+     * {@link ReplicationAPI.sendDataMoverAction()} to queue the action
+     * to the data mover service.
+     *
+     * @param {object} params - params object
+     * @param {string} params.bucketName - bucket name
+     * @param {string} params.objectKey - object key
+     * @param {string} [params.versionId] - encoded version ID
+     * @param {string} [params.eTag] - ETag of object
+     * @param {string} [params.lastModified] - object last modification date
+     * @param {string} params.toLocation - name of target location
+     * @param {string} params.originLabel - label to mark origin of
+     * request (for metrics accounting)
+     * @param {string} params.fromLocation - source location name (for
+     * metrics accounting)
+     * @param {string} params.contentLength - content length (for
+     * metrics accounting)
+     * @param {string} [params.resultsTopic] - name of topic to get
+     * result message (no result will be published if not provided)
+     * @return {ActionQueueEntry} new action entry
+     */
+    static createCopyLocationAction(params) {
+        const action = ActionQueueEntry.create('copyLocation');
+        action
+            .setAttribute('target', {
+                bucket: params.bucketName,
+                key: params.objectKey,
+                version: params.versionId,
+                eTag: params.eTag,
+                lastModified: params.lastModified,
+            })
+            .setAttribute('toLocation', params.toLocation)
+            .setAttribute('metrics', {
+                origin: params.originLabel,
+                fromLocation: params.fromLocation,
+                contentLength: params.contentLength,
+            });
+        if (params.resultsTopic) {
+            action.setResultsTopic(params.resultsTopic);
+        }
+        return action;
+    }
+
+    /**
+     * Send an action to the data mover service
+     *
+     * @param {BackbeatProducer} producer - backbeat producer instance
+     * @param {ActionQueueEntry} action - The action entry to send to
+     * the data mover service
+     * @param {Logger.newRequestLogger} log - logger object
+     * @param {Function} cb - callback: cb(err)
+     * @return {undefined}
+     */
+    static sendDataMoverAction(producer, action, log, cb) {
+        const { bucket, key } = action.getAttribute('target');
+        const kafkaEntries = [{ key: `${bucket}/${key}`,
+                                message: action.toKafkaMessage() }];
+        producer.sendToTopic(dataMoverTopic, kafkaEntries, (err, reports) => {
+            if (err) {
+                log.error('could not send data mover action',
+                          Object.assign({
+                              method: 'ReplicationAPI.sendDataMoverAction',
+                              error: err,
+                          }, action.getLogInfo()));
+                return cb(err);
+            }
+            log.debug('sent action to the data mover',
+                      Object.assign({
+                          method: 'ReplicationAPI.sendDataMoverAction',
+                      }, action.getLogInfo()));
+            const { origin, fromLocation, contentLength } =
+                  action.getAttribute('metrics');
+            ReplicationMetrics.onReplicationQueued(
+                origin, fromLocation, action.getAttribute('toLocation'),
+                contentLength, reports[0].partition);
+            return cb();
+        });
+    }
+
+    static getDataMoverTopic() {
+        return dataMoverTopic;
+    }
+
+    static setDataMoverTopic(newTopicName) {
+        dataMoverTopic = newTopicName;
+    }
+}
+
+module.exports = ReplicationAPI;

--- a/extensions/replication/ReplicationMetric.js
+++ b/extensions/replication/ReplicationMetric.js
@@ -2,6 +2,10 @@ const { Logger } = require('werelogs');
 
 const MetricsModel = require('../../lib/models/MetricsModel');
 
+/**
+ * Legacy: consider converting replication metrics with
+ * Prometheus-based {@link ReplicationMetrics} class
+ */
 class ReplicationMetric {
     constructor() {
         this._log = new Logger('ReplicationMetric');

--- a/extensions/replication/ReplicationMetrics.js
+++ b/extensions/replication/ReplicationMetrics.js
@@ -1,0 +1,122 @@
+const { ZenkoMetrics } = require('arsenal').metrics;
+
+const config = require('../../conf/Config');
+const { promMetricNames } = require('./constants');
+
+const SIZE_BUCKETS = [
+    { label: '<10KB', lt: 1e+4 },
+    { label: '10..30KB', lt: 3e+4 },
+    { label: '30..100KB', lt: 1e+5 },
+    { label: '100..300KB', lt: 3e+5 },
+    { label: '300KB..1MB', lt: 1e+6 },
+    { label: '1..3MB', lt: 3e+6 },
+    { label: '3..10MB', lt: 1e+7 },
+    { label: '10..30MB', lt: 3e+7 },
+    { label: '30..100MB', lt: 1e+8 },
+    { label: '100..300MB', lt: 3e+8 },
+    { label: '300MB..1GB', lt: 1e+9 },
+    { label: '1..3GB', lt: 3e+9 },
+    { label: '3..10GB', lt: 1e+10 },
+    { label: '10..30GB', lt: 3e+10 },
+    { label: '30..100GB', lt: 1e+11 },
+    { label: '100..300GB', lt: 3e+11 },
+    { label: '300..1TB', lt: 1e+12 },
+    { label: '>1TB', lt: Infinity },
+];
+
+const TIME_BUCKETS = [0.03, 0.1, 0.3, 1, 3, 10, 30, 100, 300, 1000, 3000];
+
+const replicationQueuedTotal = ZenkoMetrics.createCounter({
+    name: promMetricNames.replicationQueuedTotal,
+    help: 'Number of objects queued for replication',
+    labelNames: ['origin', 'partition', 'fromLocation', 'fromLocationType',
+                 'toLocation', 'toLocationType'],
+});
+
+const replicationQueuedBytes = ZenkoMetrics.createCounter({
+    name: promMetricNames.replicationQueuedBytes,
+    help: 'Number of bytes queued for replication',
+    labelNames: ['origin', 'partition', 'fromLocation', 'fromLocationType',
+                 'toLocation', 'toLocationType'],
+});
+
+const replicationProcessedBytes = ZenkoMetrics.createCounter({
+    name: promMetricNames.replicationProcessedBytes,
+    help: 'Number of bytes replicated',
+    labelNames: ['origin', 'fromLocation', 'fromLocationType',
+                 'toLocation', 'toLocationType', 'status'],
+});
+
+const replicationProcessedElapsedSeconds = ZenkoMetrics.createHistogram({
+    name: promMetricNames.replicationElapsedSeconds,
+    help: 'Replication jobs elapsed time in seconds',
+    buckets: TIME_BUCKETS,
+    labelNames: ['origin', 'fromLocation', 'fromLocationType',
+                 'toLocation', 'toLocationType', 'status',
+                 'contentLengthRange'],
+});
+
+let bootstrapList = config.getBootstrapList();
+config.on('bootstrap-list-update', () => {
+    bootstrapList = config.getBootstrapList();
+});
+
+/**
+ * Get the type of this location (see mapping in
+ * conf/Config.js:locationTypeMatch)
+ *
+ * @param {string} location - location name
+ * @return {string} location type if set in config, or 'local'
+ * otherwise (for non-replicated locations), this is a bit of a
+ * shortcut but we can then set the fromLocationType field in metrics
+ * to 'local' when reading from a non-cloud location.
+ */
+function _getReplicationEndpointType(location) {
+    const replicationEndpoint = bootstrapList
+          .find(endpoint => endpoint.site === location);
+    return (replicationEndpoint && replicationEndpoint.type) || 'local';
+}
+
+class ReplicationMetrics extends ZenkoMetrics {
+    static onReplicationQueued(originLabel, fromLocation, toLocation,
+                               contentLength, partition) {
+        const fromLocationType = _getReplicationEndpointType(fromLocation);
+        const toLocationType = _getReplicationEndpointType(toLocation);
+
+        replicationQueuedTotal.inc({
+            origin: originLabel,
+            fromLocation, fromLocationType,
+            toLocation, toLocationType, partition,
+        });
+
+        replicationQueuedBytes.inc({
+            origin: originLabel,
+            fromLocation, fromLocationType,
+            toLocation, toLocationType, partition,
+        }, contentLength);
+    }
+
+    static onReplicationProcessed(originLabel, fromLocation, toLocation,
+                                  contentLength, status, elapsedMs) {
+        const fromLocationType = _getReplicationEndpointType(fromLocation);
+        const toLocationType = _getReplicationEndpointType(toLocation);
+
+        replicationProcessedBytes.inc({
+            origin: originLabel,
+            fromLocation, fromLocationType,
+            toLocation, toLocationType, status,
+        }, contentLength);
+
+        const sizeBucket = SIZE_BUCKETS.find(
+            bucket => contentLength < bucket.lt);
+        replicationProcessedElapsedSeconds.observe({
+            origin: originLabel,
+            fromLocation, fromLocationType,
+            toLocation, toLocationType,
+            status,
+            contentLengthRange: sizeBucket.label,
+        }, elapsedMs / 1000);
+    }
+}
+
+module.exports = ReplicationMetrics;

--- a/extensions/replication/constants.js
+++ b/extensions/replication/constants.js
@@ -13,6 +13,12 @@ const constants = {
     metricsTypeQueued: 'queued',
     metricsTypeCompleted: 'completed',
     metricsTypeFailed: 'failed',
+    promMetricNames: {
+        replicationQueuedTotal: 'zenko_replication_queued_total',
+        replicationQueuedBytes: 'zenko_replication_queued_bytes',
+        replicationProcessedBytes: 'zenko_replication_processed_bytes',
+        replicationElapsedSeconds: 'zenko_replication_elapsed_seconds',
+    },
     redisKeys: {
         opsPending: testIsOn ? 'test:bb:opspending' : 'bb:crr:opspending',
         bytesPending: testIsOn ? 'test:bb:bytespending' : 'bb:crr:bytespending',

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -130,6 +130,7 @@ class BackbeatProducer extends EventEmitter {
     _onDeliveryReport(error, report) {
         const sendCtx = report.opaque;
         const cbOnce = sendCtx.cbOnce;
+        sendCtx.receivedReports.push(report);
         --sendCtx.pendingReportsCount;
         if (error) {
             this._log.error('error in delivery report retrieval', {
@@ -147,7 +148,7 @@ class BackbeatProducer extends EventEmitter {
             // all delivery reports received (if errors occurred, the
             // callback will have been called earlier so this will be
             // a no-op)
-            cbOnce();
+            cbOnce(null, sendCtx.receivedReports);
         }
         return undefined;
     }
@@ -213,7 +214,8 @@ class BackbeatProducer extends EventEmitter {
             return this;
         }
         const sendCtx = { cbOnce: jsutil.once(cb),
-                          pendingReportsCount: entries.length };
+                          pendingReportsCount: entries.length,
+                          receivedReports: [] };
         try {
             entries.forEach(item => {
                 let partition = null;

--- a/tests/functional/lib/BackbeatProducer.js
+++ b/tests/functional/lib/BackbeatProducer.js
@@ -27,16 +27,22 @@ const oneMessage = [{ key: 'foo', message: 'hello world' }];
         });
         after(() => { producer = null; });
 
-        it('should be able to send one message', done => {
-            producer.send(oneMessage, err => {
+        it('should be able to send one message and get delivery reports back',
+        done => {
+            producer.send(oneMessage, (err, reports) => {
                 assert.ifError(err);
+                assert(Array.isArray(reports));
+                assert.strictEqual(reports.length, 1);
                 done();
             });
         }).timeout(30000);
 
-        it('should be able to send a batch of messages', done => {
-            producer.send(multipleMessages, err => {
+        it('should be able to send a batch of messages and get delivery ' +
+        'reports back', done => {
+            producer.send(multipleMessages, (err, reports) => {
                 assert.ifError(err);
+                assert(Array.isArray(reports));
+                assert.strictEqual(reports.length, 3);
                 done();
             });
         }).timeout(30000);

--- a/tests/unit/gc/GarbageCollectorProducer.spec.js
+++ b/tests/unit/gc/GarbageCollectorProducer.spec.js
@@ -27,7 +27,11 @@ class KafkaProducerMock {
                                    JSON.parse(messages[0].message));
             this._expectedMessage = null;
         }
-        return process.nextTick(cb);
+        return process.nextTick(() => cb(null, messages.map(() => ({
+            topic: 'gc-topic',
+            partition: 1,
+            offset: 2,
+        }))));
     }
 }
 

--- a/tests/unit/replication/ReplicationMetrics.js
+++ b/tests/unit/replication/ReplicationMetrics.js
@@ -1,0 +1,136 @@
+const assert = require('assert');
+
+const { ZenkoMetrics } = require('arsenal').metrics;
+const ReplicationMetrics =
+      require('../../../extensions/replication/ReplicationMetrics');
+const { promMetricNames } =
+      require('../../../extensions/replication/constants');
+
+describe('ReplicationMetrics', () => {
+    it('should maintain replication queuing metrics', () => {
+        ReplicationMetrics.onReplicationQueued(
+            'testOrigin', 'fromLoc', 'toLoc', 123456, 2);
+
+        const totalMetric = ZenkoMetrics.getMetric(
+            promMetricNames.replicationQueuedTotal);
+        const totalValues = totalMetric.get().values;
+        // only one metric value exists because we published with one
+        // distinct label set
+        assert.strictEqual(totalValues.length, 1);
+        const totalValue = totalValues[0];
+        assert.strictEqual(totalValue.value, 1);
+        assert.deepStrictEqual(totalValue.labels, {
+            origin: 'testOrigin',
+            fromLocation: 'fromLoc',
+            fromLocationType: 'local',
+            toLocation: 'toLoc',
+            toLocationType: 'local',
+            partition: 2,
+        });
+        // reset counter not to alter other tests
+        totalMetric.reset();
+
+        const bytesMetric = ZenkoMetrics.getMetric(
+            promMetricNames.replicationQueuedBytes);
+        const bytesValues = bytesMetric.get().values;
+        // only one metric value exists because we published with one
+        // distinct label set
+        assert.strictEqual(bytesValues.length, 1);
+        const bytesValue = bytesValues[0];
+        assert.strictEqual(bytesValue.value, 123456);
+        assert.deepStrictEqual(bytesValue.labels, {
+            origin: 'testOrigin',
+            fromLocation: 'fromLoc',
+            fromLocationType: 'local',
+            toLocation: 'toLoc',
+            toLocationType: 'local',
+            partition: 2,
+        });
+        // reset counter not to alter other tests
+        bytesMetric.reset();
+    });
+
+    it('should maintain replication processed metrics', () => {
+        // Push a few "processed" metrics
+        // object of 123456 bytes processed successfully in 300ms
+        ReplicationMetrics.onReplicationProcessed(
+            'testOrigin', 'fromLoc', 'toLoc', 123456,
+            'success', 300);
+        // object of 12345678 bytes processed successfully in 2s
+        ReplicationMetrics.onReplicationProcessed(
+            'testOrigin', 'fromLoc', 'toLoc', 12345678,
+            'success', 2000);
+        // object of 12345678 bytes processed with error in 5s
+        ReplicationMetrics.onReplicationProcessed(
+            'testOrigin', 'fromLoc', 'toLoc', 12345678,
+            'error', 5000);
+
+        // Check that the byte count is accurate
+        const bytesMetric = ZenkoMetrics.getMetric(
+            promMetricNames.replicationProcessedBytes);
+        const bytesValues = bytesMetric.get().values;
+
+        // only one metric value exists because we published with one
+        // distinct label set
+        assert.strictEqual(bytesValues.length, 2);
+        const successBytes = bytesValues.find(
+            value => value.labels.status === 'success');
+        const errorBytes = bytesValues.find(
+            value => value.labels.status === 'error');
+        assert.strictEqual(successBytes.value, 12469134);
+        assert.deepStrictEqual(successBytes.labels, {
+            origin: 'testOrigin',
+            fromLocation: 'fromLoc',
+            fromLocationType: 'local',
+            toLocation: 'toLoc',
+            toLocationType: 'local',
+            status: 'success',
+        });
+        assert.strictEqual(errorBytes.value, 12345678);
+        assert.deepStrictEqual(errorBytes.labels, {
+            origin: 'testOrigin',
+            fromLocation: 'fromLoc',
+            fromLocationType: 'local',
+            toLocation: 'toLoc',
+            toLocationType: 'local',
+            status: 'error',
+        });
+        // reset counter not to alter other tests
+        bytesMetric.reset();
+
+        // Check that the elapsed time histogram is accurate.
+        //
+        // Focusing on the metric labeled as "success" and "10..30MB"
+        // range, we have pushed one metric in this category with 2
+        // seconds of elapsed time, check that time buckets reflect
+        // this. We will not check the other values pushed to keep the
+        // test short, as they basically share the same logic.
+
+        const elapsedMetric = ZenkoMetrics.getMetric(
+            promMetricNames.replicationElapsedSeconds);
+        const elapsedValues = elapsedMetric.get().values;
+
+        // check that all histogram values which "less-or-equal" timing
+        // criteria is below 2 seconds for this size range is 0 (as no
+        // metric was pushed with timing less than 2 seconds)
+        const leBelowTwoSeconds10M = elapsedValues.filter(
+            value => (value.labels.status === 'success' &&
+                      value.labels.contentLengthRange === '10..30MB' &&
+                      value.labels.le < 2));
+        assert(leBelowTwoSeconds10M.length > 0);
+        assert(leBelowTwoSeconds10M.every(value => value.value === 0));
+
+        // check that all histogram values which "less-or-equal" timing
+        // criteria is above 2 seconds for this size range is 1 (as we
+        // pushed a metric in this size range with 2 seconds elapsed)
+        const leAboveTwoSeconds10M = elapsedValues.filter(
+            value => (value.labels.status === 'success' &&
+                      value.labels.contentLengthRange === '10..30MB' &&
+                      value.labels.le > 2));
+        assert(leAboveTwoSeconds10M.length > 0);
+        assert(leAboveTwoSeconds10M.every(value => value.value === 1));
+
+        // reset counter not to alter other tests
+        elapsedMetric.reset();
+    });
+});


### PR DESCRIPTION
Add queued and processed metrics to the data mover.

In order to have the data mover completely manage its own metrics and
have a cleaner API, created a ReplicationAPI class containing methods
to create action entries and to send them to the data mover queue,
with a list of documented parameters.