### PR TITLE
feature: ZENKO-1520 BackbeatConsumer and BackbeatProducer metrics

### DIFF
--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -326,6 +326,12 @@ class BackbeatConsumer extends EventEmitter {
                     this._processingQueue.push(entry, (err, completionArgs) => {
                         this._onEntryProcessingDone(err, entry, completionArgs);
                     });
+                    // update Zenko metrics with the latest consumed
+                    // message timestamp, to later allow computing
+                    // backlog metrics on demand
+                    KafkaBacklogMetrics.onMessageConsumed(
+                        entry.topic, entry.partition, this._groupId,
+                        entry.timestamp / 1000);
                     return undefined;
                 });
             }

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -2,11 +2,11 @@ const { EventEmitter } = require('events');
 const { Producer } = require('node-rdkafka');
 const joi = require('joi');
 
-const errors = require('arsenal').errors;
-const jsutil = require('arsenal').jsutil;
+const { errors, jsutil } = require('arsenal');
 const Logger = require('werelogs').Logger;
 
 const { withTopicPrefix } = require('./util/topic');
+const KafkaBacklogMetrics = require('./KafkaBacklogMetrics');
 
 // waits for an ack for messages
 const REQUIRE_ACKS = 'all';
@@ -132,6 +132,7 @@ class BackbeatProducer extends EventEmitter {
         const cbOnce = sendCtx.cbOnce;
         sendCtx.receivedReports.push(report);
         --sendCtx.pendingReportsCount;
+        KafkaBacklogMetrics.onDeliveryReportReceived(error);
         if (error) {
             this._log.error('error in delivery report retrieval', {
                 error: error.message,
@@ -140,10 +141,12 @@ class BackbeatProducer extends EventEmitter {
             this.emit('error', error);
             return cbOnce(error);
         }
-        const { topic, partition, offset } = report;
+        const { topic, partition, offset, timestamp } = report;
         const key = report.key && report.key.toString();
         this._log.debug('delivery report received',
-                        { topic, partition, offset, key });
+                        { topic, partition, offset, timestamp, key });
+        KafkaBacklogMetrics.onMessagePublished(
+            topic, partition, timestamp / 1000);
         if (sendCtx.pendingReportsCount === 0) {
             // all delivery reports received (if errors occurred, the
             // callback will have been called earlier so this will be
@@ -165,7 +168,7 @@ class BackbeatProducer extends EventEmitter {
     * sends entries/messages to the topic configured in producer
     * @param {Object[]} entries - array of entries objects with properties
     * key and message ([{ key: 'foo', message: 'hello world'}, ...])
-    * @param {callback} cb - cb(err)
+    * @param {callback} cb - cb(err, deliveryReports)
     * @return {this} current instance
     */
     send(entries, cb) {
@@ -186,7 +189,7 @@ class BackbeatProducer extends EventEmitter {
     * @param {string} topic - topic to send messages to
     * @param {Object[]} entries - array of entries objects with properties
     * key and message ([{ key: 'foo', message: 'hello world'}, ...])
-    * @param {callback} cb - cb(err)
+    * @param {callback} cb - cb(err, deliveryReports)
     * @return {this} current instance
     */
     sendToTopic(topic, entries, cb) {

--- a/lib/KafkaBacklogMetrics.js
+++ b/lib/KafkaBacklogMetrics.js
@@ -3,9 +3,38 @@ const { EventEmitter } = require('events');
 const zookeeper = require('node-zookeeper-client');
 
 const Logger = require('werelogs').Logger;
-const errors = require('arsenal').errors;
+const { errors, metrics } = require('arsenal');
 
 const zookeeperHelper = require('./clients/zookeeper');
+const { promMetricNames } = require('./constants').kafkaBacklogMetrics;
+
+const latestPublishedMessageTimestampGauge = metrics.ZenkoMetrics.createGauge({
+    name: promMetricNames.latestPublishedMessageTimestamp,
+    help: 'Timestamp of latest published message',
+    labelNames: ['topic', 'partition'],
+});
+
+const deliveryReportsCounter = metrics.ZenkoMetrics.createCounter({
+    name: promMetricNames.deliveryReportsTotal,
+    help: 'Number of delivery reports received',
+    labelNames: ['status'],
+});
+
+const latestConsumedMessageTimestampGauge = metrics.ZenkoMetrics.createGauge({
+    name: promMetricNames.latestConsumedMessageTimestamp,
+    help: 'Timestamp of latest consumed message',
+    // "consumergroup" is lowercase to match convention of metrics
+    // exposed by Kafka.
+    labelNames: ['topic', 'partition', 'consumergroup'],
+});
+
+const latestConsumeEventTimestampGauge = metrics.ZenkoMetrics.createGauge({
+    name: promMetricNames.latestConsumeEventTimestamp,
+    help: 'Timestamp of last time a consumer consumed a message',
+    // "consumergroup" is lowercase to match convention of metrics
+    // exposed by Kafka.
+    labelNames: ['topic', 'partition', 'consumergroup'],
+});
 
 // global error instances for private use
 const CheckConditionError = new Error();
@@ -39,6 +68,57 @@ class KafkaBacklogMetrics extends EventEmitter {
         return this._zookeeper &&
             this._zookeeper.getState().code ===
             zookeeper.State.SYNC_CONNECTED.code;
+    }
+
+    /**
+     * This function updates the Zenko metrics with the latest
+     * published message timestamp (metrics are published normally via
+     * a Prometheus endpoint in the process).
+     *
+     * @param {string} topic - topic name
+     * @param {number} partition - partition number of published message
+     * @param {number} timestamp - timestamp as seconds since epoch
+     * @return {undefined}
+     */
+    static onMessagePublished(topic, partition, timestamp) {
+        latestPublishedMessageTimestampGauge.set({
+            topic, partition,
+        }, timestamp);
+    }
+
+    /**
+     * This function tracks delivery reports received metrics
+     *
+     * @param {Error} [error] - Error received in the delivery report
+     * callback, if any
+     * @return {undefined}
+     */
+    static onDeliveryReportReceived(error) {
+        deliveryReportsCounter.inc({
+            status: error ? 'error' : 'success',
+        });
+    }
+
+    /**
+     * This function updates the Zenko metrics with the latest
+     * consumed message timestamp, and the consumption event timestamp
+     * (metrics are published normally via a Prometheus endpoint in
+     * the process).
+     *
+     * @param {string} topic - topic name
+     * @param {number} partition - partition number of consumed message
+     * @param {string} consumerGroup - name of consumer group
+     * @param {number} timestamp - timestamp as seconds since epoch
+     * @return {undefined}
+     */
+    static onMessageConsumed(topic, partition, consumerGroup, timestamp) {
+        latestConsumedMessageTimestampGauge.set({
+            topic, partition, consumergroup: consumerGroup,
+        }, timestamp);
+
+        latestConsumeEventTimestampGauge.set({
+            topic, partition, consumergroup: consumerGroup,
+        }, Date.now() / 1000);
     }
 
     _getPartitionsOffsetsZkPath(topic) {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,15 @@
+const constants = {
+    kafkaBacklogMetrics: {
+        promMetricNames: {
+            latestPublishedMessageTimestamp:
+            'zenko_queue_latest_published_message_timestamp',
+            deliveryReportsTotal: 'zenko_queue_delivery_reports_total',
+            latestConsumedMessageTimestamp:
+            'zenko_queue_latest_consumed_message_timestamp',
+            latestConsumeEventTimestamp:
+            'zenko_queue_latest_consume_event_timestamp',
+        },
+    },
+};
+
+module.exports = constants;

--- a/tests/functional/lib/BackbeatConsumer.js
+++ b/tests/functional/lib/BackbeatConsumer.js
@@ -1,8 +1,13 @@
 const assert = require('assert');
 const async = require('async');
+
+const { metrics } = require('arsenal');
+
 const zookeeperHelper = require('../../../lib/clients/zookeeper');
 const BackbeatProducer = require('../../../lib/BackbeatProducer');
 const BackbeatConsumer = require('../../../lib/BackbeatConsumer');
+const { promMetricNames } =
+      require('../../../lib/constants').kafkaBacklogMetrics;
 const zookeeperConf = { connectionString: 'localhost:2181' };
 const producerKafkaConf = {
     hosts: 'localhost:9092',
@@ -77,6 +82,12 @@ describe('BackbeatConsumer main tests', () => {
         let topicOffset;
         let consumerOffset;
         const zkMetricsPath = `/test/kafka-backlog-metrics/${topic}/0`;
+        const latestConsumedMetric = metrics.ZenkoMetrics.getMetric(
+            promMetricNames.latestConsumedMessageTimestamp);
+        const beforeConsume = Date.now();
+        // reset to 0 before the test
+        latestConsumedMetric.reset();
+
         function _checkZkMetrics(done) {
             async.waterfall([
                 next => zookeeper.getData(`${zkMetricsPath}/topic`, next),
@@ -91,6 +102,12 @@ describe('BackbeatConsumer main tests', () => {
                 assert.strictEqual(topicOffset, consumerOffset);
                 done();
             });
+        }
+        function _checkPromMetrics() {
+            const latestConsumedMetricValues =
+                  latestConsumedMetric.get().values;
+            assert.strictEqual(latestConsumedMetricValues.length, 1);
+            assert(latestConsumedMetricValues[0].value >= beforeConsume / 1000);
         }
         consumer.subscribe();
         consumer.on('consumed', messagesConsumed => {
@@ -111,6 +128,9 @@ describe('BackbeatConsumer main tests', () => {
                 assert.deepStrictEqual(
                     messages.map(e => e.message),
                     consumedMessages.map(buffer => buffer.toString()));
+                // Prometheus metrics are updated locally in memory so
+                // immediately visible
+                _checkPromMetrics();
             }
         });
         consumeCb = done;


### PR DESCRIPTION
Add metrics to BackbeatConsumer and BackbeatProducer, notably the
timestamp of the latest consumed and produced message, respectively.

This will be used when gathering backlog metrics for lifecycle
transitions, to know when the backlog starts when querying data mover
metrics in Prometheus.