### PR TITLE
improvement: ZENKO-1828 use debian image base

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,8 @@
 node_modules
+localData/*
+localMetadata/*
+.git
+.github
+.tox
+coverage
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,26 @@
-FROM node:8-alpine
+FROM node:8-slim
 
 WORKDIR /usr/src/app
 
-RUN apk --no-cache add \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    build-essential \
+    wget \
     bash \
-    g++ \
-    ca-certificates \
-    lz4-dev \
-    musl-dev \
-    cyrus-sasl-dev \
-    openssl-dev \
-    make \
     python \
+    git \
     jq
 
-RUN apk add --no-cache --virtual .build-deps gcc zlib-dev libc-dev bsd-compat-headers py-setuptools git
-
 ENV DOCKERIZE_VERSION v0.6.1
-RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
-    && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
-
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
 COPY package.json package-lock.json /usr/src/app/
 RUN npm install --production \
     && rm -rf /var/lib/apt/lists/* \
-    && npm cache clear --force \
     && rm -rf ~/.node-gyp \
-    && rm -rf /tmp/npm-* \
-    && apk del .build-deps
+    && rm -rf /tmp/npm-*
 
 # Keep the .git directory in order to properly report version
 COPY . /usr/src/app


### PR DESCRIPTION
The switch alpine based images brought unexpected issues and a lot of unknowns. Since the switch was premature, we are reverting back to using debian based images from official nodejs repo

