### PR TITLE
INTEGRATION [PR#710 > development/7.5] bugfix: include passwords in redis configuration

### DIFF
--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -45,6 +45,7 @@ const joiSchema = {
                 port: joi.number().required(),
             })
         ),
+        sentinelPassword: joi.string().default('').allow(''),
     },
     certFilePaths: certFilePathsJoi,
     internalCertFilePaths: certFilePathsJoi,


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #710.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.5/bugfix/S3C-2019-redis-authentication`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.5/bugfix/S3C-2019-redis-authentication
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.5/bugfix/S3C-2019-redis-authentication
```

Please always comment pull request #710 instead of this one.