### PR TITLE
improvement: ZENKO-1876 ingestion health probe

### DIFF
--- a/bin/ingestion.js
+++ b/bin/ingestion.js
@@ -224,11 +224,16 @@ function updateProcessors(zkClient, bootstrapList) {
 
 function loadHealthcheck() {
     healthServer.onReadyCheck(() => {
-        const state = ingestionPopulator.zkStatus();
-        if (state.code === zookeeper.State.SYNC_CONNECTED.code) {
+        const zkState = ingestionPopulator.zkStatus();
+        const producerReady = ingestionPopulator.producerStatus();
+        if (zkState.code === zookeeper.State.SYNC_CONNECTED.code
+            && producerReady) {
             return true;
         }
-        log.error(`Zookeeper is not connected! ${state}`);
+        log.error('Ingestion populator is not ready', {
+            zkState,
+            producerReady,
+        });
         return false;
     });
     log.info('Starting health probe server');

--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -610,7 +610,9 @@ class MongoQueueProcessor {
     }
 
     isReady() {
-        return this._consumer && this._consumer.isReady();
+        const internalClient = this._mongoClient.client;
+        return this._consumer && this._consumer.isReady() &&
+               internalClient && internalClient.isConnected();
     }
 }
 

--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -767,6 +767,10 @@ class IngestionPopulator {
         ], done);
     }
 
+    producerStatus() {
+        return this._producer && this._producer.isReady();
+    }
+
     zkStatus() {
         return this.zkClient.getState();
     }


### PR DESCRIPTION
Liveness probe should additionally check for kafka producer
state on ingestion populator and for mongo client state on
ingestion processor