### PR TITLE
bugfix: ZENKO-1907 fix kafka backlog check

### DIFF
--- a/extensions/lifecycle/conductor/LifecycleConductor.js
+++ b/extensions/lifecycle/conductor/LifecycleConductor.js
@@ -65,7 +65,6 @@ class LifecycleConductor {
         this._kafkaBacklogMetrics = null;
         this._started = false;
         this._cronJob = null;
-        this._totalProcessingCycles = 0;
 
         this.logger = new Logger('Backbeat:Lifecycle:Conductor');
     }
@@ -134,9 +133,7 @@ class LifecycleConductor {
                 }
                 return this._producer.send(entries, next);
             },
-        ], () => {
-            ++this._totalProcessingCycles;
-        });
+        ], () => {});
     }
 
     _controlBacklog(done) {
@@ -146,8 +143,7 @@ class LifecycleConductor {
         // - on first processing cycle (to guarantee progress in case
         //   of restarts)
         if (!this.lcConfig.conductor.backlogControl.enabled ||
-            !this.kafkaConfig.backlogMetrics ||
-            this._totalProcessingCycles === 0) {
+            !this.kafkaConfig.backlogMetrics) {
             return process.nextTick(done);
         }
         // check that previous lifecycle batch has completely been

--- a/lib/KafkaBacklogMetrics.js
+++ b/lib/KafkaBacklogMetrics.js
@@ -6,6 +6,7 @@ const Logger = require('werelogs').Logger;
 const { errors, metrics } = require('arsenal');
 
 const zookeeperHelper = require('./clients/zookeeper');
+const { readUInt64BE } = require('./util/buffer');
 const { promMetricNames } = require('./constants').kafkaBacklogMetrics;
 
 const latestPublishedMessageTimestampGauge = metrics.ZenkoMetrics.createGauge({
@@ -39,6 +40,9 @@ const latestConsumeEventTimestampGauge = metrics.ZenkoMetrics.createGauge({
 // global error instances for private use
 const CheckConditionError = new Error();
 const NoNodeError = new Error();
+
+// special value for the returned offset when the node holding it is outdated
+const OutdatedOffset = {};
 
 class KafkaBacklogMetrics extends EventEmitter {
     constructor(zookeeperEndpoint, backlogMetricsConfig) {
@@ -162,7 +166,7 @@ class KafkaBacklogMetrics extends EventEmitter {
         this._log.debug('reading kafka offset from zookeeper', {
             topic, partition, offsetType, label,
         });
-        this._zookeeper.getData(zkPath, (err, offsetData) => {
+        this._zookeeper.getData(zkPath, (err, offsetData, offsetStat) => {
             if (err) {
                 if (err.getCode() === zookeeper.Exception.NO_NODE) {
                     this._log.debug(
@@ -177,6 +181,38 @@ class KafkaBacklogMetrics extends EventEmitter {
                         error: err.message,
                     });
                 return cb(errors.InternalError);
+            }
+            const mtime = readUInt64BE(offsetStat.mtime);
+            const lastModAgeMs = Date.now() - mtime;
+            // if mtime of a consumer or topic node is older than
+            // twice the regular update interval, we consider it's an
+            // outdated node, ignore and delete it. This may be due to
+            // a deleted location, or partitions with no active
+            // consumer yet. Snapshot nodes are allowed to be older
+            // since they are not regularly refreshed, but then the
+            // topic offset might still be detected as outdated.
+            if ((offsetType === 'consumers' || offsetType === 'topic') &&
+                lastModAgeMs >
+                this._backlogMetricsConfig.intervalS * 1000 * 2) {
+                this._log.debug(
+                    'requested kafka offset mtime is too old, deleting it', {
+                        topic, partition, offsetType, label, lastModAgeMs,
+                    });
+                return this._zookeeper.remove(zkPath, -1, err => {
+                    if (err) {
+                        this._log.warn(
+                            'error deleting outdated kafka offset node ' +
+                                'from zookeeper', {
+                                    topic, partition, offsetType, label,
+                                    zkPath,
+                                    error: err.message,
+                                });
+                    }
+                    // return OutdatedOffset object for an outdated
+                    // offset, later we will detect this special value
+                    // and ignore it
+                    return cb(null, OutdatedOffset);
+                });
             }
             let offset;
             try {
@@ -430,13 +466,21 @@ class KafkaBacklogMetrics extends EventEmitter {
                         }
                     },
                     (offset, next) => {
+                        if (offset === OutdatedOffset) {
+                            // topic offset is outdated, skip check
+                            return next();
+                        }
                         targetOffset = offset;
-                        if (Number.isInteger(consumerOffsets)) {
+                        if (!Array.isArray(consumerOffsets)) {
                             consumerOffsets = [{
                                 label: groupId,
                                 offset: consumerOffsets,
                             }];
                         }
+                        // remove outdated consumer offsets
+                        consumerOffsets = consumerOffsets.filter(
+                            consumerOffsetInfo =>
+                                consumerOffsetInfo.offset !== OutdatedOffset);
                         const partitionNumber = Number.parseInt(partition, 10);
                         consumerOffsets.forEach(consumerOffsetInfo => {
                             let lag = targetOffset - consumerOffsetInfo.offset;

--- a/lib/util/buffer.js
+++ b/lib/util/buffer.js
@@ -1,0 +1,22 @@
+/**
+ * Convert buffer contents as a long integer in big endian format into
+ * a Number
+ *
+ * Note that the function does not check for overflow if buf contains
+ * a number greater than 2**53.
+ *
+ * @param {Buffer} buf - input buffer
+ * @return {Number} - input buffer converted to a plain javascript Number
+ */
+function readUInt64BE(buf) {
+    // node 8.x Buffer does not have readBigUInt64BE() function, so we
+    // parse the upper half and bottom half separately, then join them
+    // into a single Number.
+    const msb = buf.readUInt32BE(0);
+    const lsb = buf.readUInt32BE(4);
+    return msb * (2 ** 32) + lsb;
+}
+
+module.exports = {
+    readUInt64BE,
+};

--- a/tests/unit/lib/util/buffer.spec.js
+++ b/tests/unit/lib/util/buffer.spec.js
@@ -1,0 +1,18 @@
+const assert = require('assert');
+
+const { readUInt64BE } = require('../../../../lib/util/buffer');
+
+describe('readUInt64BE', () => {
+    it('should parse a small long number in big endian', () => {
+        const tsBuf = new Buffer([0, 0, 0, 0, 0, 0, 0, 3]);
+        const value = readUInt64BE(tsBuf);
+        assert.strictEqual(value, 3);
+    });
+
+    it('should parse a long number greater than 2**32 in big endian', () => {
+        // taken from an actual timestamp value from a zookeeper node
+        const tsBuf = new Buffer([0, 0, 1, 107, 118, 199, 180, 164]);
+        const value = readUInt64BE(tsBuf);
+        assert.strictEqual(value, 1561065927844);
+    });
+});


### PR DESCRIPTION
Fix kafka backlog check with removed locations or other situations
where nodes become unused (like with partitions waiting to be
consumed).

The fix consists of ignoring (and deleting) nodes that have been
updated since longer than twice the interval of the offset publishing
task. Since those updates normally occur regularly, nodes that did not
get updated are normally obsolete and should be ignored and deleted.

Also removed the check that forces the first batch to be executed
regardless of the backlog, it's now unnecessary since obsolete nodes
will be ignored, and it's better to enforce the check after a restart.
