### PR TITLE
bugfix: S3C-2311 allow producer to send messages >1MB

### DIFF
--- a/eve/workers/unit_and_feature_tests/Dockerfile
+++ b/eve/workers/unit_and_feature_tests/Dockerfile
@@ -5,6 +5,10 @@ FROM spotify/kafka
 #
 COPY ./backbeat_packages.list ./buildbot_worker_packages.list /tmp/
 
+# Workaround since Jessie release has been archived recently
+# (https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html)
+RUN rm -f /etc/apt/sources.list.d/jessie-backports.list
+
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && cat /tmp/*packages.list | xargs apt-get install -y \
     && pip install pip==9.0.1 \

--- a/eve/workers/unit_and_feature_tests/Dockerfile
+++ b/eve/workers/unit_and_feature_tests/Dockerfile
@@ -25,3 +25,6 @@ ARG BUILDBOT_VERSION=0.9.1
 
 RUN pip install buildbot-worker==$BUILDBOT_VERSION
 ADD supervisor/buildbot_worker.conf /etc/supervisor/conf.d/
+
+RUN echo "message.max.bytes=5000020" \
+    >> /opt/kafka_2.11-0.10.1.0/config/server.properties

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -13,6 +13,14 @@ const ACK_TIMEOUT = 5000;
 // max time in ms. to wait for flush to complete
 const FLUSH_TIMEOUT = 5000;
 
+/**
+* Backbeat replication topic is currently setup with a config
+* max.message.bytes of 5MB. Producers need to update their
+* messageMaxBytes to get at least 5MB put in the Kafka topic, adding a
+* little extra bytes of padding for approximation.
+*/
+const PRODUCER_MESSAGE_MAX_BYTES = 5000020;
+
 const CLIENT_ID = 'BackbeatProducer';
 
 class BackbeatProducer extends EventEmitter {
@@ -34,10 +42,11 @@ class BackbeatProducer extends EventEmitter {
             }).required(),
             topic: joi.string().required(),
             pollIntervalMs: joi.number().default(2000),
+            messageMaxBytes: joi.number().default(PRODUCER_MESSAGE_MAX_BYTES),
         };
         const validConfig = joi.attempt(config, configJoi,
                                         'invalid config params');
-        const { kafka, topic, pollIntervalMs } = validConfig;
+        const { kafka, topic, pollIntervalMs, messageMaxBytes } = validConfig;
 
         this._kafkaHosts = kafka.hosts;
         this._log = new Logger(CLIENT_ID);
@@ -47,6 +56,7 @@ class BackbeatProducer extends EventEmitter {
         // create a new producer instance
         this._producer = new Producer({
             'metadata.broker.list': this._kafkaHosts,
+            'message.max.bytes': messageMaxBytes,
             'dr_cb': true,
         }, {
             'request.required.acks': REQUIRE_ACKS,

--- a/tests/functional/lib/BackbeatProducer.js
+++ b/tests/functional/lib/BackbeatProducer.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const { errors } = require('arsenal');
-const BackbeatProducer = require('../../lib/BackbeatProducer');
+const BackbeatProducer = require('../../../lib/BackbeatProducer');
 const kafkaConf = { hosts: 'localhost:9092' };
 const topic = 'backbeat-producer-spec';
 const multipleMessages = [
@@ -9,6 +9,8 @@ const multipleMessages = [
     { key: 'qux', message: 'hi' },
 ];
 const oneMessage = [{ key: 'foo', message: 'hello world' }];
+const oneBigMessage = [{ key: 'large-foo',
+                         message: new Buffer(3000000).fill('x').toString() }];
 
 
 [
@@ -36,6 +38,14 @@ const oneMessage = [{ key: 'foo', message: 'hello world' }];
 
         it('should be able to send a batch of messages', done => {
             producer.send(multipleMessages, err => {
+                assert.ifError(err);
+                done();
+            });
+        }).timeout(30000);
+
+        it('should be able to send a big ' +
+        `${oneBigMessage[0].message.length / 1000000}MB message`, done => {
+            producer.send(oneBigMessage, err => {
                 assert.ifError(err);
                 done();
             });


### PR DESCRIPTION
Add the configuration value 'message.max.bytes' to the backbeat
producer so that it can handle larger messages. Set it to 5MB by
default since this is the configured limit on the brokers.

Re-enable the few backbeat producer tests that have been left alone
from a earlier refactor, by moving them from tests/functional/ to
tests/functional/lib/.