### PR TITLE
INTEGRATION [PR#731 > development/8.1] bugfix: S3C-2311 allow producer to send messages >1MB

### DIFF
--- a/eve/workers/unit_and_feature_tests/Dockerfile
+++ b/eve/workers/unit_and_feature_tests/Dockerfile
@@ -5,6 +5,10 @@ FROM spotify/kafka
 #
 COPY ./backbeat_packages.list ./buildbot_worker_packages.list /tmp/
 
+# Workaround since Jessie release has been archived recently
+# (https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html)
+RUN rm -f /etc/apt/sources.list.d/jessie-backports.list
+
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - \
     && cat /tmp/*packages.list | xargs apt-get install -y \
     && pip install pip==9.0.1 \
@@ -25,3 +29,6 @@ ARG BUILDBOT_VERSION=0.9.1
 
 RUN pip install buildbot-worker==$BUILDBOT_VERSION
 ADD supervisor/buildbot_worker.conf /etc/supervisor/conf.d/
+
+RUN echo "message.max.bytes=5000020" \
+    >> /opt/kafka_2.11-0.10.1.0/config/server.properties

--- a/eve/workers/unit_and_feature_tests/Dockerfile
+++ b/eve/workers/unit_and_feature_tests/Dockerfile
@@ -5,6 +5,10 @@ FROM spotify/kafka
 #
 COPY ./backbeat_packages.list ./buildbot_worker_packages.list /tmp/
 
+# Workaround since Jessie release has been archived recently
+# (https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html)
+RUN rm -f /etc/apt/sources.list.d/jessie-backports.list
+
 RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && cat /tmp/*packages.list | xargs apt-get install -y \
     && pip install pip==9.0.1 \

--- a/eve/workers/unit_and_feature_tests/Dockerfile
+++ b/eve/workers/unit_and_feature_tests/Dockerfile
@@ -5,6 +5,10 @@ FROM spotify/kafka
 #
 COPY ./backbeat_packages.list ./buildbot_worker_packages.list /tmp/
 
+# Workaround since Jessie release has been archived recently
+# (https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html)
+RUN rm -f /etc/apt/sources.list.d/jessie-backports.list
+
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - \
     && curl -fsSL https://get.docker.com | bash - \
     && cat /tmp/*packages.list | xargs apt-get install -y \
@@ -26,3 +30,6 @@ ARG BUILDBOT_VERSION=0.9.1
 
 RUN pip install buildbot-worker==$BUILDBOT_VERSION
 ADD supervisor/buildbot_worker.conf /etc/supervisor/conf.d/
+
+RUN echo "message.max.bytes=5000020" \
+    >> /opt/kafka_2.11-0.10.1.0/config/server.properties

--- a/eve/workers/unit_and_feature_tests/Dockerfile
+++ b/eve/workers/unit_and_feature_tests/Dockerfile
@@ -25,3 +25,6 @@ ARG BUILDBOT_VERSION=0.9.1
 
 RUN pip install buildbot-worker==$BUILDBOT_VERSION
 ADD supervisor/buildbot_worker.conf /etc/supervisor/conf.d/
+
+RUN echo "message.max.bytes=5000020" \
+    >> /opt/kafka_2.11-0.10.1.0/config/server.properties

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -16,11 +16,10 @@ const ACK_TIMEOUT = 5000;
 const FLUSH_TIMEOUT = 5000;
 
 /**
-* Given that the largest object JSON from S3 is about 1.6 MB and adding some
-* padding to it, Backbeat replication topic is currently setup with a config
-* max.message.bytes.limit to 5MB. Producers need to update their messageMaxBytes
-* to get at least 5MB put in the Kafka topic, adding a little extra bytes of
-* padding for approximation.
+* Backbeat replication topic is currently setup with a config
+* max.message.bytes of 5MB. Producers need to update their
+* messageMaxBytes to get at least 5MB put in the Kafka topic, adding a
+* little extra bytes of padding for approximation.
 */
 const PRODUCER_MESSAGE_MAX_BYTES = 5000020;
 
@@ -49,22 +48,22 @@ class BackbeatProducer extends EventEmitter {
             topic: joi.string().required(),
             keyedPartitioner: joi.boolean().default(true),
             pollIntervalMs: joi.number().default(2000),
-            messageMaxBytes: joi.number(),
+            messageMaxBytes: joi.number().default(PRODUCER_MESSAGE_MAX_BYTES),
         };
         const validConfig = joi.attempt(config, configJoi,
                                         'invalid config params');
         const { kafka, topic, pollIntervalMs, messageMaxBytes } = validConfig;
+
         this._kafkaHosts = kafka.hosts;
         this._log = new Logger(CLIENT_ID);
         this._topic = withTopicPrefix(topic);
         this._ready = false;
-        this._messageMaxBytes = messageMaxBytes || PRODUCER_MESSAGE_MAX_BYTES;
 
         // create a new producer instance
         this._producer = new Producer({
             'metadata.broker.list': this._kafkaHosts,
+            'message.max.bytes': messageMaxBytes,
             'dr_cb': true,
-            'message.max.bytes': this._messageMaxBytes,
         }, {
             'request.required.acks': REQUIRE_ACKS,
             'request.timeout.ms': ACK_TIMEOUT,

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -13,6 +13,14 @@ const ACK_TIMEOUT = 5000;
 // max time in ms. to wait for flush to complete
 const FLUSH_TIMEOUT = 5000;
 
+/**
+* Backbeat replication topic is currently setup with a config
+* max.message.bytes of 5MB. Producers need to update their
+* messageMaxBytes to get at least 5MB put in the Kafka topic, adding a
+* little extra bytes of padding for approximation.
+*/
+const PRODUCER_MESSAGE_MAX_BYTES = 5000020;
+
 const CLIENT_ID = 'BackbeatProducer';
 
 class BackbeatProducer extends EventEmitter {
@@ -34,10 +42,11 @@ class BackbeatProducer extends EventEmitter {
             }).required(),
             topic: joi.string().required(),
             pollIntervalMs: joi.number().default(2000),
+            messageMaxBytes: joi.number().default(PRODUCER_MESSAGE_MAX_BYTES),
         };
         const validConfig = joi.attempt(config, configJoi,
                                         'invalid config params');
-        const { kafka, topic, pollIntervalMs } = validConfig;
+        const { kafka, topic, pollIntervalMs, messageMaxBytes } = validConfig;
 
         this._kafkaHosts = kafka.hosts;
         this._log = new Logger(CLIENT_ID);
@@ -47,6 +56,7 @@ class BackbeatProducer extends EventEmitter {
         // create a new producer instance
         this._producer = new Producer({
             'metadata.broker.list': this._kafkaHosts,
+            'message.max.bytes': messageMaxBytes,
             'dr_cb': true,
         }, {
             'request.required.acks': REQUIRE_ACKS,

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -16,11 +16,10 @@ const ACK_TIMEOUT = 5000;
 const FLUSH_TIMEOUT = 5000;
 
 /**
-* Given that the largest object JSON from S3 is about 1.6 MB and adding some
-* padding to it, Backbeat replication topic is currently setup with a config
-* max.message.bytes.limit to 5MB. Producers need to update their messageMaxBytes
-* to get at least 5MB put in the Kafka topic, adding a little extra bytes of
-* padding for approximation.
+* Backbeat replication topic is currently setup with a config
+* max.message.bytes of 5MB. Producers need to update their
+* messageMaxBytes to get at least 5MB put in the Kafka topic, adding a
+* little extra bytes of padding for approximation.
 */
 const PRODUCER_MESSAGE_MAX_BYTES = 5000020;
 
@@ -50,22 +49,22 @@ class BackbeatProducer extends EventEmitter {
             topic: joi.string(),
             keyedPartitioner: joi.boolean().default(true),
             pollIntervalMs: joi.number().default(2000),
-            messageMaxBytes: joi.number(),
+            messageMaxBytes: joi.number().default(PRODUCER_MESSAGE_MAX_BYTES),
         };
         const validConfig = joi.attempt(config, configJoi,
                                         'invalid config params');
         const { kafka, topic, pollIntervalMs, messageMaxBytes } = validConfig;
+
         this._kafkaHosts = kafka.hosts;
         this._log = new Logger(CLIENT_ID);
         this._topic = topic && withTopicPrefix(topic);
         this._ready = false;
-        this._messageMaxBytes = messageMaxBytes || PRODUCER_MESSAGE_MAX_BYTES;
 
         // create a new producer instance
         this._producer = new Producer({
             'metadata.broker.list': this._kafkaHosts,
+            'message.max.bytes': messageMaxBytes,
             'dr_cb': true,
-            'message.max.bytes': this._messageMaxBytes,
         }, {
             'request.required.acks': REQUIRE_ACKS,
             'request.timeout.ms': ACK_TIMEOUT,

--- a/tests/functional/lib/BackbeatProducer.js
+++ b/tests/functional/lib/BackbeatProducer.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const { errors } = require('arsenal');
-const BackbeatProducer = require('../../lib/BackbeatProducer');
+const BackbeatProducer = require('../../../lib/BackbeatProducer');
 const kafkaConf = { hosts: 'localhost:9092' };
 const topic = 'backbeat-producer-spec';
 const multipleMessages = [
@@ -9,6 +9,8 @@ const multipleMessages = [
     { key: 'qux', message: 'hi' },
 ];
 const oneMessage = [{ key: 'foo', message: 'hello world' }];
+const oneBigMessage = [{ key: 'large-foo',
+                         message: new Buffer(3000000).fill('x').toString() }];
 
 
 [
@@ -36,6 +38,14 @@ const oneMessage = [{ key: 'foo', message: 'hello world' }];
 
         it('should be able to send a batch of messages', done => {
             producer.send(multipleMessages, err => {
+                assert.ifError(err);
+                done();
+            });
+        }).timeout(30000);
+
+        it('should be able to send a big ' +
+        `${oneBigMessage[0].message.length / 1000000}MB message`, done => {
+            producer.send(oneBigMessage, err => {
                 assert.ifError(err);
                 done();
             });

--- a/tests/functional/lib/BackbeatProducer.js
+++ b/tests/functional/lib/BackbeatProducer.js
@@ -11,6 +11,8 @@ const multipleMessages = [
     { key: 'qux', message: 'hi' },
 ];
 const oneMessage = [{ key: 'foo', message: 'hello world' }];
+const oneBigMessage = [{ key: 'large-foo',
+                         message: new Buffer(3000000).fill('x').toString() }];
 
 
 [
@@ -55,6 +57,14 @@ const oneMessage = [{ key: 'foo', message: 'hello world' }];
                 assert.ifError(err);
                 assert(Array.isArray(reports));
                 assert.strictEqual(reports.length, 3);
+                done();
+            });
+        }).timeout(30000);
+
+        it('should be able to send a big ' +
+        `${oneBigMessage[0].message.length / 1000000}MB message`, done => {
+            producer.send(oneBigMessage, err => {
+                assert.ifError(err);
                 done();
             });
         }).timeout(30000);

--- a/tests/functional/lib/BackbeatProducer.js
+++ b/tests/functional/lib/BackbeatProducer.js
@@ -9,6 +9,8 @@ const multipleMessages = [
     { key: 'qux', message: 'hi' },
 ];
 const oneMessage = [{ key: 'foo', message: 'hello world' }];
+const oneBigMessage = [{ key: 'large-foo',
+                         message: new Buffer(3000000).fill('x').toString() }];
 
 
 [
@@ -36,6 +38,14 @@ const oneMessage = [{ key: 'foo', message: 'hello world' }];
 
         it('should be able to send a batch of messages', done => {
             producer.send(multipleMessages, err => {
+                assert.ifError(err);
+                done();
+            });
+        }).timeout(30000);
+
+        it('should be able to send a big ' +
+        `${oneBigMessage[0].message.length / 1000000}MB message`, done => {
+            producer.send(oneBigMessage, err => {
                 assert.ifError(err);
                 done();
             });

--- a/tests/unit/backbeatProducer.js
+++ b/tests/unit/backbeatProducer.js
@@ -2,29 +2,9 @@ const assert = require('assert');
 
 const BackbeatProducer = require('../../lib/BackbeatProducer');
 
-const { kafka, extensions } = require('../config.json');
-
-const CONSUMER_FETCH_MAX_BYTES = 5000020;
+const { kafka } = require('../config.json');
 
 describe('backbeatProducer', () => {
-    it('should have a default max message bytes value', () => {
-        const backbeatProducer = new BackbeatProducer({
-            kafka,
-            topic: extensions.replication.topic,
-        });
-        assert.strictEqual(backbeatProducer._messageMaxBytes,
-            CONSUMER_FETCH_MAX_BYTES);
-    });
-
-    it('should allow setting a custom max message bytes value', () => {
-        const backbeatProducer = new BackbeatProducer({
-            kafka,
-            topic: extensions.replication.topic,
-            messageMaxBytes: 1000,
-        });
-        assert.strictEqual(backbeatProducer._messageMaxBytes, 1000);
-    });
-
     it('should use default topic name without prefix', () => {
         const backbeatProducer = new BackbeatProducer({
             kafka,


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #731.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-2311-producerRefusesMessagesLargerThan1MB`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-2311-producerRefusesMessagesLargerThan1MB
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-2311-producerRefusesMessagesLargerThan1MB
```

Please always comment pull request #731 instead of this one.