### PR TITLE
bugfix: S3C-2325 avoid double callback to fix flaky test

### DIFF
--- a/tests/unit/replication/MultipleBackendTask.js
+++ b/tests/unit/replication/MultipleBackendTask.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const jsutil = require('arsenal').jsutil;
 
 const config = require('../../config.json');
 const MultipleBackendTask =
@@ -43,8 +44,9 @@ describe('MultipleBackendTask', function test() {
 
     describe('::initiateMultipartUpload', () => {
         it('should use exponential backoff if retryable error ', done => {
-            setTimeout(() => done(), 4000); // Retries will exceed test timeout.
-            requestInitiateMPU({ retryable: true }, done);
+            const doneOnce = jsutil.once(done);
+            setTimeout(doneOnce, 4000); // Retries will exceed test timeout.
+            requestInitiateMPU({ retryable: true }, doneOnce);
         });
 
         it('should not use exponential backoff if non-retryable error ', done =>


### PR DESCRIPTION
MultipleBackendTask unit test was leaving a lingering callback in the
background, potentially being called at any later moment during the
next tests. Fix this by enforcing callback to be called only once.