### PR TITLE
INTEGRATION [PR#736 > development/7.5] bugfix: S3C-2325 avoid double callback to fix flaky test

### DIFF
--- a/tests/unit/replication/MultipleBackendTask.js
+++ b/tests/unit/replication/MultipleBackendTask.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const jsutil = require('arsenal').jsutil;
 
 const config = require('../../config.json');
 const MultipleBackendTask =
@@ -43,8 +44,9 @@ describe('MultipleBackendTask', function test() {
 
     describe('::initiateMultipartUpload', () => {
         it('should use exponential backoff if retryable error ', done => {
-            setTimeout(() => done(), 4000); // Retries will exceed test timeout.
-            requestInitiateMPU({ retryable: true }, done);
+            const doneOnce = jsutil.once(done);
+            setTimeout(doneOnce, 4000); // Retries will exceed test timeout.
+            requestInitiateMPU({ retryable: true }, doneOnce);
         });
 
         it('should not use exponential backoff if non-retryable error ', done =>


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #736.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.5/bugfix/S3C-2325-multipleBackendTaskFlakyTest`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.5/bugfix/S3C-2325-multipleBackendTaskFlakyTest
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.5/bugfix/S3C-2325-multipleBackendTaskFlakyTest
```

Please always comment pull request #736 instead of this one.