### PR TITLE
improvement: S3C-2286 upgrade node.js to 10.x

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -8,10 +8,11 @@ branches:
 stages:
   pre-merge:
     worker:
-      type: docker
-      path: eve/workers/unit_and_feature_tests
-      volumes:
-        - '/home/eve/workspace'
+      type: kube_pod
+      path: eve/workers/unit_and_feature_tests/pod.yml
+      images:
+        unit_and_feature_tests: eve/workers/unit_and_feature_tests
+        kafka: eve/workers/kafka
     steps:
       - Git:
           name: fetch source

--- a/eve/workers/kafka/Dockerfile
+++ b/eve/workers/kafka/Dockerfile
@@ -1,0 +1,3 @@
+FROM spotify/kafka
+
+RUN echo "message.max.bytes=5000020" >> /opt/kafka_2.11-0.10.1.0/config/server.properties

--- a/eve/workers/unit_and_feature_tests/Dockerfile
+++ b/eve/workers/unit_and_feature_tests/Dockerfile
@@ -1,17 +1,20 @@
-FROM spotify/kafka
+FROM buildpack-deps:xenial-curl
 
 #
 # Install apt packages needed by backbeat and buildbot_worker
 #
+ENV LANG C.UTF-8
 COPY ./backbeat_packages.list ./buildbot_worker_packages.list /tmp/
 
-# Workaround since Jessie release has been archived recently
-# (https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html)
-RUN rm -f /etc/apt/sources.list.d/jessie-backports.list
-
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - \
+RUN curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && echo "deb http://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && apt-get update \
     && cat /tmp/*packages.list | xargs apt-get install -y \
+    && git clone https://github.com/tj/n.git \
+    && make -C ./n \
+    && n 10 latest \
     && pip install pip==9.0.1 \
+    && rm -rf ./n \
     && rm -rf /var/lib/apt/lists/* \
     && rm -f /tmp/*packages.list
 
@@ -30,5 +33,4 @@ ARG BUILDBOT_VERSION=0.9.1
 RUN pip install buildbot-worker==$BUILDBOT_VERSION
 ADD supervisor/buildbot_worker.conf /etc/supervisor/conf.d/
 
-RUN echo "message.max.bytes=5000020" \
-    >> /opt/kafka_2.11-0.10.1.0/config/server.properties
+CMD ["/bin/bash", "-l", "-c", "buildbot-worker create-worker . $BUILDMASTER:$BUILDMASTER_PORT $WORKERNAME $WORKERPASS   && buildbot-worker start --nodaemon"]

--- a/eve/workers/unit_and_feature_tests/backbeat_packages.list
+++ b/eve/workers/unit_and_feature_tests/backbeat_packages.list
@@ -1,3 +1,2 @@
 build-essential
 nodejs
-redis-server

--- a/eve/workers/unit_and_feature_tests/pod.yml
+++ b/eve/workers/unit_and_feature_tests/pod.yml
@@ -1,0 +1,40 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: worker
+spec:
+  containers:
+    - name: unit-and-feature-tests
+      image: "{{ images.unit_and_feature_tests }}"
+      resources:
+        requests:
+          cpu: "250m"
+          memory: 1Gi
+        limits:
+          cpu: "1"
+          memory: 1Gi
+      volumeMounts:
+        - name: workspace
+          mountPath: /home/eve/workspace
+    - name: kafka
+      image: "{{ images.kafka }}"
+      resources:
+        requests:
+          cpu: "250m"
+          memory: 1Gi
+        limits:
+          cpu: "1"
+          memory: 1Gi
+    - name: redis
+      image: redis:alpine
+      resources:
+        requests:
+          cpu: "250m"
+          memory: 1Gi
+        limits:
+          cpu: "1"
+          memory: 1Gi
+  volumes:
+    - name: workspace
+      emptyDir: {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "1.0.0",
+  "version": "7.4.5",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {
@@ -28,11 +28,11 @@
   },
   "homepage": "https://github.com/scality/backbeat#readme",
   "dependencies": {
-    "arsenal": "scality/Arsenal#bfb4a30",
+    "arsenal": "scality/Arsenal#9f2e74e",
     "async": "^2.3.0",
     "aws-sdk": "2.147.0",
     "backo": "^1.1.0",
-    "bucketclient": "scality/bucketclient#b74165ac",
+    "bucketclient": "scality/bucketclient#36e1279",
     "commander": "^2.11.0",
     "eslint": "^2.4.0",
     "eslint-config-airbnb": "^6.0.0",
@@ -43,8 +43,8 @@
     "node-schedule": "^1.2.0",
     "node-zookeeper-client": "^0.2.2",
     "uuid": "^3.1.0",
-    "vaultclient": "scality/vaultclient#fbd9988d",
-    "werelogs": "scality/werelogs#0ff7ec82"
+    "vaultclient": "scality/vaultclient#90762d2",
+    "werelogs": "scality/werelogs#4e0d97c"
   },
   "devDependencies": {
     "mocha": "^3.3.0"


### PR DESCRIPTION
**What does this pull request do?**
Upgrades nodeJS for backbeat
Adds more control over how pods are deployed on eve
Adds redis and kafka pods for backbeat server to start

**Which issue does this PR fix?**
fixes [S3C-2286](https://scality.atlassian.net/browse/S3C-2286)


for reviewers, please take a look at all branches (Especially 8.0 and 8.1) as it contains more changes