### PR TITLE
bf: multiple logreaders skipping entries issue

### DIFF
--- a/extensions/ingestion/IngestionQueuePopulator.js
+++ b/extensions/ingestion/IngestionQueuePopulator.js
@@ -13,7 +13,7 @@ class IngestionQueuePopulator extends QueuePopulatorExtension {
     }
 
     // called by _processLogEntry in lib/queuePopulator/LogReader.js
-    filter(entry) {
+    filter(entry, entriesToPublish) {
         if (entry.type !== 'put' && entry.type !== 'del') {
             this.log.trace('skipping entry because not type put or del');
             return;
@@ -32,7 +32,8 @@ class IngestionQueuePopulator extends QueuePopulatorExtension {
                        { entryBucket: entry.bucket, entryKey: entry.key });
         this.publish(this.config.topic,
                      `${entry.bucket}/${entry.key}`,
-                     JSON.stringify(entry));
+                     JSON.stringify(entry),
+                    entriesToPublish);
 
         this._incrementMetrics(entry.bucket);
     }

--- a/lib/queuePopulator/IngestionReader.js
+++ b/lib/queuePopulator/IngestionReader.js
@@ -261,6 +261,9 @@ class IngestionReader extends LogReader {
     }
 
     _processLogEntry(batchState, record, entry) {
+        const {
+            entriesToPublish
+        } = batchState;
         // NOTE: Using zenkoName because should be unique to other entries.
 
         // for a "del", entry.value will not exist but we still need to
@@ -277,7 +280,7 @@ class IngestionReader extends LogReader {
                 bucket: entry.bucket,
                 key: entry.key,
                 value: entry.value,
-            }));
+            }, entriesToPublish));
         } else {
             let key;
             let db;
@@ -304,16 +307,15 @@ class IngestionReader extends LogReader {
                 bucket: db,
                 key,
                 value: entry.value,
-            }));
+            }, entriesToPublish));
         }
     }
 
     _processPrepareEntries(batchState, done) {
         const {
-            entriesToPublish, logRes, logStats, logger, initState,
+            logRes, logStats, logger, initState,
         } = batchState;
 
-        this._setEntryBatch(entriesToPublish);
         // if logRes.log is empty (empty listObjectVersions listing), skip
         if (!logRes.log) {
             return done();
@@ -335,8 +337,6 @@ class IngestionReader extends LogReader {
         if (logRes.info.start === null || logRes.log === null) {
             return done(null);
         }
-
-        this._setEntryBatch(entriesToPublish);
 
         logRes.log.on('data', record => {
             logStats.nbLogRecordsRead += 1;

--- a/lib/queuePopulator/QueuePopulatorExtension.js
+++ b/lib/queuePopulator/QueuePopulatorExtension.js
@@ -64,10 +64,18 @@ class QueuePopulatorExtension {
      * @param {string} topic - topic name
      * @param {string} key - key of the kafka entry, for keyed partitioning
      * @param {string} message - kafka message
+     * @param {Object} [optEntriesToPublish] - optional batch
      * @return {undefined}
      */
-    publish(topic, key, message) {
-        assert(this._batch,
+    publish(topic, key, message, optEntriesToPublish) {
+        let __batch;
+        if (optEntriesToPublish) {
+            __batch = optEntriesToPublish;
+        } else {
+            __batch = this._batch;
+        }
+
+        assert(__batch,
                'logic error: QueuePopulatorExtension.publish() called ' +
                'without an active batch. Please make sure it\'s called ' +
                'synchronously from the filter() method.');
@@ -75,10 +83,10 @@ class QueuePopulatorExtension {
         const kafkaEntry = { key: encodeURIComponent(key), message };
         this.log.trace('queueing kafka entry to topic',
                        { key: kafkaEntry.key, topic });
-        if (this._batch[topic] === undefined) {
-            this._batch[topic] = [kafkaEntry];
+        if (__batch[topic] === undefined) {
+            __batch[topic] = [kafkaEntry];
         } else {
-            this._batch[topic].push(kafkaEntry);
+            __batch[topic].push(kafkaEntry);
         }
     }
 


### PR DESCRIPTION
Fix the issue occuring when multiple logreaders
are present and use setEntryBatch to override
the _batch buffer of the same (unique) ingestion extension
by specifying the buffer as a parameter of filter() and publish()