### PR TITLE
INTEGRATION [PR#783 > development/8.2] ZENKO-2275 updating CA certs due to failure when reaching github

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /usr/src/app
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
+    ca-certificates \
     build-essential \
     wget \
     bash \


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #783.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/bugfix/ZENKO-2275-update-ca-certs`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/bugfix/ZENKO-2275-update-ca-certs
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/bugfix/ZENKO-2275-update-ca-certs
```

Please always comment pull request #783 instead of this one.