### PR TITLE
improvement: ZENKO-2265 make ingestion not wait between batches

### DIFF
--- a/lib/queuePopulator/IngestionReader.js
+++ b/lib/queuePopulator/IngestionReader.js
@@ -197,9 +197,16 @@ class IngestionReader extends LogReader {
     processLogEntries(params, done) {
         this._batchInProgress = true;
 
-        super.processLogEntries(params, err => {
+        super.processLogEntries(params, (err, hasMoreLog) => {
             this._batchInProgress = false;
-            return done(err);
+            if (err) {
+                return done(err);
+            }
+            if (hasMoreLog) {
+                // keep ingesting new log without waiting
+                return this.processLogEntries(params, done);
+            }
+            return done();
         });
     }
 
@@ -355,6 +362,11 @@ class IngestionReader extends LogReader {
         });
         logRes.log.on('end', () => {
             logger.debug('ending record stream');
+            if (logRes.info.start + logStats.nbLogRecordsRead
+                <= logRes.info.cseq) {
+                logger.debug('there is more log to read');
+                logStats.hasMoreLog = true;
+            }
             return done();
         });
         return undefined;

--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -184,7 +184,8 @@ class LogReader {
      * @param {Number} [params.timeoutMs] - timeout after which the
      *   batch will be stopped if still running (default 10000ms)
      * @param {function} done - callback when done processing the
-     *   entries
+     *   entries - done(error) or done(null, {boolean} hasMoreLog:
+     *   true if there is more log to read)
      * @return {undefined}
      */
     processLogEntries(params, done) {
@@ -193,6 +194,7 @@ class LogReader {
             logStats: {
                 nbLogRecordsRead: 0,
                 nbLogEntriesRead: 0,
+                hasMoreLog: false,
             },
             entriesToPublish: {},
             publishedEntries: {},
@@ -221,6 +223,7 @@ class LogReader {
                     readRecords: batchState.logStats.nbLogRecordsRead,
                     readEntries: batchState.logStats.nbLogEntriesRead,
                     skippedRecords: batchState.logStats.skippedRecords,
+                    hasMoreLog: batchState.logStats.hasMoreLog,
                     queuedEntries,
                 };
                 // Use heuristics to log when:
@@ -239,7 +242,7 @@ class LogReader {
                     logSource: this.getLogInfo(),
                     logOffset: this.getLogOffset(),
                 });
-                return done();
+                return done(null, stats.hasMoreLog);
             });
         return undefined;
     }


### PR DESCRIPTION
Instead of inconditionally triggering ingestion batches every 5
seconds, which becomes inefficient as the batch size gets small and
quick to process, do the following:

- check if the batch just processed was at the end of the log
- if so, trigger a new batch immediately

This way, we can process batches in series without waiting and
converge quicker when processing an existing raft log.