### PR TITLE
improvement:ZENKO-2262 Start OOB in paused state

### DIFF
--- a/bin/ingestion.js
+++ b/bin/ingestion.js
@@ -141,7 +141,8 @@ function checkAndApplyScheduleResume(zkClient, data, location, cb) {
  */
 function setupZkLocationNode(zkClient, location, done) {
     const path = `${getIngestionZkPath()}/${location}`;
-    const data = JSON.stringify({ paused: false });
+    // set initial ingestion `paused` state of a new location to `true`
+    const data = JSON.stringify({ paused: true });
     zkClient.create(path, Buffer.from(data), err => {
         if (err && err.name === 'NODE_EXISTS') {
             return zkClient.getData(path, (err, data) => {
@@ -181,6 +182,8 @@ function setupZkLocationNode(zkClient, location, done) {
             });
             return done(err);
         }
+        // add the new location to paused locations
+        ingestionPopulator.setPausedLocationState(location);
         return done();
     });
 }


### PR DESCRIPTION
### Why is this change required? What problem does it solve?
**Problem**: OOB S3C/AWS is used in the context of D/R to a storage location which requires setting up replication to the  location. OOB starts ingesting objects as soon as it is setup and by the time replication is setup there a few objects that are ingested that will not be replicated (since replication only queues objects after the replication workflow is enabled). This shows the gap in the workflow where some objects are not replicated

**Solution**: To address the gap, start OOB in paused state by default when it is setup. This way the user can setup replication workflow and then enable OOB, there by having the control on when the objects are ingested.
