### PR TITLE
bugfix: S3C-2645 replication socket fd leak

### DIFF
--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -311,6 +311,9 @@ class ReplicateObject extends BackbeatTask {
         const doneOnce = jsutil.once(done);
         const partObj = new ObjectMDLocation(part);
         const partNumber = partObj.getPartNumber();
+        let destReq = null;
+        let sourceReqAborted = false;
+        let destReqAborted = false;
         const sourceReq = this.S3source.getObject({
             Bucket: sourceEntry.getBucket(),
             Key: sourceEntry.getObjectKey(),
@@ -319,39 +322,51 @@ class ReplicateObject extends BackbeatTask {
         });
         attachReqUids(sourceReq, log);
         sourceReq.on('error', err => {
+            if (!sourceReqAborted && !destReqAborted) {
+                destReq.abort();
+                destReqAborted = true;
+            }
             // eslint-disable-next-line no-param-reassign
             err.origin = 'source';
             if (err.statusCode === 404) {
                 return doneOnce(err);
             }
-            log.error('an error occurred on getObject from S3',
-                { method: 'ReplicateObject._getAndPutPartOnce',
-                    entry: sourceEntry.getLogInfo(),
-                    part,
-                    origin: 'source',
-                    peer: this.sourceConfig.s3,
-                    error: err.message,
-                    httpStatus: err.statusCode });
+            if (!sourceReqAborted) {
+                log.error('an error occurred on getObject from S3',
+                          { method: 'ReplicateObject._getAndPutPartOnce',
+                            entry: sourceEntry.getLogInfo(),
+                            part,
+                            origin: 'source',
+                            peer: this.sourceConfig.s3,
+                            error: err.message,
+                            httpStatus: err.statusCode });
+            }
             return doneOnce(err);
         });
         const incomingMsg = sourceReq.createReadStream();
         incomingMsg.on('error', err => {
+            if (!sourceReqAborted && !destReqAborted) {
+                destReq.abort();
+                destReqAborted = true;
+            }
             if (err.statusCode === 404) {
                 return doneOnce(errors.ObjNotFound);
             }
-            // eslint-disable-next-line no-param-reassign
-            err.origin = 'source';
-            log.error('an error occurred when streaming data from S3',
-                { method: 'ReplicateObject._getAndPutPartOnce',
-                    entry: destEntry.getLogInfo(),
-                    part,
-                    origin: 'source',
-                    peer: this.sourceConfig.s3,
-                    error: err.message });
+            if (!sourceReqAborted) {
+                // eslint-disable-next-line no-param-reassign
+                err.origin = 'source';
+                log.error('an error occurred when streaming data from S3',
+                          { method: 'ReplicateObject._getAndPutPartOnce',
+                            entry: destEntry.getLogInfo(),
+                            part,
+                            origin: 'source',
+                            peer: this.sourceConfig.s3,
+                            error: err.message });
+            }
             return doneOnce(err);
         });
         log.debug('putting data', { entry: destEntry.getLogInfo(), part });
-        const destReq = this.backbeatDest.putData({
+        destReq = this.backbeatDest.putData({
             Bucket: destEntry.getBucket(),
             Key: destEntry.getObjectKey(),
             CanonicalID: destEntry.getOwnerId(),
@@ -362,15 +377,19 @@ class ReplicateObject extends BackbeatTask {
         attachReqUids(destReq, log);
         return destReq.send((err, data) => {
             if (err) {
-                // eslint-disable-next-line no-param-reassign
-                err.origin = 'target';
-                log.error('an error occurred on putData to S3',
-                    { method: 'ReplicateObject._getAndPutPartOnce',
-                        entry: destEntry.getLogInfo(),
-                        part,
-                        origin: 'target',
-                        peer: this.destBackbeatHost,
-                        error: err.message });
+                if (!destReqAborted) {
+                    sourceReq.abort();
+                    sourceReqAborted = true;
+                    // eslint-disable-next-line no-param-reassign
+                    err.origin = 'target';
+                    log.error('an error occurred on putData to S3',
+                              { method: 'ReplicateObject._getAndPutPartOnce',
+                                entry: destEntry.getLogInfo(),
+                                part,
+                                origin: 'target',
+                                peer: this.destBackbeatHost,
+                                error: err.message });
+                }
                 return doneOnce(err);
             }
             partObj.setDataLocation(data.Location[0]);

--- a/tests/functional/replication/streamedCopy.spec.js
+++ b/tests/functional/replication/streamedCopy.spec.js
@@ -1,0 +1,194 @@
+const http = require('http');
+const assert = require('assert');
+
+const werelogs = require('werelogs');
+const Logger = werelogs.Logger;
+
+const QueueProcessor = require('../../../extensions/replication' +
+                               '/queueProcessor/QueueProcessor');
+const ReplicateObject =
+      require('../../../extensions/replication/tasks/ReplicateObject');
+
+const constants = {
+    bucket: 'test-bucket',
+    objectKey: 'test-object',
+    versionId: 'test-object-versionId',
+    dataStoreName: 'us-east-1',
+    // data size should be sufficient to have data held in the socket
+    // buffers, 10MB seems to work
+    contents: Buffer.alloc(10000000).fill('Z'),
+};
+
+const qpParams = [
+    { hosts: 'localhost:9092' },
+    { auth: { type: 'account', account: 'bart' },
+      s3: { host: '127.0.0.1',
+            port: 7777 },
+      transport: 'http',
+    },
+    { auth: { type: 'account', account: 'bart' },
+      bootstrapList: [{
+          site: 'sf', servers: ['127.0.0.2:7777'],
+      }],
+      transport: 'http' },
+    { topic: 'backbeat-func-test-dummy-topic',
+      replicationStatusTopic: 'backbeat-func-test-repstatus',
+      queueProcessor: {
+          retry: {
+              scality: { timeoutS: 5 },
+          },
+          groupId: 'backbeat-func-test-group-id',
+      },
+    },
+    {},
+    {},
+    'sf',
+    { topic: 'metrics-test-topic' },
+];
+
+const mockSourceEntry = {
+    getLogInfo: () => ({}),
+    getContentLength: () => constants.contents.length,
+    getBucket: () => constants.bucket,
+    getObjectKey: () => constants.objectKey,
+    getEncodedVersionId: () => constants.versionId,
+    getDataStoreName: () => constants.dataStoreName,
+    getReplicationIsNFS: () => false,
+    getOwnerId: () => 'bart',
+    getContentMd5: () => 'bac4bea7bac4bea7bac4bea7bac4bea7',
+    getReplicationStorageType: () => 'aws_s3',
+    getUserMetadata: () => {},
+    getContentType: () => 'application/octet-stream',
+    getCacheControl: () => undefined,
+    getContentDisposition: () => undefined,
+    getContentEncoding: () => undefined,
+    getTags: () => {},
+    setReplicationSiteDataStoreVersionId: () => {},
+};
+
+const mockPartInfo = {
+    key: 'bac4bea7bac4bea7bac4bea7bac4bea7bac4bea7',
+    start: 0,
+    size: constants.contents.length,
+    dataStoreName: 'us-east-1',
+    dataStoreETag: '1:',
+};
+
+const log = new Logger('test:streamedCopy');
+
+class S3Mock {
+    constructor() {
+        this.log = new Logger('test:streamedCopy:S3Mock');
+
+        this.testScenario = null;
+    }
+
+    setTestScenario(testScenario) {
+        this.testScenario = testScenario;
+    }
+
+    onRequest(req, res) {
+        if (req.method === 'PUT') {
+            assert.strictEqual(
+                req.url, `/_/backbeat/data/${constants.bucket}` +
+                    `/${constants.objectKey}`);
+            const chunks = [];
+            req.on('data', chunk => {
+                if (this.testScenario === 'abortPut') {
+                    log.info('aborting PUT request');
+                    res.socket.end();
+                    res.socket.destroy();
+                } else {
+                    chunks.push(chunk);
+                }
+            });
+            req.on('end', () => {
+                res.write('[{"key":"target-key","dataStoreName":"us-east-2"}]');
+                res.end();
+            });
+        } else if (req.method === 'GET') {
+            assert.strictEqual(
+                req.url, `/${constants.bucket}/${constants.objectKey}` +
+                    `?partNumber=1&versionId=${constants.versionId}`);
+            if (this.testScenario === 'abortGet') {
+                log.info('aborting GET request');
+                res.socket.end();
+                res.socket.destroy();
+            } else {
+                res.write(constants.contents);
+                res.end();
+            }
+        } else {
+            assert(false, `did not expect HTTP method ${req.method}`);
+        }
+    }
+}
+
+describe('streamed copy functional tests', () => {
+    let httpServer;
+    let s3mock;
+    let qp;
+    beforeEach(done => {
+        s3mock = new S3Mock();
+        httpServer = http.createServer(
+            (req, res) => s3mock.onRequest(req, res));
+        httpServer.listen(7777);
+        qp = new QueueProcessor(...qpParams);
+        qp._mProducer = {
+            getProducer: () => ({
+                send: () => {},
+            }),
+            publishMetrics: () => {},
+        };
+        process.nextTick(done);
+    });
+
+    afterEach(done => {
+        httpServer.close();
+        process.nextTick(done);
+    });
+
+    [{ name: 'ReplicateObject::_getAndPutPartOnce',
+       call: cb => {
+           const repTask = new ReplicateObject(qp);
+           repTask._setupSourceClients('dummyrole', log);
+           repTask._setupDestClients('dummyrole', log);
+           repTask._getAndPutPartOnce(
+               mockSourceEntry, mockSourceEntry, mockPartInfo,
+               log.newRequestLogger(), cb);
+       },
+     }].forEach(testedFunc => {
+         ['noError', 'abortGet', 'abortPut'].forEach(testScenario => {
+             it(`${testedFunc.name} with test scenario ${testScenario}`,
+             done => {
+                 s3mock.setTestScenario(testScenario);
+                 testedFunc.call(err => {
+                     if (testScenario === 'noError') {
+                         assert.ifError(err);
+                     } else {
+                         assert(err);
+                     }
+                     // socket processing in the agent is asynchronous, so
+                     // we have to make the check asynchronous too
+                     setTimeout(() => {
+                         if (testScenario === 'abortGet' ||
+                             testScenario === 'abortPut') {
+                             // check that sockets have been properly
+                             // closed after an error occurred
+                             const srcAgentSockets = qp.sourceHTTPAgent.sockets;
+                             assert.strictEqual(
+                                 Object.keys(srcAgentSockets).length, 0,
+                                 'HTTP source agent still has open sockets');
+                             const dstAgentSockets = qp.destHTTPAgent.sockets;
+                             assert.strictEqual(
+                                 Object.keys(dstAgentSockets).length, 0,
+                                 'HTTP dest agent still has open sockets');
+                         }
+                         s3mock.setTestScenario(null);
+                         done();
+                     }, 0);
+                 });
+             });
+         });
+     });
+});


### PR DESCRIPTION
Fix a socket fd leak in replication streaming cases for the following
cases:

- ReplicateObject full object or part replication, GET fails during
  data transfer

- ReplicateObject full object or part replication, PUT fails during
  data transfer