### PR TITLE
INTEGRATION [PR#809 > development/8.2] ci: ZENKO-2340 rename the docker registry namespace from zenko-dev to…

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -12,7 +12,7 @@ models:
   - SetProperty: &registry_url
       name: registry
       property: registry_url
-      value: registry.scality.com/zenko-dev/backbeat
+      value: registry.scality.com/zenko/backbeat
   - SetProperty: &docker_tag_revision
       name: Set docker tag revision property
       property: docker_tag_revision


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #809.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/improvement/ZENKO-2340-rename-zenko-registry-namespace`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/improvement/ZENKO-2340-rename-zenko-registry-namespace
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/improvement/ZENKO-2340-rename-zenko-registry-namespace
```

Please always comment pull request #809 instead of this one.