### PR TITLE
bugfix: ZENKO-2406 fix regression of ZENKO-2233 with empty objects

### DIFF
--- a/extensions/replication/tasks/CopyLocationTask.js
+++ b/extensions/replication/tasks/CopyLocationTask.js
@@ -306,10 +306,12 @@ class CopyLocationTask extends BackbeatTask {
             Body: incomingMsg,
         });
         let aborted = false;
-        incomingMsg.once('error', () => {
-            destReq.abort();
-            aborted = true;
-        });
+        if (incomingMsg) {
+            incomingMsg.once('error', () => {
+                destReq.abort();
+                aborted = true;
+            });
+        }
         attachReqUids(destReq, log);
         return destReq.send((err, data) => {
             if (err) {

--- a/extensions/replication/tasks/MultipleBackendTask.js
+++ b/extensions/replication/tasks/MultipleBackendTask.js
@@ -875,10 +875,12 @@ class MultipleBackendTask extends ReplicateObject {
             Body: incomingMsg,
         });
         let aborted = false;
-        incomingMsg.once('error', () => {
-            destReq.abort();
-            aborted = true;
-        });
+        if (incomingMsg) {
+            incomingMsg.once('error', () => {
+                destReq.abort();
+                aborted = true;
+            });
+        }
         attachReqUids(destReq, log);
         return destReq.send((err, data) => {
             if (err) {


### PR DESCRIPTION
Fix a regression where replication of empty objects triggers an
exception.