### PR TITLE
INTEGRATION [PR#811 > development/8.2] bugfix: ZENKO-2406 fix regression of ZENKO-2233 with empty objects

### DIFF
--- a/extensions/replication/tasks/CopyLocationTask.js
+++ b/extensions/replication/tasks/CopyLocationTask.js
@@ -306,10 +306,12 @@ class CopyLocationTask extends BackbeatTask {
             Body: incomingMsg,
         });
         let aborted = false;
-        incomingMsg.once('error', () => {
-            destReq.abort();
-            aborted = true;
-        });
+        if (incomingMsg) {
+            incomingMsg.once('error', () => {
+                destReq.abort();
+                aborted = true;
+            });
+        }
         attachReqUids(destReq, log);
         return destReq.send((err, data) => {
             if (err) {

--- a/extensions/replication/tasks/MultipleBackendTask.js
+++ b/extensions/replication/tasks/MultipleBackendTask.js
@@ -875,10 +875,12 @@ class MultipleBackendTask extends ReplicateObject {
             Body: incomingMsg,
         });
         let aborted = false;
-        incomingMsg.once('error', () => {
-            destReq.abort();
-            aborted = true;
-        });
+        if (incomingMsg) {
+            incomingMsg.once('error', () => {
+                destReq.abort();
+                aborted = true;
+            });
+        }
         attachReqUids(destReq, log);
         return destReq.send((err, data) => {
             if (err) {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #811.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/bugfix/ZENKO-2406-assertIncomingMsgNull`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/bugfix/ZENKO-2406-assertIncomingMsgNull
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/bugfix/ZENKO-2406-assertIncomingMsgNull
```

Please always comment pull request #811 instead of this one.