### PR TITLE
bf: create the missing value.key prop in objectMD

### DIFF
--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -455,6 +455,10 @@ class MongoQueueProcessor {
             this._updateReplicationInfo(sourceEntry, bucketInfo, content,
                 zenkoObjMd);
 
+            // Some object stores we are ingesting from (e.g. S3C) do
+            // not populate the value.key property.
+            sourceEntry.setKey(key);
+
             const objVal = sourceEntry.getValue();
             const params = {};
             if (sourceEntry.getVersionId()) {

--- a/tests/functional/ingestion/MongoQueueProcessor.js
+++ b/tests/functional/ingestion/MongoQueueProcessor.js
@@ -328,6 +328,8 @@ describe('MongoQueueProcessor', function mqp() {
                 assert.strictEqual(added.length, 1);
                 const objVal = added[0].objVal;
                 assert.strictEqual(added[0].key, versionKey);
+                // key shall now be always populated
+                assert.deepStrictEqual(objVal.key, KEY);
                 // acl should reset
                 assert.deepStrictEqual(objVal.acl, new ObjectMD().getAcl());
                 // owner md should update


### PR DESCRIPTION
We ingest from S3C which does not have the change to perform the
setKey() at object creation.