### PR TITLE
INTEGRATION [PR#813 > development/8.2] bf: create the missing value.key prop in objectMD

### DIFF
--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -455,6 +455,10 @@ class MongoQueueProcessor {
             this._updateReplicationInfo(sourceEntry, bucketInfo, content,
                 zenkoObjMd);
 
+            // Some object stores we are ingesting from (e.g. S3C) do
+            // not populate the value.key property.
+            sourceEntry.setKey(key);
+
             const objVal = sourceEntry.getValue();
             const params = {};
             if (sourceEntry.getVersionId()) {

--- a/tests/functional/ingestion/MongoQueueProcessor.js
+++ b/tests/functional/ingestion/MongoQueueProcessor.js
@@ -328,6 +328,8 @@ describe('MongoQueueProcessor', function mqp() {
                 assert.strictEqual(added.length, 1);
                 const objVal = added[0].objVal;
                 assert.strictEqual(added[0].key, versionKey);
+                // key shall now be always populated
+                assert.deepStrictEqual(objVal.key, KEY);
                 // acl should reset
                 assert.deepStrictEqual(objVal.acl, new ObjectMD().getAcl());
                 // owner md should update


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #813.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/bugfix/ZENKO-2337-missing-setkey`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/bugfix/ZENKO-2337-missing-setkey
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/bugfix/ZENKO-2337-missing-setkey
```

Please always comment pull request #813 instead of this one.