### PR TITLE
INTEGRATION [PR#817 > development/7.6] ZENKO-2514 setup yarn install in worker container for caching

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,1 +1,10 @@
-{ "extends": "scality" }
+{
+    "extends": "scality",
+    "settings": {
+        "import/resolver": {
+          "node": {
+            "paths": ["/backbeat/node_modules", "node_modules"]
+          }
+        }
+      }
+}

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -11,7 +11,9 @@ stages:
       type: kube_pod
       path: eve/workers/unit_and_feature_tests/pod.yml
       images:
-        unit_and_feature_tests: eve/workers/unit_and_feature_tests
+        unit_and_feature_tests:
+          context: .
+          dockerfile: eve/workers/unit_and_feature_tests/Dockerfile
         kafka: eve/workers/kafka
     steps:
       - Git:
@@ -19,10 +21,6 @@ stages:
           repourl: '%(prop:git_reference)s'
           shallow: True
           retryFetch: True
-          haltOnFailure: True
-      - ShellCommand:
-          name: yarn install
-          command: rm -rf node_modules && yarn install --unsafe-perm
           haltOnFailure: True
       - ShellCommand:
           name: run static analysis tools on markdown

--- a/eve/workers/unit_and_feature_tests/Dockerfile
+++ b/eve/workers/unit_and_feature_tests/Dockerfile
@@ -7,6 +7,8 @@ ENV LANG C.UTF-8
 ENV PATH=$PATH:/backbeat/node_modules/.bin
 ENV NODE_PATH=/backbeat/node_modules
 
+VOLUME /home/eve/workspace
+
 COPY eve/workers/unit_and_feature_tests/backbeat_packages.list \
     eve/workers/unit_and_feature_tests/buildbot_worker_packages.list /tmp/
 
@@ -48,5 +50,7 @@ ARG BUILDBOT_VERSION=0.9.1
 
 RUN pip install buildbot-worker==$BUILDBOT_VERSION
 ADD eve/workers/unit_and_feature_tests/supervisor/buildbot_worker.conf /etc/supervisor/conf.d/
+
+WORKDIR /home/eve/workspace
 
 CMD ["/bin/bash", "-l", "-c", "buildbot-worker create-worker . $BUILDMASTER:$BUILDMASTER_PORT $WORKERNAME $WORKERPASS   && buildbot-worker start --nodaemon"]

--- a/eve/workers/unit_and_feature_tests/Dockerfile
+++ b/eve/workers/unit_and_feature_tests/Dockerfile
@@ -1,11 +1,14 @@
 FROM buildpack-deps:xenial-curl
 
+ARG NODE_ENV=development
+
 #
 # Install apt packages needed by backbeat and buildbot_worker
 #
 ENV LANG C.UTF-8
 ENV PATH=$PATH:/backbeat/node_modules/.bin
 ENV NODE_PATH=/backbeat/node_modules
+ENV NODE_ENV=${NODE_ENV}
 
 VOLUME /home/eve/workspace
 

--- a/eve/workers/unit_and_feature_tests/Dockerfile
+++ b/eve/workers/unit_and_feature_tests/Dockerfile
@@ -4,7 +4,13 @@ FROM buildpack-deps:xenial-curl
 # Install apt packages needed by backbeat and buildbot_worker
 #
 ENV LANG C.UTF-8
-COPY ./backbeat_packages.list ./buildbot_worker_packages.list /tmp/
+ENV PATH=$PATH:/backbeat/node_modules/.bin
+ENV NODE_PATH=/backbeat/node_modules
+
+COPY eve/workers/unit_and_feature_tests/backbeat_packages.list \
+    eve/workers/unit_and_feature_tests/buildbot_worker_packages.list /tmp/
+
+WORKDIR /backbeat
 
 RUN curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb http://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
@@ -19,6 +25,16 @@ RUN curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && rm -f /tmp/*packages.list
 
 #
+# Install yarn dependencies
+#
+
+COPY package.json yarn.lock /backbeat/
+
+RUN yarn cache clean \
+    && yarn install --frozen-lockfile \
+    && yarn cache clean
+
+#
 # Add user eve
 #
 RUN adduser -u 1042 --home /home/eve --disabled-password --gecos "" eve \
@@ -31,6 +47,6 @@ RUN adduser -u 1042 --home /home/eve --disabled-password --gecos "" eve \
 ARG BUILDBOT_VERSION=0.9.1
 
 RUN pip install buildbot-worker==$BUILDBOT_VERSION
-ADD supervisor/buildbot_worker.conf /etc/supervisor/conf.d/
+ADD eve/workers/unit_and_feature_tests/supervisor/buildbot_worker.conf /etc/supervisor/conf.d/
 
 CMD ["/bin/bash", "-l", "-c", "buildbot-worker create-worker . $BUILDMASTER:$BUILDMASTER_PORT $WORKERNAME $WORKERPASS   && buildbot-worker start --nodaemon"]


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #817.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.6/feature/ZENKO-2514-cache-yarn-install`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.6/feature/ZENKO-2514-cache-yarn-install
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.6/feature/ZENKO-2514-cache-yarn-install
```

Please always comment pull request #817 instead of this one.