### PR TITLE
bugfix: ZENKO-2447 pause resume corrections

### DIFF
--- a/bin/ingestion.js
+++ b/bin/ingestion.js
@@ -25,8 +25,10 @@ const { connectionString, autoCreateNamespace } = zkConfig;
 const RESUME_NODE = 'scheduledResume';
 
 const log = new werelogs.Logger('Backbeat:IngestionPopulator');
-werelogs.configure({ level: config.log.logLevel,
-    dump: config.log.dumpLevel });
+werelogs.configure({
+    level: config.log.logLevel,
+    dump: config.log.dumpLevel
+});
 
 const healthServer = new HealthProbeServer({
     bindAddress: config.healthcheckServer.bindAddress,
@@ -38,35 +40,12 @@ let ingestionPopulator;
 // memoize
 const configuredLocations = {};
 
+const zkClient = zookeeperWrapper.createClient(connectionString, {
+    autoCreateNamespace,
+});
+
 function getIngestionZkPath() {
     return `${zookeeperNamespace}${zkStatePath}`;
-}
-
-function queueBatch(ingestionPopulator, log) {
-    log.debug('start queueing ingestion batch');
-    const maxRead = qpConfig.batchMaxRead;
-    // apply updates to Ingestion Readers
-    ingestionPopulator.applyUpdates(err => {
-        if (err) {
-            log.fatal('error occurred applying updates to ingestion readers', {
-                error: err,
-                method: 'bin::ingestion.queueBatch',
-            });
-            scheduler.cancel();
-            process.exit(1);
-        }
-        ingestionPopulator.processLogEntries({ maxRead }, err => {
-            if (err) {
-                log.fatal('an error occurred during ingestion', {
-                    method: 'bin::ingestion.queueBatch',
-                    error: err,
-                });
-                scheduler.cancel();
-                process.exit(1);
-            }
-        });
-    });
-    return undefined;
 }
 
 /**
@@ -148,14 +127,16 @@ function setupZkLocationNode(zkClient, location, done) {
             return zkClient.getData(path, (err, data) => {
                 if (err) {
                     log.fatal('could not check location status in zookeeper',
-                        { method: 'bin::ingestion.setupZkLocationNode',
-                          zookeeperPath: path,
-                          error: err.message });
+                        {
+                            method: 'bin::ingestion.setupZkLocationNode',
+                            zookeeperPath: path,
+                            error: err.message,
+                        });
                     return done(err);
                 }
-                let d;
+                let locationData;
                 try {
-                    d = JSON.parse(data.toString());
+                    locationData = JSON.parse(data.toString());
                 } catch (e) {
                     log.fatal('error setting state for queue processor', {
                         method: 'bin::ingestion.setupZkLocationNode',
@@ -164,11 +145,11 @@ function setupZkLocationNode(zkClient, location, done) {
                     });
                     return done(e);
                 }
-                if (d[RESUME_NODE]) {
-                    return checkAndApplyScheduleResume(zkClient, d, location,
-                        done);
+                if (locationData[RESUME_NODE]) {
+                    return checkAndApplyScheduleResume(zkClient, locationData,
+                        location, done);
                 }
-                if (data.paused === true) {
+                if (locationData.paused) {
                     ingestionPopulator.setPausedLocationState(location);
                 }
                 return done();
@@ -191,7 +172,7 @@ function setupZkLocationNode(zkClient, location, done) {
 function updateProcessors(zkClient, bootstrapList) {
     const active = Object.keys(configuredLocations);
     const update = bootstrapList.map(i => i.site);
-    const allLocations = [...new Set(active.concat(update))];
+    const allLocations = new Set(active.concat(update));
 
     async.each(allLocations, (location, next) => {
         if (!update.includes(location)) {
@@ -225,6 +206,66 @@ function updateProcessors(zkClient, bootstrapList) {
     });
 }
 
+/**
+ * Refresh processors by checking zookeeper states and use the state(s) to,
+ * update ingestionPopulator's paused locations list.
+ * @param {node-zookeeper-client.Client} zkClient - zookeeper client
+ * @param {Logger.newRequestLogger} log - request logger object
+ * @param {Function} cb - callback(error)
+ * @return {undefined}
+ */
+function refreshProcessors(zkClient, log, cb) {
+    const bootstrapList = config.getBootstrapList();
+    const active = Object.keys(configuredLocations);
+    const update = bootstrapList.map(i => i.site);
+    const locations = new Set(active.concat(update));
+    const ingestionZkPath = getIngestionZkPath();
+
+    return async.each(locations, (location, next) => {
+        const path = `${ingestionZkPath}/${location}`;
+        return zkClient.getData(path, (err, data) => {
+            if (err) {
+                log.fatal('could not check location status in zookeeper',
+                    {
+                        method: 'bin::ingestion.refreshProcessors',
+                        zookeeperPath: path,
+                        error: err.message,
+                    });
+                return next(err);
+            }
+            let locationData;
+            try {
+                locationData = JSON.parse(data.toString());
+            } catch (e) {
+                log.fatal('error getting state for location', {
+                    method: 'bin::ingestion.refreshProcessors',
+                    location,
+                    error: reshapeExceptionError(e),
+                });
+                return next(e);
+            }
+            if (locationData[RESUME_NODE]) {
+                return checkAndApplyScheduleResume(zkClient, locationData,
+                    location, next);
+            }
+            if (locationData.paused) {
+                ingestionPopulator.setPausedLocationState(location);
+            } else {
+                ingestionPopulator.removePausedLocationState(location);
+            }
+            return next();
+        });
+    }, err => {
+        if (err) {
+            log.fatal('error in refreshing zk location node', {
+                method: 'bin::ingestion.refreshProcessors',
+            });
+            return cb(err);
+        }
+        return cb();
+    });
+}
+
 function loadHealthcheck() {
     healthServer.onReadyCheck(() => {
         const state = ingestionPopulator.zkStatus();
@@ -245,6 +286,50 @@ function loadProcessors(zkClient) {
     config.on('bootstrap-list-update', () => {
         bootstrapList = config.getBootstrapList();
         updateProcessors(zkClient, bootstrapList);
+    });
+}
+
+function queueBatch(ingestionPopulator, zkClient, log) {
+    log.debug('start queueing ingestion batch');
+    const maxRead = qpConfig.batchMaxRead;
+    // refresh processors before applying updates to Ingestion Readers
+    return async.series([
+        next => refreshProcessors(zkClient, log, err => {
+            if (err) {
+                log.fatal('error refreshing processors', {
+                    error: err,
+                    method: 'bin::ingestion.queueBatch',
+                });
+                return next(err);
+            }
+            return next();
+        }),
+        next => ingestionPopulator.applyUpdates(err => {
+            if (err) {
+                log.fatal('error applying updates to ingestion readers', {
+                    error: err,
+                    method: 'bin::ingestion.queueBatch',
+                });
+                return next(err);
+            }
+            return next();
+        }),
+        next => ingestionPopulator.processLogEntries({ maxRead }, err => {
+            if (err) {
+                log.fatal('an error occurred during ingestion', {
+                    method: 'bin::ingestion.queueBatch',
+                    error: err,
+                });
+                return next(err);
+            }
+            return next();
+        }),
+    ], err => {
+        if (err) {
+            scheduler.cancel();
+            process.exit(1);
+        }
+        return undefined;
     });
 }
 
@@ -271,7 +356,7 @@ function initAndStart(zkClient) {
             done => ingestionPopulator.open(done),
             done => {
                 scheduler = schedule.scheduleJob(ingestionExtConfigs.cronRule,
-                    () => queueBatch(ingestionPopulator, log));
+                    () => queueBatch(ingestionPopulator, zkClient, log));
                 done();
             },
         ], err => {
@@ -287,9 +372,6 @@ function initAndStart(zkClient) {
     });
 }
 
-const zkClient = zookeeperWrapper.createClient(connectionString, {
-    autoCreateNamespace,
-});
 zkClient.connect();
 zkClient.once('error', err => {
     log.fatal('error connecting to zookeeper', {


### PR DESCRIPTION
#### Why is this change required? What problem does it solve?

OOB ingestion pause via orbit did not pause the readers. Corrections are made to set readers to pause state when paused via orbit.