### PR TITLE
bugfix: S3C-2899 strip vformat v1 key prefix in queue populator

### DIFF
--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -1,5 +1,8 @@
 const async = require('async');
 
+const { versioning } = require('arsenal');
+const { DbPrefixes } = versioning.VersioningConstants;
+
 const BackbeatProducer = require('../BackbeatProducer');
 const ReplicationQueuePopulator =
     require('../../extensions/replication/ReplicationQueuePopulator');
@@ -278,13 +281,22 @@ class LogReader {
     }
 
     _processLogEntry(batchState, record, entry) {
+        function _transformKey(key) {
+            if (key.startsWith(DbPrefixes.Master)) {
+                return key.slice(DbPrefixes.Master.length);
+            }
+            if (key.startsWith(DbPrefixes.Version)) {
+                return key.slice(DbPrefixes.Version.length);
+            }
+            return key;
+        }
         if (entry.key === undefined || entry.value === undefined) {
             return;
         }
         this._extensions.forEach(ext => ext.filter({
             type: entry.type,
             bucket: record.db,
-            key: entry.key,
+            key: _transformKey(entry.key),
             value: entry.value,
         }));
     }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "commander": "^2.11.0",
     "eslint": "^2.4.0",
     "eslint-config-airbnb": "^6.0.0",
-    "eslint-config-scality": "scality/Guidelines#71a059ad",
+    "eslint-config-scality": "scality/Guidelines#20dfffc",
     "eslint-plugin-react": "^4.2.3",
     "node-rdkafka": "2.2.0",
     "node-schedule": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/scality/backbeat#readme",
   "dependencies": {
     "@hapi/joi": "^15.1.0",
-    "arsenal": "scality/Arsenal#bbfc32e",
+    "arsenal": "scality/Arsenal#5f66ee9",
     "async": "^2.3.0",
     "aws-sdk": "2.147.0",
     "backo": "^1.1.0",

--- a/tests/unit/lib/queuePopulator/LogReader.spec.js
+++ b/tests/unit/lib/queuePopulator/LogReader.spec.js
@@ -1,0 +1,51 @@
+const assert = require('assert');
+
+const { versioning } = require('arsenal');
+const { DbPrefixes } = versioning.VersioningConstants;
+
+const LogReader = require('../../../../lib/queuePopulator/LogReader');
+
+describe('LogReader', () => {
+    let logReader;
+    let filteredEntry;
+
+    before(() => {
+        logReader = new LogReader({
+            extensions: [{
+                filter: entry => { filteredEntry = entry; },
+            }],
+        });
+    });
+
+    [{
+        desc: 'v0 master key',
+        key: 'v0-master-key',
+        processedKey: 'v0-master-key',
+    }, {
+        desc: 'v0 version key',
+        key: 'v0-version-key\u0000version-id',
+        processedKey: 'v0-version-key\u0000version-id',
+    }, {
+        desc: 'v1 master key',
+        key: `${DbPrefixes.Master}v1-master-key`,
+        processedKey: 'v1-master-key',
+    }, {
+        desc: 'v1 version key',
+        key: `${DbPrefixes.Version}v1-version-key\u0000version-id`,
+        processedKey: 'v1-version-key\u0000version-id',
+    }].forEach(testCase => {
+        it(`LogReader::_processLogEntry() should process entry with a ${testCase.desc}`, () => {
+            logReader._processLogEntry(null, { db: 'db' }, {
+                type: 'put',
+                key: testCase.key,
+                value: '{}',
+            });
+            assert.deepStrictEqual(filteredEntry, {
+                type: 'put',
+                bucket: 'db',
+                key: testCase.processedKey,
+                value: '{}',
+            });
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -716,9 +716,9 @@ eslint-config-airbnb@^6.0.0:
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-6.2.0.tgz#4a28196aa4617de01b8c914e992a82e5d0886a6e"
   integrity sha1-SigZaqRhfeAbjJFOmSqC5dCIam4=
 
-eslint-config-scality@scality/Guidelines#71a059ad:
+eslint-config-scality@scality/Guidelines#20dfffc:
   version "1.1.0"
-  resolved "https://codeload.github.com/scality/Guidelines/tar.gz/71a059ad3fa0598d5bbb923badda58ccf06cc8a6"
+  resolved "https://codeload.github.com/scality/Guidelines/tar.gz/20dfffcc863bdb3c6bbc93b283e99a33b2fd6136"
   dependencies:
     commander "1.3.2"
     markdownlint "0.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -145,10 +145,11 @@ arraybuffer.slice@0.0.6:
   resolved "https://registry.yarnpkg.com/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz#f33b2159f0532a3f3107a272c0ccfbd1ad2979ca"
   integrity sha1-8zshWfBTKj8xB6JywMz70a0peco=
 
-arsenal@scality/Arsenal#9f2e74e:
-  version "7.4.3"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/9f2e74ec6972527c2a9ca6ecb4155618f123fc19"
+arsenal@scality/Arsenal#5f66ee9:
+  version "7.5.0"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/5f66ee992af62fe9658bd8fe2625719bf30f4d65"
   dependencies:
+    "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
     ajv "4.10.0"
     async "~2.1.5"
@@ -156,7 +157,6 @@ arsenal@scality/Arsenal#9f2e74e:
     diskusage "^1.1.1"
     ioredis "4.9.5"
     ipaddr.js "1.2.0"
-    joi "^10.6"
     level "~5.0.1"
     level-sublevel "~6.6.5"
     node-forge "^0.7.1"
@@ -170,11 +170,10 @@ arsenal@scality/Arsenal#9f2e74e:
   optionalDependencies:
     ioctl "2.0.0"
 
-arsenal@scality/Arsenal#bbfc32e:
-  version "7.5.0"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/bbfc32e67e6d0b10f77539fb318b727d9cb297d0"
+arsenal@scality/Arsenal#9f2e74e:
+  version "7.4.3"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/9f2e74ec6972527c2a9ca6ecb4155618f123fc19"
   dependencies:
-    "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
     ajv "4.10.0"
     async "~2.1.5"
@@ -182,6 +181,7 @@ arsenal@scality/Arsenal#bbfc32e:
     diskusage "^1.1.1"
     ioredis "4.9.5"
     ipaddr.js "1.2.0"
+    joi "^10.6"
     level "~5.0.1"
     level-sublevel "~6.6.5"
     node-forge "^0.7.1"


### PR DESCRIPTION
Return entries with keys stripped of their v1 vformat key prefix to
the queue populator extensions