### PR TITLE
bugfix: ZENKO-2645 increase garbage collector unit tests timeout

### DIFF
--- a/tests/unit/gc/GarbageCollector.spec.js
+++ b/tests/unit/gc/GarbageCollector.spec.js
@@ -8,7 +8,8 @@ const GarbageCollectorTask =
       require('../../../extensions/gc/tasks/GarbageCollectorTask');
 const ActionQueueEntry = require('../../../lib/models/ActionQueueEntry');
 
-describe('garbage collector', () => {
+describe('garbage collector', function garbageCollector() {
+    this.timeout(10000);
     let gc;
     let gcTask;
     let httpServer;


### PR DESCRIPTION
Improve flakiness by increasing the unit test timeout of garbage
collector from 2 to 10 seconds