### PR TITLE
INTEGRATION [PR#850 > development/8.2] bugfix: ZENKO-2645 increase garbage collector unit tests timeout

### DIFF
--- a/tests/unit/gc/GarbageCollector.spec.js
+++ b/tests/unit/gc/GarbageCollector.spec.js
@@ -8,7 +8,8 @@ const GarbageCollectorTask =
       require('../../../extensions/gc/tasks/GarbageCollectorTask');
 const ActionQueueEntry = require('../../../lib/models/ActionQueueEntry');
 
-describe('garbage collector', () => {
+describe('garbage collector', function garbageCollector() {
+    this.timeout(10000);
     let gc;
     let gcTask;
     let httpServer;


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #850.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/bugfix/ZENKO-2645-flakyTestGarbageCollector`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/bugfix/ZENKO-2645-flakyTestGarbageCollector
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/bugfix/ZENKO-2645-flakyTestGarbageCollector
```

Please always comment pull request #850 instead of this one.