### PR TITLE
INTEGRATION [PR#894 > development/7.8] improvement: S3C-2837 gather and log kafka consumer lag metrics

### DIFF
--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -50,6 +50,7 @@ const joiSchema = {
         groupId: joi.string().required(),
         retryTimeoutS: joi.number().default(300),
         concurrency: joi.number().greater(0).default(10),
+        logConsumerMetricsIntervalS: joi.number().greater(0).default(60),
     },
     replicationStatusProcessor: {
         groupId: joi.string().required(),

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -309,6 +309,7 @@ class QueueProcessor extends EventEmitter {
                 groupId,
                 concurrency: this.repConfig.queueProcessor.concurrency,
                 queueProcessor: this.processKafkaEntry.bind(this),
+                logConsumerMetricsIntervalS: this.repConfig.queueProcessor.logConsumerMetricsIntervalS,
             });
             this._consumer.on('error', () => {});
             this._consumer.on('ready', () => {

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -37,6 +37,9 @@ class BackbeatConsumer extends EventEmitter {
      * that can be processed in parallel
      * @param {number} [config.fetchMaxBytes] - max. bytes to fetch in a
      * fetch loop
+     * @param {number} [config.logConsumerMetricsIntervalS] - set to an
+     * interval number in seconds to log topic consumer metrics from
+     * kafka statistics
      * @param {boolean} [config.bootstrap=false] - TEST ONLY: true to
      * bootstrap the consumer with test messages until it starts
      * consuming them
@@ -58,13 +61,14 @@ class BackbeatConsumer extends EventEmitter {
             concurrency: joi.number().greater(0).default(CONCURRENCY_DEFAULT),
             fetchMaxBytes: joi.number(),
             bootstrap: joi.boolean().default(false),
+            logConsumerMetricsIntervalS: joi.number(),
         };
         const validConfig = joi.attempt(config, configJoi,
                                         'invalid config params');
 
         const { zookeeper, kafka, topic, groupId, queueProcessor,
                 fromOffset, concurrency, fetchMaxBytes,
-                bootstrap } = validConfig;
+                bootstrap, logConsumerMetricsIntervalS } = validConfig;
 
         this._zookeeperEndpoint = zookeeper && zookeeper.connectionString;
         this._kafkaHosts = kafka.hosts;
@@ -76,6 +80,7 @@ class BackbeatConsumer extends EventEmitter {
         this._concurrency = concurrency;
         this._fetchMaxBytes = fetchMaxBytes;
         this._bootstrap = bootstrap;
+        this._logConsumerMetricsIntervalS = logConsumerMetricsIntervalS;
         this._offsetLedger = new OffsetLedger();
 
         this._processingQueue = null;
@@ -120,11 +125,51 @@ class BackbeatConsumer extends EventEmitter {
         if (this._fetchMaxBytes !== undefined) {
             consumerParams['fetch.message.max.bytes'] = this._fetchMaxBytes;
         }
+        if (this._logConsumerMetricsIntervalS !== undefined) {
+            consumerParams['statistics.interval.ms'] = this._logConsumerMetricsIntervalS * 1000;
+        }
         this._consumer = new kafka.KafkaConsumer(consumerParams);
         this._consumer.connect();
         return this._consumer.once('ready', () => {
             this._consumerReady = true;
             this._checkIfReady();
+            if (this._logConsumerMetricsIntervalS !== undefined) {
+                this._consumer.on('event.stats', res => {
+                    const statsObj = JSON.parse(res.message);
+                    if (typeof statsObj !== 'object') {
+                        return undefined;
+                    }
+                    const topicStats = statsObj.topics[this._topic];
+                    if (typeof topicStats !== 'object') {
+                        return undefined;
+                    }
+                    const consumerStats = {
+                        lag: {},
+                    };
+                    // Gather stats per partition consumed by this
+                    // consumer instance
+                    Object.keys(topicStats.partitions).forEach(partition => {
+                        /* eslint-disable camelcase */
+                        const { stored_offset, consumer_lag } =
+                              topicStats.partitions[partition];
+                        // It looks like the consumer_lag gets counted
+                        // even when the stored_offset is negative (as
+                        // an error code when there is no offset
+                        // stored yet, much likely), so need to check
+                        // that stored_offset is positive before
+                        // adding to the stats object.
+                        if (stored_offset >= 0 && consumer_lag >= 0) {
+                            consumerStats.lag[partition] = consumer_lag;
+                        }
+                        /* eslint-enable camelcase */
+                    });
+                    this._log.info('topic consumer statistics', {
+                        topic: this._topic,
+                        consumerStats,
+                    });
+                    return undefined;
+                });
+            }
         });
     }
 

--- a/tests/functional/lib/BackbeatConsumer.js
+++ b/tests/functional/lib/BackbeatConsumer.js
@@ -1,5 +1,7 @@
 const assert = require('assert');
 const async = require('async');
+
+const { jsutil } = require('arsenal');
 const BackbeatProducer = require('../../../lib/BackbeatProducer');
 const BackbeatConsumer = require('../../../lib/BackbeatConsumer');
 const zookeeperConf = { connectionString: 'localhost:2181' };
@@ -217,3 +219,99 @@ describe('BackbeatConsumer "deferred committable" tests', () => {
         });
     });
 });
+
+describe('BackbeatConsumer statistics logging tests', () => {
+    const topic = 'backbeat-consumer-spec-statistics';
+    const groupId = `replication-group-${Math.random()}`;
+    const messages = [
+        { key: 'foo', message: '{"hello":"foo"}' },
+        { key: 'bar', message: '{"world":"bar"}' },
+        { key: 'qux', message: '{"hi":"qux"}' },
+    ];
+    let producer;
+    let consumer;
+    let consumedMessages = [];
+
+    function queueProcessor(message, cb) {
+        consumedMessages.push(message.value);
+        process.nextTick(cb);
+    }
+    before(function before(done) {
+        this.timeout(60000);
+
+        producer = new BackbeatProducer({
+            kafka: kafkaConf,
+            topic,
+            pollIntervalMs: 100,
+        });
+        consumer = new BackbeatConsumer({
+            zookeeper: zookeeperConf,
+            kafka: kafkaConf, groupId, topic,
+            queueProcessor,
+            concurrency: 10,
+            bootstrap: true,
+            // this enables statistics logging
+            logConsumerMetricsIntervalS: 1,
+        });
+        async.parallel([
+            innerDone => producer.on('ready', innerDone),
+            innerDone => consumer.on('ready', innerDone),
+        ], done);
+    });
+    afterEach(() => {
+        consumedMessages = [];
+        consumer.removeAllListeners('consumed');
+    });
+    after(done => {
+        async.parallel([
+            innerDone => producer.close(innerDone),
+            innerDone => consumer.close(innerDone),
+        ], done);
+    });
+
+    it('should be able to log consumer statistics', done => {
+        const doneOnce = jsutil.once(done);
+        producer.send(messages, err => {
+            assert.ifError(err);
+        });
+        let totalConsumed = 0;
+        // It would have been nice to check that the lag is strictly
+        // positive when we haven't consumed yet, but the lag seems
+        // off when no consumer offset has been written yet to Kafka,
+        // so it cannot be tested reliably until we start consuming.
+        consumer.subscribe();
+        consumer.on('consumed', messagesConsumed => {
+            totalConsumed += messagesConsumed;
+            assert(totalConsumed <= messages.length);
+            if (totalConsumed === messages.length) {
+                setTimeout(() => {
+                    consumer._log = {
+                        error: () => {},
+                        warn: () => {},
+                        info: (message, args) => {
+                            if (message.indexOf('statistics') !== -1) {
+                                assert.strictEqual(args.topic, topic);
+                                const consumerStats = args.consumerStats;
+                                assert.strictEqual(typeof consumerStats, 'object');
+                                const lagStats = consumerStats.lag;
+                                assert.strictEqual(typeof lagStats, 'object');
+                                // there should be one consumed partition
+                                assert.strictEqual(Object.keys(lagStats).length, 1);
+                                // everything should have been
+                                // consumed hence consumer offsets
+                                // stored equal topic offset, and lag
+                                // should be 0.
+                                const partitionLag = lagStats['0'];
+                                assert.strictEqual(partitionLag, 0);
+                                doneOnce();
+                            }
+                        },
+                        debug: () => {},
+                        trace: () => {},
+                    };
+                }, 5000);
+            }
+        });
+    }).timeout(30000);
+});
+


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #894.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.8/improvement/S3C-2837-showConsumerLagInLogs`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.8/improvement/S3C-2837-showConsumerLagInLogs
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.8/improvement/S3C-2837-showConsumerLagInLogs
```

Please always comment pull request #894 instead of this one.