### PR TITLE
Bugfix/s3 c 3319 notification constants correction

### DIFF
--- a/extensions/notification/NotificationQueuePopulator.js
+++ b/extensions/notification/NotificationQueuePopulator.js
@@ -27,9 +27,8 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
     }
 
     _getBucketNodeZkPath(bucket) {
-        const { zkBucketNotificationPath, zkConfigParentNode }
-            = notifConstants;
-        return `/${zkBucketNotificationPath}/${zkConfigParentNode}/${bucket}`;
+        const { zkConfigParentNode } = notifConstants;
+        return `/${zkConfigParentNode}/${bucket}`;
     }
 
     _getBucketNotifConfig(bucket, done) {

--- a/extensions/notification/constants.js
+++ b/extensions/notification/constants.js
@@ -1,10 +1,9 @@
 const constants = {
     extensionName: 'notification',
     nameFilter: {
-        prefix: 'prefix',
-        suffix: 'suffix',
+        prefix: 'Prefix',
+        suffix: 'Suffix',
     },
-    zkBucketNotificationPath: 'bucket-notification',
     bucketNotifConfigPropName: 'notificationConfiguration',
     zkConfigParentNode: 'config',
     arn: {

--- a/extensions/notification/queueProcessor/QueueProcessor.js
+++ b/extensions/notification/queueProcessor/QueueProcessor.js
@@ -82,9 +82,8 @@ class QueueProcessor extends EventEmitter {
     }
 
     _getBucketNodeZkPath(bucket) {
-        const { zkBucketNotificationPath, zkConfigParentNode }
-            = notifConstants;
-        return `/${zkBucketNotificationPath}/${zkConfigParentNode}/${bucket}`;
+        const { zkConfigParentNode } = notifConstants;
+        return `/${zkConfigParentNode}/${bucket}`;
     }
 
     _getResourceIdFromArn(arn) {

--- a/extensions/notification/utils/config.js
+++ b/extensions/notification/utils/config.js
@@ -32,11 +32,13 @@ function configArrayToMap(bnConfigs) {
 function validateEntryWithFilter(filterRules, entry) {
     const { key } = entry;
     return filterRules.every(rule => {
-        if (rule.name === constants.nameFilter.prefix) {
-            return key.startsWith(rule.value);
+        const { name, value } = rule;
+        const { prefix, suffix } = constants.nameFilter;
+        if (name.toLowerCase() === prefix.toLowerCase()) {
+            return key.startsWith(value);
         }
-        if (rule.name === constants.nameFilter.suffix) {
-            return key.endsWith(rule.value);
+        if (name.toLowerCase() === suffix.toLowerCase()) {
+            return key.endsWith(value);
         }
         return false;
     });

--- a/tests/unit/notification/utils/config.js
+++ b/tests/unit/notification/utils/config.js
@@ -25,7 +25,7 @@ const testConfigs = [
                     queueArn: 'q2',
                     filterRules: [
                         {
-                            name: 'prefix',
+                            name: 'Prefix',
                             value: 'abcd',
                         },
                     ],
@@ -43,7 +43,7 @@ const testConfigs = [
                     queueArn: 'q3',
                     filterRules: [
                         {
-                            name: 'suffix',
+                            name: 'Suffix',
                             value: '.png',
                         },
                     ],
@@ -74,11 +74,11 @@ const testConfigs = [
                     queueArn: 'q5',
                     filterRules: [
                         {
-                            name: 'prefix',
+                            name: 'Prefix',
                             value: 'abcd',
                         },
                         {
-                            name: 'suffix',
+                            name: 'Suffix',
                             value: '.png',
                         },
                     ],
@@ -101,11 +101,11 @@ const testConfigs = [
                     queueArn: 'q62',
                     filterRules: [
                         {
-                            name: 'prefix',
+                            name: 'Prefix',
                             value: 'abcd',
                         },
                         {
-                            name: 'suffix',
+                            name: 'Suffix',
                             value: '.png',
                         },
                     ],


### PR DESCRIPTION
Bucket notification constants correction.

- Removed redundant `zkBucketNotificationPath` constant.
- Corrected `nameFilter` prefix and suffix values.