### PR TITLE
bugfix: S3C-2775 provide versionID to 'PUT /_/backbeat/metadata' request

### DIFF
--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -418,6 +418,7 @@ class ReplicateObject extends BackbeatTask {
         const req = this.backbeatDest.putMetadata({
             Bucket: entry.getBucket(),
             Key: entry.getObjectKey(),
+            VersionId: entry.getEncodedVersionId(),
             ContentLength: Buffer.byteLength(mdBlob),
             Body: mdBlob,
             ReplicationContent: replicationContent,

--- a/extensions/replication/utils/BackbeatMetadataProxy.js
+++ b/extensions/replication/utils/BackbeatMetadataProxy.js
@@ -61,6 +61,7 @@ class BackbeatMetadataProxy extends BackbeatTask {
         const req = this.backbeatSource.putMetadata({
             Bucket: entry.getBucket(),
             Key: entry.getObjectKey(),
+            VersionId: entry.getEncodedVersionId(),
             ContentLength: Buffer.byteLength(mdBlob),
             Body: mdBlob,
         });

--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -549,6 +549,12 @@
                         "location": "uri",
                         "locationName": "Key"
                     },
+                    "VersionId": {
+                        "type": "string",
+                        "documentation": "VersionId used to reference a specific version of the object.",
+                        "location": "querystring",
+                        "locationName": "versionId"
+                    },
                     "ContentLength": {
                         "location": "header",
                         "locationName": "Content-Length",


### PR DESCRIPTION
Add the versionId in the query string on 'PUT /_/backbeat/metadata'
requests.

The goal is to be correct regarding the check done in cloudserver
backbeat routes: instead of checking the master version metadata, it
will check the target version object, resulting in a ObjNotFound error
if the specific version does not exist. This in turn allows to fix
UTAPI counting of replicated objects, by providing the information of
whether an existing object with the same version exists.