### PR TITLE
ZENKO-2810 update backbeat's npm package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "8.1.1",
+  "version": "8.2.5",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
As this version is used to be refered in our docker registry we
can with this change add the proper tag in it.