### PR TITLE
ZENKO-2810 upload docker image with short version

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -21,12 +21,21 @@ models:
       name: Set docker tag latest property
       property: docker_tag_latest
       value: "%(prop:registry_url)s:latest-%(prop:product_version)s"
+  - SetPropertyFromCommand: &short_version
+      name: Set short version
+      property: short_version
+      command: echo "%(prop:product_version)s" | grep -o '^[0-9]*\.[0-9]*'
+  - SetProperty: &docker_tag_short_version
+      name: Set docker tag latest short version property
+      property: docker_tag_short_version
+      value: "%(prop:registry_url)s:latest-%(prop:short_version)s"
   - ShellCommand: &docker_build
       name: Build docker image
       command: >-
         docker build
         -t %(prop:docker_tag_revision)s
         -t %(prop:docker_tag_latest)s
+        -t %(prop:docker_tag_short_version)s
         .
   - ShellCommand: &wait_docker_daemon
       name: Wait for Docker daemon to be ready
@@ -134,6 +143,7 @@ stages:
       - SetProperty: *registry_url
       - SetProperty: *docker_tag_revision
       - SetProperty: *docker_tag_latest
+      - SetProperty: *docker_tag_short_version
       - ShellCommand: *docker_build
 
   post-merge:
@@ -149,12 +159,14 @@ stages:
             -p '%(secret:harbor_password)s'
             registry.scality.com
       - SetProperty: *registry_url
+      - SetPropertyFromCommand: *short_version
       - SetProperty: *docker_tag_revision
       - SetProperty: *docker_tag_latest
+      - SetProperty: *docker_tag_short_version
       - ShellCommand: *docker_build
       - ShellCommand: &docker_push
           name: Push images
           command: |
             docker push %(prop:docker_tag_revision)s
             docker push %(prop:docker_tag_latest)s
-
+            docker push %(prop:docker_tag_short_version)s


### PR DESCRIPTION
With the following changes we will make available on merge docker images with the following tag: `latest-8.1`

This will allow us to call backbeat docker image that relates to the `development/*` branches 