### PR TITLE
INTEGRATION [PR#1055 > development/8.2] ZENKO-2810 upload docker image with short version

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -21,12 +21,21 @@ models:
       name: Set docker tag latest property
       property: docker_tag_latest
       value: "%(prop:registry_url)s:latest-%(prop:product_version)s"
+  - SetPropertyFromCommand: &short_version
+      name: Set short version
+      property: short_version
+      command: echo "%(prop:product_version)s" | grep -o '^[0-9]*\.[0-9]*'
+  - SetProperty: &docker_tag_short_version
+      name: Set docker tag latest short version property
+      property: docker_tag_short_version
+      value: "%(prop:registry_url)s:latest-%(prop:short_version)s"
   - ShellCommand: &docker_build
       name: Build docker image
       command: >-
         docker build
         -t %(prop:docker_tag_revision)s
         -t %(prop:docker_tag_latest)s
+        -t %(prop:docker_tag_short_version)s
         .
   - ShellCommand: &wait_docker_daemon
       name: Wait for Docker daemon to be ready
@@ -129,6 +138,7 @@ stages:
       - SetProperty: *registry_url
       - SetProperty: *docker_tag_revision
       - SetProperty: *docker_tag_latest
+      - SetProperty: *docker_tag_short_version
       - ShellCommand: *docker_build
 
   post-merge:
@@ -144,11 +154,14 @@ stages:
             -p '%(secret:harbor_password)s'
             registry.scality.com
       - SetProperty: *registry_url
+      - SetPropertyFromCommand: *short_version
       - SetProperty: *docker_tag_revision
       - SetProperty: *docker_tag_latest
+      - SetProperty: *docker_tag_short_version
       - ShellCommand: *docker_build
       - ShellCommand: &docker_push
           name: Push images
           command: |
             docker push %(prop:docker_tag_revision)s
             docker push %(prop:docker_tag_latest)s
+            docker push %(prop:docker_tag_short_version)s


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1055.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/feature/ZENKO-2810-upload-short-version-docker-registry`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/feature/ZENKO-2810-upload-short-version-docker-registry
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/feature/ZENKO-2810-upload-short-version-docker-registry
```

Please always comment pull request #1055 instead of this one.