### PR TITLE
improvement: S3C-3387 add notification message logs

### DIFF
--- a/extensions/notification/NotificationQueuePopulator.js
+++ b/extensions/notification/NotificationQueuePopulator.js
@@ -153,6 +153,13 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
             if (configUtil.validateEntry(config, ent)) {
                 const message
                     = messageUtil.addLogAttributes(value, ent);
+                this.log.info('publishing message', {
+                    method: 'NotificationQueuePopulator._processObjectEntry',
+                    bucket,
+                    key: message.key,
+                    eventType,
+                    eventTime: message.dateTime,
+                });
                 this.publish(this.notificationConfig.topic,
                     bucket,
                     JSON.stringify(message));

--- a/extensions/notification/destination/KafkaNotificationDestination.js
+++ b/extensions/notification/destination/KafkaNotificationDestination.js
@@ -60,9 +60,12 @@ class KafkaNotificationDestination extends NotificationDestination {
      * @return {undefined}
      */
     send(messages, done) {
-        this._notificationProducer.send(messages, err => {
-            if (err) {
-                this._log.trace('error publishing message');
+        this._notificationProducer.send(messages, error => {
+            if (error) {
+                this._log.error('error publishing message', {
+                    method: 'KafkaNotificationDestination.send',
+                    error,
+                });
             }
             done();
         });

--- a/extensions/notification/queueProcessor/QueueProcessor.js
+++ b/extensions/notification/queueProcessor/QueueProcessor.js
@@ -197,6 +197,16 @@ class QueueProcessor extends EventEmitter {
                         key: this.destinationId,
                         message,
                     };
+                    const msgDesc = 'sending message to external destination';
+                    const eventRecord = message.Records[0];
+                    this.logger.info(msgDesc, {
+                        method: 'QueueProcessor.processKafkaEntry',
+                        bucket,
+                        key,
+                        eventType: eventRecord.eventName,
+                        eventTime: eventRecord.eventTime,
+                        destination: this.destinationId,
+                    });
                     return this._destination.send([msg], done);
                 }
                 return done();


### PR DESCRIPTION
- Adds a log before publishing message to internal queue
- Adds a log before sending message to external destination
- Changed log level from trace to error in KafkaNotificationDestination