### PR TITLE
bf: S3C-3442 disable metrics for notification

### DIFF
--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -98,14 +98,19 @@ class QueuePopulator {
     }
 
     _setupMetricsClients(cb) {
-        // Metrics Consumer
-        this._mConsumer = new MetricsConsumer(this.rConfig, this.mConfig,
-            this.kafkaConfig);
-        this._mConsumer.start();
+        // TODO: Handle metrics for bucket notification
+        if (this.extConfigs.replication) {
+            // Metrics Consumer
+            this._mConsumer = new MetricsConsumer(this.rConfig, this.mConfig,
+                this.kafkaConfig);
+            this._mConsumer.start();
 
-        // Metrics Producer
-        this._mProducer = new MetricsProducer(this.kafkaConfig, this.mConfig);
-        this._mProducer.setupProducer(cb);
+            // Metrics Producer
+            this._mProducer = new MetricsProducer(this.kafkaConfig,
+                this.mConfig);
+            return this._mProducer.setupProducer(cb);
+        }
+        return cb();
     }
 
     /**


### PR DESCRIPTION
Metrics setup produces error in notification populator. Metrics is not necessary for bucket notification at this moment and so it is disabled now.