### PR TITLE
INTEGRATION [PR#1142 > development/8.1] bf: S3C-3455 notification config manager crash

### DIFF
--- a/extensions/notification/NotificationConfigManager.js
+++ b/extensions/notification/NotificationConfigManager.js
@@ -210,6 +210,34 @@ class NotificationConfigManager {
         });
     }
 
+    _checkConfigurationParentNode(cb) {
+        const method
+            = 'BucketNotificationConfigManager._checkConfigurationParentNode';
+        const zkPath = `/${this._parentNode}`;
+        return async.waterfall([
+            next => this._checkNodeExists(zkPath, next),
+            (exists, next) => {
+                if (!exists) {
+                    this.log.debug('parent configuration zookeeper node does ' +
+                        'not exist', { method, zkPath });
+                    return this._zkClient.mkdirp(zkPath, err => next(err));
+                }
+                this.log.debug('parent configuration zookeeper node exists',
+                    { method, zkPath });
+                return next();
+            },
+        ], err => {
+            if (err) {
+                const errMsg
+                    = 'error checking configuration zookeeper parent node';
+                this.log.error(errMsg, { method, zkPath });
+            }
+            this.log.debug('parent configuration zookeeper checked/added',
+                { method, zkPath });
+            return this._callbackHandler(cb);
+        });
+    }
+
     _createBucketNotifConfigNode(bucket, cb) {
         const method
             = 'BucketNotificationConfigManager._createBucketNotifConfigNode';
@@ -390,11 +418,13 @@ class NotificationConfigManager {
      * @return {undefined}
      */
     init(cb) {
-        return this._listBucketsWithConfig((err, buckets) => {
-            if (err) {
-                return cb(err);
-            }
-            return this._updateLocalStore(buckets, cb);
+        return this._checkConfigurationParentNode(() => {
+            return this._listBucketsWithConfig((err, buckets) => {
+                if (err) {
+                    return cb(err);
+                }
+                return this._updateLocalStore(buckets, cb);
+            });
         });
     }
 }

--- a/tests/unit/notification/NotificationConfigManager.js
+++ b/tests/unit/notification/NotificationConfigManager.js
@@ -5,9 +5,11 @@ const ZookeeperMock = require('zookeeper-mock');
 
 const NotificationConfigManager
     = require('../../../extensions/notification/NotificationConfigManager');
+const constants
+    = require('../../../extensions/notification/constants');
 
 const logger = new werelogs.Logger('NotificationConfigManager:test');
-const zkConfigParentNode = 'config';
+const { zkConfigParentNode } = constants;
 const concurrency = 10;
 const bucketPrefix = 'bucket';
 const timeoutMs = 100;
@@ -62,6 +64,32 @@ function deleteTestConfigs(zkClient, cb) {
     });
 }
 
+function checkCount(zkClient, manager, cb) {
+    listBuckets(zkClient, (err, buckets) => {
+        assert.ifError(err);
+        const zkConfigCount = buckets.length;
+        const managerConfigs = manager.getBucketsWithConfigs();
+        assert.strictEqual(zkConfigCount, managerConfigs.length);
+        cb();
+    });
+}
+
+function managerInit(manager, cb) {
+    manager.init(err => {
+        assert.ifError(err);
+        cb();
+    });
+}
+
+function checkParentConfigZkNode(manager, cb) {
+    const zkPath = `/${zkConfigParentNode}`;
+    manager._checkNodeExists(zkPath, (err, exists) => {
+        assert.ifError(err);
+        assert(exists);
+        cb();
+    });
+}
+
 describe('NotificationConfigManager', () => {
     const zkClient = new ZookeeperMock();
     const params = {
@@ -70,111 +98,103 @@ describe('NotificationConfigManager', () => {
         logger,
     };
 
-    function checkCount(manager, cb) {
-        listBuckets(zkClient, (err, buckets) => {
-            assert.ifError(err);
-            const zkConfigCount = buckets.length;
-            const managerConfigs = manager.getBucketsWithConfigs();
-            assert.strictEqual(zkConfigCount, managerConfigs.length);
-            cb();
+    describe('Constructor', () => {
+        after(() => {
+            zkClient._resetState();
         });
-    }
 
-    function managerInit(manager, cb) {
-        manager.init(err => {
-            assert.ifError(err);
-            cb();
-        });
-    }
-
-    beforeEach(done => populateTestConfigs(zkClient, 5, done));
-
-    afterEach(() => {
-        zkClient._resetState();
-    });
-
-    it('constructor and init checks', done => {
-        assert.throws(() => new NotificationConfigManager());
-        assert.throws(() => new NotificationConfigManager({}));
-        assert.throws(() => new NotificationConfigManager({
-            zkClient: null,
-            logger: null,
-        }));
-        const manager = new NotificationConfigManager(params);
-        assert(manager instanceof NotificationConfigManager);
-        async.series([
-            next => managerInit(manager, next),
-            next => checkCount(manager, next),
-        ], done);
-    });
-
-    it('should get bucket notification configuration', () => {
-        const manager = new NotificationConfigManager(params);
-        managerInit(manager, () => {
-            const bucket = 'bucket1';
-            const result = manager.getConfig(bucket);
-            assert.strictEqual(result.bucket, bucket);
+        it('constructor and init checks', done => {
+            assert.throws(() => new NotificationConfigManager());
+            assert.throws(() => new NotificationConfigManager({}));
+            assert.throws(() => new NotificationConfigManager({
+                zkClient: null,
+                logger: null,
+            }));
+            const manager = new NotificationConfigManager(params);
+            assert(manager instanceof NotificationConfigManager);
+            async.series([
+                next => managerInit(manager, next),
+                next => checkParentConfigZkNode(manager, next),
+            ], done);
         });
     });
 
-    it('should return undefined for a non-existing bucket', () => {
-        const manager = new NotificationConfigManager(params);
-        managerInit(manager, () => {
-            const bucket = 'bucket100';
-            const result = manager.getConfig(bucket);
-            assert.strictEqual(result, undefined);
-        });
-    });
+    describe('Operations', () => {
+        beforeEach(done => populateTestConfigs(zkClient, 5, done));
 
-    it('should add bucket notification configuration', done => {
-        const manager = new NotificationConfigManager(params);
-        managerInit(manager, () => {
-            const bucket = 'bucket100';
-            const config = getTestConfigValue(bucket);
-            const result = manager.setConfig(bucket, config);
-            assert(result);
-            setTimeout(() => {
-                checkCount(manager, done);
-            }, timeoutMs);
+        afterEach(() => {
+            zkClient._resetState();
         });
-    });
 
-    it('should update bucket notification configuration', done => {
-        const manager = new NotificationConfigManager(params);
-        managerInit(manager, () => {
-            const bucket = 'bucket1';
-            const config = getTestConfigValue(`${bucket}-updated`);
-            const result = manager.setConfig(bucket, config);
-            assert(result);
-            setTimeout(() => {
-                const updatedConfig = manager.getConfig(bucket);
-                assert.strictEqual(updatedConfig.bucket, `${bucket}-updated`);
-                checkCount(manager, done);
-            }, timeoutMs);
+        it('should get bucket notification configuration', () => {
+            const manager = new NotificationConfigManager(params);
+            managerInit(manager, () => {
+                const bucket = 'bucket1';
+                const result = manager.getConfig(bucket);
+                assert.strictEqual(result.bucket, bucket);
+            });
         });
-    });
 
-    it('should remove bucket notification configuration', done => {
-        const manager = new NotificationConfigManager(params);
-        managerInit(manager, () => {
-            const bucket = 'bucket1';
-            let result = manager.removeConfig(bucket);
-            assert(result);
-            setTimeout(() => {
-                result = manager.getConfig(bucket);
+        it('should return undefined for a non-existing bucket', () => {
+            const manager = new NotificationConfigManager(params);
+            managerInit(manager, () => {
+                const bucket = 'bucket100';
+                const result = manager.getConfig(bucket);
                 assert.strictEqual(result, undefined);
-                checkCount(manager, done);
-            }, timeoutMs);
+            });
         });
-    });
 
-    it('config count should be zero when all configs are removed', done => {
-        const manager = new NotificationConfigManager(params);
-        async.series([
-            next => managerInit(manager, next),
-            next => deleteTestConfigs(zkClient, next),
-            next => setTimeout(next, timeoutMs),
-            next => checkCount(manager, next),
-        ], done);
+        it('should add bucket notification configuration', done => {
+            const manager = new NotificationConfigManager(params);
+            managerInit(manager, () => {
+                const bucket = 'bucket100';
+                const config = getTestConfigValue(bucket);
+                const result = manager.setConfig(bucket, config);
+                assert(result);
+                setTimeout(() => {
+                    checkCount(zkClient, manager, done);
+                }, timeoutMs);
+            });
+        });
+
+        it('should update bucket notification configuration', done => {
+            const manager = new NotificationConfigManager(params);
+            managerInit(manager, () => {
+                const bucket = 'bucket1';
+                const config = getTestConfigValue(`${bucket}-updated`);
+                const result = manager.setConfig(bucket, config);
+                assert(result);
+                setTimeout(() => {
+                    const updatedConfig = manager.getConfig(bucket);
+                    assert.strictEqual(updatedConfig.bucket,
+                        `${bucket}-updated`);
+                    checkCount(zkClient, manager, done);
+                }, timeoutMs);
+            });
+        });
+
+        it('should remove bucket notification configuration', done => {
+            const manager = new NotificationConfigManager(params);
+            managerInit(manager, () => {
+                const bucket = 'bucket1';
+                let result = manager.removeConfig(bucket);
+                assert(result);
+                setTimeout(() => {
+                    result = manager.getConfig(bucket);
+                    assert.strictEqual(result, undefined);
+                    checkCount(zkClient, manager, done);
+                }, timeoutMs);
+            });
+        });
+
+        it('config count should be zero when all configs are removed', done => {
+            const manager = new NotificationConfigManager(params);
+            async.series([
+                next => managerInit(manager, next),
+                next => deleteTestConfigs(zkClient, next),
+                next => setTimeout(next, timeoutMs),
+                next => checkCount(zkClient, manager, next),
+            ], done);
+        });
     });
 });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1142.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-3455-notification-configuration-manager-crash`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-3455-notification-configuration-manager-crash
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-3455-notification-configuration-manager-crash
```

Please always comment pull request #1142 instead of this one.