### PR TITLE
INTEGRATION [PR#1234 > development/7.9] bugfix: S3C-3685 stop reading new log entries after provisioning update

### DIFF
--- a/bin/queuePopulator.js
+++ b/bin/queuePopulator.js
@@ -21,25 +21,20 @@ werelogs.configure({ level: config.log.logLevel,
 /* eslint-disable no-param-reassign */
 function queueBatch(queuePopulator, taskState) {
     if (taskState.batchInProgress) {
-        log.warn('skipping replication batch: previous one still in progress');
+        log.debug('skipping replication batch: previous one still in progress');
         return undefined;
     }
     log.debug('start queueing replication batch');
     taskState.batchInProgress = true;
     const maxRead = qpConfig.batchMaxRead;
-    queuePopulator.processAllLogEntries({ maxRead }, (err, counters) => {
+    queuePopulator.processAllLogEntries({ maxRead }, err => {
         taskState.batchInProgress = false;
         if (err) {
             log.error('an error occurred during replication', {
                 method: 'QueuePopulator::task.queueBatch',
                 error: err,
             });
-            return undefined;
         }
-        const logFunc = (counters.some(counter => counter.readRecords > 0) ?
-            log.info : log.debug).bind(log);
-        logFunc('replication batch finished', { counters });
-        return undefined;
     });
     return undefined;
 }

--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -212,44 +212,23 @@ class LogReader {
                           || !params.maxRead
                           || (batchState.logStats.nbLogRecordsRead
                               < params.maxRead);
-                return done(null, {
+                // Using this specific single-item array format for
+                // logging to keep compatibility with existing ELK stack
+                // scraping method
+                const counters = [{
                     readRecords: batchState.logStats.nbLogRecordsRead,
                     readEntries: batchState.logStats.nbLogEntriesRead,
                     queuedEntries,
                     processedAll,
+                    logSource: this.getLogInfo(),
+                    logOffset: this.getLogOffset(),
+                }];
+                this.log.info('replication batch finished', {
+                    counters,
                 });
+                return done(null, processedAll);
             });
         return undefined;
-    }
-
-    processAllLogEntries(params, done) {
-        const self = this;
-        const countersTotal = {
-            readRecords: 0,
-            readEntries: 0,
-            queuedEntries: {},
-        };
-        function cbProcess(err, counters) {
-            if (err) {
-                return done(err);
-            }
-            countersTotal.readRecords += counters.readRecords;
-            countersTotal.readEntries += counters.readEntries;
-            Object.keys(counters.queuedEntries).forEach(topic => {
-                if (countersTotal.queuedEntries[topic] === undefined) {
-                    countersTotal.queuedEntries[topic] = 0;
-                }
-                countersTotal.queuedEntries[topic] +=
-                    counters.queuedEntries[topic];
-            });
-            self.log.debug('process batch finished',
-                           { counters, countersTotal });
-            if (counters.processedAll) {
-                return done(null, countersTotal);
-            }
-            return self.processLogEntries(params, cbProcess);
-        }
-        return self.processLogEntries(params, cbProcess);
     }
 
     /* eslint-disable no-param-reassign */

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -236,20 +236,21 @@ class QueuePopulator {
     }
 
     _processAllLogEntries(params, done) {
-        return async.map(
+        return async.each(
             this.logReaders,
-            (logReader, done) => logReader.processAllLogEntries(params, done),
-            (err, results) => {
-                if (err) {
-                    return done(err);
-                }
-                const annotatedResults = results.map(
-                    (result, i) => Object.assign(result, {
-                        logSource: this.logReaders[i].getLogInfo(),
-                        logOffset: this.logReaders[i].getLogOffset(),
-                    }));
-                return done(null, annotatedResults);
-            });
+            (logReader, readerDone) => {
+                const batchCb = (err, processedAll) => {
+                    if (err) {
+                        return readerDone(err);
+                    }
+                    if (processedAll || this.logReadersUpdate) {
+                        return readerDone();
+                    }
+                    return logReader.processLogEntries(params, batchCb);
+                };
+                logReader.processLogEntries(params, batchCb);
+            },
+            done);
     }
 
     processAllLogEntries(params, done) {

--- a/tests/unit/QueuePopulator.spec.js
+++ b/tests/unit/QueuePopulator.spec.js
@@ -1,0 +1,55 @@
+const assert = require('assert');
+
+const { Logger } = require('werelogs');
+
+const QueuePopulator = require('../../lib/queuePopulator/QueuePopulator');
+const LogReader = require('../../lib/queuePopulator/LogReader');
+
+class MockLogReader extends LogReader {
+    constructor(queuePopulator, id) {
+        super({
+            logger: new Logger('MockLogReader'),
+        });
+        this.queuePopulator = queuePopulator;
+        this.id = id;
+        this.processLogEntriesCallCount = 0;
+    }
+
+    setup(cb) {
+        process.nextTick(cb);
+    }
+
+    processLogEntries(params, done) {
+        this.log.info('processLogEntries', { id: this.id });
+        this.processLogEntriesCallCount += 1;
+        // check that the provisioning update triggered below stopped
+        // the original provisioned raft session from being processed
+        assert(this.processLogEntriesCallCount <= 2);
+        if (this.processLogEntriesCallCount === 2) {
+            // at the 2nd invocation, trigger a provisioning update
+            this.queuePopulator.logReadersUpdate = [
+                new MockLogReader(this.queuePopulator, 'raft_2'),
+            ];
+        }
+        const processedAll = (this.id === 'raft_2');
+        process.nextTick(() => done(null, {
+            queuedEntries: {},
+            processedAll,
+        }));
+    }
+}
+
+describe('QueuePopulator', () => {
+    it('should stop processing old raft sessions after provisioning update', done => {
+        const qp = new QueuePopulator({}, {}, {
+            logSource: 'bucketd',
+        }, null, null, null, {});
+        const logReader1 = new MockLogReader(qp, 'raft_1');
+        qp.logReadersUpdate = [logReader1];
+        qp.processAllLogEntries({}, err => {
+            assert.ifError(err);
+            assert.strictEqual(logReader1.processLogEntriesCallCount, 2);
+            done();
+        });
+    });
+});

--- a/tests/unit/QueuePopulator.spec.js
+++ b/tests/unit/QueuePopulator.spec.js
@@ -32,10 +32,7 @@ class MockLogReader extends LogReader {
             ];
         }
         const processedAll = (this.id === 'raft_2');
-        process.nextTick(() => done(null, {
-            queuedEntries: {},
-            processedAll,
-        }));
+        process.nextTick(() => done(null, processedAll));
     }
 }
 


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1234.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.9/bugfix/S3C-3685-stopProvisioningAfterRedispatch`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.9/bugfix/S3C-3685-stopProvisioningAfterRedispatch
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.9/bugfix/S3C-3685-stopProvisioningAfterRedispatch
```

Please always comment pull request #1234 instead of this one.