### PR TITLE
bugfix: S3C-3657 retry on stream error

### DIFF
--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -355,6 +355,7 @@ class ReplicateObject extends BackbeatTask {
             if (!sourceReqAborted) {
                 // eslint-disable-next-line no-param-reassign
                 err.origin = 'source';
+                err.retryable = true;
                 log.error('an error occurred when streaming data from S3',
                           { method: 'ReplicateObject._getAndPutPartOnce',
                             entry: destEntry.getLogInfo(),

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -921,6 +921,36 @@ describe('queue processor functional tests with mocking', () => {
                     });
                 });
             });
+
+            it('should retry on error streaming from source S3 on getObject', done => {
+                s3mock.setParam('routes.source.s3.getObject.handler', (req, url, query, res) => {
+                    const partNumber = Number.parseInt(query.partNumber, 10);
+                    const resBody = s3mock.getParam('partsContents')[partNumber - 1];
+                    assert.strictEqual(query.versionId,
+                                       s3mock.getParam('versionIdEncoded'));
+
+                    res.setHeader('content-type', 'application/octet-stream');
+                    res.setHeader('content-length', resBody.length);
+                    res.writeHead(200);
+                    res.write(resBody.slice(0, -1));
+                    setTimeout(() => res.socket.destroy(), 1000);
+                    // restore original GET handler so that the next retry will succeed
+                    s3mock.resetParam('routes.source.s3.getObject.handler');
+                }, { _static: true });
+
+                async.parallel([
+                    done => {
+                        s3mock.onPutSourceMd = done;
+                    },
+                    done => queueProcessor.processKafkaEntry(
+                        s3mock.getParam('kafkaEntry'), err => {
+                            assert.ifError(err);
+                            assert(s3mock.hasPutTargetData);
+                            assert(s3mock.hasPutTargetMd);
+                            done();
+                        }),
+                ], done);
+            });
         });
 
         describe('target Vault errors', () => {


### PR DESCRIPTION
* bugfix: S3C-3657 failing test showing lack of retry

Add a functional test showing that retries do not occur when there is a stream error during data transfer from cloudserver

* bugfix: S3C-3657 retry on stream error

Retry when the GET data stream triggers an error (e.g. received less bytes than expected, if cloudserver closes the connection before backbeat receives everything).
