### PR TITLE
bugfix: S3C-2665 helper for removing orphans cleanly

### DIFF
--- a/lib/util/mapLimitWaitPendingIfError.js
+++ b/lib/util/mapLimitWaitPendingIfError.js
@@ -1,0 +1,68 @@
+/**
+ * Custom variant of async.mapLimit, where a failure does not call the
+ * callback immediately, but waits until the pending requests complete
+ * before returning the error and the latest array of results. It does
+ * not trigger the remaining non-started requests after an error
+ * occurs.
+ *
+ * The initial motivation to write this function is for cleaning up
+ * orphan data after a failed replication: in this case we must wait
+ * for all pending requests if an error occurs, but not trigger new
+ * requests, so that we have the full list of orphans to delete
+ * afterwards without missing the in-progress requests at the time the
+ * error occurs.
+ *
+ * @param {Array} coll - collection to iterate over
+ *
+ * @param {number} limit - The maximum number of async operations at a
+ * time
+ *
+ * @param {AsyncFunction} iteratee - An async function to apply to
+ * each item in coll. The iteratee should complete with the
+ * transformed item. Invoked with (item, callback).
+ *
+ * @param {function} callback - A callback which is called when all
+ * iteratee functions have finished, or an error occurs. Results is an
+ * array of the transformed items from the coll. Invoked with (err,
+ * results).
+ *
+ * @return {undefined}
+ */
+function mapLimitWaitPendingIfError(coll, limit, iteratee, callback) {
+    if (coll.length === 0) {
+        return callback(null, []);
+    }
+    const results = [];
+    let nPendingRequests = 0;
+    let nextIdx = 0;
+    let pendingError = null;
+    const processNext = () => {
+        const idx = nextIdx;
+        nextIdx += 1;
+        nPendingRequests += 1;
+        iteratee(coll[idx], (err, res) => {
+            nPendingRequests -= 1;
+            results[idx] = res;
+            if (err) {
+                // don't trigger any new request
+                nextIdx = coll.length;
+                if (!pendingError) {
+                    pendingError = err;
+                }
+                if (nPendingRequests === 0) {
+                    callback(pendingError, results);
+                }
+            } else if (nextIdx < coll.length) {
+                processNext();
+            } else if (nPendingRequests === 0) {
+                callback(pendingError, results);
+            }
+        });
+    };
+    while (nextIdx < Math.min(coll.length, limit)) {
+        processNext();
+    }
+    return undefined;
+}
+
+module.exports = mapLimitWaitPendingIfError;

--- a/tests/unit/lib/util/mapLimitWaitPendingIfError.spec.js
+++ b/tests/unit/lib/util/mapLimitWaitPendingIfError.spec.js
@@ -1,0 +1,140 @@
+const assert = require('assert');
+
+const mapLimitWaitPendingIfError =
+      require('../../../../lib/util/mapLimitWaitPendingIfError');
+
+describe('mapLimitWaitPendingIfError', () => {
+    it('should process an empty array', done => {
+        mapLimitWaitPendingIfError([], 10, (item, itemCb) => {
+            setTimeout(() => itemCb(null, item * 2), Math.random() * 10);
+        }, (err, results) => {
+            assert.ifError(err);
+            assert.deepStrictEqual(results, []);
+            done();
+        });
+    });
+    [
+        {
+            arrayDesc: 'smaller than the concurrency limit',
+            limit: 10,
+        },
+        {
+            arrayDesc: 'equal to the concurrency limit',
+            limit: 5,
+        },
+        {
+            arrayDesc: 'larger than the concurrency limit',
+            limit: 3,
+        },
+        {
+            arrayDesc: 'with a concurrency limit of 1',
+            limit: 1,
+        },
+    ].forEach(testCase => {
+        it(`should process an array ${testCase.arrayDesc}`, done => {
+            let concurrency = 0;
+            mapLimitWaitPendingIfError([1, 2, 3, 4, 5], testCase.limit, (item, itemCb) => {
+                concurrency += 1;
+                assert(concurrency <= testCase.limit);
+                setTimeout(() => {
+                    concurrency -= 1;
+                    itemCb(null, item * 2);
+                }, Math.random() * 10);
+            }, (err, results) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(results, [2, 4, 6, 8, 10]);
+                done();
+            });
+        });
+    });
+    it('should launch tasks in parallel up to the concurrency limit', done => {
+        let concurrency = 0;
+        const cbs = [];
+        let testDone = false;
+        mapLimitWaitPendingIfError([1, 2, 3, 4, 5], 3, (item, itemCb) => {
+            concurrency += 1;
+            assert(concurrency <= 3);
+            const itemDone = () => {
+                concurrency -= 1;
+                process.nextTick(() => itemCb(null, item * 2));
+            };
+            if (testDone) {
+                itemDone();
+            } else {
+                cbs.push(itemDone);
+                if (concurrency === 3) {
+                    setTimeout(() => {
+                        cbs.forEach(cb => cb());
+                    }, 10);
+                    testDone = true;
+                }
+            }
+        }, (err, results) => {
+            assert.ifError(err);
+            assert.deepStrictEqual(results, [2, 4, 6, 8, 10]);
+            done();
+        });
+    });
+
+    it('should stop processing new requests on error', done => {
+        mapLimitWaitPendingIfError([1, 2, 3, 4, 5], 1, (item, itemCb) => {
+            // check that no more item is processed after an error
+            // occurs (limit is 1 so item are processed in order)
+            assert(item <= 3);
+            if (item === 3) {
+                process.nextTick(() => itemCb(new Error('OOPS'), 'error item'));
+            } else {
+                process.nextTick(() => itemCb(null, item * 2));
+            }
+        }, (err, results) => {
+            assert(err);
+            assert.deepStrictEqual(results, [2, 4, 'error item']);
+            done();
+        });
+    });
+
+    it('should finish all pending requests on error', done => {
+        let concurrency = 0;
+        const cbs = [];
+        mapLimitWaitPendingIfError([1, 2, 3, 4, 5], 5, (item, itemCb) => {
+            concurrency += 1;
+            if (concurrency === 5) {
+                process.nextTick(() => {
+                    itemCb(new Error('OOPS'), 'error item');
+                    setTimeout(() => {
+                        cbs.forEach(cb => cb());
+                    }, 10);
+                });
+            } else {
+                cbs.push(() => itemCb(null, item * 2));
+            }
+        }, (err, results) => {
+            assert(err);
+            assert.deepStrictEqual(results, [2, 4, 6, 8, 'error item']);
+            done();
+        });
+    });
+
+    it('should return the first error', done => {
+        mapLimitWaitPendingIfError([1, 2, 3, 4, 5], 5, (item, itemCb) => {
+            const errorCb = () => itemCb(
+                new Error(`OOPS ${item}`), `error item ${item}`);
+            if (item === 3) {
+                process.nextTick(errorCb);
+            } else {
+                setTimeout(errorCb, 10);
+            }
+        }, (err, results) => {
+            assert(err);
+            assert.strictEqual(err.message, 'OOPS 3');
+            assert.deepStrictEqual(results, [
+                'error item 1',
+                'error item 2',
+                'error item 3',
+                'error item 4',
+                'error item 5',
+            ]);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Helper function that will be needed to remove all orphaned data after
a replication failure. The async.mapLimit function does not wait for
pending requests after an error, which makes it not suitable since we
need to wait for pending PUT rquests that also will need to be cleaned
up.