### PR TITLE
bf: S3C-3716 processor crash on vault refresh

### DIFF
--- a/lib/credentials/RoleCredentials.js
+++ b/lib/credentials/RoleCredentials.js
@@ -82,17 +82,21 @@ class RoleCredentials extends AWS.Credentials {
                     // instead of passing a possibly global arsenal
                     // error returned by vault client, because AWS
                     // client is transforming it its own way.
-                    const newErr = err.customizeDescription(err.description);
+                    // Any uncaught error or non arsenal error is treated as
+                    // internal error.
+                    const newErr = err.customizeDescription ?
+                        err.customizeDescription(err.description)
+                        : err.InternalError;
 
                     // Stick with the AWS SDK way of returning whether
                     // the error is retryable
                     newErr.retryable =
                         (err.InternalError ||
-                         err.code === 'InternalError' ||
-                         err.code === 500 ||
-                         err.ServiceUnavailable ||
-                         err.code === 'ServiceUnavailable' ||
-                         err.code === 503);
+                            err.code === 'InternalError' ||
+                            err.code === 500 ||
+                            err.ServiceUnavailable ||
+                            err.code === 'ServiceUnavailable' ||
+                            err.code === 503);
                     return cb(newErr);
                 }
                 /*

--- a/tests/unit/RoleCredentials.js
+++ b/tests/unit/RoleCredentials.js
@@ -13,7 +13,9 @@ const SecretAccessKey = 'qscwdvefb1234567890';
 const SessionToken = '1234567890-=+asdfg';
 const vaultHost = '127.0.0.1';
 const vaultPort = 8080;
-const server = http.createServer((req, res) => {
+let simulateServerError = false;
+const server = http.createServer();
+server.on('request', (req, res) => {
     const Expiration = Date.now() + 1000; // expire on 1 second
     const payload = JSON.stringify({
         Credentials: {
@@ -23,6 +25,9 @@ const server = http.createServer((req, res) => {
             Expiration,
         },
     });
+    if (simulateServerError) {
+        req.socket.destroy();
+    }
     res.writeHead(200, {
         'content-type': 'application/json',
         'content-length': Buffer.byteLength(payload),
@@ -44,7 +49,6 @@ function _assertCredentials(err, roleCredentials, cb) {
     return cb();
 }
 
-
 describe('Credentials Manager', () => {
     let roleCredentials = null;
     let vaultServer = null;
@@ -57,6 +61,9 @@ describe('Credentials Manager', () => {
             new Logger('test:RoleCredentials').newRequestLogger('requids'));
         vaultServer = server.listen(vaultPort).on('error', done);
         done();
+    });
+    afterEach(() => {
+        simulateServerError = false;
     });
     after(() => {
         roleCredentials = null;
@@ -85,5 +92,19 @@ describe('Credentials Manager', () => {
                     roleCredentials, done));
             }, retryTimeout);
         });
+    });
+
+    it('should handle non arsenal errors on refresh', function test(done) {
+        this.timeout(10000);
+        const retryTimeout = (roleCredentials.expiration - Date.now()) +
+            1000;
+        return setTimeout(() => {
+            assert.strictEqual(roleCredentials.expired, false);
+            simulateServerError = true;
+            roleCredentials.get(err => {
+                assert(err);
+                done();
+            });
+        }, retryTimeout);
     });
 });


### PR DESCRIPTION
Changes are made to handle unhandle exceptions from vault to prevent replication processor crash.