### PR TITLE
INTEGRATION [PR#1305 > development/7.9] bf: S3C-3716 processor crash on vault refresh

### DIFF
--- a/lib/credentials/RoleCredentials.js
+++ b/lib/credentials/RoleCredentials.js
@@ -82,17 +82,21 @@ class RoleCredentials extends AWS.Credentials {
                     // instead of passing a possibly global arsenal
                     // error returned by vault client, because AWS
                     // client is transforming it its own way.
-                    const newErr = err.customizeDescription(err.description);
+                    // Any uncaught error or non arsenal error is treated as
+                    // internal error.
+                    const newErr = err.customizeDescription ?
+                        err.customizeDescription(err.description)
+                        : err.InternalError;
 
                     // Stick with the AWS SDK way of returning whether
                     // the error is retryable
                     newErr.retryable =
                         (err.InternalError ||
-                         err.code === 'InternalError' ||
-                         err.code === 500 ||
-                         err.ServiceUnavailable ||
-                         err.code === 'ServiceUnavailable' ||
-                         err.code === 503);
+                            err.code === 'InternalError' ||
+                            err.code === 500 ||
+                            err.ServiceUnavailable ||
+                            err.code === 'ServiceUnavailable' ||
+                            err.code === 503);
                     return cb(newErr);
                 }
                 /*


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1305.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.9/bugfix/S3C-3716-processor-crash-on-vault-credentials-refresh`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.9/bugfix/S3C-3716-processor-crash-on-vault-credentials-refresh
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.9/bugfix/S3C-3716-processor-crash-on-vault-credentials-refresh
```

Please always comment pull request #1305 instead of this one.