### PR TITLE
improvement: S3C-3790 configurable MPU concurrency

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -58,7 +58,8 @@
             "queueProcessor": {
                 "groupId": "backbeat-replication-group",
                 "retryTimeoutS": 300,
-                "concurrency": 10
+                "concurrency": 10,
+                "mpuPartsConcurrency": 10
             },
             "replicationStatusProcessor": {
                 "groupId": "backbeat-replication-group",

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -50,6 +50,7 @@ const joiSchema = {
         groupId: joi.string().required(),
         retryTimeoutS: joi.number().default(300),
         concurrency: joi.number().greater(0).default(10),
+        mpuPartsConcurrency: joi.number().greater(0).default(10),
         logConsumerMetricsIntervalS: joi.number().greater(0).default(60),
     },
     replicationStatusProcessor: {

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -46,13 +46,13 @@ const joiSchema = {
     replicationFailedTopic: joi.string().required(),
     monitorReplicationFailureExpiryTimeS:
         joi.number().default(CRR_FAILURE_EXPIRY),
-    queueProcessor: {
+    queueProcessor: joi.object({
         groupId: joi.string().required(),
         retryTimeoutS: joi.number().default(300),
         concurrency: joi.number().greater(0).default(10),
         mpuPartsConcurrency: joi.number().greater(0).default(10),
         logConsumerMetricsIntervalS: joi.number().greater(0).default(60),
-    },
+    }).required(),
     replicationStatusProcessor: {
         groupId: joi.string().required(),
         retryTimeoutS: joi.number().default(300),

--- a/extensions/replication/tasks/MultipleBackendTask.js
+++ b/extensions/replication/tasks/MultipleBackendTask.js
@@ -8,8 +8,6 @@ const ObjectMDLocation = require('arsenal').models.ObjectMDLocation;
 const ReplicateObject = require('./ReplicateObject');
 const { attachReqUids } = require('../../../lib/clients/utils');
 
-const MPU_CONC_LIMIT = 10;
-
 class MultipleBackendTask extends ReplicateObject {
 
     _getReplicationEndpointType() {
@@ -251,7 +249,8 @@ class MultipleBackendTask extends ReplicateObject {
                 return doneOnce(err);
             }
             const locations = sourceEntry.getReducedLocations();
-            return async.mapLimit(locations, MPU_CONC_LIMIT, (part, done) =>
+            const mpuConcLimit = this.repConfig.queueProcessor.mpuPartsConcurrency;
+            return async.mapLimit(locations, mpuConcLimit, (part, done) =>
                 this._getAndPutMPUPart(sourceEntry, destEntry, part, uploadId,
                     log, (err, data) => {
                         if (err) {
@@ -528,7 +527,8 @@ class MultipleBackendTask extends ReplicateObject {
         if (locations.length === 0) {
             return this._getAndPutPart(sourceEntry, destEntry, null, log, cb);
         }
-        return async.mapLimit(locations, MPU_CONC_LIMIT, (part, done) =>
+        const mpuConcLimit = this.repConfig.queueProcessor.mpuPartsConcurrency;
+        return async.mapLimit(locations, mpuConcLimit, (part, done) =>
             this._getAndPutPart(sourceEntry, destEntry, part, log, done), cb);
     }
 

--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -15,8 +15,6 @@ const RoleCredentials =
           require('../../../lib/credentials/RoleCredentials');
 const { metricsExtension, metricsTypeProcessed } = require('../constants');
 
-const MPU_CONC_LIMIT = 10;
-
 function _extractAccountIdFromRole(role) {
     return role.split(':')[4];
 }
@@ -303,7 +301,8 @@ class ReplicateObject extends BackbeatTask {
             return cb(errors.InvalidObjectState);
         }
         const locations = sourceEntry.getReducedLocations();
-        return mapLimitWaitPendingIfError(locations, MPU_CONC_LIMIT, (part, done) => {
+        const mpuConcLimit = this.repConfig.queueProcessor.mpuPartsConcurrency;
+        return mapLimitWaitPendingIfError(locations, mpuConcLimit, (part, done) => {
             this._getAndPutPart(sourceEntry, destEntry, part, log, done);
         }, (err, destLocations) => {
             if (err) {

--- a/tests/config.json
+++ b/tests/config.json
@@ -51,6 +51,9 @@
                     "account": "bart"
                 }
             },
+            "queueProcessor": {
+                "groupId": "backbeat-replication-group"
+            },
             "topic": "backbeat-replication",
             "replicationStatusTopic": "backbeat-replication-status",
             "replicationFailedTopic": "backbeat-replication-failed"

--- a/tests/config.roleAuth.json
+++ b/tests/config.roleAuth.json
@@ -49,6 +49,9 @@
                     "type": "role"
                 }
             },
+            "queueProcessor": {
+                "groupId": "backbeat-replication-group"
+            },
             "topic": "backbeat-replication",
             "replicationStatusTopic": "backbeat-replication-status",
             "replicationFailedTopic": "backbeat-replication-failed"

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -697,6 +697,7 @@ describe('queue processor functional tests with mocking', () => {
               queueProcessor: {
                   retryTimeoutS: 5,
                   groupId: 'backbeat-func-test-group-id',
+                  mpuPartsConcurrency: 10,
               },
             }, {
             }, {


### PR DESCRIPTION
Add a configuration value to tune MPU part replication concurrency,
instead of a hard-coded value.

Note that in 7.x branches, only the CRR-style replication is affected,
but the patch is also applied to Zenko logic for MPU.