### PR TITLE
improvement: S3C-3826 use generic message in log reader

### DIFF
--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -245,7 +245,7 @@ class LogReader {
                     logSource: this.getLogInfo(),
                     logOffset: this.getLogOffset(),
                 }];
-                this.log.info('replication batch finished', {
+                this.log.info('batch finished', {
                     counters,
                 });
                 return done(null, processedAll);


### PR DESCRIPTION
The class `LogReader` is used by both replication and notification populators and it should have a generic message when a batch is finished.