### PR TITLE
bf: S3C-3829 Ignore placeholder log entries

### DIFF
--- a/extensions/notification/utils/config.js
+++ b/extensions/notification/utils/config.js
@@ -69,6 +69,14 @@ function filterConfigsByEvent(bnConfigs, event) {
  */
 function validateEntry(bnConfig, entry) {
     const { bucket, eventType } = entry;
+    /**
+     * if the event type is unavailable, it is an entry that is a
+     * placeholder for deletion or cleanup, these entries should be ignored and
+     * not be processed.
+    */
+    if (!eventType) {
+        return false;
+    }
     const notifConf = bnConfig.notificationConfiguration;
     // check if the entry belongs to the bucket in the configuration
     if (bucket !== bnConfig.bucket) {

--- a/tests/unit/notification/utils/config.js
+++ b/tests/unit/notification/utils/config.js
@@ -247,6 +247,15 @@ const tests = [
         },
         pass: false,
     },
+    {
+        desc: 'fail if the event type is unavailable',
+        entry: {
+            eventType: undefined,
+            bucket: 'bucket8',
+            key: 'abcd.png',
+        },
+        pass: false,
+    },
 ];
 
 describe('Notification configuration util', () => {


### PR DESCRIPTION
Notification populator should not process placeholder log entries created for deletion or cleanup.