### PR TITLE
bugfix: S3C-3769 Timeout for populator batches

### DIFF
--- a/bin/queuePopulator.js
+++ b/bin/queuePopulator.js
@@ -24,10 +24,15 @@ function queueBatch(queuePopulator, taskState) {
         log.debug('skipping replication batch: previous one still in progress');
         return undefined;
     }
+    const onTimeout = () => {
+        // reset the flag to allow a new batch to start in case the
+        // previous batch timed out
+        taskState.batchInProgress = false;
+    };
     log.debug('start queueing replication batch');
     taskState.batchInProgress = true;
     const maxRead = qpConfig.batchMaxRead;
-    queuePopulator.processAllLogEntries({ maxRead }, err => {
+    queuePopulator.processAllLogEntries({ maxRead, onTimeout }, err => {
         taskState.batchInProgress = false;
         if (err) {
             log.error('an error occurred during replication', {

--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -10,6 +10,8 @@ const ReplicationQueuePopulator =
 const { metricsExtension, metricsTypeQueued } =
     require('../../extensions/replication/constants');
 
+const BATCH_TIMEOUT_SECONDS = 300;
+
 class LogReader {
 
     /**
@@ -170,6 +172,8 @@ class LogReader {
      *   from the log. Records may contain multiple entries and all entries
      *   are not queued, so the number of queued entries is not directly
      *   related to this number.
+     * @param {function} [params.onTimeout] - optional callback,
+     *   called when a single batch times out
      * @param {function} done - callback when done processing the
      *   entries. Called with an error, or null and a statistics object as
      *   second argument. On success, the statistics contain the following:
@@ -194,6 +198,15 @@ class LogReader {
             debugStep: '[INIT]',
         };
 
+        const batchTimeoutTimer = setTimeout(() => {
+            this.log.error('replication batch timeout', {
+                logStats: batchState.logStats,
+                batchStep: batchState.debugStep,
+            });
+            if (params.onTimeout) {
+                params.onTimeout();
+            }
+        }, BATCH_TIMEOUT_SECONDS * 1000);
         async.waterfall([
             next => this._processReadRecords(params, batchState, next),
             next => this._processPrepareEntries(batchState, next),
@@ -201,6 +214,7 @@ class LogReader {
             next => this._processSaveLogOffset(batchState, next),
         ],
             err => {
+                clearTimeout(batchTimeoutTimer);
                 if (err) {
                     return done(err);
                 }

--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -191,6 +191,7 @@ class LogReader {
             },
             entriesToPublish: {},
             publishedEntries: {},
+            debugStep: '[INIT]',
         };
 
         async.waterfall([
@@ -226,6 +227,7 @@ class LogReader {
                 this.log.info('replication batch finished', {
                     counters,
                 });
+                batchState.debugStep = '[FINISHED]';
                 return done(null, processedAll);
             });
         return undefined;
@@ -244,12 +246,14 @@ class LogReader {
         this.log.debug('reading records', { readOptions });
         this.logConsumer.readRecords(readOptions, (err, res) => {
             if (err) {
+                batchState.debugStep = 'read records [ERROR]';
                 this.log.error(
                     'error while reading log records',
                     { method: 'LogReader._processReadRecords',
                         params, error: err });
                 return done(err);
             }
+            batchState.debugStep = 'read records [END]';
             this.log.debug(
                 'readRecords callback',
                 { method: 'LogReader._processReadRecords',
@@ -284,10 +288,12 @@ class LogReader {
         const { entriesToPublish, logRes, logStats } = batchState;
 
         if (logRes.info.start === null) {
+            batchState.debugStep = 'prepare entries [END]';
             return done(null);
         }
 
         logRes.log.on('data', record => {
+            batchState.debugStep = 'prepare entries [DATA]';
             this.log.debug('received log data',
                            { nbEntries: record.entries.length,
                              info: logRes.info });
@@ -302,19 +308,21 @@ class LogReader {
             this._unsetEntryBatch();
         });
         logRes.log.on('error', err => {
+            batchState.debugStep = 'prepare entries [ERROR]';
             this.log.error('error fetching entries from log',
                 { method: 'LogReader._processPrepareEntries',
                     error: err });
             return done(err);
         });
         logRes.log.on('end', () => {
+            batchState.debugStep = 'prepare entries [END]';
             this.log.debug('ending record stream', { info: logRes.info });
             return done();
         });
         return undefined;
     }
 
-    _setupProducer(topic, done) {
+    _setupProducer(topic, batchState, done) {
         if (this._producers[topic] !== undefined) {
             return process.nextTick(done);
         }
@@ -322,8 +330,12 @@ class LogReader {
             kafka: { hosts: this.kafkaConfig.hosts },
             topic,
         });
-        producer.once('error', done);
+        producer.once('error', err => {
+            batchState.debugStep = 'setup producer [ERROR]';
+            done(err);
+        });
         producer.once('ready', () => {
+            batchState.debugStep = 'setup producer [READY]';
             this.log.debug('producer is ready',
                            { kafkaConfig: this.kafkaConfig,
                              topic });
@@ -353,8 +365,11 @@ class LogReader {
                 return done();
             }
             return async.series([
-                done => this._setupProducer(topic, done),
-                done => this._producers[topic].send(topicEntries, done),
+                done => this._setupProducer(topic, batchState, done),
+                done => this._producers[topic].send(topicEntries, err => {
+                    batchState.debugStep = `producer send [${err ? 'ERROR' : 'END'}]`;
+                    done(err);
+                }),
             ], err => {
                 if (err) {
                     this.log.error(
@@ -393,7 +408,10 @@ class LogReader {
         if (batchState.nextLogOffset !== undefined &&
             batchState.nextLogOffset !== this.logOffset) {
             this.logOffset = batchState.nextLogOffset;
-            return this._writeLogOffset(done);
+            return this._writeLogOffset(err => {
+                batchState.debugStep = `save log offset [${err ? 'ERROR' : 'END'}]`;
+                done(err);
+            });
         }
         return process.nextTick(() => done());
     }


### PR DESCRIPTION
In case a populator batch takes too long to execute fully, trigger a
timeout, which both logs it along with the step at which the current
batch is, and allow a new batch to start.

This is a workaround to ensure the queue populator can make progress,
and should help investigation whenever a case of timeout happens, to
know what calls are causing the timeout.

Add debugging info about the current step of the LogReader, to help
investigating at what step it may be stuck.

Tested manually:

- introduced a random hook preventing a callback to be called during a batch processing, up to 10 times
- upgraded backbeat
- checked that backbeat logs the step at which it stopped, allows new batches to restart and keeps going

Note: Zenko does not have the workaround, the codebase is too different.