### PR TITLE
bugfix: S3C-3769 batch timeout for notification populator

### DIFF
--- a/bin/notification.js
+++ b/bin/notification.js
@@ -27,10 +27,15 @@ function queueBatch(queuePopulator, taskState) {
         log.debug('skipping notification batch: previous one still in progress');
         return undefined;
     }
+    const onTimeout = () => {
+        // reset the flag to allow a new batch to start in case the
+        // previous batch timed out
+        taskState.batchInProgress = false;
+    };
     log.debug('start queueing notification batch');
     taskState.batchInProgress = true;
     const maxRead = qpConfig.batchMaxRead;
-    queuePopulator.processAllLogEntries({ maxRead }, err => {
+    queuePopulator.processAllLogEntries({ maxRead, onTimeout }, err => {
         taskState.batchInProgress = false;
         if (err) {
             log.error('an error occurred during notification', {


### PR DESCRIPTION
Add batch timeout functionality for the notification populator, with
the same logic than for the replication populator, so that it can
restart new batches after a timeout.

To be merged after #1358 .