### PR TITLE
INTEGRATION [PR#1362 > development/8.2] bugfix: S3C-3769 batch timeout for notification populator

### DIFF
--- a/bin/notification.js
+++ b/bin/notification.js
@@ -27,10 +27,15 @@ function queueBatch(queuePopulator, taskState) {
         log.debug('skipping notification batch: previous one still in progress');
         return undefined;
     }
+    const onTimeout = () => {
+        // reset the flag to allow a new batch to start in case the
+        // previous batch timed out
+        taskState.batchInProgress = false;
+    };
     log.debug('start queueing notification batch');
     taskState.batchInProgress = true;
     const maxRead = qpConfig.batchMaxRead;
-    queuePopulator.processAllLogEntries({ maxRead }, err => {
+    queuePopulator.processAllLogEntries({ maxRead, onTimeout }, err => {
         taskState.batchInProgress = false;
         if (err) {
             log.error('an error occurred during notification', {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1362.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/bugfix/S3C-3769-timeoutForBucketNotificationPopulatorBatch`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/bugfix/S3C-3769-timeoutForBucketNotificationPopulatorBatch
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/bugfix/S3C-3769-timeoutForBucketNotificationPopulatorBatch
```

Please always comment pull request #1362 instead of this one.