### PR TITLE
INTEGRATION [PR#1374 > development/8.1] bugfix: S3C-3833 refresh role credentials earlier

### DIFF
--- a/lib/credentials/RoleCredentials.js
+++ b/lib/credentials/RoleCredentials.js
@@ -8,7 +8,7 @@ const configJoi = {
     vaultclient: joi.object().required(),
     extension: joi.string().required(),
     roleArn: joi.string().required(),
-    refreshCredsAnticipationMs: joi.number().default(60000),
+    refreshCredsAnticipationSeconds: joi.number().greater(0).default(60),
 };
 
 /**
@@ -24,26 +24,26 @@ class RoleCredentials extends AWS.Credentials {
      * @param {string} extension - name of the extension
      * @param {string} roleArn - ARN of the role
      * @param {RequestLogger} log - request logger instance
-     * @param {number} refreshCredsAnticipationMs - credentials must
-     * be refreshed earlier than their effective expiration time to
-     * avoid race conditions, this sets from how many milliseconds
+     * @param {number} refreshCredsAnticipationSeconds - credentials
+     * must be refreshed earlier than their effective expiration time
+     * to avoid race conditions, this sets from how many seconds
      * before expiration time credentials are refreshed
      */
     constructor(vaultclient, extension, roleArn, log,
-                refreshCredsAnticipationMs) {
+                refreshCredsAnticipationSeconds) {
         super();
         const params = joi.attempt({
             vaultclient,
             extension,
             roleArn,
-            refreshCredsAnticipationMs,
+            refreshCredsAnticipationSeconds,
         }, configJoi);
 
         this._vaultclient = vaultclient;
         this._log = new Logger('Backbeat').newRequestLogger(log.getUids());
         this._extension = extension;
         this._roleArn = roleArn;
-        this._refreshCredsAnticipationMs = params.refreshCredsAnticipationMs;
+        this._refreshCredsAnticipationSeconds = params.refreshCredsAnticipationSeconds;
         this.accessKeyId = null;
         this.secretAccessKey = null;
         this.sessionToken = null;
@@ -140,7 +140,8 @@ class RoleCredentials extends AWS.Credentials {
      * @return {boolean} - true if expired, false otherwise
      */
     needsRefresh() {
-        return Date.now() > this.expiration - this._refreshCredsAnticipationMs ||
+        return Date.now() >
+            this.expiration - this._refreshCredsAnticipationSeconds * 1000 ||
             !this.accessKeyId ||
             !this.secretAccessKey;
     }

--- a/lib/credentials/RoleCredentials.js
+++ b/lib/credentials/RoleCredentials.js
@@ -8,6 +8,7 @@ const configJoi = {
     vaultclient: joi.object().required(),
     extension: joi.string().required(),
     roleArn: joi.string().required(),
+    refreshCredsAnticipationMs: joi.number().default(60000),
 };
 
 /**
@@ -23,15 +24,26 @@ class RoleCredentials extends AWS.Credentials {
      * @param {string} extension - name of the extension
      * @param {string} roleArn - ARN of the role
      * @param {RequestLogger} log - request logger instance
+     * @param {number} refreshCredsAnticipationMs - credentials must
+     * be refreshed earlier than their effective expiration time to
+     * avoid race conditions, this sets from how many milliseconds
+     * before expiration time credentials are refreshed
      */
-    constructor(vaultclient, extension, roleArn, log) {
+    constructor(vaultclient, extension, roleArn, log,
+                refreshCredsAnticipationMs) {
         super();
-        joi.attempt({ vaultclient, extension, roleArn }, configJoi);
+        const params = joi.attempt({
+            vaultclient,
+            extension,
+            roleArn,
+            refreshCredsAnticipationMs,
+        }, configJoi);
 
         this._vaultclient = vaultclient;
         this._log = new Logger('Backbeat').newRequestLogger(log.getUids());
         this._extension = extension;
         this._roleArn = roleArn;
+        this._refreshCredsAnticipationMs = params.refreshCredsAnticipationMs;
         this.accessKeyId = null;
         this.secretAccessKey = null;
         this.sessionToken = null;
@@ -128,7 +140,8 @@ class RoleCredentials extends AWS.Credentials {
      * @return {boolean} - true if expired, false otherwise
      */
     needsRefresh() {
-        return Date.now() > this.expiration || !this.accessKeyId ||
+        return Date.now() > this.expiration - this._refreshCredsAnticipationMs ||
+            !this.accessKeyId ||
             !this.secretAccessKey;
     }
 }

--- a/tests/unit/RoleCredentials.js
+++ b/tests/unit/RoleCredentials.js
@@ -16,7 +16,7 @@ const vaultPort = 8080;
 let simulateServerError = false;
 const server = http.createServer();
 server.on('request', (req, res) => {
-    const Expiration = Date.now() + 1000; // expire on 1 second
+    const Expiration = Date.now() + 2000; // expire after 2 seconds
     const payload = JSON.stringify({
         Credentials: {
             AccessKeyId,
@@ -59,7 +59,7 @@ describe('Credentials Manager', () => {
         roleCredentials = new RoleCredentials(
             vaultclient, role, extension,
             new Logger('test:RoleCredentials').newRequestLogger('requids'),
-            110);
+            1);
         vaultServer = server.listen(vaultPort).on('error', done);
         done();
     });
@@ -86,7 +86,7 @@ describe('Credentials Manager', () => {
             // wait for less than the expiration time minus the
             // anticipation delay to ensure credentials have not
             // expired
-            const retryTimeout = (roleCredentials.expiration - Date.now()) - 200;
+            const retryTimeout = (roleCredentials.expiration - Date.now()) - 1500;
             return setTimeout(() => roleCredentials.get(
                 err => _assertCredentials(err, roleCredentials, err => {
                     assert.ifError(err);
@@ -162,6 +162,6 @@ describe('Credentials Manager', () => {
         const rc = new RoleCredentials(
             vaultclient, role, extension,
             new Logger('test:RoleCredentials').newRequestLogger('requids'));
-        assert(rc._refreshCredsAnticipationMs > 0);
+        assert(rc._refreshCredsAnticipationSeconds > 0);
     });
 });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1374.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-3833-refreshRoleCredentialsEarlier`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-3833-refreshRoleCredentialsEarlier
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-3833-refreshRoleCredentialsEarlier
```

Please always comment pull request #1374 instead of this one.