### PR TITLE
INTEGRATION [PR#1374 > development/7.9] bugfix: S3C-3833 refresh role credentials earlier

### DIFF
--- a/lib/credentials/RoleCredentials.js
+++ b/lib/credentials/RoleCredentials.js
@@ -8,6 +8,7 @@ const configJoi = {
     vaultclient: joi.object().required(),
     extension: joi.string().required(),
     roleArn: joi.string().required(),
+    refreshCredsAnticipationSeconds: joi.number().greater(0).default(60),
 };
 
 /**
@@ -23,15 +24,26 @@ class RoleCredentials extends AWS.Credentials {
      * @param {string} extension - name of the extension
      * @param {string} roleArn - ARN of the role
      * @param {RequestLogger} log - request logger instance
+     * @param {number} refreshCredsAnticipationSeconds - credentials
+     * must be refreshed earlier than their effective expiration time
+     * to avoid race conditions, this sets from how many seconds
+     * before expiration time credentials are refreshed
      */
-    constructor(vaultclient, extension, roleArn, log) {
+    constructor(vaultclient, extension, roleArn, log,
+                refreshCredsAnticipationSeconds) {
         super();
-        joi.attempt({ vaultclient, extension, roleArn }, configJoi);
+        const params = joi.attempt({
+            vaultclient,
+            extension,
+            roleArn,
+            refreshCredsAnticipationSeconds,
+        }, configJoi);
 
         this._vaultclient = vaultclient;
         this._log = new Logger('Backbeat').newRequestLogger(log.getUids());
         this._extension = extension;
         this._roleArn = roleArn;
+        this._refreshCredsAnticipationSeconds = params.refreshCredsAnticipationSeconds;
         this.accessKeyId = null;
         this.secretAccessKey = null;
         this.sessionToken = null;
@@ -128,7 +140,9 @@ class RoleCredentials extends AWS.Credentials {
      * @return {boolean} - true if expired, false otherwise
      */
     needsRefresh() {
-        return Date.now() > this.expiration || !this.accessKeyId ||
+        return Date.now() >
+            this.expiration - this._refreshCredsAnticipationSeconds * 1000 ||
+            !this.accessKeyId ||
             !this.secretAccessKey;
     }
 }

--- a/tests/unit/RoleCredentials.js
+++ b/tests/unit/RoleCredentials.js
@@ -16,7 +16,7 @@ const vaultPort = 8080;
 let simulateServerError = false;
 const server = http.createServer();
 server.on('request', (req, res) => {
-    const Expiration = Date.now() + 1000; // expire on 1 second
+    const Expiration = Date.now() + 2000; // expire after 2 seconds
     const payload = JSON.stringify({
         Credentials: {
             AccessKeyId,
@@ -58,7 +58,8 @@ describe('Credentials Manager', () => {
             undefined, proxyPath);
         roleCredentials = new RoleCredentials(
             vaultclient, role, extension,
-            new Logger('test:RoleCredentials').newRequestLogger('requids'));
+            new Logger('test:RoleCredentials').newRequestLogger('requids'),
+            1);
         vaultServer = server.listen(vaultPort).on('error', done);
         done();
     });
@@ -75,22 +76,68 @@ describe('Credentials Manager', () => {
             roleCredentials, done));
     });
 
+    it('should use same credentials if not expired or about to expire', function test(done) {
+        this.timeout(10000);
+        roleCredentials.get(err => {
+            if (err) {
+                return done(err);
+            }
+            const currentExpiration = roleCredentials.expiration;
+            // wait for less than the expiration time minus the
+            // anticipation delay to ensure credentials have not
+            // expired
+            const retryTimeout = (roleCredentials.expiration - Date.now()) - 1500;
+            return setTimeout(() => roleCredentials.get(
+                err => _assertCredentials(err, roleCredentials, err => {
+                    assert.ifError(err);
+                    // expiration should not have changed, meaning
+                    // credentials have not been refreshed
+                    assert.strictEqual(currentExpiration, roleCredentials.expiration);
+                    done();
+                })), retryTimeout);
+        });
+    });
+
     it('should refresh credentials upon expiration', function test(done) {
         this.timeout(10000);
         roleCredentials.get(err => {
             if (err) {
                 return done(err);
             }
-            // wait for an extra second after timeout to ensure credentials
-            // have expired
-            const retryTimeout = (roleCredentials.expiration - Date.now()) +
-                1000;
-            return setTimeout(() => {
-                assert(roleCredentials.expired === false,
-                    'expected credentials to expire');
-                roleCredentials.get(err => _assertCredentials(err,
-                    roleCredentials, done));
-            }, retryTimeout);
+            const currentExpiration = roleCredentials.expiration;
+            // wait for more than the expiration time to ensure
+            // credentials have expired
+            const retryTimeout = (roleCredentials.expiration - Date.now()) + 1000;
+            return setTimeout(() => roleCredentials.get(
+                err => _assertCredentials(err, roleCredentials, err => {
+                    assert.ifError(err);
+                    // expiration should have changed, meaning
+                    // credentials have been refreshed
+                    assert.notStrictEqual(currentExpiration, roleCredentials.expiration);
+                    done();
+                })), retryTimeout);
+        });
+    });
+
+    it('should refresh credentials a bit before expiration', function test(done) {
+        this.timeout(10000);
+        roleCredentials.get(err => {
+            if (err) {
+                return done(err);
+            }
+            const currentExpiration = roleCredentials.expiration;
+            // wait for slightly less than the expiration time but
+            // more than the anticipation delay for renewing
+            // credentials about to expire
+            const retryTimeout = (roleCredentials.expiration - Date.now()) - 100;
+            return setTimeout(() => roleCredentials.get(
+                err => _assertCredentials(err, roleCredentials, err => {
+                    assert.ifError(err);
+                    // expiration should have changed, meaning
+                    // credentials have been refreshed
+                    assert.notStrictEqual(currentExpiration, roleCredentials.expiration);
+                    done();
+                })), retryTimeout);
         });
     });
 
@@ -99,12 +146,22 @@ describe('Credentials Manager', () => {
         const retryTimeout = (roleCredentials.expiration - Date.now()) +
             1000;
         return setTimeout(() => {
-            assert.strictEqual(roleCredentials.expired, false);
             simulateServerError = true;
             roleCredentials.get(err => {
                 assert(err);
                 done();
             });
         }, retryTimeout);
+    });
+
+    it('RoleCredentials should use a default renewal anticipation delay if not explicit', () => {
+        const vaultclient = new Client(
+            vaultHost, vaultPort, undefined,
+            undefined, undefined, undefined, undefined, undefined, undefined,
+            undefined, proxyPath);
+        const rc = new RoleCredentials(
+            vaultclient, role, extension,
+            new Logger('test:RoleCredentials').newRequestLogger('requids'));
+        assert(rc._refreshCredsAnticipationSeconds > 0);
     });
 });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1374.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.9/bugfix/S3C-3833-refreshRoleCredentialsEarlier`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.9/bugfix/S3C-3833-refreshRoleCredentialsEarlier
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.9/bugfix/S3C-3833-refreshRoleCredentialsEarlier
```

Please always comment pull request #1374 instead of this one.