### PR TITLE
improvement: S3C-3835 start populating from latest cseq

### DIFF
--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -116,7 +116,7 @@ class LogReader {
                                 error: err });
                         return done(err);
                     }
-                    return done(null, 1);
+                    return this._initializeLogOffset(done);
                 });
             }
             if (data) {
@@ -136,7 +136,31 @@ class LogReader {
                         logOffset });
                 return done(null, logOffset);
             }
-            return done(null, 1);
+            return this._initializeLogOffset(done);
+        });
+    }
+
+    _initializeLogOffset(done) {
+        const pathToLogOffset = this.pathToLogOffset;
+        this.log.debug('initializing log offset', {
+            method: 'LogReader._initializeLogOffset',
+            zkPath: pathToLogOffset,
+        });
+        this.logConsumer.readRecords({ limit: 1 }, (err, res) => {
+            if (err) {
+                this.log.error('error while reading log', {
+                    method: 'LogReader._initializeLogOffset',
+                    error: err,
+                });
+                return done(err);
+            }
+            const logOffset = res.info.cseq + 1;
+            this.log.info('starting after latest log sequence', {
+                method: 'LogReader._initializeLogOffset',
+                zkPath: pathToLogOffset,
+                logOffset,
+            });
+            return done(null, logOffset);
         });
     }
 


### PR DESCRIPTION
Instead of starting populating entries from the beginning of each raft
session, start from the current cseq offset to skip existing data
written before the initial installation of the queue populator
(e.g. after enabling CRR or bucket notifications on an existing
installation).

This avoids having to go through an entire raft session log before
beginning to populate new entries.