### PR TITLE
INTEGRATION [PR#1402 > development/8.2] improvement: S3C-3835 start populating from latest cseq

### DIFF
--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -116,7 +116,7 @@ class LogReader {
                                 error: err });
                         return done(err);
                     }
-                    return done(null, 1);
+                    return this._initializeLogOffset(done);
                 });
             }
             if (data) {
@@ -136,7 +136,31 @@ class LogReader {
                         logOffset });
                 return done(null, logOffset);
             }
-            return done(null, 1);
+            return this._initializeLogOffset(done);
+        });
+    }
+
+    _initializeLogOffset(done) {
+        const pathToLogOffset = this.pathToLogOffset;
+        this.log.debug('initializing log offset', {
+            method: 'LogReader._initializeLogOffset',
+            zkPath: pathToLogOffset,
+        });
+        this.logConsumer.readRecords({ limit: 1 }, (err, res) => {
+            if (err) {
+                this.log.error('error while reading log', {
+                    method: 'LogReader._initializeLogOffset',
+                    error: err,
+                });
+                return done(err);
+            }
+            const logOffset = res.info.cseq + 1;
+            this.log.info('starting after latest log sequence', {
+                method: 'LogReader._initializeLogOffset',
+                zkPath: pathToLogOffset,
+                logOffset,
+            });
+            return done(null, logOffset);
         });
     }
 


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1402.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/improvement/S3C-3835-startReadingLogFromLatestCseq`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/improvement/S3C-3835-startReadingLogFromLatestCseq
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/improvement/S3C-3835-startReadingLogFromLatestCseq
```

Please always comment pull request #1402 instead of this one.