### PR TITLE
INTEGRATION [PR#1415 > development/8.2] Bugfix/zenko 3234/queue populator missing extensions

### DIFF
--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -80,6 +80,7 @@ class QueuePopulator {
      * @return {undefined}
      */
     open(cb) {
+        this._loadExtensions();
         async.series([
             next => this._setupMetricsClients(err => {
                 if (err) {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1415.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/bugfix/ZENKO-3234/queuePopulatorMissingExtensions`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/bugfix/ZENKO-3234/queuePopulatorMissingExtensions
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/bugfix/ZENKO-3234/queuePopulatorMissingExtensions
```

Please always comment pull request #1415 instead of this one.