### PR TITLE
INTEGRATION [PR#1422 > development/8.1] bugfix: S3C-3955 ignore errors from readRecords during LogReader setup

### DIFF
--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -148,11 +148,23 @@ class LogReader {
         });
         this.logConsumer.readRecords({ limit: 1 }, (err, res) => {
             if (err) {
-                this.log.error('error while reading log', {
-                    method: 'LogReader._initializeLogOffset',
-                    error: err,
-                });
-                return done(err);
+                // FIXME: getRaftLog metadata route returns 500 when
+                // its cache does not contain the queried raft
+                // session. For the sake of simplicity, in order to
+                // allow the populator to make progress, we choose to
+                // accept errors fetching the current offset during
+                // setup phase and fallback to starting from offset
+                // 1. It would be better to have metadata return
+                // special success statuses in such case.
+                this.log.warn(
+                    'error reading initial log offset, ' +
+                        'default to initial offset 1', {
+                            method: 'LogReader._initializeLogOffset',
+                            zkPath: pathToLogOffset,
+                            logOffset: 1,
+                            error: err,
+                        });
+                return done(null, 1);
             }
             const logOffset = res.info.cseq + 1;
             this.log.info('starting after latest log sequence', {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1422.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-3955-ignoreReadRecordsErrorAtLogReaderSetup`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-3955-ignoreReadRecordsErrorAtLogReaderSetup
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-3955-ignoreReadRecordsErrorAtLogReaderSetup
```

Please always comment pull request #1422 instead of this one.