### PR TITLE
improvement: S3C-3978 log broker and sasl errors

### DIFF
--- a/extensions/notification/destination/KafkaProducer.js
+++ b/extensions/notification/destination/KafkaProducer.js
@@ -83,15 +83,11 @@ class KafkaProducer extends EventEmitter {
                 this._onDeliveryReport.bind(this));
         });
         this._producer.on('event.error', error => {
-            if (!['broker transport failure',
-                'all broker connections are down']
-                .includes(error.message)) {
-                this._log.error('error with producer', {
-                    error: error.message,
-                    method: 'KakfaProducer.constructor',
-                });
-                this.emit('error', error);
-            }
+            this._log.error('error with producer', {
+                error: error.message,
+                method: 'KakfaProducer.constructor',
+            });
+            this.emit('error', error);
         });
         return this;
     }


### PR DESCRIPTION
Enable broker and SASL errors to be logged with notification producer. Current notification kafka producer uses generic implementation of producer used in other extensions and it does not logs broker level errors.