### PR TITLE
bugfix: allow forcing transitions 1 day early

### DIFF
--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -405,6 +405,15 @@ topic is the following:
 * **action**: type of lifecycle action, e.g. "deleteObject"
 * **details**: additional info related to the action
 
+## Manual Testing
+
+### Transition
+
+To ease manual testing or demos of transition policies, for which delays are at
+least 1 day, the `TRANSITION_ONE_DAY_EARLIER=true` environment variable
+subtracts 1 day from the trigger date. This makes policies with `Days: 1`
+effectively immedidate.
+
 ## Links
 
 * AWS Lifecycle Reference:

--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -14,6 +14,8 @@ const ReplicationAPI = require('../../replication/ReplicationAPI');
 const MAX_KEYS = process.env.CI === 'true' ? 3 : 1000;
 // concurrency mainly used in async calls
 const CONCURRENCY_DEFAULT = 10;
+// moves lifecycle transition deadlines 1 day earlier, mostly for testing
+const transitionOneDayEarlier = process.env.TRANSITION_ONE_DAY_EARLIER === 'true';
 
 function isLifecycleUser(canonicalID) {
     const canonicalIDArray = canonicalID.split('/');
@@ -581,7 +583,9 @@ class LifecycleTask extends BackbeatTask {
         if (transition.Days !== undefined) {
             const lastModifiedTime = this._getTimestamp(lastModified);
             const oneDay = 24 * 60 * 60 * 1000; // Milliseconds in a day.
-            return lastModifiedTime + (transition.Days * oneDay);
+            const timeTravel = transitionOneDayEarlier ? -oneDay : 0;
+
+            return lastModifiedTime + (transition.Days * oneDay) + timeTravel;
         }
         return undefined;
     }


### PR DESCRIPTION
Adds a knob for testing transition policies 1 day earlier. Users were trying to use `CI=true` and expected transitions to behave like expiration and happen 1 day before the due date, which is not implemented.

Did not reuse the `CI` environment variable because it:
- controls too many unrelated knobs
- is evaluated too late, when transition rules have already been dismissed for being in the future