### PR TITLE
Add bucket scanner base data types

### DIFF
--- a/bucket-scanner/pkg/counter/base_counter.go
+++ b/bucket-scanner/pkg/counter/base_counter.go
@@ -1,0 +1,37 @@
+package counter
+
+import (
+	"fmt"
+	"sync/atomic"
+
+	"github.com/scality/backbeat/bucket-scanner/pkg/types"
+)
+
+type baseCounter struct {
+	count int64
+}
+
+// NewBaseCounter returns an atomic counter
+func NewBaseCounter() *baseCounter {
+	return &baseCounter{}
+}
+
+func (c *baseCounter) Incr(key types.HashedNamer) {
+	atomic.AddInt64(&c.count, 1)
+}
+
+func (c *baseCounter) Decr(key types.HashedNamer) {
+	atomic.AddInt64(&c.count, -1)
+}
+
+func (c *baseCounter) Get() int64 {
+	return atomic.LoadInt64(&c.count)
+}
+
+func (c *baseCounter) Set(i int64) {
+	atomic.StoreInt64(&c.count, i)
+}
+
+func (c *baseCounter) String() string {
+	return fmt.Sprint(c.Get())
+}

--- a/bucket-scanner/pkg/counter/base_counter_test.go
+++ b/bucket-scanner/pkg/counter/base_counter_test.go
@@ -1,0 +1,57 @@
+package counter_test
+
+import (
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/scality/backbeat/bucket-scanner/pkg/counter"
+)
+
+func increment(c counter.Counter, startSignal chan struct{}, wg *sync.WaitGroup) {
+	defer wg.Done()
+
+	<-startSignal
+
+	for i := 0; i < 250000; i++ {
+		c.Incr(nil)
+		<-time.After(time.Microsecond)
+	}
+}
+
+var _ = Describe("BaseCounter", func() {
+	It("should increment atomically", func() {
+		wg := &sync.WaitGroup{}
+		c := counter.NewBaseCounter()
+		startSignal := make(chan struct{})
+
+		wg.Add(4)
+		go increment(c, startSignal, wg)
+		go increment(c, startSignal, wg)
+		go increment(c, startSignal, wg)
+		go increment(c, startSignal, wg)
+
+		close(startSignal)
+		wg.Wait()
+
+		Expect(c.Get()).To(Equal(int64(1000000)))
+	})
+
+	It("should implement Get", func() {
+		c := counter.NewBaseCounter()
+
+		c.Set(30)
+
+		Expect(c.Get()).To(Equal(int64(30)))
+	})
+
+	It("should implement String", func() {
+		c := counter.NewBaseCounter()
+
+		c.Set(30)
+
+		Expect(c.String()).To(Equal("30"))
+	})
+})

--- a/bucket-scanner/pkg/counter/counter_suite_test.go
+++ b/bucket-scanner/pkg/counter/counter_suite_test.go
@@ -1,0 +1,13 @@
+package counter_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCounter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Counter Suite")
+}

--- a/bucket-scanner/pkg/counter/replication/by_status_counter_set.go
+++ b/bucket-scanner/pkg/counter/replication/by_status_counter_set.go
@@ -1,0 +1,129 @@
+package replication
+
+import (
+	"github.com/scality/backbeat/bucket-scanner/pkg/counter"
+	"github.com/scality/backbeat/bucket-scanner/pkg/types"
+	log "github.com/sirupsen/logrus"
+)
+
+type (
+	ByStatusCounterSet struct {
+		Pending    counter.Counter
+		Failed     counter.Counter
+		Completed  counter.Counter
+		Replica    counter.Counter
+		NoStatus   counter.Counter
+		Processing counter.Counter
+
+		name string
+	}
+
+	SerializedByStatusCounterSet struct {
+		Pending    int64 `json:"pending"`
+		Failed     int64 `json:"failed"`
+		Completed  int64 `json:"completed"`
+		Replica    int64 `json:"replica"`
+		NoStatus   int64 `json:"nostatus"`
+		Processing int64 `json:"processing"`
+	}
+)
+
+func NewByStatusCounterSet(name string) *ByStatusCounterSet {
+	return &ByStatusCounterSet{
+		Pending:    counter.NewTrackingCounter(),
+		Failed:     counter.NewTrackingCounter(),
+		Completed:  counter.NewTrackingCounter(),
+		Replica:    counter.NewTrackingCounter(),
+		NoStatus:   counter.NewTrackingCounter(),
+		Processing: counter.NewTrackingCounter(),
+
+		name: name,
+	}
+}
+
+func (bscs *ByStatusCounterSet) CopyTo(other *ByStatusCounterSet) {
+	other.Pending.Set(bscs.Pending.Get())
+	other.Failed.Set(bscs.Failed.Get())
+	other.Completed.Set(bscs.Completed.Get())
+	other.Replica.Set(bscs.Replica.Get())
+	other.NoStatus.Set(bscs.NoStatus.Get())
+	other.Processing.Set(bscs.Processing.Get())
+}
+
+func (bscs *ByStatusCounterSet) Add(other *ByStatusCounterSet) {
+	bscs.Pending.Set(bscs.Pending.Get() + other.Pending.Get())
+	bscs.Failed.Set(bscs.Failed.Get() + other.Failed.Get())
+	bscs.Completed.Set(bscs.Completed.Get() + other.Completed.Get())
+	bscs.Replica.Set(bscs.Replica.Get() + other.Replica.Get())
+	bscs.NoStatus.Set(bscs.NoStatus.Get() + other.NoStatus.Get())
+	bscs.Processing.Set(bscs.Processing.Get() + other.Processing.Get())
+}
+
+func (bscs *ByStatusCounterSet) Reset() {
+	bscs.Pending.Set(0)
+	bscs.Failed.Set(0)
+	bscs.Completed.Set(0)
+	bscs.Replica.Set(0)
+	bscs.NoStatus.Set(0)
+	bscs.Processing.Set(0)
+}
+
+func (bscs *ByStatusCounterSet) Serialize() *SerializedByStatusCounterSet {
+	return &SerializedByStatusCounterSet{
+		Pending:    bscs.Pending.Get(),
+		Failed:     bscs.Failed.Get(),
+		Completed:  bscs.Completed.Get(),
+		Replica:    bscs.Replica.Get(),
+		NoStatus:   bscs.NoStatus.Get(),
+		Processing: bscs.Processing.Get(),
+	}
+}
+
+func (bscs *ByStatusCounterSet) LoadSerialized(s *SerializedByStatusCounterSet) {
+	bscs.Pending.Set(s.Pending)
+	bscs.Failed.Set(s.Failed)
+	bscs.Completed.Set(s.Completed)
+	bscs.Replica.Set(s.Replica)
+	bscs.NoStatus.Set(s.NoStatus)
+	bscs.Processing.Set(s.Processing)
+}
+
+func (bscs *ByStatusCounterSet) CountReplicationStatus(status types.ReplicationStatus, subject types.HashedNamer, isTransition bool) {
+	switch status {
+	case types.ReplicationStatusCompleted:
+		if isTransition {
+			bscs.Pending.Decr(subject)
+		}
+		bscs.Completed.Incr(subject)
+		log.Debugf("[%s] marking completed %v isTransition=%v", bscs.name, subject, isTransition)
+
+	case types.ReplicationStatusPending:
+		bscs.Pending.Incr(subject)
+
+	case types.ReplicationStatusFailed:
+		if isTransition {
+			bscs.Pending.Decr(subject)
+		}
+		bscs.Failed.Incr(subject)
+
+	case types.ReplicationStatusReplica:
+		bscs.Replica.Incr(subject)
+
+	case types.ReplicationStatusProcessing:
+		bscs.Processing.Incr(subject)
+
+	default:
+		bscs.NoStatus.Incr(subject)
+	}
+}
+
+func (s *SerializedByStatusCounterSet) ToMap() map[string]interface{} {
+	return map[string]interface{}{
+		"pending":    s.Pending,
+		"failed":     s.Failed,
+		"completed":  s.Completed,
+		"replica":    s.Replica,
+		"nostatus":   s.NoStatus,
+		"processing": s.Processing,
+	}
+}

--- a/bucket-scanner/pkg/counter/replication/by_status_counter_set_test.go
+++ b/bucket-scanner/pkg/counter/replication/by_status_counter_set_test.go
@@ -1,0 +1,138 @@
+package replication_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/scality/backbeat/bucket-scanner/pkg/counter/replication"
+	"github.com/scality/backbeat/bucket-scanner/pkg/types"
+)
+
+func setValues(cs *replication.ByStatusCounterSet) {
+	cs.Completed.Set(1)
+	cs.Failed.Set(2)
+	cs.NoStatus.Set(3)
+	cs.Pending.Set(4)
+	cs.Replica.Set(5)
+	cs.Processing.Set(6)
+}
+
+func expectDoubleValues(cs *replication.ByStatusCounterSet) {
+	Expect(cs.Serialize()).To(Equal(&replication.SerializedByStatusCounterSet{
+		Pending:    int64(8),
+		Failed:     int64(4),
+		Completed:  int64(2),
+		Replica:    int64(10),
+		NoStatus:   int64(6),
+		Processing: int64(12),
+	}))
+}
+
+var _ = Describe("ByStatusCounterSet", func() {
+	Describe("Reset", func() {
+		It("should reset all values", func() {
+			cs1 := replication.NewByStatusCounterSet("")
+			cs2 := replication.NewByStatusCounterSet("")
+
+			setValues(cs1)
+			cs1.Reset()
+
+			Expect(cs1).To(Equal(cs2))
+		})
+	})
+
+	Describe("Add", func() {
+		It("should add all fields", func() {
+			cs1 := replication.NewByStatusCounterSet("")
+			cs2 := replication.NewByStatusCounterSet("")
+
+			setValues(cs1)
+			setValues(cs2)
+
+			cs1.Add(cs2)
+
+			expectDoubleValues(cs1)
+		})
+	})
+
+	Describe("toMap", func() {
+		It("should copy all values around", func() {
+			cs := replication.NewByStatusCounterSet("")
+			setValues(cs)
+			Expect(cs.Serialize().ToMap()).To(Equal(map[string]interface{}{
+				"completed":  int64(1),
+				"failed":     int64(2),
+				"nostatus":   int64(3),
+				"pending":    int64(4),
+				"replica":    int64(5),
+				"processing": int64(6),
+			}))
+		})
+	})
+
+	Describe("CopyTo/Serialize/LoadSerialized Roundtripping", func() {
+		It("should copy all values around", func() {
+			cs1 := replication.NewByStatusCounterSet("")
+			cs2 := replication.NewByStatusCounterSet("")
+			cs3 := replication.NewByStatusCounterSet("")
+
+			setValues(cs1)
+			cs1.CopyTo(cs2)
+			s := cs2.Serialize()
+			cs3.LoadSerialized(s)
+
+			Expect(cs3).To(Equal(cs1))
+		})
+	})
+
+	Describe("CountReplicationStatus", func() {
+		obj := &types.ObjectMetadata{}
+		var cs *replication.ByStatusCounterSet
+
+		BeforeEach(func() {
+			cs = replication.NewByStatusCounterSet("")
+		})
+
+		It("should count pending objects", func() {
+			cs.CountReplicationStatus(types.ReplicationStatusPending, obj, false)
+			Expect(cs.Pending.Get()).To(BeEquivalentTo(1))
+		})
+
+		It("should count failed objects (absolute counting)", func() {
+			cs.CountReplicationStatus(types.ReplicationStatusFailed, obj, false)
+			Expect(cs.Failed.Get()).To(BeEquivalentTo(1))
+		})
+
+		It("should count completed objects (absolute counting)", func() {
+			cs.CountReplicationStatus(types.ReplicationStatusCompleted, obj, false)
+			Expect(cs.Completed.Get()).To(BeEquivalentTo(1))
+		})
+
+		It("should count failed objects (realtime transition)", func() {
+			cs.CountReplicationStatus(types.ReplicationStatusFailed, obj, true)
+			Expect(cs.Failed.Get()).To(BeEquivalentTo(1))
+			Expect(cs.Pending.Get()).To(BeEquivalentTo(-1))
+		})
+
+		It("should count completed objects (realtime transition)", func() {
+			cs.CountReplicationStatus(types.ReplicationStatusCompleted, obj, true)
+			Expect(cs.Completed.Get()).To(BeEquivalentTo(1))
+			Expect(cs.Pending.Get()).To(Equal(int64(-1)))
+		})
+
+		It("should count replica objects", func() {
+			cs.CountReplicationStatus(types.ReplicationStatusReplica, obj, false)
+			Expect(cs.Replica.Get()).To(BeEquivalentTo(1))
+		})
+
+		It("should count nostatus objects", func() {
+			cs.CountReplicationStatus("", obj, false)
+			Expect(cs.NoStatus.Get()).To(BeEquivalentTo(1))
+		})
+
+		It("should count processing objects", func() {
+			cs.CountReplicationStatus(types.ReplicationStatusProcessing, obj, false)
+			Expect(cs.Processing.Get()).To(BeEquivalentTo(1))
+		})
+	})
+})

--- a/bucket-scanner/pkg/counter/replication/counter_set.go
+++ b/bucket-scanner/pkg/counter/replication/counter_set.go
@@ -1,0 +1,119 @@
+package replication
+
+import (
+	"sync"
+
+	"github.com/scality/backbeat/bucket-scanner/pkg/types"
+)
+
+type (
+	CounterSet struct {
+		sync.Mutex
+		Global           *ByStatusCounterSet
+		ByTargetLocation map[types.SiteName]*ByStatusCounterSet
+
+		name string
+	}
+
+	SerializedCounterSet struct {
+		Global     *SerializedByStatusCounterSet                    `json:"global"`
+		ByLocation map[types.SiteName]*SerializedByStatusCounterSet `json:"byLocation"`
+	}
+)
+
+func New(name string) *CounterSet {
+	return &CounterSet{
+		Global:           NewByStatusCounterSet(name + ":global"),
+		ByTargetLocation: make(map[types.SiteName]*ByStatusCounterSet),
+
+		name: name,
+	}
+}
+
+func (cs *CounterSet) CopyTo(other *CounterSet) {
+	other.Lock()
+	defer other.Unlock()
+
+	cs.Global.CopyTo(other.Global)
+
+	other.ByTargetLocation = make(map[types.SiteName]*ByStatusCounterSet)
+	for k, v := range cs.ByTargetLocation {
+		n := NewByStatusCounterSet(other.name + ":" + string(k))
+		v.CopyTo(n)
+		other.ByTargetLocation[k] = n
+	}
+}
+
+func (cs *CounterSet) Add(other *CounterSet) {
+	cs.Lock()
+	defer cs.Unlock()
+
+	cs.Global.Add(other.Global)
+
+	for k, v := range other.ByTargetLocation {
+		m := cs.getTargetLocation(k)
+		m.Add(v)
+	}
+}
+
+func (cs *CounterSet) Reset() {
+	cs.Lock()
+	defer cs.Unlock()
+
+	cs.Global.Reset()
+	cs.ByTargetLocation = make(map[types.SiteName]*ByStatusCounterSet)
+}
+
+func (cs *CounterSet) GetTargetLocation(location types.SiteName) *ByStatusCounterSet {
+	cs.Lock()
+	defer cs.Unlock()
+
+	return cs.getTargetLocation(location)
+}
+
+func (cs *CounterSet) getTargetLocation(location types.SiteName) *ByStatusCounterSet {
+	bscs, ok := cs.ByTargetLocation[location]
+	if !ok {
+		bscs = NewByStatusCounterSet(cs.name + ":" + string(location))
+		cs.ByTargetLocation[location] = bscs
+	}
+
+	return bscs
+}
+
+func (cs *CounterSet) Serialize() *SerializedCounterSet {
+	cs.Lock()
+	defer cs.Unlock()
+
+	byLocation := map[types.SiteName]*SerializedByStatusCounterSet{}
+
+	for location, bscs := range cs.ByTargetLocation {
+		byLocation[location] = bscs.Serialize()
+	}
+
+	return &SerializedCounterSet{
+		Global:     cs.Global.Serialize(),
+		ByLocation: byLocation,
+	}
+}
+
+func (cs *CounterSet) LoadSerialized(s *SerializedCounterSet) {
+	cs.Global.LoadSerialized(s.Global)
+
+	for k, v := range s.ByLocation {
+		l := cs.GetTargetLocation(k)
+		l.LoadSerialized(v)
+	}
+}
+
+// CountReplicationStatus updates global counters as well as per-location breakdown
+// based on the replication info. If isTransition is true, pending counters will be
+// decremented to keep the total numbers balanced. Otherwise it is assumed that a new
+// object is counted and the net totals are added 1.
+func (cs *CounterSet) CountReplicationStatus(info *types.ObjectReplicationInfo, subject types.HashedNamer, isTransition bool) {
+	cs.Global.CountReplicationStatus(info.Status, subject, isTransition)
+
+	for _, status := range info.Backends {
+		cs.GetTargetLocation(status.Site).CountReplicationStatus(status.Status, subject, isTransition)
+	}
+}

--- a/bucket-scanner/pkg/counter/replication/counter_set_test.go
+++ b/bucket-scanner/pkg/counter/replication/counter_set_test.go
@@ -1,0 +1,244 @@
+package replication_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/scality/backbeat/bucket-scanner/pkg/counter/replication"
+	"github.com/scality/backbeat/bucket-scanner/pkg/types"
+)
+
+var _ = Describe("CounterSet", func() {
+	Describe("Add", func() {
+		It("should add all fields for all regions", func() {
+			cs1 := replication.New("")
+			cs2 := replication.New("")
+
+			setValues(cs1.Global)
+			setValues(cs1.GetTargetLocation("loc1"))
+			setValues(cs2.Global)
+			setValues(cs2.GetTargetLocation("loc1"))
+
+			cs1.Add(cs2)
+
+			expectDoubleValues(cs1.Global)
+			expectDoubleValues(cs1.ByTargetLocation["loc1"])
+		})
+	})
+
+	Describe("Reset", func() {
+		It("should reset all values", func() {
+			cs1 := replication.New("")
+
+			setValues(cs1.Global)
+			setValues(cs1.GetTargetLocation("loc1"))
+
+			cs1.Reset()
+
+			Expect(cs1).To(Equal(replication.New("")))
+		})
+	})
+
+	Describe("CopyTo/Serialize/LoadSerialized Roundtripping", func() {
+		It("should copy all values around", func() {
+			cs1 := replication.New("")
+			cs2 := replication.New("")
+			cs3 := replication.New("")
+
+			setValues(cs1.Global)
+			setValues(cs1.GetTargetLocation("loc1"))
+			cs1.CopyTo(cs2)
+			s := cs2.Serialize()
+			cs3.LoadSerialized(s)
+
+			Expect(cs3).To(Equal(cs1))
+		})
+	})
+
+	Describe("CountReplicationStatus", func() {
+		var cs *replication.CounterSet
+		obj := &types.ObjectMetadata{}
+
+		pendingInfo := &types.ObjectReplicationInfo{
+			Status: types.ReplicationStatusPending,
+			Backends: []types.ReplicationBackendStatus{
+				{
+					Site:   "site1",
+					Status: types.ReplicationStatusPending,
+				},
+				{
+					Site:   "site2",
+					Status: types.ReplicationStatusCompleted,
+				},
+			},
+		}
+
+		completedInfo := &types.ObjectReplicationInfo{
+			Status: types.ReplicationStatusCompleted,
+			Backends: []types.ReplicationBackendStatus{
+				{
+					Site:   "site1",
+					Status: types.ReplicationStatusPending,
+				},
+				{
+					Site:   "site2",
+					Status: types.ReplicationStatusCompleted,
+				},
+			},
+		}
+
+		failedInfo := &types.ObjectReplicationInfo{
+			Status: types.ReplicationStatusFailed,
+			Backends: []types.ReplicationBackendStatus{
+				{
+					Site:   "site1",
+					Status: types.ReplicationStatusPending,
+				},
+				{
+					Site:   "site2",
+					Status: types.ReplicationStatusFailed,
+				},
+			},
+		}
+
+		nostatusInfo := &types.ObjectReplicationInfo{
+			Status: "",
+			Backends: []types.ReplicationBackendStatus{
+				{
+					Site:   "site1",
+					Status: types.ReplicationStatusPending,
+				},
+				{
+					Site:   "site2",
+					Status: "",
+				},
+			},
+		}
+
+		replicaInfo := &types.ObjectReplicationInfo{
+			Status: types.ReplicationStatusReplica,
+			Backends: []types.ReplicationBackendStatus{
+				{
+					Site:   "site1",
+					Status: types.ReplicationStatusPending,
+				},
+				{
+					Site:   "site2",
+					Status: types.ReplicationStatusReplica,
+				},
+			},
+		}
+
+		processingInfo := &types.ObjectReplicationInfo{
+			Status: types.ReplicationStatusProcessing,
+			Backends: []types.ReplicationBackendStatus{
+				{
+					Site:   "site1",
+					Status: types.ReplicationStatusPending,
+				},
+				{
+					Site:   "site2",
+					Status: types.ReplicationStatusCompleted,
+				},
+			},
+		}
+
+		BeforeEach(func() {
+			cs = replication.New("")
+		})
+
+		It("should update global and per-location pending counters", func() {
+			cs.CountReplicationStatus(pendingInfo, obj, false)
+
+			Expect(cs.Global.Pending.Get()).To(Equal(int64(1)))
+			Expect(cs.ByTargetLocation["site1"].Pending.Get()).To(BeEquivalentTo(1))
+		})
+
+		It("should update global and per-location replica counters", func() {
+			cs.CountReplicationStatus(replicaInfo, obj, false)
+
+			Expect(cs.Global.Replica.Get()).To(Equal(int64(1)))
+			Expect(cs.ByTargetLocation["site2"].Replica.Get()).To(BeEquivalentTo(1))
+		})
+
+		It("should update global and per-location nostatus counters", func() {
+			cs.CountReplicationStatus(nostatusInfo, obj, false)
+
+			Expect(cs.Global.NoStatus.Get()).To(Equal(int64(1)))
+			Expect(cs.ByTargetLocation["site2"].NoStatus.Get()).To(BeEquivalentTo(1))
+		})
+
+		It("should update global and per-location processing counters", func() {
+			cs.CountReplicationStatus(processingInfo, obj, false)
+
+			Expect(cs.Global.Processing.Get()).To(Equal(int64(1)))
+			// PROCESSING is a synthetic status on the top-level object md, not per-backend
+			// so no testing it at the backend level
+			Expect(cs.ByTargetLocation["site2"].Completed.Get()).To(BeEquivalentTo(1))
+		})
+
+		It("should update global and per-location completed counters (absolute counting)", func() {
+			cs.CountReplicationStatus(completedInfo, obj, false)
+
+			Expect(cs.Global.Pending.Get()).To(BeEquivalentTo(0))
+			Expect(cs.Global.Completed.Get()).To(BeEquivalentTo(1))
+			Expect(cs.ByTargetLocation["site1"].Pending.Get()).To(BeEquivalentTo(1))
+			Expect(cs.ByTargetLocation["site1"].Completed.Get()).To(BeEquivalentTo(0))
+			Expect(cs.ByTargetLocation["site2"].Pending.Get()).To(BeEquivalentTo(0))
+			Expect(cs.ByTargetLocation["site2"].Completed.Get()).To(BeEquivalentTo(1))
+		})
+
+		It("should update global and per-location completed counters (realtime transition)", func() {
+			cs.CountReplicationStatus(completedInfo, obj, true)
+
+			Expect(cs.Global.Pending.Get()).To(BeEquivalentTo(-1))
+			Expect(cs.Global.Completed.Get()).To(BeEquivalentTo(1))
+			Expect(cs.ByTargetLocation["site1"].Pending.Get()).To(BeEquivalentTo(1))
+			Expect(cs.ByTargetLocation["site1"].Completed.Get()).To(BeEquivalentTo(0))
+			Expect(cs.ByTargetLocation["site2"].Pending.Get()).To(BeEquivalentTo(-1))
+			Expect(cs.ByTargetLocation["site2"].Completed.Get()).To(BeEquivalentTo(1))
+		})
+
+		It("should update global and per-location failed counters (absolute counting)", func() {
+			cs.CountReplicationStatus(failedInfo, obj, false)
+
+			Expect(cs.Global.Pending.Get()).To(BeEquivalentTo(0))
+			Expect(cs.Global.Failed.Get()).To(BeEquivalentTo(1))
+			Expect(cs.ByTargetLocation["site1"].Pending.Get()).To(BeEquivalentTo(1))
+			Expect(cs.ByTargetLocation["site1"].Failed.Get()).To(BeEquivalentTo(0))
+			Expect(cs.ByTargetLocation["site2"].Pending.Get()).To(BeEquivalentTo(0))
+			Expect(cs.ByTargetLocation["site2"].Failed.Get()).To(BeEquivalentTo(1))
+		})
+
+		It("should update global and per-location failed counters (realtime transition)", func() {
+			cs.CountReplicationStatus(failedInfo, obj, true)
+
+			Expect(cs.Global.Pending.Get()).To(BeEquivalentTo(-1))
+			Expect(cs.Global.Failed.Get()).To(BeEquivalentTo(1))
+			Expect(cs.ByTargetLocation["site1"].Pending.Get()).To(BeEquivalentTo(1))
+			Expect(cs.ByTargetLocation["site1"].Failed.Get()).To(BeEquivalentTo(0))
+			Expect(cs.ByTargetLocation["site2"].Pending.Get()).To(BeEquivalentTo(-1))
+			Expect(cs.ByTargetLocation["site2"].Failed.Get()).To(BeEquivalentTo(1))
+		})
+	})
+
+	Describe("GetTargetLocation", func() {
+		It("should return existing ByTargetLocation if available", func() {
+			cs := replication.New("")
+			bscs := replication.NewByStatusCounterSet("")
+
+			cs.ByTargetLocation["site1"] = bscs
+
+			Expect(cs.GetTargetLocation("site1")).To(BeIdenticalTo(bscs))
+			Expect(cs.GetTargetLocation("site1")).To(Equal(bscs))
+		})
+
+		It("should initialize a new ByTargetLocation if needed", func() {
+			cs := replication.New("cs")
+			bscs := replication.NewByStatusCounterSet("cs:a")
+
+			Expect(cs.GetTargetLocation("a")).NotTo(BeIdenticalTo(bscs))
+			Expect(cs.GetTargetLocation("a")).To(Equal(bscs))
+		})
+	})
+})

--- a/bucket-scanner/pkg/counter/replication/replication_suite_test.go
+++ b/bucket-scanner/pkg/counter/replication/replication_suite_test.go
@@ -1,0 +1,13 @@
+package replication_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestReplication(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Replication Suite")
+}

--- a/bucket-scanner/pkg/counter/tracking_counter.go
+++ b/bucket-scanner/pkg/counter/tracking_counter.go
@@ -1,0 +1,15 @@
+package counter
+
+type trackingCounter struct {
+	baseCounter
+}
+
+// NewTrackingCounter returns a counter keeps track of them item being counted
+// to avoid incrementing twice for it if we see it from 2 difference sources,
+// or decrementing when it hasn't been accounted for after our process was started.
+// TODO: Not Implemented!
+func NewTrackingCounter() *trackingCounter {
+	return &trackingCounter{
+		baseCounter: *NewBaseCounter(),
+	}
+}

--- a/bucket-scanner/pkg/counter/types.go
+++ b/bucket-scanner/pkg/counter/types.go
@@ -1,0 +1,10 @@
+package counter
+
+import "github.com/scality/backbeat/bucket-scanner/pkg/types"
+
+type Counter interface {
+	Incr(subject types.HashedNamer)
+	Decr(subject types.HashedNamer)
+	Get() int64
+	Set(i int64)
+}

--- a/bucket-scanner/pkg/types/types.go
+++ b/bucket-scanner/pkg/types/types.go
@@ -1,0 +1,236 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"hash/maphash"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+type ObjectHash uint64
+
+type HashedNamer interface {
+	fmt.Stringer
+	HashedName() ObjectHash
+}
+
+type BucketReplicationConfiguration struct {
+	Destination string
+}
+
+type BucketVersioningStatus string
+
+const (
+	BucketVersioningStatusEnabled   BucketVersioningStatus = "Enabled"
+	BucketVersioningStatusSuspended                        = "Suspended"
+	BucketVersioningStatusNone                             = ""
+)
+
+type BucketVersioningConfiguration struct {
+	Status BucketVersioningStatus
+}
+
+type BucketMetadata struct {
+	ReplicationConfiguration BucketReplicationConfiguration
+	VersioningConfiguration  BucketVersioningConfiguration
+}
+
+type ReplicationStatus string
+type SiteName string
+
+const (
+	ReplicationStatusPending    ReplicationStatus = "PENDING"
+	ReplicationStatusProcessing ReplicationStatus = "PROCESSING"
+	ReplicationStatusCompleted  ReplicationStatus = "COMPLETED"
+	ReplicationStatusFailed     ReplicationStatus = "FAILED"
+	ReplicationStatusReplica    ReplicationStatus = "REPLICA"
+)
+
+type ReplicationBackendStatus struct {
+	Site               SiteName          `json:"site"`
+	Status             ReplicationStatus `json:"status"`
+	DataStoreVersionID string            `json:"dataStoreVersionId"`
+}
+
+type ObjectReplicationInfo struct {
+	Status   ReplicationStatus          `json:"status"`
+	Backends []ReplicationBackendStatus `json:"backends"`
+}
+
+var HashSeed = maphash.MakeSeed()
+
+func HashString(s string) ObjectHash {
+	var h maphash.Hash
+	h.SetSeed(HashSeed)
+	h.WriteString(s)
+	return ObjectHash(h.Sum64())
+}
+
+func (objectReplicationInfo *ObjectReplicationInfo) String() string {
+	backends, err := json.Marshal(objectReplicationInfo.Backends)
+	if err != nil {
+		backends = []byte("(invalid)")
+	}
+
+	return fmt.Sprintf("status=%s backends=%s", objectReplicationInfo.Status, backends)
+}
+
+type ObjectMetadata struct {
+	ReplicationInfo *ObjectReplicationInfo `json:"replicationInfo"`
+
+	// Not present in the actual blob but needed for name hashing
+	Key    string
+	Bucket string
+}
+
+func (objectMetadata *ObjectMetadata) String() string {
+	if objectMetadata.Key == "" {
+		panic("empty key")
+	}
+
+	if objectMetadata.Bucket == "" {
+		panic("empty bucket")
+	}
+
+	return fmt.Sprintf("replicationInfo=(%s) key=(%s) bucket=(%s)", objectMetadata.ReplicationInfo, objectMetadata.Key, objectMetadata.Bucket)
+}
+
+func (objectMetadata *ObjectMetadata) HashedName() ObjectHash {
+	if objectMetadata.Key == "" {
+		panic("empty key")
+	}
+
+	if objectMetadata.Bucket == "" {
+		panic("empty bucket")
+	}
+
+	key := "b:" + objectMetadata.Bucket + ",k:" + objectMetadata.Key
+	return HashString(key)
+}
+
+func readObjectMetadata(bucket string, key string, b string) (*ObjectMetadata, error) {
+	md := &ObjectMetadata{}
+
+	err := json.Unmarshal([]byte(b), md)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unmarshal object md '%s'", b)
+	}
+
+	md.Bucket = bucket
+	md.Key = key
+
+	return md, nil
+}
+
+func ParseObjectMetadata(bucket string, key string, blob string) (*ObjectMetadata, error) {
+	return readObjectMetadata(bucket, key, blob)
+}
+
+type ReplicationMessage struct {
+	Type        string `json:"type"`
+	Bucket      string `json:"bucket"`
+	Key         string `json:"key"`
+	StringValue string `json:"value"`
+	ParsedValue *ObjectMetadata
+}
+
+func (replicationMessage *ReplicationMessage) String() string {
+	return fmt.Sprintf("type=%s bucket=%s key=%s value=(%s)",
+		replicationMessage.Type, replicationMessage.Bucket, replicationMessage.Key, replicationMessage.ParsedValue)
+}
+
+func (m *ReplicationMessage) HashedName() ObjectHash {
+	key := "b:" + m.Bucket + ",k:" + m.Key
+	return HashString(key)
+}
+
+func ParseReplicationMessage(b []byte) (*ReplicationMessage, error) {
+	m := &ReplicationMessage{}
+
+	err := json.Unmarshal(b, m)
+	if err != nil {
+		return nil, errors.Wrap(err, "unmarshal replication Message")
+	}
+
+	if m.StringValue != "" {
+		md, err := readObjectMetadata(m.Bucket, m.Key, m.StringValue)
+		if err != nil {
+			return nil, errors.Wrap(err, "read embedded object metadata")
+		}
+
+		m.ParsedValue = md
+		m.StringValue = ""
+	}
+
+	return m, nil
+}
+
+type FailedMessage struct {
+	Key    string `json:"key"`
+	Member string `json:"member"`
+	Score  int64  `json:"score"`
+}
+
+func (m *FailedMessage) String() string {
+	scoreAsDate := time.Unix(m.Score/1000, 0)
+
+	return fmt.Sprintf("member=%v key=%v score=(value=%v asdate=%v)", m.Member, m.Key, m.Score, scoreAsDate)
+}
+
+func (m *FailedMessage) HashedName() ObjectHash {
+	// example member: "repl-source:obj-key:393833393136383839373034363039393939393952473030312020382e3737342e313138:arn%3Aaws%3Aiam%3A%3A401219569273%3Arole%2Fbb-replication-1607386758902"
+	bucket := strings.Split(m.Member, ":")[0] // TODO handle malformed
+	key := "b:" + bucket + ",k:" + m.Key
+	return HashString(key)
+}
+
+func ParseFailedMessage(b []byte) (*FailedMessage, error) {
+	m := &FailedMessage{}
+
+	err := json.Unmarshal(b, m)
+	if err != nil {
+		return nil, errors.Wrap(err, "unmarshal failed Message")
+	}
+
+	return m, nil
+}
+
+type StatusMessage struct {
+	Bucket      string `json:"bucket"`
+	Key         string `json:"key"`
+	StringValue string `json:"value"`
+	ParsedValue *ObjectMetadata
+}
+
+func (m *StatusMessage) String() string {
+	return fmt.Sprintf("bucket=%s key=%s value=(%s)", m.Bucket, m.Key, m.ParsedValue)
+}
+
+func (m *StatusMessage) HashedName() ObjectHash {
+	key := "b:" + m.Bucket + ",k:" + m.Key
+	return HashString(key)
+}
+
+func ParseStatusMessage(b []byte) (*StatusMessage, error) {
+	m := &StatusMessage{}
+
+	err := json.Unmarshal(b, m)
+	if err != nil {
+		return nil, errors.Wrap(err, "unmarshal status Message")
+	}
+
+	if m.StringValue != "" {
+		md, err := readObjectMetadata(m.Bucket, m.Key, m.StringValue)
+		if err != nil {
+			return nil, errors.Wrap(err, "read embedded object metadata")
+		}
+
+		m.ParsedValue = md
+		m.StringValue = ""
+	}
+
+	return m, nil
+}

--- a/bucket-scanner/pkg/types/types_suite_test.go
+++ b/bucket-scanner/pkg/types/types_suite_test.go
@@ -1,0 +1,13 @@
+package types_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTypes(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Types Suite")
+}

--- a/bucket-scanner/pkg/types/types_test.go
+++ b/bucket-scanner/pkg/types/types_test.go
@@ -1,0 +1,119 @@
+package types_test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/scality/backbeat/bucket-scanner/pkg/types"
+)
+
+func unescapeJSON(s string) []byte {
+	var u string
+	_ = json.Unmarshal([]byte(s), &u)
+	return []byte(u)
+}
+
+var _ = Describe("Types", func() {
+	objectMD := &types.ObjectMetadata{
+		ReplicationInfo: &types.ObjectReplicationInfo{
+			Status: types.ReplicationStatusFailed,
+			Backends: []types.ReplicationBackendStatus{
+				{Site: "site1", Status: types.ReplicationStatusPending, DataStoreVersionID: "v1"},
+				{Site: "site2", Status: types.ReplicationStatusFailed},
+			},
+		},
+		Key:    "k",
+		Bucket: "b",
+	}
+	objectMDStr := `"{\"replicationInfo\":{\"status\":\"FAILED\",\"backends\":[{\"site\":\"site1\",\"status\":\"PENDING\",\"dataStoreVersionId\":\"v1\"},{\"site\":\"site2\",\"status\":\"FAILED\"}]}}"`
+	memberStr := "b:obj-key:393833393136383839373034363039393939393952473030312020382e3737342e313138:arn%3Aaws%3Aiam%3A%3A401219569273%3Arole%2Fbb-replication-1607386758902"
+
+	expectedHash := types.HashString("b:b,k:k")
+
+	Describe("Parsers", func() {
+		cases := []struct {
+			name   string
+			parser func([]byte) (interface{}, error)
+			input  []byte
+			ref    interface{}
+		}{
+			{
+				name: "ObjectMD",
+				parser: func(buf []byte) (interface{}, error) {
+					return types.ParseObjectMetadata("b", "k", string(buf))
+				},
+				input: unescapeJSON(objectMDStr),
+				ref:   objectMD,
+			},
+			{
+				name: "StatusMessage",
+				parser: func(buf []byte) (interface{}, error) {
+					return types.ParseStatusMessage(buf)
+				},
+				input: []byte(fmt.Sprintf(`{
+					"bucket": "b",
+					"key": "k",
+					"value": %s
+				}`, objectMDStr)),
+				ref: &types.StatusMessage{
+					Bucket:      "b",
+					Key:         "k",
+					ParsedValue: objectMD,
+				},
+			},
+			{
+				name: "ReplicationMessage",
+				parser: func(buf []byte) (interface{}, error) {
+					return types.ParseReplicationMessage(buf)
+				},
+				input: []byte(fmt.Sprintf(`{
+					"type": "put",
+					"bucket": "b",
+					"key": "k",
+					"value": %s
+				}`, objectMDStr)),
+				ref: &types.ReplicationMessage{
+					Type:        "put",
+					Bucket:      "b",
+					Key:         "k",
+					ParsedValue: objectMD,
+				},
+			},
+			{
+				name: "FailedMessage",
+				parser: func(buf []byte) (interface{}, error) {
+					return types.ParseFailedMessage(buf)
+				},
+				input: []byte(fmt.Sprintf(`{
+					"member": "%s",
+					"key": "k",
+					"score": 2
+				}`, memberStr)),
+				ref: &types.FailedMessage{
+					Key:    "k",
+					Score:  2,
+					Member: memberStr,
+				},
+			},
+		}
+
+		for _, c := range cases {
+			c := c
+			It("should parse "+c.name, func() {
+				o, err := c.parser(c.input)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(o).To(Equal(c.ref))
+			})
+
+			It("should hash "+c.name, func() {
+				o, err := c.parser(c.input)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(o.(types.HashedNamer).HashedName()).To(Equal(expectedHash))
+			})
+		}
+	})
+
+})

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -32,6 +32,10 @@ stages:
           name: run unit tests
           command: yarn test
       - ShellCommand:
+          name: run bucket scanner unit tests
+          command: ginkgo -r --randomizeAllSpecs --randomizeSuites --failOnPending --cover --trace --race --progress -nodes 4
+          workdir: '%(prop:builddir)s/build/bucket-scanner'
+      - ShellCommand:
           name: run backbeat routes test
           command: bash ./eve/workers/unit_and_feature_tests/run_server_tests.bash ft_test:api:routes
           workdir: '%(prop:builddir)s/build'

--- a/eve/workers/unit_and_feature_tests/Dockerfile
+++ b/eve/workers/unit_and_feature_tests/Dockerfile
@@ -10,6 +10,11 @@ ENV PATH=$PATH:/backbeat/node_modules/.bin
 ENV NODE_PATH=/backbeat/node_modules
 ENV NODE_ENV=${NODE_ENV}
 
+ENV GO_VERSION=1.16.2
+ENV GINKGO_VERSION=v1.15.2
+
+ENV GO_ARCHIVE=go${GO_VERSION}.linux-amd64.tar.gz
+
 VOLUME /home/eve/workspace
 
 COPY eve/workers/unit_and_feature_tests/backbeat_packages.list \
@@ -25,6 +30,11 @@ RUN curl -sS http://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && make -C ./n \
     && n 10 latest \
     && pip install pip==9.0.1 \
+    && curl -LO https://golang.org/dl/${GO_ARCHIVE} \
+    && tar zxvf ${GO_ARCHIVE} -C /usr/local \
+    && GOPATH=/usr/local /usr/local/go/bin/go get github.com/onsi/ginkgo/ginkgo@${GINKGO_VERSION} \
+    && ln -s /usr/local/go/bin/go /usr/local/bin \
+    && rm -f ${GO_ARCHIVE} \
     && rm -rf ./n \
     && rm -rf /var/lib/apt/lists/* \
     && rm -f /tmp/*packages.list


### PR DESCRIPTION
First piece of the upcoming bucket scanner:

- data types for object metadata
- data types for atomic counters
- data types for CRR metrics groups per object status * per backend