### PR TITLE
INTEGRATION [PR#1557 > development/7.9] ft: S3C-4195 Add console output module to bucket scanner

### DIFF
--- a/bucket-scanner/pkg/console/console.go
+++ b/bucket-scanner/pkg/console/console.go
@@ -1,0 +1,13 @@
+package console
+
+import (
+	"time"
+)
+
+func NewMonitor(echoInterval time.Duration, interactive bool) Monitor {
+	if interactive {
+		return newInteractiveMonitor(echoInterval)
+	}
+
+	return &LoggingMonitor{}
+}

--- a/bucket-scanner/pkg/console/interactive.go
+++ b/bucket-scanner/pkg/console/interactive.go
@@ -1,0 +1,128 @@
+package console
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gosuri/uilive"
+)
+
+var (
+	_ Monitor = &InteractiveMonitor{}
+	_ Channel = &InteractiveChannel{}
+)
+
+type (
+	InteractiveChannel struct {
+		sync.Mutex
+		name   string
+		value  string
+		buffer bytes.Buffer
+	}
+
+	InteractiveMonitor struct {
+		sync.Mutex
+		channels     []*InteractiveChannel
+		writer       *uilive.Writer
+		echoInterval time.Duration
+	}
+)
+
+func (c *InteractiveChannel) Output(msg map[string]interface{}) {
+	var keys []string
+	for k := range msg {
+		keys = append(keys, k)
+	}
+
+	sort.Strings(keys)
+
+	c.Lock()
+	defer c.Unlock()
+
+	c.buffer.Reset()
+	c.buffer.WriteString(c.name)
+	c.buffer.WriteString(": ")
+
+	for _, k := range keys {
+		c.buffer.WriteString(k)
+		c.buffer.WriteRune('=')
+		c.buffer.WriteString(fmt.Sprint(msg[k]))
+		c.buffer.WriteRune(' ')
+	}
+
+	c.value = c.buffer.String()
+}
+
+func (c *InteractiveChannel) getValue() string {
+	c.Lock()
+	defer c.Unlock()
+
+	return c.value
+}
+
+func newInteractiveMonitor(echoInterval time.Duration) *InteractiveMonitor {
+	return &InteractiveMonitor{
+		writer:       uilive.New(),
+		echoInterval: echoInterval,
+	}
+}
+
+func (m *InteractiveMonitor) Start(ctx context.Context) {
+	m.writer.Start()
+
+	go func() {
+		t := time.NewTicker(m.echoInterval)
+		defer t.Stop()
+		defer m.flush()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+
+			case <-t.C:
+				m.flush()
+			}
+		}
+	}()
+}
+
+func (m *InteractiveMonitor) Stop() {
+	m.flush()
+	m.writer.Stop()
+}
+
+func (m *InteractiveMonitor) AppendDebug(name string) Channel {
+	return m.Append(name)
+}
+
+func (m *InteractiveMonitor) Append(name string) Channel {
+	ch := &InteractiveChannel{
+		name: name,
+	}
+
+	m.Lock()
+	defer m.Unlock()
+
+	m.channels = append(m.channels, ch)
+
+	return ch
+}
+
+func (m *InteractiveMonitor) flush() {
+	var lines []string
+
+	m.Lock()
+	for _, ch := range m.channels {
+		lines = append(lines, ch.getValue())
+	}
+	m.Unlock()
+
+	output := strings.Join(lines, "\n")
+	fmt.Fprintln(m.writer, output)
+}

--- a/bucket-scanner/pkg/console/logging.go
+++ b/bucket-scanner/pkg/console/logging.go
@@ -1,0 +1,51 @@
+package console
+
+import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	_ Channel = &LoggingChannel{}
+	_ Monitor = &LoggingMonitor{}
+)
+
+type (
+	LoggingChannel struct {
+		log     *log.Entry
+		isDebug bool
+	}
+
+	LoggingMonitor struct {
+	}
+)
+
+func (c *LoggingChannel) Output(msg map[string]interface{}) {
+	l := c.log.WithFields(msg)
+
+	if c.isDebug {
+		l.Debug("debug")
+	} else {
+		l.Info("progress report")
+	}
+}
+
+func (m *LoggingMonitor) Start(ctx context.Context) {
+}
+
+func (m *LoggingMonitor) Stop() {
+}
+
+func (m *LoggingMonitor) Append(name string) Channel {
+	return &LoggingChannel{
+		log: log.WithField("name", name),
+	}
+}
+
+func (m *LoggingMonitor) AppendDebug(name string) Channel {
+	return &LoggingChannel{
+		log:     log.WithField("name", name),
+		isDebug: true,
+	}
+}

--- a/bucket-scanner/pkg/console/test/main.go
+++ b/bucket-scanner/pkg/console/test/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/scality/backbeat/bucket-scanner/pkg/console"
+)
+
+const delay = 200 * time.Millisecond
+
+func testMonitor(ctx context.Context, c console.Monitor) {
+	ch1 := c.Append("component1")
+	ch2 := c.Append("component2")
+	ch3 := c.Append("component3")
+
+	c.Start(ctx)
+
+	for i := 0; i < 10; i++ {
+		ch1.Output(map[string]interface{}{
+			"a": i,
+		})
+
+		<-time.After(delay)
+
+		ch2.Output(map[string]interface{}{
+			"c": i + 1,
+		})
+
+		<-time.After(delay)
+
+		ch3.Output(map[string]interface{}{
+			"e": i - 1,
+		})
+
+		<-time.After(delay)
+	}
+
+	c.Stop()
+}
+
+func main() {
+	ctx := context.Background()
+
+	testMonitor(ctx, console.NewMonitor(delay, true))
+	testMonitor(ctx, console.NewMonitor(delay, false))
+}

--- a/bucket-scanner/pkg/console/types.go
+++ b/bucket-scanner/pkg/console/types.go
@@ -1,0 +1,17 @@
+package console
+
+import "context"
+
+type (
+	Channel interface {
+		Output(msg map[string]interface{})
+	}
+
+	Monitor interface {
+		Start(ctx context.Context)
+		Stop()
+
+		Append(name string) Channel
+		AppendDebug(name string) Channel
+	}
+)


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1557.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.9/feature/S3C-4195-bucket-scanner-output`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.9/feature/S3C-4195-bucket-scanner-output
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.9/feature/S3C-4195-bucket-scanner-output
```

Please always comment pull request #1557 instead of this one.