### PR TITLE
INTEGRATION [PR#1647 > development/8.2] build(deps): bump ioredis from 4.25.0 to 4.27.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "bucketclient": "scality/bucketclient#949f11a",
     "commander": "^2.11.0",
     "fcntl": "github:scality/node-fcntl",
-    "ioredis": "^4.9.5",
+    "ioredis": "^4.27.1",
     "minimatch": "^3.0.4",
     "mongodb": "^3.1.13",
     "node-forge": "^0.7.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2598,10 +2598,10 @@ ioredis@4.9.5:
     redis-parser "^3.0.0"
     standard-as-callback "^2.0.1"
 
-ioredis@^4.9.5:
-  version "4.25.0"
-  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.25.0.tgz#bc78d1fcda9d2b6f120f47c5764672734810b369"
-  integrity sha512-UoeqXpZB05aerGD3gB9NiigMsAyph+N+GWH8+3lX1+26caVV03GkL6JoLxS2HCxyvqCWbNsVSZTAp5W12qe23A==
+ioredis@^4.27.1, ioredis@^4.9.5:
+  version "4.27.1"
+  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.27.1.tgz#4ef947b455a1b995baa4b0d7e2c4e4f75f746421"
+  integrity sha512-PaFNFeBbOcEYHXAdrJuy7uesJcyvzStTM1aYMchTuky+VgKqDbXhnTJHaDsjAwcTwPx8Asatx+l2DW8zZ2xlsQ==
   dependencies:
     cluster-key-slot "^1.1.0"
     debug "^4.3.1"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1647.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/dependabot/npm_and_yarn/ioredis-4.27.1`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/dependabot/npm_and_yarn/ioredis-4.27.1
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/dependabot/npm_and_yarn/ioredis-4.27.1
```

Please always comment pull request #1647 instead of this one.