### PR TITLE
INTEGRATION [PR#1693 > development/7.10] bugfix: S3C-4447 Probe server off by default

### DIFF
--- a/bin/queuePopulator.js
+++ b/bin/queuePopulator.js
@@ -49,16 +49,24 @@ function queueBatch(queuePopulator, taskState) {
 const queuePopulator = new QueuePopulator(
     zkConfig, kafkaConfig, qpConfig, httpsConfig, mConfig, rConfig, extConfigs);
 
-const probeServer = new ProbeServer(qpConfig.probeServer);
+let probeServer;
+if (process.env.BACKBEAT_ENABLE_PROBE_SERVER === 'true' &&
+    qpConfig.probeServer !== undefined) {
+    probeServer = new ProbeServer(qpConfig.probeServer);
+}
 
 async.waterfall([
     done => {
+        if (probeServer === undefined) {
+            return done();
+        }
         probeServer.addHandler(
             DEFAULT_LIVE_ROUTE,
             (res, log) => queuePopulator.handleLiveness(res, log)
         );
         probeServer._cbOnListening = done;
         probeServer.start();
+        return undefined;
     },
     done => queuePopulator.open(done),
     done => {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1693.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/bugfix/S3C-4447_OptionalProbeServer`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/bugfix/S3C-4447_OptionalProbeServer
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/bugfix/S3C-4447_OptionalProbeServer
```

Please always comment pull request #1693 instead of this one.