### PR TITLE
INTEGRATION [PR#1710 > development/8.1] bugfix: S3C-4425 dont wait for failed queue delivery report

### DIFF
--- a/extensions/replication/failedCRR/FailedCRRConsumer.js
+++ b/extensions/replication/failedCRR/FailedCRRConsumer.js
@@ -104,7 +104,8 @@ class FailedCRRConsumer {
             if (err && err.retryable === true) {
                 log.info('publishing entry back into the kafka queue');
                 const entry = Buffer.from(kafkaEntry.value).toString();
-                return this._failedCRRProducer.publishFailedCRREntry(entry, cb);
+                this._failedCRRProducer.publishFailedCRREntry(entry);
+                return cb();
             }
             if (err) {
                 log.error('could not add redis sorted set member', {

--- a/extensions/replication/failedCRR/FailedCRRConsumer.js
+++ b/extensions/replication/failedCRR/FailedCRRConsumer.js
@@ -22,7 +22,7 @@ class FailedCRRConsumer {
         this._kafkaConfig = config.kafka;
         this._topic = config.extensions.replication.replicationFailedTopic;
         this.logger = new Logger('Backbeat:FailedCRRConsumer');
-        this._failedCRRProducer = new FailedCRRProducer(this.kafkaConfig);
+        this._failedCRRProducer = new FailedCRRProducer(this._kafkaConfig);
         this._backbeatTask = new BackbeatTask();
         this._statsClient = new StatsModel(redisClient);
     }

--- a/extensions/replication/failedCRR/FailedCRRProducer.js
+++ b/extensions/replication/failedCRR/FailedCRRProducer.js
@@ -8,9 +8,11 @@ const config = require('../../../conf/Config');
 class FailedCRRProducer {
     /**
      * Create the retry producer.
+     *
+     * @param {object} kafkaConfig - kafka config param
      */
-    constructor() {
-        this._kafkaConfig = config.kafka;
+    constructor(kafkaConfig) {
+        this._kafkaConfig = kafkaConfig;
         this._topic = config.extensions.replication.replicationFailedTopic;
         this._producer = null;
         this._log = new Logger('Backbeat:FailedCRRProducer');

--- a/extensions/replication/failedCRR/FailedCRRProducer.js
+++ b/extensions/replication/failedCRR/FailedCRRProducer.js
@@ -45,15 +45,18 @@ class FailedCRRProducer {
     /**
      * Publish the given message to the retry Kafka topic.
      * @param {String} message - The message to publish
-     * @param {Function} cb - The callback function
+     * @param {Function} [deliveryReportCb] - called when Kafka
+     * returns a delivery report
      * @return {undefined}
      */
-    publishFailedCRREntry(message, cb) {
+    publishFailedCRREntry(message, deliveryReportCb) {
         this._producer.send([{ message }], err => {
             if (err) {
                 this._log.trace('error publishing retry entry');
             }
-            return cb();
+            if (deliveryReportCb) {
+                deliveryReportCb();
+            }
         });
     }
 }

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -138,10 +138,14 @@ class BackbeatProducer extends EventEmitter {
     * sends entries/messages to the given topic
     * @param {Object[]} entries - array of entries objects with properties
     * key and message ([{ key: 'foo', message: 'hello world'}, ...])
-    * @param {callback} cb - cb(err)
+    * @param {callback} deliveryReportCb - callback called when Kafka
+    * returns a delivery report for this message: deliveryReportCb(err).
+    * NOTE: it can take a couple seconds for a delivery report to be
+    * received, hence it may not be a good idea to actively wait for
+    * this callback in the critical path.
     * @return {this} current instance
     */
-    send(entries, cb) {
+    send(entries, deliveryReportCb) {
         this._log.debug('publishing entries',
             { method: 'BackbeatProducer.send' });
         if (!this._ready) {
@@ -150,13 +154,13 @@ class BackbeatProducer extends EventEmitter {
                     method: 'BackbeatProducer.send',
                     ready: this._ready,
                 });
-                cb(errors.InternalError);
+                deliveryReportCb(errors.InternalError);
             });
         }
         if (entries.length === 0) {
-            return process.nextTick(cb);
+            return process.nextTick(deliveryReportCb);
         }
-        const sendCtx = { cbOnce: jsutil.once(cb),
+        const sendCtx = { cbOnce: jsutil.once(deliveryReportCb),
                           pendingReportsCount: entries.length };
         try {
             entries.forEach(item => this._producer.produce(

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -12,6 +12,7 @@ const errors = require('arsenal').errors;
 const werelogs = require('werelogs');
 const Logger = werelogs.Logger;
 
+const replicationConstants = require('../../../extensions/replication/constants');
 const QueueProcessor = require('../../../extensions/replication' +
                                '/queueProcessor/QueueProcessor');
 const ReplicationStatusProcessor =
@@ -722,6 +723,7 @@ describe('queue processor functional tests with mocking', () => {
                       retryTimeoutS: 5,
                       groupId: 'backbeat-func-test-group-id',
                   },
+                  monitorReplicationFailures: true,
                 }, {
                 });
             replicationStatusProcessor.start({ bootstrap: true }, done);
@@ -1094,15 +1096,28 @@ describe('queue processor functional tests with mocking', () => {
         });
 
         describe('retry behavior', () => {
-            it('should give up retries after configured timeout (5s)',
-            done => {
+            it('should give up retries after configured timeout (5s)', done => {
                 s3mock.installS3ErrorResponder('source.s3.getObject',
                                                errors.InternalError);
                 s3mock.setExpectedReplicationStatus('FAILED');
-
                 async.parallel([
                     done => {
                         s3mock.onPutSourceMd = done;
+                    },
+                    done => {
+                        const failedCRRProducer = replicationStatusProcessor._FailedCRRProducer;
+                        const origPublishFailedMethod = failedCRRProducer.publishFailedCRREntry;
+                        failedCRRProducer.publishFailedCRREntry = message => {
+                            const parsedFailedQueueMessage = JSON.parse(message);
+                            assert(parsedFailedQueueMessage.key.startsWith(
+                                `${replicationConstants.redisKeys.failedCRR}:${queueProcessor.site}:`));
+                            assert.strictEqual(
+                                parsedFailedQueueMessage.member,
+                                `${s3mock.getParam('source.bucket')}:${s3mock.getParam('key')}`
+                              + `:${s3mock.getParam('versionIdEncoded')}`);
+                            failedCRRProducer.publishFailedCRREntry = origPublishFailedMethod;
+                            done();
+                        };
                     },
                     done => queueProcessor.processKafkaEntry(
                         s3mock.getParam('kafkaEntry'), err => {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1710.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.1/bugfix/S3C-4425-dontWaitForFailedQueueDeliveryReport`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.1/bugfix/S3C-4425-dontWaitForFailedQueueDeliveryReport
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.1/bugfix/S3C-4425-dontWaitForFailedQueueDeliveryReport
```

Please always comment pull request #1710 instead of this one.