### PR TITLE
bugfix: INTGR-22 Undefined metric value for log size

### DIFF
--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -474,9 +474,11 @@ class LogReader {
     _processSaveLogOffset(batchState, done) {
         if (batchState.nextLogOffset !== undefined &&
             batchState.nextLogOffset !== this.logOffset) {
+            // different logs use different fields for tracking the size
+            const logSize = batchState.logRes.info.cseq || batchState.logRes.info.end;
             this.logOffset = batchState.nextLogOffset;
             this._metricsHandler.logReadOffset(this.getMetricLabels(), this.logOffset);
-            this._metricsHandler.logSize(this.getMetricLabels(), batchState.logRes.info.end);
+            this._metricsHandler.logSize(this.getMetricLabels(), logSize);
             return this._writeLogOffset(err => {
                 batchState.debugStep = `save log offset [${err ? 'ERROR' : 'END'}]`;
                 done(err);


### PR DESCRIPTION
* Bucket file log used info.end but raft log uses info.cseq
* The actual Jira ticket is INTGR-22...