### PR TITLE
INTEGRATION [PR#1721 > development/8.2] feature: S3C-4500 Add probe server for queue processor

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -63,7 +63,11 @@
                 "groupId": "backbeat-replication-group",
                 "retryTimeoutS": 300,
                 "concurrency": 10,
-                "mpuPartsConcurrency": 10
+                "mpuPartsConcurrency": 10,
+                "probeServer": {
+                    "bindAddress": "localhost",
+                    "port": 4043
+                }
             },
             "replicationStatusProcessor": {
                 "groupId": "backbeat-replication-group",

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -52,6 +52,10 @@ const joiSchema = {
         concurrency: joi.number().greater(0).default(10),
         mpuPartsConcurrency: joi.number().greater(0).default(10),
         logConsumerMetricsIntervalS: joi.number().greater(0).default(60),
+        probeServer: joi.object({
+            bindAddress: joi.string().default('localhost'),
+            port: joi.number().required(),
+        }),
     }).required(),
     replicationStatusProcessor: {
         groupId: joi.string().required(),

--- a/extensions/replication/queueProcessor/Probe.js
+++ b/extensions/replication/queueProcessor/Probe.js
@@ -28,7 +28,8 @@ function startProbeServer(queueProcessors, config, callback) {
     }
     const probeServer = new ProbeServer(config);
     probeServer.addHandler(
-        DEFAULT_LIVE_ROUTE,
+        // for backwards compatibility we also include readiness
+        [DEFAULT_LIVE_ROUTE, '/_/health/readiness'],
         (res, log) => {
             // take all our processors and create one liveness response
             let responses = [];

--- a/extensions/replication/queueProcessor/Probe.js
+++ b/extensions/replication/queueProcessor/Probe.js
@@ -1,0 +1,38 @@
+const { ProbeServer, DEFAULT_LIVE_ROUTE } =
+    require('arsenal').network.probe.ProbeServer;
+
+/**
+ * Configure probe servers
+ * @typedef {Object} ProbeServerConfig
+ * @property {string} bindAddress - Address to bind probe server to
+ * @property {number} port - Port to bind probe server to
+ */
+
+/**
+ * Callback when Queue Processor Probe server is listening
+ * @callback DoneCallback
+ * @param {ProbeServer} [probeServer] - Probe server or undefined if disabled
+ */
+
+/**
+ * Start probe server for Queue Processor
+ * @param {QueueProcessor} queueProcessor - Queue processor
+ * @param {ProbeServerConfig} config - Configuration for probe server
+ * @param {DoneCallback} callback - Callback when probe server is up
+ */
+function startProbeServer(queueProcessor, config, callback) {
+    if (process.env.CRR_METRICS_PROBE !== 'true' || config === undefined) {
+        callback();
+        return;
+    }
+    const probeServer = new ProbeServer(config);
+    probeServer.addHandler(
+        DEFAULT_LIVE_ROUTE,
+        (res, log) => queueProcessor.handleLiveness(res, log)
+    );
+    probeServer._cbOnListening = () => callback(probeServer);
+    probeServer.start();
+    return undefined;
+}
+
+module.exports = { startProbeServer };

--- a/extensions/replication/queueProcessor/Probe.js
+++ b/extensions/replication/queueProcessor/Probe.js
@@ -16,7 +16,7 @@ const { ProbeServer, DEFAULT_LIVE_ROUTE } =
 
 /**
  * Start probe server for Queue Processor
- * @param {Map<string, QueueProcessor>} queueProcessor - Queue processor
+ * @param {Map<string, QueueProcessor>} queueProcessors - Queue processor
  * @param {ProbeServerConfig} config - Configuration for probe server
  * @param {DoneCallback} [callback] - Callback when probe server is up
  * @returns {undefined}

--- a/extensions/replication/queueProcessor/Probe.js
+++ b/extensions/replication/queueProcessor/Probe.js
@@ -21,7 +21,7 @@ const { ProbeServer, DEFAULT_LIVE_ROUTE } =
  * @param {DoneCallback} callback - Callback when probe server is up
  */
 function startProbeServer(queueProcessor, config, callback) {
-    if (process.env.CRR_METRICS_PROBE !== 'true' || config === undefined) {
+    if (process.env.CRR_METRICS_PROBE === 'false' || config === undefined) {
         callback();
         return;
     }

--- a/extensions/replication/queueProcessor/Probe.js
+++ b/extensions/replication/queueProcessor/Probe.js
@@ -19,6 +19,7 @@ const { ProbeServer, DEFAULT_LIVE_ROUTE } =
  * @param {QueueProcessor} queueProcessor - Queue processor
  * @param {ProbeServerConfig} config - Configuration for probe server
  * @param {DoneCallback} callback - Callback when probe server is up
+ * @returns {undefined}
  */
 function startProbeServer(queueProcessor, config, callback) {
     if (process.env.CRR_METRICS_PROBE !== 'true' || config === undefined) {
@@ -32,7 +33,6 @@ function startProbeServer(queueProcessor, config, callback) {
     );
     probeServer._cbOnListening = () => callback(probeServer);
     probeServer.start();
-    return undefined;
 }
 
 module.exports = { startProbeServer };

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -385,6 +385,65 @@ class QueueProcessor extends EventEmitter {
                           { entry: sourceEntry.getLogInfo() });
         return process.nextTick(done);
     }
+
+    /**
+     * Handle ProbeServer liveness check
+     *
+     * @param {http.HTTPServerResponse} res - HTTP Response to respond with
+     * @param {Logger} log - Logger
+     * @returns {string} Error response string or undefined
+     */
+    handleLiveness(res, log) {
+        const verboseLiveness = {};
+        // track and return all errors in one response
+        const responses = [];
+        if (this.replicationStatusProducer === undefined ||
+            this.replicationStatusProducer === null) {
+            verboseLiveness.replicationStatusProducer = 'undefined';
+            responses.push({
+                component: 'Replication Status Producer',
+                status: 'undefined',
+                site: this.site,
+            });
+        } else if (!this.replicationStatusProducer.isReady()) {
+            verboseLiveness.replicationStatusProducer = 'not ready';
+            responses.push({
+                component: 'Replication Status Producer',
+                status: 'not ready',
+                site: this.site,
+            });
+        } else {
+            verboseLiveness.replicationStatusProducer = 'ready';
+        }
+
+        if (this._consumer === undefined || this._consumer === null) {
+            verboseLiveness.consumer = 'undefined';
+            responses.push({
+                component: 'Consumer',
+                status: 'undefined',
+                site: this.site,
+            });
+        } else if (!this._consumer.isReady()) {
+            verboseLiveness.consumer = 'not ready';
+            responses.push({
+                component: 'Consumer',
+                status: 'not ready',
+                site: this.site,
+            });
+        } else {
+            verboseLiveness.consumer = 'ready';
+        }
+
+        log.debug('verbose liveness', verboseLiveness);
+
+        if (responses.length > 0) {
+            return JSON.stringify(responses);
+        }
+
+        res.writeHead(200);
+        res.end();
+        return undefined;
+    }
 }
 
 module.exports = QueueProcessor;

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -20,7 +20,7 @@ const EchoBucket = require('../tasks/EchoBucket');
 
 const ObjectQueueEntry = require('../utils/ObjectQueueEntry');
 const BucketQueueEntry = require('../utils/BucketQueueEntry');
-const probeUtils = require('../../../lib/util/probeUtils');
+const constants = require('../../../lib/constants');
 
 const {
     proxyVaultPath,
@@ -400,39 +400,39 @@ class QueueProcessor extends EventEmitter {
         const responses = [];
         if (this.replicationStatusProducer === undefined ||
             this.replicationStatusProducer === null) {
-            verboseLiveness.replicationStatusProducer = probeUtils.statusUndefined;
+            verboseLiveness.replicationStatusProducer = constants.statusUndefined;
             responses.push({
                 component: 'Replication Status Producer',
-                status: probeUtils.statusUndefined,
+                status: constants.statusUndefined,
                 site: this.site,
             });
         } else if (!this.replicationStatusProducer.isReady()) {
-            verboseLiveness.replicationStatusProducer = probeUtils.statusNotReady;
+            verboseLiveness.replicationStatusProducer = constants.statusNotReady;
             responses.push({
                 component: 'Replication Status Producer',
-                status: probeUtils.statusNotReady,
+                status: constants.statusNotReady,
                 site: this.site,
             });
         } else {
-            verboseLiveness.replicationStatusProducer = probeUtils.statusReady;
+            verboseLiveness.replicationStatusProducer = constants.statusReady;
         }
 
         if (this._consumer === undefined || this._consumer === null) {
-            verboseLiveness.consumer = probeUtils.statusUndefined;
+            verboseLiveness.consumer = constants.statusUndefined;
             responses.push({
                 component: 'Consumer',
-                status: probeUtils.statusUndefined,
+                status: constants.statusUndefined,
                 site: this.site,
             });
         } else if (!this._consumer.isReady()) {
-            verboseLiveness.consumer = probeUtils.statusNotReady;
+            verboseLiveness.consumer = constants.statusNotReady;
             responses.push({
                 component: 'Consumer',
-                status: probeUtils.statusNotReady,
+                status: constants.statusNotReady,
                 site: this.site,
             });
         } else {
-            verboseLiveness.consumer = probeUtils.statusReady;
+            verboseLiveness.consumer = constants.statusReady;
         }
 
         log.debug('verbose liveness', verboseLiveness);

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -20,6 +20,7 @@ const EchoBucket = require('../tasks/EchoBucket');
 
 const ObjectQueueEntry = require('../utils/ObjectQueueEntry');
 const BucketQueueEntry = require('../utils/BucketQueueEntry');
+const probeUtils = require('../../../lib/util/probeUtils');
 
 const {
     proxyVaultPath,
@@ -399,39 +400,39 @@ class QueueProcessor extends EventEmitter {
         const responses = [];
         if (this.replicationStatusProducer === undefined ||
             this.replicationStatusProducer === null) {
-            verboseLiveness.replicationStatusProducer = 'undefined';
+            verboseLiveness.replicationStatusProducer = probeUtils.statusUndefined;
             responses.push({
                 component: 'Replication Status Producer',
-                status: 'undefined',
+                status: probeUtils.statusUndefined,
                 site: this.site,
             });
         } else if (!this.replicationStatusProducer.isReady()) {
-            verboseLiveness.replicationStatusProducer = 'not ready';
+            verboseLiveness.replicationStatusProducer = probeUtils.statusNotReady;
             responses.push({
                 component: 'Replication Status Producer',
-                status: 'not ready',
+                status: probeUtils.statusNotReady,
                 site: this.site,
             });
         } else {
-            verboseLiveness.replicationStatusProducer = 'ready';
+            verboseLiveness.replicationStatusProducer = probeUtils.statusReady;
         }
 
         if (this._consumer === undefined || this._consumer === null) {
-            verboseLiveness.consumer = 'undefined';
+            verboseLiveness.consumer = probeUtils.statusUndefined;
             responses.push({
                 component: 'Consumer',
-                status: 'undefined',
+                status: probeUtils.statusUndefined,
                 site: this.site,
             });
         } else if (!this._consumer.isReady()) {
-            verboseLiveness.consumer = 'not ready';
+            verboseLiveness.consumer = probeUtils.statusNotReady;
             responses.push({
                 component: 'Consumer',
-                status: 'not ready',
+                status: probeUtils.statusNotReady,
                 site: this.site,
             });
         } else {
-            verboseLiveness.consumer = 'ready';
+            verboseLiveness.consumer = probeUtils.statusReady;
         }
 
         log.debug('verbose liveness', verboseLiveness);

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -1,4 +1,5 @@
 'use strict'; // eslint-disable-line
+const async = require('async');
 const assert = require('assert');
 const werelogs = require('werelogs');
 
@@ -12,6 +13,8 @@ const sourceConfig = repConfig.source;
 const httpsConfig = config.https;
 const internalHttpsConfig = config.internalHttps;
 const mConfig = config.metrics;
+const { ProbeServer, DEFAULT_LIVE_ROUTE } =
+    require('arsenal').network.probe.ProbeServer;
 
 const site = process.argv[2];
 assert(site, 'QueueProcessor task must be started with a site as argument');
@@ -29,16 +32,58 @@ werelogs.configure({ level: config.log.logLevel,
     dump: config.log.dumpLevel });
 
 const metricsProducer = new MetricsProducer(kafkaConfig, mConfig);
-metricsProducer.setupProducer(err => {
-    if (err) {
-        log.error('error starting metrics producer for queue processor', {
-            error: err,
-            method: 'MetricsProducer::setupProducer',
-        });
+const queueProcessor = new QueueProcessor(
+    kafkaConfig, sourceConfig, destConfig, repConfig,
+    httpsConfig, internalHttpsConfig, site, metricsProducer
+);
+
+let probeServer;
+if (process.env.CRR_METRICS_PROBE === 'true' &&
+    repConfig.queueProcessor.probeServer !== undefined) {
+    probeServer = new ProbeServer(repConfig.queueProcessor.probeServer);
+}
+
+async.waterfall([
+    done => {
+        if (probeServer === undefined) {
+            return done();
+        }
+        probeServer.addHandler(
+            DEFAULT_LIVE_ROUTE,
+            (res, log) => queueProcessor.handleLiveness(res, log)
+        );
+        probeServer._cbOnListening = done;
+        probeServer.start();
         return undefined;
+    },
+    done => {
+        metricsProducer.setupProducer(err => {
+            if (err) {
+                log.error('error starting metrics producer for queue processor', {
+                    error: err,
+                    method: 'MetricsProducer::setupProducer',
+                });
+            }
+            done(err);
+        });
+    },
+    done => {
+        queueProcessor.on('ready', done);
+        queueProcessor.start();
+    },
+], err => {
+    if (err) {
+        log.error('error during queue processor initialization', {
+            method: 'QueueProcessor::task',
+            error: err,
+        });
+        process.exit(1);
     }
-    const queueProcessor = new QueueProcessor(
-        kafkaConfig, sourceConfig, destConfig, repConfig,
-        httpsConfig, internalHttpsConfig, site, metricsProducer);
-    return queueProcessor.start();
+});
+
+process.on('SIGTERM', () => {
+    log.info('received SIGTERM, exiting');
+    queueProcessor.stop(() => {
+        process.exit(0);
+    });
 });

--- a/lib/MetricsProducer.js
+++ b/lib/MetricsProducer.js
@@ -9,7 +9,7 @@ const MetricsModel = require('./models/MetricsModel');
 class MetricsProducer {
     /**
     * @constructor
-     * @param {Object} kafkaConfig - kafka connection config
+    * @param {Object} kafkaConfig - kafka connection config
     * @param {Object} mConfig - metrics configurations
     */
     constructor(kafkaConfig, mConfig) {

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,6 +1,8 @@
-module.exports = {
+const constants = {
     statusReady: 'READY',
     statusUndefined: 'UNDEFINED',
     statusNotReady: 'NOT_READY',
     statusNotConnected: 'NOT_CONNECTED',
 };
+
+module.exports = constants;

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -10,6 +10,8 @@ const MetricsConsumer = require('../MetricsConsumer');
 const FailedCRRConsumer =
     require('../../extensions/replication/failedCRR/FailedCRRConsumer');
 const promClient = require('prom-client');
+const probeUtils = require('../util/probeUtils');
+
 const metricLabels = ['origin', 'logName', 'logId', 'containerName'];
 promClient.register.setDefaultLabels({
     origin: 'replication',
@@ -395,7 +397,7 @@ class QueuePopulator {
         if (zkState.code !== ZKState.SYNC_CONNECTED.code) {
             responses.push({
                 component: 'Zookeeper',
-                status: 'not connected',
+                status: probeUtils.statusNotConnected,
                 code: zkState.code,
             });
         }
@@ -407,7 +409,7 @@ class QueuePopulator {
                 if (!status) {
                     responses.push({
                         component: 'log reader',
-                        status: 'not ready',
+                        status: probeUtils.statusNotReady,
                         topic,
                     });
                 }

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -10,7 +10,7 @@ const MetricsConsumer = require('../MetricsConsumer');
 const FailedCRRConsumer =
     require('../../extensions/replication/failedCRR/FailedCRRConsumer');
 const promClient = require('prom-client');
-const probeUtils = require('../util/probeUtils');
+const constants = require('../constants');
 
 const metricLabels = ['origin', 'logName', 'logId', 'containerName'];
 promClient.register.setDefaultLabels({
@@ -397,7 +397,7 @@ class QueuePopulator {
         if (zkState.code !== ZKState.SYNC_CONNECTED.code) {
             responses.push({
                 component: 'Zookeeper',
-                status: probeUtils.statusNotConnected,
+                status: constants.statusNotConnected,
                 code: zkState.code,
             });
         }
@@ -409,7 +409,7 @@ class QueuePopulator {
                 if (!status) {
                     responses.push({
                         component: 'log reader',
-                        status: probeUtils.statusNotReady,
+                        status: constants.statusNotReady,
                         topic,
                     });
                 }

--- a/lib/util/probeUtils.js
+++ b/lib/util/probeUtils.js
@@ -1,0 +1,6 @@
+module.exports = {
+    statusReady: 'READY',
+    statusUndefined: 'UNDEFINED',
+    statusNotReady: 'NOT_READY',
+    statusNotConnected: 'NOT_CONNECTED',
+};

--- a/tests/functional/replication/probe.spec.js
+++ b/tests/functional/replication/probe.spec.js
@@ -55,7 +55,7 @@ describe('Probe server', () => {
         startProbeServer(mockQp, config, probeServer => {
             probeServer.onStop(done);
             http.get(`http://localhost:52555${DEFAULT_LIVE_ROUTE}`, res => {
-                assert.strictEqual(500, res.statusCode);
+                assert.strictEqual(res.statusCode, 500);
 
                 const rawData = [];
                 res.on('data', chunk => {

--- a/tests/functional/replication/probe.spec.js
+++ b/tests/functional/replication/probe.spec.js
@@ -13,7 +13,7 @@ function mockQueueProcessor() {
         site: {
             handleLiveness: sinon.stub(),
         }
-    }
+    };
 }
 
 describe('Probe server', () => {

--- a/tests/functional/replication/probe.spec.js
+++ b/tests/functional/replication/probe.spec.js
@@ -1,0 +1,71 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const { startProbeServer } =
+    require('../../../extensions/replication/queueProcessor/Probe');
+const { DEFAULT_LIVE_ROUTE } = require('arsenal').network.probe.ProbeServer;
+const http = require('http');
+
+/** Return a mock queue processor for testing
+*/
+function mockQueueProcessor() {
+    return {
+        handleLiveness: sinon.stub(),
+    }
+}
+
+describe('Probe server', () => {
+    afterEach(() => {
+        // reset any possible env var set
+        delete process.env.CRR_METRICS_PROBE;
+    });
+
+    it('is not created when disabled', done => {
+        process.env.CRR_METRICS_PROBE = 'false';
+        const mockQp = mockQueueProcessor();
+        const config = {
+            bindAddress: 'localhost',
+            port: 52555,
+        };
+        startProbeServer(mockQp, config, probeServer => {
+            assert.strictEqual(probeServer, undefined);
+            done();
+        });
+    });
+
+    it('is not created with no config', done => {
+        process.env.CRR_METRICS_PROBE = 'true';
+        const mockQp = mockQueueProcessor();
+        const config = undefined;
+        startProbeServer(mockQp, config, probeServer => {
+            assert.strictEqual(probeServer, undefined);
+            done();
+        });
+    });
+
+    it('creates probe server for liveness', done => {
+        process.env.CRR_METRICS_PROBE = 'true';
+        const mockQp = mockQueueProcessor();
+        // return sample error for liveness
+        mockQp.handleLiveness.returns('error msg');
+        const config = {
+            bindAddress: 'localhost',
+            port: 52555,
+        };
+        startProbeServer(mockQp, config, probeServer => {
+            probeServer.onStop(done);
+            http.get('http://localhost:52555' + DEFAULT_LIVE_ROUTE, res => {
+                assert.strictEqual(500, res.statusCode);
+
+                let rawData = [];
+                res.on('data', chunk => {
+                    rawData.push(chunk);
+                });
+                res.on('end', () => {
+                    data = JSON.parse(rawData.join(''));
+                    assert.strictEqual(data.errorMessage, 'error msg');
+                    probeServer.stop();
+                });
+            });
+        });
+    })
+});

--- a/tests/functional/replication/probe.spec.js
+++ b/tests/functional/replication/probe.spec.js
@@ -5,12 +5,13 @@ const { startProbeServer } =
 const { DEFAULT_LIVE_ROUTE } = require('arsenal').network.probe.ProbeServer;
 const http = require('http');
 
-/** Return a mock queue processor for testing
+/**
+ * @returns {Object} Mock queue processor
 */
 function mockQueueProcessor() {
     return {
         handleLiveness: sinon.stub(),
-    }
+    };
 }
 
 describe('Probe server', () => {
@@ -53,19 +54,19 @@ describe('Probe server', () => {
         };
         startProbeServer(mockQp, config, probeServer => {
             probeServer.onStop(done);
-            http.get('http://localhost:52555' + DEFAULT_LIVE_ROUTE, res => {
+            http.get(`http://localhost:52555${DEFAULT_LIVE_ROUTE}`, res => {
                 assert.strictEqual(500, res.statusCode);
 
-                let rawData = [];
+                const rawData = [];
                 res.on('data', chunk => {
                     rawData.push(chunk);
                 });
                 res.on('end', () => {
-                    data = JSON.parse(rawData.join(''));
+                    const data = JSON.parse(rawData.join(''));
                     assert.strictEqual(data.errorMessage, 'error msg');
                     probeServer.stop();
                 });
             });
         });
-    })
+    });
 });

--- a/tests/unit/QueuePopulator.spec.js
+++ b/tests/unit/QueuePopulator.spec.js
@@ -1,43 +1,9 @@
 const assert = require('assert');
-
-const { Logger } = require('werelogs');
 const sinon = require('sinon');
 
 const zookeeper = require('node-zookeeper-client');
 const QueuePopulator = require('../../lib/queuePopulator/QueuePopulator');
-const LogReader = require('../../lib/queuePopulator/LogReader');
 const probeUtils = require('../../lib/util/probeUtils');
-
-class MockLogReader extends LogReader {
-    constructor(queuePopulator, id) {
-        super({
-            logger: new Logger('MockLogReader'),
-        });
-        this.queuePopulator = queuePopulator;
-        this.id = id;
-        this.processLogEntriesCallCount = 0;
-    }
-
-    setup(cb) {
-        process.nextTick(cb);
-    }
-
-    processLogEntries(params, done) {
-        this.log.info('processLogEntries', { id: this.id });
-        this.processLogEntriesCallCount += 1;
-        // check that the provisioning update triggered below stopped
-        // the original provisioned raft session from being processed
-        assert(this.processLogEntriesCallCount <= 2);
-        if (this.processLogEntriesCallCount === 2) {
-            // at the 2nd invocation, trigger a provisioning update
-            this.queuePopulator.logReadersUpdate = [
-                new MockLogReader(this.queuePopulator, 'raft_2'),
-            ];
-        }
-        const processedAll = (this.id === 'raft_2');
-        process.nextTick(() => done(null, processedAll));
-    }
-}
 
 describe('QueuePopulator', () => {
     let qp;
@@ -45,16 +11,6 @@ describe('QueuePopulator', () => {
         qp = new QueuePopulator({}, {}, {
             logSource: 'bucketd',
         }, null, null, null, {});
-    });
-
-    it('should stop processing old raft sessions after provisioning update', done => {
-        const logReader1 = new MockLogReader(qp, 'raft_1');
-        qp.logReadersUpdate = [logReader1];
-        qp.processAllLogEntries({}, err => {
-            assert.ifError(err);
-            assert.strictEqual(logReader1.processLogEntriesCallCount, 2);
-            done();
-        });
     });
 
     describe('handle liveness', () => {

--- a/tests/unit/QueuePopulator.spec.js
+++ b/tests/unit/QueuePopulator.spec.js
@@ -6,7 +6,7 @@ const sinon = require('sinon');
 const zookeeper = require('node-zookeeper-client');
 const QueuePopulator = require('../../lib/queuePopulator/QueuePopulator');
 const LogReader = require('../../lib/queuePopulator/LogReader');
-const probeUtils = require('../../lib/util/probeUtils');
+const constants = require('../../lib/constants');
 
 class MockLogReader extends LogReader {
     constructor(queuePopulator, id) {
@@ -142,7 +142,7 @@ describe('QueuePopulator', () => {
                 [
                     {
                         component: 'log reader',
-                        status: probeUtils.statusNotReady,
+                        status: constants.statusNotReady,
                         topic: 'topicB',
                     },
                 ]

--- a/tests/unit/QueuePopulator.spec.js
+++ b/tests/unit/QueuePopulator.spec.js
@@ -6,6 +6,7 @@ const sinon = require('sinon');
 const zookeeper = require('node-zookeeper-client');
 const QueuePopulator = require('../../lib/queuePopulator/QueuePopulator');
 const LogReader = require('../../lib/queuePopulator/LogReader');
+const probeUtils = require('../../lib/util/probeUtils');
 
 class MockLogReader extends LogReader {
     constructor(queuePopulator, id) {
@@ -141,7 +142,7 @@ describe('QueuePopulator', () => {
                 [
                     {
                         component: 'log reader',
-                        status: 'not ready',
+                        status: probeUtils.statusNotReady,
                         topic: 'topicB',
                     },
                 ]

--- a/tests/unit/replication/QueueProcessor.spec.js
+++ b/tests/unit/replication/QueueProcessor.spec.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const sinon = require('sinon');
-const probeUtils = require('../../../lib/util/probeUtils');
+const constants = require('../../../lib/constants');
 
 const QueueProcessor =
     require('../../../extensions/replication/queueProcessor/QueueProcessor');
@@ -84,11 +84,11 @@ describe('Queue Processor', () => {
                 [
                     {
                         component: 'Replication Status Producer',
-                        status: probeUtils.statusUndefined,
+                        status: constants.statusUndefined,
                         site: 'site',
                     }, {
                         component: 'Consumer',
-                        status: probeUtils.statusUndefined,
+                        status: constants.statusUndefined,
                         site: 'site',
                     },
                 ]
@@ -98,8 +98,8 @@ describe('Queue Processor', () => {
                 mockLog.debug,
                 sinon.match.any, // we don't care about the debug label
                 {
-                    replicationStatusProducer: probeUtils.statusUndefined,
-                    consumer: probeUtils.statusUndefined,
+                    replicationStatusProducer: constants.statusUndefined,
+                    consumer: constants.statusUndefined,
                 }
             );
         });
@@ -120,11 +120,11 @@ describe('Queue Processor', () => {
                 [
                     {
                         component: 'Replication Status Producer',
-                        status: probeUtils.statusNotReady,
+                        status: constants.statusNotReady,
                         site: 'site',
                     }, {
                         component: 'Consumer',
-                        status: probeUtils.statusNotReady,
+                        status: constants.statusNotReady,
                         site: 'site',
                     },
                 ]

--- a/tests/unit/replication/QueueProcessor.spec.js
+++ b/tests/unit/replication/QueueProcessor.spec.js
@@ -9,52 +9,49 @@ describe('Queue Processor', () => {
     let qp;
     beforeEach(() => {
         qp = new QueueProcessor(
+            { connectionString: '127.0.0.1:2181/backbeat',
+              autoCreateNamespace: false },
+            null,
             { hosts: 'localhost:9092' },
-            {
-                auth: {
-                    type: 'role',
-                    vault: {
-                        host: 'localhost:9093',
-                        port: 7777,
-                    },
-                },
-                s3: {
-                    host: 'localhost:9094',
-                    port: 7777,
-                },
+            { auth: { type: 'role',
+                vault: { host: 'localhost:9093',
+                    port: 7777 } },
+                s3: { host: 'localhost:9094',
+                    port: 7777 },
                 transport: 'http',
             },
-            {
-                auth: {
-                    type: 'role',
-                },
-                bootstrapList: [
-                    { site: 'sf', servers: ['localhost:9094'] },
-                ],
-                transport: 'http',
+            { auth: { type: 'role' },
+                bootstrapList: [{
+                    site: 'site', servers: ['localhost:9095'],
+                }, {
+                    site: 'toazure', type: 'azure',
+                }],
+                transport: 'http' },
+            { topic: 'backbeat-func-test-dummy-topic',
+              replicationStatusTopic: 'backbeat-func-test-repstatus',
+              queueProcessor: {
+                  retry: {
+                      scality: { timeoutS: 5 },
+                      azure: { timeoutS: 5 },
+                  },
+                  groupId: 'backbeat-func-test-group-id',
+                  mpuPartsConcurrency: 10,
+              },
             },
-            {
-                topic: 'backbeat-func-test-dummy-topic',
-                replicationStatusTopic: 'backbeat-func-test-repstatus',
-                queueProcessor: {
-                    retryTimeoutS: 5,
-                    groupId: 'backbeat-func-test-group-id',
-                    mpuPartsConcurrency: 10,
-                },
-            },
-            { }, { }, 'site', undefined
+            { host: '127.0.0.1',
+              port: 6379 },
+            { topic: 'metrics-test-topic' },
+            {},
+            {},
+            'site',
         );
     });
 
     describe('handle liveness', () => {
-        let mockRes;
         let mockLog;
         beforeEach(() => {
-            mockRes = sinon.spy();
             mockLog = sinon.spy();
             mockLog.debug = sinon.spy();
-            mockRes.writeHead = sinon.spy();
-            mockRes.end = sinon.spy();
         });
 
         afterEach(() => {
@@ -71,16 +68,14 @@ describe('Queue Processor', () => {
 
             qp.replicationStatusProducer = mockProducer;
             qp._consumer = mockConsumer;
-            const response = qp.handleLiveness(mockRes, mockLog);
-            assert.strictEqual(response, undefined);
-            sinon.assert.calledOnceWithExactly(mockRes.writeHead, 200);
-            sinon.assert.calledOnce(mockRes.end);
+            const response = qp.handleLiveness(mockLog);
+            assert.deepStrictEqual(response, []);
         });
 
         it('with undefined components', () => {
-            const response = qp.handleLiveness(mockRes, mockLog);
+            const response = qp.handleLiveness(mockLog);
             assert.deepStrictEqual(
-                JSON.parse(response),
+                response,
                 [
                     {
                         component: 'Replication Status Producer',
@@ -114,9 +109,9 @@ describe('Queue Processor', () => {
 
             qp.replicationStatusProducer = mockProducer;
             qp._consumer = mockConsumer;
-            const response = qp.handleLiveness(mockRes, mockLog);
+            const response = qp.handleLiveness(mockLog);
             assert.deepStrictEqual(
-                JSON.parse(response),
+                response,
                 [
                     {
                         component: 'Replication Status Producer',

--- a/tests/unit/replication/QueueProcessor.spec.js
+++ b/tests/unit/replication/QueueProcessor.spec.js
@@ -1,6 +1,4 @@
 const assert = require('assert');
-
-const { Logger } = require('werelogs');
 const sinon = require('sinon');
 const probeUtils = require('../../../lib/util/probeUtils');
 
@@ -17,31 +15,31 @@ describe('Queue Processor', () => {
                     type: 'role',
                     vault: {
                         host: 'localhost:9093',
-                        port: 7777
-                    }
+                        port: 7777,
+                    },
                 },
                 s3: {
                     host: 'localhost:9094',
-                    port: 7777
+                    port: 7777,
                 },
                 transport: 'http',
             },
             {
                 auth: {
-                    type: 'role'
+                    type: 'role',
                 },
                 bootstrapList: [
-                    { site: 'sf', servers: [ 'localhost:9094', ]}
+                    { site: 'sf', servers: ['localhost:9094'] },
                 ],
-                transport: 'http'
+                transport: 'http',
             },
             {
                 topic: 'backbeat-func-test-dummy-topic',
                 replicationStatusTopic: 'backbeat-func-test-repstatus',
-                    queueProcessor: {
-                      retryTimeoutS: 5,
-                      groupId: 'backbeat-func-test-group-id',
-                      mpuPartsConcurrency: 10,
+                queueProcessor: {
+                    retryTimeoutS: 5,
+                    groupId: 'backbeat-func-test-group-id',
+                    mpuPartsConcurrency: 10,
                 },
             },
             { }, { }, 'site', undefined
@@ -65,10 +63,10 @@ describe('Queue Processor', () => {
 
         it('with ready components', () => {
             const mockConsumer = {
-                isReady: sinon.stub().returns(true)
+                isReady: sinon.stub().returns(true),
             };
             const mockProducer = {
-                isReady: sinon.stub().returns(true)
+                isReady: sinon.stub().returns(true),
             };
 
             qp.replicationStatusProducer = mockProducer;
@@ -87,12 +85,12 @@ describe('Queue Processor', () => {
                     {
                         component: 'Replication Status Producer',
                         status: probeUtils.statusUndefined,
-                        site: 'site'
-                    },{
+                        site: 'site',
+                    }, {
                         component: 'Consumer',
                         status: probeUtils.statusUndefined,
-                        site: 'site'
-                    }
+                        site: 'site',
+                    },
                 ]
             );
             // only need to test this once as it matches the response anyway
@@ -108,10 +106,10 @@ describe('Queue Processor', () => {
 
         it('with not ready components', () => {
             const mockConsumer = {
-                isReady: sinon.stub().returns(false)
+                isReady: sinon.stub().returns(false),
             };
             const mockProducer = {
-                isReady: sinon.stub().returns(false)
+                isReady: sinon.stub().returns(false),
             };
 
             qp.replicationStatusProducer = mockProducer;
@@ -123,12 +121,12 @@ describe('Queue Processor', () => {
                     {
                         component: 'Replication Status Producer',
                         status: probeUtils.statusNotReady,
-                        site: 'site'
-                    },{
+                        site: 'site',
+                    }, {
                         component: 'Consumer',
                         status: probeUtils.statusNotReady,
-                        site: 'site'
-                    }
+                        site: 'site',
+                    },
                 ]
             );
         });

--- a/tests/unit/replication/QueueProcessor.spec.js
+++ b/tests/unit/replication/QueueProcessor.spec.js
@@ -1,0 +1,136 @@
+const assert = require('assert');
+
+const { Logger } = require('werelogs');
+const sinon = require('sinon');
+const probeUtils = require('../../../lib/util/probeUtils');
+
+const QueueProcessor =
+    require('../../../extensions/replication/queueProcessor/QueueProcessor');
+
+describe('Queue Processor', () => {
+    let qp;
+    beforeEach(() => {
+        qp = new QueueProcessor(
+            { hosts: 'localhost:9092' },
+            {
+                auth: {
+                    type: 'role',
+                    vault: {
+                        host: 'localhost:9093',
+                        port: 7777
+                    }
+                },
+                s3: {
+                    host: 'localhost:9094',
+                    port: 7777
+                },
+                transport: 'http',
+            },
+            {
+                auth: {
+                    type: 'role'
+                },
+                bootstrapList: [
+                    { site: 'sf', servers: [ 'localhost:9094', ]}
+                ],
+                transport: 'http'
+            },
+            {
+                topic: 'backbeat-func-test-dummy-topic',
+                replicationStatusTopic: 'backbeat-func-test-repstatus',
+                    queueProcessor: {
+                      retryTimeoutS: 5,
+                      groupId: 'backbeat-func-test-group-id',
+                      mpuPartsConcurrency: 10,
+                },
+            },
+            { }, { }, 'site', undefined
+        );
+    });
+
+    describe('handle liveness', () => {
+        let mockRes;
+        let mockLog;
+        beforeEach(() => {
+            mockRes = sinon.spy();
+            mockLog = sinon.spy();
+            mockLog.debug = sinon.spy();
+            mockRes.writeHead = sinon.spy();
+            mockRes.end = sinon.spy();
+        });
+
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        it('with ready components', () => {
+            const mockConsumer = {
+                isReady: sinon.stub().returns(true)
+            };
+            const mockProducer = {
+                isReady: sinon.stub().returns(true)
+            };
+
+            qp.replicationStatusProducer = mockProducer;
+            qp._consumer = mockConsumer;
+            const response = qp.handleLiveness(mockRes, mockLog);
+            assert.strictEqual(response, undefined);
+            sinon.assert.calledOnceWithExactly(mockRes.writeHead, 200);
+            sinon.assert.calledOnce(mockRes.end);
+        });
+
+        it('with undefined components', () => {
+            const response = qp.handleLiveness(mockRes, mockLog);
+            assert.deepStrictEqual(
+                JSON.parse(response),
+                [
+                    {
+                        component: 'Replication Status Producer',
+                        status: probeUtils.statusUndefined,
+                        site: 'site'
+                    },{
+                        component: 'Consumer',
+                        status: probeUtils.statusUndefined,
+                        site: 'site'
+                    }
+                ]
+            );
+            // only need to test this once as it matches the response anyway
+            sinon.assert.calledOnceWithExactly(
+                mockLog.debug,
+                sinon.match.any, // we don't care about the debug label
+                {
+                    replicationStatusProducer: probeUtils.statusUndefined,
+                    consumer: probeUtils.statusUndefined,
+                }
+            );
+        });
+
+        it('with not ready components', () => {
+            const mockConsumer = {
+                isReady: sinon.stub().returns(false)
+            };
+            const mockProducer = {
+                isReady: sinon.stub().returns(false)
+            };
+
+            qp.replicationStatusProducer = mockProducer;
+            qp._consumer = mockConsumer;
+            const response = qp.handleLiveness(mockRes, mockLog);
+            assert.deepStrictEqual(
+                JSON.parse(response),
+                [
+                    {
+                        component: 'Replication Status Producer',
+                        status: probeUtils.statusNotReady,
+                        site: 'site'
+                    },{
+                        component: 'Consumer',
+                        status: probeUtils.statusNotReady,
+                        site: 'site'
+                    }
+                ]
+            );
+        });
+    });
+});


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1721.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/feature/S3C-4500_AddProbeServerForQueueProcessor`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/feature/S3C-4500_AddProbeServerForQueueProcessor
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/feature/S3C-4500_AddProbeServerForQueueProcessor
```

Please always comment pull request #1721 instead of this one.