### PR TITLE
bugfix: S3C-4493 RoleCredentials: fix error handling

### DIFF
--- a/lib/credentials/RoleCredentials.js
+++ b/lib/credentials/RoleCredentials.js
@@ -90,15 +90,14 @@ class RoleCredentials extends AWS.Credentials {
                         error: err,
                         method: 'RoleCredentials.refresh',
                     });
-                    // We need to generate a new error instance
-                    // instead of passing a possibly global arsenal
-                    // error returned by vault client, because AWS
-                    // client is transforming it its own way.
+                    // We need to generate a new error instance using
+                    // customizeDescription() because AWS client is
+                    // transforming it its own way.
                     // Any uncaught error or non arsenal error is treated as
                     // internal error.
                     const newErr = err.customizeDescription ?
                         err.customizeDescription(err.description)
-                        : err.InternalError;
+                        : errors.InternalError.customizeDescription(err.message);
 
                     // Stick with the AWS SDK way of returning whether
                     // the error is retryable

--- a/tests/unit/RoleCredentials.js
+++ b/tests/unit/RoleCredentials.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const http = require('http');
 const { Client } = require('vaultclient');
 const { Logger } = require('werelogs');
+const { errors } = require('arsenal');
 const { proxyPath } = require('../../extensions/replication/constants');
 const RoleCredentials = require('../../lib/credentials/RoleCredentials');
 
@@ -17,16 +18,18 @@ let simulateServerError = false;
 const server = http.createServer();
 server.on('request', (req, res) => {
     const Expiration = Date.now() + 2000; // expire after 2 seconds
-    const payload = JSON.stringify({
-        Credentials: {
-            AccessKeyId,
-            SecretAccessKey,
-            SessionToken,
-            Expiration,
-        },
-    });
+    let payload;
     if (simulateServerError) {
-        req.socket.destroy();
+        payload = '{INVALIDJSON}';
+    } else {
+        payload = JSON.stringify({
+            Credentials: {
+                AccessKeyId,
+                SecretAccessKey,
+                SessionToken,
+                Expiration,
+            },
+        });
     }
     res.writeHead(200, {
         'content-type': 'application/json',
@@ -149,6 +152,9 @@ describe('Credentials Manager', () => {
             simulateServerError = true;
             roleCredentials.get(err => {
                 assert(err);
+                // check that err is another instance distinct from
+                // the global arsenal error
+                assert.notStrictEqual(err, errors.InternalError);
                 done();
             });
         }, retryTimeout);


### PR DESCRIPTION
Fix by returning a copy of InternalError from arsenal errors.

Make sure we return a copy of the arsenal error to avoid side effects
with AWS SDK modifying the error properties.

Also fix the unit test to actually trigger a non-arsenal error like
described, as previously the "socket.destroy()" was caught as an
arsenal error in Vaultclient.