### PR TITLE
feature: S3C-4464 Dev docs for Prometheus in Queue Pop

### DIFF
--- a/docs/probe-requests.md
+++ b/docs/probe-requests.md
@@ -1,0 +1,27 @@
+# Probe Requests
+Backbeat services include an HTTP endpoint to probe the current status of the process.
+This endpoint can be used for healthchecks in tools like HAProxy or liveness checks
+in Kubernetes.
+It can also be manually viewed for verbose logs if needed.
+
+> Currently the probe is only in Queue Populator and Queue Processor.
+
+## Configuration
+Under `conf/config.json` you can specify the probe server settings.
+
+> Currently SSL/TLS is not supported
+
+## Usage
+After you start the process you can view the current status at
+`http://{bindAddress}:{port}/_/live`.
+
+An example Kubernetes probe configuration is as follows:
+```
+# pod.yaml
+    livenessProbe:
+      httpGet:
+        path: /_/live
+        port: ${port}
+      initialDelaySeconds: 3
+      periodSeconds: 3
+```

--- a/docs/probe-requests.md
+++ b/docs/probe-requests.md
@@ -1,4 +1,5 @@
 # Probe Requests
+
 Backbeat services include an HTTP endpoint to probe the current status of the process.
 This endpoint can be used for healthchecks in tools like HAProxy or liveness checks
 in Kubernetes.
@@ -7,15 +8,18 @@ It can also be manually viewed for verbose logs if needed.
 > Currently the probe is only in Queue Populator and Queue Processor.
 
 ## Configuration
+
 Under `conf/config.json` you can specify the probe server settings.
 
 > Currently SSL/TLS is not supported
 
 ## Usage
+
 After you start the process you can view the current status at
 `http://{bindAddress}:{port}/_/live`.
 
 An example Kubernetes probe configuration is as follows:
+
 ```
 # pod.yaml
     livenessProbe:

--- a/docs/replication-metrics.md
+++ b/docs/replication-metrics.md
@@ -1,14 +1,18 @@
 # Replication Metrics
+
 Prometheus metrics are provided for replication through HTTP routes.
 
 > Currently metrics are only provided for the queue populator.
 
 ## Configuration
+
 Under `conf/config.json` you can specify the probe server settings.
 
 > Currently SSL/TLS is not supported
 
-When starting processes you will have to enable the probe server by setting an environment variable.
+When starting processes you will have to enable the probe server by setting an
+environment variable.
+
 ```
 export CRR_METRICS_PROBE=true
 ```
@@ -16,11 +20,13 @@ export CRR_METRICS_PROBE=true
 After you start the process you can view prometheus metrics at `http://{bindAddress}:{port}/_/metrics`.
 
 ## Connecting to Prometheus
+
 Download and get started with [Prometheus](https://prometheus.io/) by following the
 official [getting started](https://prometheus.io/docs/prometheus/latest/getting_started/)
 guide.
 
 Below is a sample configuration using the default queue populator configuration values.
+
 ```
 # prom.yml
 global:

--- a/docs/replication-metrics.md
+++ b/docs/replication-metrics.md
@@ -1,0 +1,38 @@
+# Replication Metrics
+Prometheus metrics are provided for replication through HTTP routes.
+
+> Currently metrics are only provided for the queue populator.
+
+## Configuration
+Under `conf/config.json` you can specify the probe server settings.
+
+> Currently SSL/TLS is not supported
+
+When starting processes you will have to enable the probe server by setting an environment variable.
+```
+export CRR_METRICS_PROBE=true
+```
+
+After you start the process you can view prometheus metrics at `http://{bindAddress}:{port}/_/metrics`.
+
+## Connecting to Prometheus
+Download and get started with [Prometheus](https://prometheus.io/) by following the
+official [getting started](https://prometheus.io/docs/prometheus/latest/getting_started/)
+guide.
+
+Below is a sample configuration using the default queue populator configuration values.
+```
+# prom.yml
+global:
+  scrape_interval:     15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: queue_populator
+    metrics_path: /_/metrics
+    static_configs:
+      - targets: ['localhost:4042']
+```
+
+Start Prometheus by providing this file as the config file parameter.
+`./prometheus --config.file=prom.yml`


### PR DESCRIPTION
* details prometheus setup, will help TSKB
* specifies how to use the probe server for health or liveness checks

Notes:
7.10 and onward the env var is flipped
I used a k8s example even in 7.x, this may or may not be ideal...