### PR TITLE
INTEGRATION [PR#1753 > development/8.2] bugfix: S3C-4530 Remove log reader to resolve ciruclar structure

### DIFF
--- a/extensions/replication/ReplicationQueuePopulator.js
+++ b/extensions/replication/ReplicationQueuePopulator.js
@@ -27,10 +27,14 @@ class ReplicationQueuePopulator extends QueuePopulatorExtension {
             entry.key.startsWith(mpuBucketPrefix)) {
             return;
         }
+        // remove logReader to prevent circular stringify
+        const publishedEntry = Object.assign({}, entry);
+        delete publishedEntry.logReader;
+
         this.log.trace('publishing bucket replication entry',
                        { bucket: entry.bucket });
         this.publish(this.repConfig.topic,
-                     entry.bucket, JSON.stringify(entry));
+                     entry.bucket, JSON.stringify(publishedEntry));
     }
 
     _filterVersionedKey(entry) {

--- a/tests/unit/replication/ReplicationQueuePopulator.spec.js
+++ b/tests/unit/replication/ReplicationQueuePopulator.spec.js
@@ -132,4 +132,21 @@ describe('replication queue populator', () => {
             labels
         );
     });
+
+    it('can publish when filtering bucket op', () => {
+        const labels = { a: 10 }; // dummy metric labels
+        const metricLabelsStub = sinon.stub();
+        metricLabelsStub.returns(labels);
+        const entry = Object.assign({}, {
+            type: 'put',
+            bucket: 'test-bucket-source',
+            key: 'a-test-key\u000098477724999464999999RG001  1.30.12',
+            logReader: {},
+        }, { value: JSON.stringify(kafkaValue) });
+        // force the circular reference
+        entry.logReader.entry = entry;
+
+        // should not throw
+        rqp._filterBucketOp(entry);
+    });
 });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1753.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/bugfix/S3C-4530_RepQueuePopulatorCircularStructure`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/bugfix/S3C-4530_RepQueuePopulatorCircularStructure
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/bugfix/S3C-4530_RepQueuePopulatorCircularStructure
```

Please always comment pull request #1753 instead of this one.