### PR TITLE
bugfix: S3C-4541 Return error and probe server for callback

### DIFF
--- a/extensions/replication/queueProcessor/Probe.js
+++ b/extensions/replication/queueProcessor/Probe.js
@@ -9,8 +9,10 @@ const { ProbeServer, DEFAULT_LIVE_ROUTE } =
  */
 
 /**
- * Callback when Queue Processor Probe server is listening
+ * Callback when Queue Processor Probe server is listening.
+ * Note that a disabled probe server does not pass an error to the callback.
  * @callback DoneCallback
+ * @param {Object} [err] - Possible error creating a probe server
  * @param {ProbeServer} [probeServer] - Probe server or undefined if disabled
  */
 
@@ -31,7 +33,8 @@ function startProbeServer(queueProcessor, config, callback) {
         DEFAULT_LIVE_ROUTE,
         (res, log) => queueProcessor.handleLiveness(res, log)
     );
-    probeServer._cbOnListening = () => callback(probeServer);
+    probeServer.onListening(() => callback(undefined, probeServer));
+    probeServer.onError(err => callback(err));
     probeServer.start();
 }
 

--- a/extensions/replication/queueProcessor/Probe.js
+++ b/extensions/replication/queueProcessor/Probe.js
@@ -33,7 +33,7 @@ function startProbeServer(queueProcessor, config, callback) {
         DEFAULT_LIVE_ROUTE,
         (res, log) => queueProcessor.handleLiveness(res, log)
     );
-    probeServer.onListening(() => callback(undefined, probeServer));
+    probeServer.onListening(() => callback(null, probeServer));
     probeServer.onError(err => callback(err));
     probeServer.start();
 }

--- a/tests/functional/replication/probe.spec.js
+++ b/tests/functional/replication/probe.spec.js
@@ -14,7 +14,7 @@ function mockQueueProcessor() {
     };
 }
 
-describe('Probe server', () => {
+describe.only('Probe server', () => {
     afterEach(() => {
         // reset any possible env var set
         delete process.env.CRR_METRICS_PROBE;
@@ -27,7 +27,8 @@ describe('Probe server', () => {
             bindAddress: 'localhost',
             port: 52555,
         };
-        startProbeServer(mockQp, config, probeServer => {
+        startProbeServer(mockQp, config, (err, probeServer) => {
+            assert.ifError(err);
             assert.strictEqual(probeServer, undefined);
             done();
         });
@@ -37,7 +38,23 @@ describe('Probe server', () => {
         process.env.CRR_METRICS_PROBE = 'true';
         const mockQp = mockQueueProcessor();
         const config = undefined;
-        startProbeServer(mockQp, config, probeServer => {
+        startProbeServer(mockQp, config, (err, probeServer) => {
+            assert.ifError(err);
+            assert.strictEqual(probeServer, undefined);
+            done();
+        });
+    });
+
+    it('calls back with error if one occurred', done => {
+        process.env.CRR_METRICS_PROBE = 'true';
+        const mockQp = mockQueueProcessor();
+        const config = {
+            bindAddress: 'httppp://badaddress',
+            // inject an error with a bad port
+            port: 52525,
+        };
+        startProbeServer(mockQp, config, (err, probeServer) => {
+            assert.notStrictEqual(err, undefined);
             assert.strictEqual(probeServer, undefined);
             done();
         });
@@ -52,7 +69,8 @@ describe('Probe server', () => {
             bindAddress: 'localhost',
             port: 52555,
         };
-        startProbeServer(mockQp, config, probeServer => {
+        startProbeServer(mockQp, config, (err, probeServer) => {
+            assert.ifError(err);
             probeServer.onStop(done);
             http.get(`http://localhost:52555${DEFAULT_LIVE_ROUTE}`, res => {
                 assert.strictEqual(res.statusCode, 500);

--- a/tests/functional/replication/probe.spec.js
+++ b/tests/functional/replication/probe.spec.js
@@ -14,7 +14,7 @@ function mockQueueProcessor() {
     };
 }
 
-describe.only('Probe server', () => {
+describe('Probe server', () => {
     afterEach(() => {
         // reset any possible env var set
         delete process.env.CRR_METRICS_PROBE;


### PR DESCRIPTION
* Use onListening instead of directly assigning private var
* Add onError to handle errors