### PR TITLE
INTEGRATION [PR#1777 > development/7.10] feature: S3C-4556 Switch probe server to site specific mapping

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -64,10 +64,17 @@
                 "retryTimeoutS": 300,
                 "concurrency": 10,
                 "mpuPartsConcurrency": 10,
-                "probeServer": {
-                    "bindAddress": "localhost",
-                    "port": 4043
-                }
+                "probeServer": [
+                    {
+                        "site": "sf",
+                        "bindAddress": "localhost",
+                        "port": "4043"
+                    }, {
+                        "site" : "us-east-1",
+                        "bindAddress": "localhost",
+                        "port": "4044"
+                    }
+                ]
             },
             "replicationStatusProcessor": {
                 "groupId": "backbeat-replication-group",

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -52,10 +52,13 @@ const joiSchema = {
         concurrency: joi.number().greater(0).default(10),
         mpuPartsConcurrency: joi.number().greater(0).default(10),
         logConsumerMetricsIntervalS: joi.number().greater(0).default(60),
-        probeServer: joi.object({
-            bindAddress: joi.string().default('localhost'),
-            port: joi.number().required(),
-        }),
+        probeServer: joi.array().items(
+            joi.object({
+                site: joi.string().required(),
+                bindAddress: joi.string().default('localhost'),
+                port: joi.number().required(),
+            })
+        ),
     }).required(),
     replicationStatusProcessor: {
         groupId: joi.string().required(),

--- a/extensions/replication/queueProcessor/Probe.js
+++ b/extensions/replication/queueProcessor/Probe.js
@@ -38,4 +38,20 @@ function startProbeServer(queueProcessor, config, callback) {
     probeServer.start();
 }
 
-module.exports = { startProbeServer };
+
+/**
+ * Get probe config will pull the configuration for the probe server based on
+ * the provided site key.
+ *
+ * @param {Object} queueProcessorConfig - Configuration of the queue processor that
+ *      holds the probe server configs for all sites
+ * @param {string} site - Name of the site we are processing
+ * @returns {ProbeServerConfig|undefined} Config for site or undefined if not found
+ */
+function getProbeConfig(queueProcessorConfig, site) {
+    return queueProcessorConfig &&
+        queueProcessorConfig.probeServer &&
+        queueProcessorConfig.probeServer.filter(c => c.site === site)[0];
+}
+
+module.exports = { startProbeServer, getProbeConfig };

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -13,7 +13,7 @@ const sourceConfig = repConfig.source;
 const httpsConfig = config.https;
 const internalHttpsConfig = config.internalHttps;
 const mConfig = config.metrics;
-const { startProbeServer } = require('./Probe');
+const { startProbeServer, getProbeConfig } = require('./Probe');
 
 const site = process.argv[2];
 assert(site, 'QueueProcessor task must be started with a site as argument');
@@ -22,6 +22,8 @@ const bootstrapList = repConfig.destination.bootstrapList
     .filter(item => item.site === site);
 assert(bootstrapList.length === 1, 'Invalid site argument. Site must match ' +
     'one of the replication endpoints defined');
+
+const probeServerConfig = getProbeConfig(repConfig.queueProcessor, site);
 
 const destConfig = Object.assign({}, repConfig.destination);
 destConfig.bootstrapList = bootstrapList;
@@ -39,7 +41,7 @@ const queueProcessor = new QueueProcessor(
 async.waterfall([
     done => startProbeServer(
         queueProcessor,
-        repConfig.queueProcessor.probeServer,
+        probeServerConfig,
         err => {
             if (err) {
                 log.error('error starting probe server', {

--- a/tests/functional/replication/probe.spec.js
+++ b/tests/functional/replication/probe.spec.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const sinon = require('sinon');
-const { startProbeServer } =
+const { startProbeServer, getProbeConfig } =
     require('../../../extensions/replication/queueProcessor/Probe');
 const { DEFAULT_LIVE_ROUTE } = require('arsenal').network.probe.ProbeServer;
 const http = require('http');
@@ -14,7 +14,7 @@ function mockQueueProcessor() {
     };
 }
 
-describe('Probe server', () => {
+describe.only('Probe server', () => {
     afterEach(() => {
         // reset any possible env var set
         delete process.env.CRR_METRICS_PROBE;
@@ -86,5 +86,60 @@ describe('Probe server', () => {
                 });
             });
         });
+    });
+
+    it('can get config', () => {
+        const qpConfig = {
+            probeServer: [
+                {
+                    site: 'sf',
+                    bindAddress: 'localhost',
+                    port: '4043',
+                }, {
+                    site: 'us-east-1',
+                    bindAddress: 'localhost',
+                    port: '4044',
+                },
+            ],
+        };
+        const cfg = getProbeConfig(qpConfig, 'us-east-1');
+        assert.deepStrictEqual(cfg, {
+            site: 'us-east-1',
+            bindAddress: 'localhost',
+            port: '4044',
+        });
+    });
+
+    it('returns undefined if site not listed', () => {
+        const qpConfig = {
+            probeServer: [
+                {
+                    site: 'sf',
+                    bindAddress: 'localhost',
+                    port: '4043',
+                },
+            ],
+        };
+        const cfg = getProbeConfig(qpConfig, 'missing site');
+        assert.deepStrictEqual(cfg, undefined);
+    });
+
+    it('returns undefined if no sites', () => {
+        const qpConfig = {
+            probeServer: [],
+        };
+        const cfg = getProbeConfig(qpConfig, 'no configs');
+        assert.deepStrictEqual(cfg, undefined);
+    });
+
+    it('returns undefined if no probe server config', () => {
+        const qpConfig = {};
+        const cfg = getProbeConfig(qpConfig, 'no server configs');
+        assert.deepStrictEqual(cfg, undefined);
+    });
+
+    it('returns undefined if no config at all', () => {
+        const cfg = getProbeConfig(undefined, 'no server configs');
+        assert.deepStrictEqual(cfg, undefined);
     });
 });

--- a/tests/functional/replication/probe.spec.js
+++ b/tests/functional/replication/probe.spec.js
@@ -14,7 +14,7 @@ function mockQueueProcessor() {
     };
 }
 
-describe.only('Probe server', () => {
+describe('Probe server', () => {
     afterEach(() => {
         // reset any possible env var set
         delete process.env.CRR_METRICS_PROBE;


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1777.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/feature/S3C-4556_SiteSpecificProbeServerConfigs`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/feature/S3C-4556_SiteSpecificProbeServerConfigs
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/feature/S3C-4556_SiteSpecificProbeServerConfigs
```

Please always comment pull request #1777 instead of this one.