### PR TITLE
INTEGRATION [PR#1796 > development/7.10] feature: S3C-4486 Add metric for replication status

### DIFF
--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -40,7 +40,7 @@ const replicationStatusMetric = new promClient.Counter({
 
 const kafkaLagMetric = new promClient.Gauge({
     name: 'kafka_lag',
-    help: 'Number of objects behind we are in the Kafka log',
+    help: 'Number of update entries waiting to be consumed from the Kafka topic',
     labelNames: ['origin', 'containerName', 'partition'],
 });
 
@@ -48,6 +48,7 @@ const kafkaLagMetric = new promClient.Gauge({
  * Contains methods to incrememt different metrics
  * @typedef {Object} MetricsHandler
  * @property {CounterInc} status - Increments the replication status metric
+ * @property {GaugeSet} lag - Set the kafka lag metric
  */
 const metricsHandler = {
     status: wrapCounterInc(replicationStatusMetric),

--- a/extensions/replication/tasks/UpdateReplicationStatus.js
+++ b/extensions/replication/tasks/UpdateReplicationStatus.js
@@ -15,8 +15,9 @@ class UpdateReplicationStatus extends BackbeatTask {
      * @constructor
      * @param {ReplicationStatusProcessor} rsp - replication status
      *   processor instance
+     * @param {MetricsHandler} metricsHandler - instance of metric handler
      */
-    constructor(rsp) {
+    constructor(rsp, metricsHandler) {
         const rspState = rsp.getStateVars();
         super({
             retryTimeoutS:
@@ -24,6 +25,7 @@ class UpdateReplicationStatus extends BackbeatTask {
         });
         Object.assign(this, rspState);
 
+        this.metricsHandler = metricsHandler;
         this.sourceRole = null;
         this.s3sourceCredentials = null;
         this.backbeatSourceClient =
@@ -133,6 +135,9 @@ class UpdateReplicationStatus extends BackbeatTask {
                           error: err.message });
                     return done(err);
                 }
+                this.metricsHandler.status({
+                    replicationStatus: status,
+                });
                 log.end().info('replication status updated', {
                     entry: updatedSourceEntry.getLogInfo(),
                     replicationStatus:

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -101,7 +101,7 @@ class BackbeatConsumer extends EventEmitter {
         this._consumedEventTimeout = null;
 
         /** @type {ConsumerStats} */
-        this.consumerStats = {lag: {}}
+        this.consumerStats = { lag: {} };
 
         this._init();
         return this;

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -13,6 +13,12 @@ const OffsetLedger = require('./OffsetLedger');
 const CONCURRENCY_DEFAULT = 1;
 const CLIENT_ID = 'BackbeatConsumer';
 
+/**
+ * Stats on how we are consuming Kafka
+ * @typedef {Object} ConsumerStats
+ * @property {Map<string, number>} lag - Map of partitions to kafka message lag
+ */
+
 class BackbeatConsumer extends EventEmitter {
 
     /**
@@ -94,6 +100,9 @@ class BackbeatConsumer extends EventEmitter {
         this._bootstrapping = false;
         this._consumedEventTimeout = null;
 
+        /** @type {ConsumerStats} */
+        this.consumerStats = {lag: {}}
+
         this._init();
         return this;
     }
@@ -143,9 +152,10 @@ class BackbeatConsumer extends EventEmitter {
                     if (typeof topicStats !== 'object') {
                         return undefined;
                     }
-                    const consumerStats = {
-                        lag: {},
-                    };
+
+                    // reset our stats
+                    this.consumerStats = { lag: {} };
+
                     // Gather stats per partition consumed by this
                     // consumer instance
                     Object.keys(topicStats.partitions).forEach(partition => {
@@ -153,13 +163,14 @@ class BackbeatConsumer extends EventEmitter {
                         const { consumer_lag, fetch_state } =
                               topicStats.partitions[partition];
                         if (fetch_state === 'active' && consumer_lag >= 0) {
-                            consumerStats.lag[partition] = consumer_lag;
+                            this.consumerStats.lag[partition] = consumer_lag;
                         }
                         /* eslint-enable camelcase */
                     });
+
                     this._log.info('topic consumer statistics', {
                         topic: this._topic,
-                        consumerStats,
+                        consumerStats: this.consumerStats,
                     });
                     return undefined;
                 });

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -11,6 +11,7 @@ const FailedCRRConsumer =
     require('../../extensions/replication/failedCRR/FailedCRRConsumer');
 const promClient = require('prom-client');
 const constants = require('../constants');
+const { wrapCounterInc, wrapGaugeSet } = require('../util/metrics');
 
 const metricLabels = ['origin', 'logName', 'logId', 'containerName'];
 promClient.register.setDefaultLabels({
@@ -21,45 +22,12 @@ promClient.register.setDefaultLabels({
 /**
  * Labels used for Prometheus metrics
  * @typedef {Object} MetricLabels
+ * @property {string} origin - Method that began the replication
  * @property {string} logName - Name of the log we are using
  * @property {string} logId - Id of the log we are reading
  * @property {string} containerName - Name of the container running our process
  * @property {string} [publishStatus] - Result of the publishing to kafka to the topic
  */
-
-/**
- * Increment a Prometheus counter metric
- * @typedef { (labels: MetricLabels, value?: number) => void } CounterInc
- */
-
-/**
- * Set a Prometheus gauge metric
- * @typedef { (labels: MetricLabels, value: number) => void } GaugeSet
- */
-
-/**
- * WrapCounterInc wraps the Counters Inc method adding the metric labels used.
- *
- * @param {promClient.Counter} metric - Prom counter metric
- * @returns {CounterInc} - Function used to increment counter
- */
-function wrapCounterInc(metric) {
-    return (labels, value) => {
-        metric.inc(labels, value);
-    };
-}
-
-/**
- * Wrap Gauge Set wraps a Prometheus Guage's set method
- *
- * @param {promClient.Gauge} metric - Prom gauge metric
- * @returns {GaugeSet} - Function used to set gauge
- */
-function wrapGaugeSet(metric) {
-    return (labels, value) => {
-        metric.set(labels, value);
-    };
-}
 
 const logReadOffsetMetric = new promClient.Gauge({
     name: 'replication_read_offset',

--- a/lib/util/metrics.js
+++ b/lib/util/metrics.js
@@ -35,4 +35,4 @@ function wrapGaugeSet(metric) {
 module.exports = {
     wrapCounterInc,
     wrapGaugeSet,
-}
+};

--- a/lib/util/metrics.js
+++ b/lib/util/metrics.js
@@ -1,0 +1,38 @@
+/**
+ * Increment a Prometheus counter metric
+ * @typedef { (labels: MetricLabels, value?: number) => void } CounterInc
+ */
+
+/**
+ * Set a Prometheus gauge metric
+ * @typedef { (labels: MetricLabels, value: number) => void } GaugeSet
+ */
+
+/**
+ * WrapCounterInc wraps the Counters Inc method adding the metric labels used.
+ *
+ * @param {promClient.Counter} metric - Prom counter metric
+ * @returns {CounterInc} - Function used to increment counter
+ */
+function wrapCounterInc(metric) {
+    return (labels, value) => {
+        metric.inc(labels, value);
+    };
+}
+
+/**
+ * Wrap Gauge Set wraps a Prometheus Guage's set method
+ *
+ * @param {promClient.Gauge} metric - Prom gauge metric
+ * @returns {GaugeSet} - Function used to set gauge
+ */
+function wrapGaugeSet(metric) {
+    return (labels, value) => {
+        metric.set(labels, value);
+    };
+}
+
+module.exports = {
+    wrapCounterInc,
+    wrapGaugeSet,
+}

--- a/tests/unit/lib/util/metrics.spec.js
+++ b/tests/unit/lib/util/metrics.spec.js
@@ -2,7 +2,7 @@ const sinon = require('sinon');
 const { wrapCounterInc, wrapGaugeSet } =
     require('../../../../lib/util/metrics');
 
-describe.only('Metrics', () => {
+describe('Metrics', () => {
     it('can wrap counter inc', () => {
         const mockCounter = sinon.spy();
         mockCounter.inc = sinon.spy();

--- a/tests/unit/lib/util/metrics.spec.js
+++ b/tests/unit/lib/util/metrics.spec.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const { wrapCounterInc, wrapGaugeSet } =
+    require('../../../../lib/util/metrics');
+
+describe.only('Metrics', () => {
+    it('can wrap counter inc', () => {
+        const mockCounter = sinon.spy();
+        mockCounter.inc = sinon.spy();
+        const incFn = wrapCounterInc(mockCounter);
+        incFn('label', 1);
+        sinon.assert.calledOnceWithExactly(mockCounter.inc, 'label', 1);
+    })
+
+    it('can wrap gauge set', () => {
+        const mockGauge = sinon.spy();
+        mockGauge.set = sinon.spy();
+        const setFn = wrapGaugeSet(mockGauge);
+        setFn('label', 15);
+        sinon.assert.calledOnceWithExactly(mockGauge.set, 'label', 15);
+    })
+});

--- a/tests/unit/lib/util/metrics.spec.js
+++ b/tests/unit/lib/util/metrics.spec.js
@@ -1,4 +1,3 @@
-const assert = require('assert');
 const sinon = require('sinon');
 const { wrapCounterInc, wrapGaugeSet } =
     require('../../../../lib/util/metrics');
@@ -10,7 +9,7 @@ describe.only('Metrics', () => {
         const incFn = wrapCounterInc(mockCounter);
         incFn('label', 1);
         sinon.assert.calledOnceWithExactly(mockCounter.inc, 'label', 1);
-    })
+    });
 
     it('can wrap gauge set', () => {
         const mockGauge = sinon.spy();
@@ -18,5 +17,5 @@ describe.only('Metrics', () => {
         const setFn = wrapGaugeSet(mockGauge);
         setFn('label', 15);
         sinon.assert.calledOnceWithExactly(mockGauge.set, 'label', 15);
-    })
+    });
 });


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1796.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/feature/S3C-4486_ReplicationStatusMetrics`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/feature/S3C-4486_ReplicationStatusMetrics
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/feature/S3C-4486_ReplicationStatusMetrics
```

Please always comment pull request #1796 instead of this one.