### PR TITLE
feature: BB-1 Add comment for missing kafka lag

### DIFF
--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -44,6 +44,7 @@ const replicationStatusMetric = new promClient.Counter({
     labelNames: ['origin', 'containerName', 'replicationStatus'],
 });
 
+// TODO: Kafka lag is not set in 8.x branches see BB-1
 const kafkaLagMetric = new promClient.Gauge({
     name: 'kafka_lag',
     help: 'Number of update entries waiting to be consumed from the Kafka topic',


### PR DESCRIPTION
The decision was made to not forward port kafka lag as a metric due to complications and other things, a ticket was made to address this as tech debt later. This PR is here to add an inline code comment to add another point to remember.