### PR TITLE
feature: BB-8 Add Log Consumer Metric interval for status processor

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -80,6 +80,7 @@
                 "groupId": "backbeat-replication-group",
                 "retryTimeoutS": 300,
                 "concurrency": 10,
+                "logConsumerMetricsIntervalS": 60,
                 "probeServer": {
                     "bindAddress": "localhost",
                     "port": 4045

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -64,6 +64,7 @@ const joiSchema = {
         groupId: joi.string().required(),
         retryTimeoutS: joi.number().default(300),
         concurrency: joi.number().greater(0).default(10),
+        logConsumerMetricsIntervalS: joi.number().greater(0).default(60),
         probeServer: joi.object({
             bindAddress: joi.string().default('localhost'),
             port: joi.number().required(),

--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -171,6 +171,7 @@ class ReplicationStatusProcessor {
             this.repConfig.replicationStatusProcessor.concurrency,
             queueProcessor: this.processKafkaEntry.bind(this),
             bootstrap: options && options.bootstrap,
+            logConsumerMetricsIntervalS: this.repConfig.replicationStatusProcessor.logConsumerMetricsIntervalS,
         });
         this._consumer.on('error', () => {});
         this._consumer.on('ready', () => {


### PR DESCRIPTION
Without this config, the `event.stats` event does not fire and thus no Kafka lag metrics.