### PR TITLE
INTEGRATION [PR#1826 > development/7.10] feature: BB-8 Add Log Consumer Metric interval for status processor

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -80,6 +80,7 @@
                 "groupId": "backbeat-replication-group",
                 "retryTimeoutS": 300,
                 "concurrency": 10,
+                "logConsumerMetricsIntervalS": 60,
                 "probeServer": {
                     "bindAddress": "localhost",
                     "port": 4045

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -64,6 +64,7 @@ const joiSchema = {
         groupId: joi.string().required(),
         retryTimeoutS: joi.number().default(300),
         concurrency: joi.number().greater(0).default(10),
+        logConsumerMetricsIntervalS: joi.number().greater(0).default(60),
         probeServer: joi.object({
             bindAddress: joi.string().default('localhost'),
             port: joi.number().required(),

--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -171,6 +171,7 @@ class ReplicationStatusProcessor {
             this.repConfig.replicationStatusProcessor.concurrency,
             queueProcessor: this.processKafkaEntry.bind(this),
             bootstrap: options && options.bootstrap,
+            logConsumerMetricsIntervalS: this.repConfig.replicationStatusProcessor.logConsumerMetricsIntervalS,
         });
         this._consumer.on('error', () => {});
         this._consumer.on('ready', () => {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1826.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/feature/BB-8_AddLogConsumerIntervalConfigForStatusProcessor`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/feature/BB-8_AddLogConsumerIntervalConfigForStatusProcessor
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/feature/BB-8_AddLogConsumerIntervalConfigForStatusProcessor
```

Please always comment pull request #1826 instead of this one.