### PR TITLE
INTEGRATION [PR#1856 > development/8.2] BB-17: move notification filter in log reader to queue populator

### DIFF
--- a/extensions/notification/NotificationQueuePopulator.js
+++ b/extensions/notification/NotificationQueuePopulator.js
@@ -181,7 +181,8 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
      * @return {undefined}
      */
     filter(entry) {
-        const { bucket, key, value, type } = entry;
+        const { bucket, key, type } = entry;
+        const value = entry.value || '{}';
         const { error, result } = safeJsonParse(value);
         // ignore if entry's value is not valid
         if (error) {

--- a/extensions/replication/ReplicationQueuePopulator.js
+++ b/extensions/replication/ReplicationQueuePopulator.js
@@ -13,6 +13,9 @@ class ReplicationQueuePopulator extends QueuePopulatorExtension {
     }
 
     filter(entry) {
+        if (entry.key === undefined || entry.value === undefined) {
+            return undefined;
+        }
         if (entry.bucket === usersBucket) {
             return this._filterBucketOp(entry);
         }

--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -6,8 +6,6 @@ const { DbPrefixes } = versioning.VersioningConstants;
 const BackbeatProducer = require('../BackbeatProducer');
 const ReplicationQueuePopulator =
     require('../../extensions/replication/ReplicationQueuePopulator');
-const NotificationQueuePopulator =
-    require('../../extensions/notification/NotificationQueuePopulator');
 
 const { metricsExtension, metricsTypeQueued } =
     require('../../extensions/replication/constants');
@@ -367,20 +365,11 @@ class LogReader {
         }
 
         async.eachSeries(this._extensions, (ext, next) => {
-            let entryValue = entry.value;
-            const notifExtension = ext instanceof NotificationQueuePopulator;
-            if (notifExtension) {
-                entryValue = entry.value || '{}';
-            }
-            if (!notifExtension &&
-                (entry.key === undefined || entry.value === undefined)) {
-                return next();
-            }
             const entryToFilter = {
                 type: entry.type,
                 bucket: record.db,
                 key: _transformKey(entry.key),
-                value: entryValue,
+                value: entry.value,
                 logReader: this,
             };
             return _executeFilter(ext, entryToFilter, next);


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1856.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/improvement/BB-17/moveNotificationLogReaderChecksToQueuePopulator`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/improvement/BB-17/moveNotificationLogReaderChecksToQueuePopulator
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/improvement/BB-17/moveNotificationLogReaderChecksToQueuePopulator
```

Please always comment pull request #1856 instead of this one.