### PR TITLE
feature: BB-10 Add queue proc and status proc to metrics docs

### DIFF
--- a/docs/replication-metrics.md
+++ b/docs/replication-metrics.md
@@ -2,7 +2,8 @@
 
 Prometheus metrics are provided for replication through HTTP routes.
 
-> Currently metrics are only provided for the queue populator.
+> Currently metrics are provided for the queue populator, queue processor, and status
+> processor.
 
 ## Configuration
 
@@ -13,7 +14,7 @@ Under `conf/config.json` you can specify the probe server settings.
 When starting processes you will have to enable the probe server by setting an
 environment variable.
 
-```
+```sh
 export CRR_METRICS_PROBE=true
 ```
 
@@ -27,7 +28,7 @@ guide.
 
 Below is a sample configuration using the default queue populator configuration values.
 
-```
+```yaml
 # prom.yml
 global:
   scrape_interval:     15s


### PR DESCRIPTION
Include the other services that have metrics now ( after BB-11 )