### PR TITLE
bugfix: BB-20 upgrade CI test image to Ubuntu 18.04

### DIFF
--- a/eve/workers/unit_and_feature_tests/Dockerfile
+++ b/eve/workers/unit_and_feature_tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:xenial-curl
+FROM buildpack-deps:bionic-curl
 
 ARG NODE_ENV=development
 


### PR DESCRIPTION
Upgrade the CI test image from Ubuntu 16.04 to 18.04 to have Python
3.6, required by node-gyp.