### PR TITLE
improvement: BB-24 rename CRR to s3 replication

### DIFF
--- a/docs/replication-metrics.md
+++ b/docs/replication-metrics.md
@@ -15,7 +15,7 @@ When starting processes you will have to enable the probe server by setting an
 environment variable.
 
 ```sh
-export CRR_METRICS_PROBE=true
+export S3_REPLICATION_METRICS_PROBE=true
 ```
 
 After you start the process you can view prometheus metrics at `http://{bindAddress}:{port}/_/metrics`.

--- a/lib/util/probe.js
+++ b/lib/util/probe.js
@@ -22,7 +22,7 @@ const { ProbeServer } = require('arsenal').network.probe.ProbeServer;
  * @returns {undefined}
  */
 function startProbeServer(config, callback) {
-    if (process.env.CRR_METRICS_PROBE !== 'true' || config === undefined) {
+    if (process.env.S3_REPLICATION_METRICS_PROBE !== 'true' || config === undefined) {
         callback();
         return;
     }

--- a/tests/unit/lib/util/probe.spec.js
+++ b/tests/unit/lib/util/probe.spec.js
@@ -5,11 +5,11 @@ const { startProbeServer } =
 describe('Probe server', () => {
     afterEach(() => {
         // reset any possible env var set
-        delete process.env.CRR_METRICS_PROBE;
+        delete process.env.S3_REPLICATION_METRICS_PROBE;
     });
 
     it('is not created when disabled', done => {
-        process.env.CRR_METRICS_PROBE = 'false';
+        process.env.S3_REPLICATION_METRICS_PROBE = 'false';
         const config = {
             bindAddress: 'localhost',
             port: 52555,
@@ -22,7 +22,7 @@ describe('Probe server', () => {
     });
 
     it('is not created with no config', done => {
-        process.env.CRR_METRICS_PROBE = 'true';
+        process.env.S3_REPLICATION_METRICS_PROBE = 'true';
         const config = undefined;
         startProbeServer(config, (err, probeServer) => {
             assert.ifError(err);
@@ -32,7 +32,7 @@ describe('Probe server', () => {
     });
 
     it('calls back with error if one occurred', done => {
-        process.env.CRR_METRICS_PROBE = 'true';
+        process.env.S3_REPLICATION_METRICS_PROBE = 'true';
         const config = {
             bindAddress: 'httppp://badaddress',
             // inject an error with a bad port


### PR DESCRIPTION
Rename CRR to s3 replication for the variables used for s3 replication metrics monitoring.