### PR TITLE
feature: lc conductor bucket listing from bucketd

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,11 @@
 {
     "extends": "scality",
+    "parserOptions": {
+      "ecmaFeatures": {
+          "experimentalObjectRestSpread": true
+      },
+      "ecmaVersion": 6
+    },
     "settings": {
         "import/resolver": {
           "node": {

--- a/extensions/lifecycle/LifecycleConfigValidator.js
+++ b/extensions/lifecycle/LifecycleConfigValidator.js
@@ -1,5 +1,5 @@
 const joi = require('@hapi/joi');
-const { retryParamsJoi, authJoi, probeServerJoi } =
+const { retryParamsJoi, authJoi, probeServerJoi, hostPortJoi } =
     require('../../lib/config/configItems.joi.js');
 
 const joiSchema = {
@@ -8,6 +8,10 @@ const joiSchema = {
     objectTasksTopic: joi.string().required(),
     auth: authJoi.required(),
     conductor: {
+        bucketSource: joi.string().
+            valid('bucketd', 'zookeeper').default('zookeeper'),
+        bucketd: hostPortJoi.
+            when('bucketSource', { is: 'bucketd', then: joi.required() }),
         cronRule: joi.string().required(),
         concurrency: joi.number().greater(0).default(10),
         backlogControl: joi.object({

--- a/extensions/lifecycle/LifecycleQueuePopulator.js
+++ b/extensions/lifecycle/LifecycleQueuePopulator.js
@@ -128,6 +128,14 @@ class LifecycleQueuePopulator extends QueuePopulatorExtension {
             return undefined;
         }
 
+        if (this.extConfig.conductor.bucketSource !== 'zookeeper') {
+            this.log.info('bucket source is not zookeeper, skipping entry', {
+                entry,
+                bucketSource: this.extConfig.conductor.bucketSource,
+            });
+            return undefined;
+        }
+
         let bucketValue = {};
         if (this._isBucketEntryFromBucketd(entry)) {
             const parsedEntry = safeJsonParse(entry.value);

--- a/extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor.js
+++ b/extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor.js
@@ -280,6 +280,11 @@ class LifecycleBucketProcessor {
         const params = { Bucket: bucket };
         return s3.getBucketLifecycleConfiguration(params, (err, config) => {
             if (err) {
+                if (err.code === 'NoSuchLifecycleConfiguration') {
+                    this._log.debug('skipping non-lifecycled bucket', { bucket });
+                    return cb();
+                }
+
                 this._log.error('error getting bucket lifecycle config', {
                     method: 'LifecycleBucketProcessor._processBucketEntry',
                     bucket,

--- a/extensions/lifecycle/conductor/LifecycleConductor.js
+++ b/extensions/lifecycle/conductor/LifecycleConductor.js
@@ -4,14 +4,16 @@ const async = require('async');
 const schedule = require('node-schedule');
 const zookeeper = require('node-zookeeper-client');
 
-const errors = require('arsenal').errors;
+const { constants, errors } = require('arsenal');
 const Logger = require('werelogs').Logger;
+const BucketClient = require('bucketclient').RESTClient;
 
 const BackbeatProducer = require('../../../lib/BackbeatProducer');
 const zookeeperHelper = require('../../../lib/clients/zookeeper');
 const KafkaBacklogMetrics = require('../../../lib/KafkaBacklogMetrics');
 const { authTypeAssumeRole } = require('../../../lib/constants');
 const VaultClientCache = require('../../../lib/clients/VaultClientCache');
+const safeJsonParse = require('../util/safeJsonParse');
 
 const DEFAULT_CRON_RULE = '* * * * *';
 const DEFAULT_CONCURRENCY = 10;
@@ -39,6 +41,9 @@ class LifecycleConductor {
      * metrics config object (see {@link BackbeatConsumer} constructor
      * for params)
      * @param {Object} lcConfig - lifecycle configuration object
+     * @param {String} lcConfig.bucketSource - whether to fetch buckets
+     * from zookeeper or bucketd
+     * @param {Object} lcConfig.bucketd - host:port bucketd configuration
      * @param {String} lcConfig.zookeeperPath - base path for
      * lifecycle nodes in zookeeper
      * @param {String} lcConfig.bucketTasksTopic - lifecycle
@@ -64,12 +69,16 @@ class LifecycleConductor {
             this.lcConfig.conductor.cronRule || DEFAULT_CRON_RULE;
         this._concurrency =
             this.lcConfig.conductor.concurrency || DEFAULT_CONCURRENCY;
+        this._bucketSource = this.lcConfig.conductor.bucketSource;
+        this._bucketdConfig = this.lcConfig.conductor.bucketd;
         this._producer = null;
         this._zkClient = null;
+        this._bucketClient = null;
         this._kafkaBacklogMetrics = null;
         this._started = false;
         this._cronJob = null;
         this._vaultClientCache = null;
+        this._initialized = false;
 
         this.logger = new Logger('Backbeat:Lifecycle:Conductor');
     }
@@ -83,111 +92,158 @@ class LifecycleConductor {
                    (path, done) => this._zkClient.mkdirp(path, done), cb);
     }
 
-    _processBucket(ownerId, bucketName, done) {
-        this.logger.debug('processing bucket', {
-            method: 'LifecycleConductor::_processBucket',
-            ownerId,
-            bucketName,
-        });
-        return process.nextTick(() => done(null, [{
-            message: JSON.stringify({
-                action: 'processObjects',
-                target: {
-                    bucket: bucketName,
-                    owner: ownerId,
-                },
-                details: {},
-            }),
-        }]));
-    }
+    _getAccountIds(canonicalIds, cb) {
+        // if auth is not of type `assumeRole`, then
+        // the accountId can be omitted from work queue messages
+        if (this.lcConfig.auth.type !== authTypeAssumeRole) {
+            return process.nextTick(cb, null, {});
+        }
 
-    _processBucketWithAccountId(ownerId, bucketName, done) {
-        this.logger.debug('processing bucket', {
-            method: 'LifecycleConductor::_processBucketWithAccountId',
-            ownerId,
-            bucketName,
-        });
         const client = this._vaultClientCache.getClient(LIFEYCLE_CONDUCTOR_CLIENT_ID);
         const opts = {};
-        return client.getAccountIds([ownerId], opts, (err, res) => {
+        return client.getAccountIds(canonicalIds, opts, (err, res) => {
             if (err) {
-                this.logger.error(
-                    'failed to retrieve bucket owner account id, skipping', {
-                        error: err,
-                        bucket: bucketName,
-                        canonicalId: ownerId,
-                    });
-                return done();
+                return cb(err);
             }
-
-            /*
-             *  res = {
-             *      message: {
-             *          body: { canonicalId[*]: accountId },
-             *          code: 200,
-             *          message: 'Attributes retrieved'
-             *      }
-             *  }
-             */
-            return done(null, [{
-                message: JSON.stringify({
-                    action: 'processObjects',
-                    target: {
-                        bucket: bucketName,
-                        owner: ownerId,
-                        accountId: res.message.body[ownerId],
-                    },
-                    details: {},
-                }),
-            }]);
+            return cb(null, res.message.body);
         });
     }
 
     processBuckets() {
-        const zkBucketsPath = this.getBucketsZkPath();
+        const log = this.logger.newRequestLogger();
+        let nBucketsQueued = 0;
+
+        const messageSendQueue = async.cargo((tasks, done) => {
+            if (tasks.length === 0) {
+                return done();
+            }
+
+            nBucketsQueued += tasks.length;
+
+            const canonicalIds = new Set(tasks.map(t => t.canonicalId));
+            return this._getAccountIds([...canonicalIds], (err, accountIds) => {
+                if (err) {
+                    log.error('could not get account ids, skipping batch', { error: err });
+                    return done();
+                }
+                const messages = tasks.map(t => ({
+                    message: JSON.stringify({
+                        action: 'processObjects',
+                        target: {
+                            bucket: t.bucketName,
+                            owner: t.canonicalId,
+                            accountId: accountIds[t.canonicalId],
+                        },
+                        details: {},
+                    }),
+                }));
+
+                log.info('bucket push progress', { bucketsInBatch: tasks.length, nBucketsQueued });
+                return this._producer.send(messages, done);
+            });
+        }, this._concurrency);
+
         async.waterfall([
             next => this._controlBacklog(next),
             next => {
-                this.logger.info('starting new lifecycle batch');
-                this._zkClient.getChildren(
-                    zkBucketsPath,
-                    null,
-                    (err, buckets) => {
-                        if (err) {
-                            this.logger.error(
-                                'error getting list of buckets from zookeeper',
-                                { zkPath: zkBucketsPath, error: err.message });
-                        }
-                        return next(err, buckets);
-                    });
+                log.info('starting new lifecycle batch', { bucketSource: this._bucketSource });
+                this.listBuckets(messageSendQueue, log, next);
             },
-            (buckets, next) => async.concatLimit(
-                buckets, this._concurrency,
-                (bucket, done) => {
-                    const [ownerId, bucketUID, bucketName] =
+            (nBucketsListed, next) => {
+                async.until(
+                    () => nBucketsQueued === nBucketsListed,
+                    unext => setTimeout(unext, 1000),
+                    next);
+            },
+        ], err => {
+            if (err && err.Throttling) {
+                log.info('not starting new lifecycle batch', { reason: err });
+                return;
+            }
+
+            if (err) {
+                log.error('lifecycle batch failed', { error: err });
+                return;
+            }
+
+            log.info('finished pushing lifecycle batch', { nBucketsQueued });
+        });
+    }
+
+    listBuckets(queue, log, cb) {
+        if (this._bucketSource === 'zookeeper') {
+            return this.listZookeeperBuckets(queue, log, cb);
+        }
+
+        return this.listBucketdBuckets(queue, log, cb);
+    }
+
+    listZookeeperBuckets(queue, log, cb) {
+        const zkBucketsPath = this.getBucketsZkPath();
+        this._zkClient.getChildren(
+            zkBucketsPath,
+            null,
+            (err, buckets) => {
+                if (err) {
+                    log.error(
+                        'error getting list of buckets from zookeeper',
+                        { zkPath: zkBucketsPath, error: err.message });
+                    return cb(err);
+                }
+
+                const batch = buckets.map(bucket => {
+                    const [canonicalId, bucketUID, bucketName] =
                               bucket.split(':');
-                    if (!ownerId || !bucketUID || !bucketName) {
-                        this.logger.error(
+                    if (!canonicalId || !bucketUID || !bucketName) {
+                        log.error(
                             'malformed zookeeper bucket entry, skipping',
                             { zkPath: zkBucketsPath, bucket });
-                        return process.nextTick(done);
+                        return null;
                     }
-                    if (this.lcConfig.auth.type === authTypeAssumeRole) {
-                        return this._processBucketWithAccountId(ownerId, bucketName, done);
+
+                    return { canonicalId, bucketName };
+                });
+
+                queue.push(batch);
+                return process.nextTick(cb, null, batch.length);
+            });
+    }
+
+    listBucketdBuckets(queue, log, cb) {
+        let isTruncated = false;
+        let marker = null;
+        let nEnqueued = 0;
+
+        async.doWhilst(
+            next => this._bucketClient.listObject(
+                constants.usersBucket,
+                log.getSerializedUids(),
+                { marker, prefix: '', maxKeys: this._concurrency },
+                (err, resp) => {
+                    if (err) {
+                        return next(err);
                     }
-                    return this._processBucket(ownerId, bucketName, done);
-                }, next),
-            (entries, next) => {
-                this.logger.debug(
-                    'producing kafka entries',
-                    { topic: this.lcConfig.bucketTasksTopic,
-                      entries });
-                if (entries.length === 0) {
-                    return next();
+
+                    const { error, result } = safeJsonParse(resp);
+                    if (error) {
+                        return next(error);
+                    }
+
+                    isTruncated = result.IsTruncated;
+                    nEnqueued += result.Contents.length;
+
+                    result.Contents.forEach(o => {
+                        marker = o.key;
+                        const [canonicalId, bucketName] = marker.split(constants.splitter);
+                        queue.push({ canonicalId, bucketName });
+                    });
+
+                    const delay = queue.length() > this._concurrency ? 0 : 500;
+                    return setTimeout(next, delay);
                 }
-                return this._producer.send(entries, next);
-            },
-        ], () => {});
+            ),
+            () => isTruncated,
+            err => cb(err, nEnqueued));
     }
 
     _controlBacklog(done) {
@@ -265,7 +321,21 @@ class LifecycleConductor {
         });
     }
 
+    _setupBucketdClient(cb) {
+        if (this._bucketSource === 'bucketd') {
+            const { host, port } = this._bucketdConfig;
+            // TODO https support S3C-4659
+            this._bucketClient = new BucketClient(`${host}:${port}`);
+        }
+
+        process.nextTick(cb);
+    }
+
     _setupZookeeperClient(cb) {
+        if (this._bucketSource !== 'zookeeper') {
+            process.nextTick(cb);
+            return;
+        }
         this._zkClient = zookeeperHelper.createClient(
             this.zkConfig.connectionString);
         this._zkClient.connect();
@@ -284,13 +354,13 @@ class LifecycleConductor {
     }
 
     /**
-     * Initialize kafka producer and zookeeper client
+     * Initialize kafka producer and clients
      *
      * @param {function} done - callback
      * @return {undefined}
      */
     init(done) {
-        if (this._zkClient) {
+        if (this._initialized) {
             // already initialized
             return process.nextTick(done);
         }
@@ -299,6 +369,7 @@ class LifecycleConductor {
         return async.series([
             next => this._setupProducer(next),
             next => this._setupZookeeperClient(next),
+            next => this._setupBucketdClient(next),
             next => this._initKafkaBacklogMetrics(next),
         ], done);
     }
@@ -367,6 +438,7 @@ class LifecycleConductor {
             if (err) {
                 return done(err);
             }
+            this._initialized = true;
             this._startCronJob();
             return done();
         });

--- a/tests/functional/lifecycle/LifecycleConductor.spec.js
+++ b/tests/functional/lifecycle/LifecycleConductor.spec.js
@@ -2,13 +2,16 @@
 
 const assert = require('assert');
 const async = require('async');
-
+const http = require('http');
+const url = require('url');
 const werelogs = require('werelogs');
 
 const zookeeper = require('../../../lib/clients/zookeeper');
 const BackbeatTestConsumer = require('../../utils/BackbeatTestConsumer');
 const LifecycleConductor = require(
     '../../../extensions/lifecycle/conductor/LifecycleConductor');
+const configValidator = require(
+    '../../../extensions/lifecycle/LifecycleConfigValidator');
 
 const zkConfig = {
     zookeeper: {
@@ -17,38 +20,93 @@ const zkConfig = {
     },
 };
 const kafkaConfig = { hosts: '127.0.0.1:9092' };
+const repConfig = {
+    dataMoverTopic: 'backbeat-data-mover-spec',
+};
+const bucketTasksTopic = 'backbeat-lifecycle-bucket-tasks-spec';
 
-const lcConfig = {
+const expected2Messages = [
+    {
+        value: {
+            action: 'processObjects',
+            target: { bucket: 'bucket1', owner: 'owner1' },
+            details: {},
+        },
+    },
+    {
+        value: {
+            action: 'processObjects',
+            target: { bucket: 'bucket1-2', owner: 'owner1' },
+            details: {},
+        },
+    },
+];
+
+const expected4Messages = [
+    {
+        value: {
+            action: 'processObjects',
+            target: { bucket: 'bucket1', owner: 'owner1' },
+            details: {},
+        },
+    },
+    {
+        value: {
+            action: 'processObjects',
+            target: { bucket: 'bucket1-2', owner: 'owner1' },
+            details: {},
+        },
+    },
+    {
+        value: {
+            action: 'processObjects',
+            target: { bucket: 'bucket3', owner: 'owner3' },
+            details: {},
+        },
+    },
+    {
+        value: {
+            action: 'processObjects',
+            target: { bucket: 'bucket4', owner: 'owner4' },
+            details: {},
+        },
+    },
+];
+
+const baseLCConfig = {
     zookeeperPath: '/test/lifecycle',
-    bucketTasksTopic: 'backbeat-lifecycle-bucket-tasks-spec',
+    bucketTasksTopic,
     objectTasksTopic: 'backbeat-lifecycle-object-tasks-spec',
-    kafka: kafkaConfig,
     conductor: {
         cronRule: '*/5 * * * * *',
         backlogControl: {
             enabled: false,
         },
     },
-    producer: {
-        groupId: 'backbeat-lifecycle-producer-group-spec',
-    },
-    consumer: {
-        groupId: 'backbeat-lifecycle-consumer-group-spec',
-    },
     rules: {
         expiration: {
             enabled: true,
         },
     },
-    auth: { type: 'account', account: 'lifecycle' },
+    auth: {
+        type: 'account',
+        account: 'lifecycle',
+    },
 };
 
-const repConfig = {
-    dataMoverTopic: 'backbeat-data-mover-spec',
-};
+function withAccountIds(messages) {
+    return messages.map(m => ({
+        value: {
+            ...m.value,
+            target: {
+                ...m.value.target,
+                accountId: m.value.target.owner.replace('owner', 'account'),
+            },
+        },
+    }));
+}
 
-const lcConductor = new LifecycleConductor(zkConfig.zookeeper,
-                                           kafkaConfig, lcConfig, repConfig);
+const identity = _ => _;
 
 const TIMEOUT = 120000;
 const CONSUMER_TIMEOUT = 60000;
@@ -56,113 +114,268 @@ const CONSUMER_TIMEOUT = 60000;
 werelogs.configure({ level: 'info', dump: 'error' });
 
 describe('lifecycle conductor', function lifecycleConductor() {
-    let zkClient;
-    let consumer;
-
     this.timeout(TIMEOUT);
 
-    before(done => {
-        async.series([
-            next => lcConductor.init(next),
-            next => {
-                zkClient = zookeeper.createClient(
-                    zkConfig.zookeeper.connectionString,
-                    zkConfig.zookeeper);
-                zkClient.connect();
-                zkClient.once('ready', next);
-            },
-            next => lcConductor.initZkPaths(next),
-            next => {
-                consumer = new BackbeatTestConsumer({
-                    kafka: { hosts: kafkaConfig.hosts },
-                    topic: lcConfig.bucketTasksTopic,
-                    groupId: 'test-consumer-group',
+    function describeConductorSpec(opts) {
+        const {
+            description,
+            lifecycleConfig,
+            transformExpectedMessages,
+            mockBucketd,
+            mockVault,
+            setupZookeeper,
+        } = opts;
+        const bucketdPort = 14345;
+        const vaultPort = 14346;
+        const maxKeys = 2;
+
+        let vault;
+        let bucketd;
+        let bucketdListing;
+        let zkClient;
+        let bucketPopulatorStep1;
+        let bucketPopulatorStep2;
+        let consumer;
+        let lcConductor;
+
+        const vaultHandler = (req, res) => {
+            const { pathname, query } = url.parse(req.url, true);
+
+            assert.strictEqual(pathname, '/');
+            assert.strictEqual(req.method, 'GET');
+            assert.strictEqual(query.Action, 'GetAccounts');
+
+            const canonicalIds = Array.isArray(query.canonicalIds) ?
+                query.canonicalIds :
+                [query.canonicalIds];
+            const accountIds = canonicalIds.map(v => ({
+                id: v.replace('owner', 'account'),
+                canId: v,
+            }));
+
+            res.end(JSON.stringify(accountIds));
+        };
+
+        const bucketdHandler = (req, res) => {
+            const { pathname, query } = url.parse(req.url, true);
+
+            assert.strictEqual(pathname, '/default/bucket/users..bucket');
+            assert.strictEqual(req.method, 'GET');
+            assert.strictEqual(query.prefix, '');
+            assert.strictEqual(query.maxKeys, `${maxKeys}`);
+
+            const thisListing = [...bucketdListing].splice(0, query.maxKeys);
+            bucketdListing = [...bucketdListing].splice(query.maxKeys);
+
+            res.end(JSON.stringify({
+                Contents: thisListing.map(key => ({
+                    key,
+                    value: {},
+                })),
+                IsTruncated: !!bucketdListing.length,
+            }));
+        };
+
+        if (mockBucketd) {
+            lifecycleConfig.conductor.bucketd.port = bucketdPort;
+
+            bucketPopulatorStep1 = next => {
+                bucketdListing.push('owner1..|..bucket1', 'owner1..|..bucket1-2');
+                process.nextTick(next);
+            };
+
+            bucketPopulatorStep2 = next => {
+                bucketdListing.push('owner1..|..bucket1', 'owner1..|..bucket1-2');
+                bucketdListing.push('owner3..|..bucket3', 'owner4..|..bucket4');
+                process.nextTick(next);
+            };
+        }
+
+        if (mockVault) {
+            lifecycleConfig.auth.vault.port = vaultPort;
+        }
+
+        lifecycleConfig.conductor.concurrency = maxKeys;
+        // make topic unique so that different tests' bootstrap messages don't interfere
+        lifecycleConfig.bucketTasksTopic += Math.random();
+
+        const validatedLifecycleConfig = configValidator(null, lifecycleConfig);
+
+        if (setupZookeeper) {
+            assert.ok(!mockBucketd);
+
+            bucketPopulatorStep1 = next => {
+                async.each(
+                    ['owner1:uid1:bucket1', 'owner1:uid1-2:bucket1-2'],
+                    (bucket, done) => zkClient.create(
+                        `${validatedLifecycleConfig.zookeeperPath}/data/buckets/${bucket}`, done),
+                    next);
+            };
+
+            bucketPopulatorStep2 = next => {
+                async.each(
+                    ['owner3:uid3:bucket3', 'owner4:uid4:bucket4'],
+                    (bucket, done) => zkClient.create(
+                        `${validatedLifecycleConfig.zookeeperPath}/data/buckets/${bucket}`, done),
+                    next);
+            };
+        }
+
+        describe(description, () => {
+            beforeEach(done => {
+                bucketdListing = [];
+
+                lcConductor = new LifecycleConductor(zkConfig.zookeeper,
+                    kafkaConfig, validatedLifecycleConfig, repConfig);
+
+                async.series([
+                    next => lcConductor.init(next),
+                    next => {
+                        consumer = new BackbeatTestConsumer({
+                            kafka: { hosts: kafkaConfig.hosts },
+                            topic: validatedLifecycleConfig.bucketTasksTopic,
+                            groupId: 'test-consumer-group',
+                        });
+                        consumer.on('ready', next);
+                    },
+                    next => {
+                        consumer.subscribe();
+                        // it seems the consumer needs some extra time to
+                        // start consuming the first messages
+                        setTimeout(next, 2000);
+                    },
+                    next => {
+                        if (mockBucketd) {
+                            bucketd = http.createServer(bucketdHandler);
+                            bucketd.listen(bucketdPort, next);
+                        } else {
+                            process.nextTick(next);
+                        }
+                    },
+                    next => {
+                        if (mockVault) {
+                            vault = http.createServer(vaultHandler);
+                            vault.listen(vaultPort, next);
+                        } else {
+                            process.nextTick(next);
+                        }
+                    },
+                    next => {
+                        if (setupZookeeper) {
+                            zkClient = zookeeper.createClient(
+                                zkConfig.zookeeper.connectionString,
+                                zkConfig.zookeeper);
+                            zkClient.connect();
+                            zkClient.once('ready', () => {
+                                lcConductor.initZkPaths(next);
+                            });
+                        } else {
+                            process.nextTick(next);
+                        }
+                    },
+                ], done);
+            });
+
+            afterEach(done => {
+                async.series([
+                    next => {
+                        if (mockBucketd) {
+                            bucketd.close(next);
+                        } else {
+                            process.nextTick(next);
+                        }
+                    },
+                    next => {
+                        if (mockVault) {
+                            vault.close(next);
+                        } else {
+                            process.nextTick(next);
+                        }
+                    },
+                    next => {
+                        if (setupZookeeper) {
+                            zkClient.removeRecur(validatedLifecycleConfig.zookeeperPath, next);
+                        } else {
+                            process.nextTick(next);
+                        }
+                    },
+                    next => consumer.close(next),
+                    next => lcConductor.stop(next),
+                ], done);
+            });
+
+            it('should populate queue', done => {
+                async.waterfall([
+                    bucketPopulatorStep1,
+                    next => {
+                        lcConductor.processBuckets();
+                        consumer.expectUnorderedMessages(transformExpectedMessages(expected2Messages),
+                            CONSUMER_TIMEOUT, next);
+                    },
+                    bucketPopulatorStep2,
+                    next => {
+                        lcConductor.processBuckets();
+                        consumer.expectUnorderedMessages(transformExpectedMessages(expected4Messages),
+                            CONSUMER_TIMEOUT, next);
+                    },
+                ], err => {
+                    assert.ifError(err);
+                    done();
                 });
-                consumer.on('ready', next);
+            });
+        });
+    }
+
+    describeConductorSpec({
+        description: 'with auth `account` and buckets from bucketd',
+        lifecycleConfig: {
+            ...baseLCConfig,
+            conductor: {
+                ...baseLCConfig.conductor,
+                bucketSource: 'bucketd',
+                bucketd: {
+                    host: '127.0.0.1',
+                },
             },
-            next => {
-                consumer.subscribe();
-                // it seems the consumer needs some extra time to
-                // start consuming the first messages
-                setTimeout(next, 2000);
-            },
-        ], done);
+        },
+        mockBucketd: true,
+        transformExpectedMessages: identity,
     });
 
-    after(done => {
-        async.waterfall([
-            next => zkClient.removeRecur(lcConfig.zookeeperPath, next),
-            next => consumer.close(next),
-            next => lcConductor.stop(next),
-        ], done);
+    describeConductorSpec({
+        description: 'with auth `account` and buckets from zookeeper (compat mode)',
+        lifecycleConfig: baseLCConfig,
+        setupZookeeper: true,
+        transformExpectedMessages: identity,
     });
 
-    it('should populate queue from lifecycled bucket list ' +
-    'in zookeeper', done => async.waterfall([
-        next => async.each(
-            ['owner1:uid1:bucket1', 'owner2:uid2:bucket2'],
-            (bucket, done) => zkClient.create(
-                `${lcConfig.zookeeperPath}/data/buckets/${bucket}`, done),
-            next),
-        next => {
-            lcConductor.processBuckets();
-            consumer.expectUnorderedMessages([
-                {
-                    value: {
-                        action: 'processObjects',
-                        target: { bucket: 'bucket1', owner: 'owner1' },
-                        details: {},
-                    },
+    describeConductorSpec({
+        description: 'with auth `assumeRole` and buckets from bucketd',
+        lifecycleConfig: {
+            ...baseLCConfig,
+            conductor: {
+                ...baseLCConfig.conductor,
+                bucketSource: 'bucketd',
+                bucketd: {
+                    host: '127.0.0.1',
                 },
-                {
-                    value: {
-                        action: 'processObjects',
-                        target: { bucket: 'bucket2', owner: 'owner2' },
-                        details: {},
-                    },
+            },
+            auth: {
+                type: 'assumeRole',
+                roleName: 'lc',
+                sts: {
+                    host: '127.0.0.1',
+                    port: 8650,
+                    accessKey: 'ak',
+                    secretKey: 'sk',
                 },
-            ], CONSUMER_TIMEOUT, next);
+                vault: {
+                    host: '127.0.0.1',
+                },
+            },
         },
-        next => async.each(
-            ['owner3:uid3:bucket3', 'owner4:uid4:bucket4'],
-            (bucket, done) => zkClient.create(
-                `${lcConfig.zookeeperPath}/data/buckets/${bucket}`, done),
-            next),
-        next => {
-            lcConductor.processBuckets();
-            consumer.expectUnorderedMessages([
-                {
-                    value: {
-                        action: 'processObjects',
-                        target: { bucket: 'bucket1', owner: 'owner1' },
-                        details: {},
-                    },
-                },
-                {
-                    value: {
-                        action: 'processObjects',
-                        target: { bucket: 'bucket2', owner: 'owner2' },
-                        details: {},
-                    },
-                },
-                {
-                    value: {
-                        action: 'processObjects',
-                        target: { bucket: 'bucket3', owner: 'owner3' },
-                        details: {},
-                    },
-                },
-                {
-                    value: {
-                        action: 'processObjects',
-                        target: { bucket: 'bucket4', owner: 'owner4' },
-                        details: {},
-                    },
-                },
-            ], CONSUMER_TIMEOUT, next);
-        },
-    ], err => {
-        assert.ifError(err);
-        done();
-    }));
+        mockBucketd: true,
+        mockVault: true,
+        transformExpectedMessages: withAccountIds,
+    });
 });


### PR DESCRIPTION
Implements getting the list of buckets to lifecycle from a bucketd listing, instead of Zookeeper.

This keeps the Zookeeper dataset from growing linearly with the data plane's number of buckets, which would destabilize the quorum and worsen transient issues. The compromise is that more messages go through Kafka, which are then processed in parallel - buckets are either ignored or queued for listing by the bucket processor processes. The listing operation itself is relatively cheap.

Best case: all buckets have a lifecycle configuration; no change in the number of messages transiting through Kafka.
Worst case: no buckets have a lifecycle configuration; 1 message per bucket go through Kafka (instead of 0),  then are ignored by the bucket processor.

Note: had to enable object spread for eslint, as the `Object.assign` equivalent was unreadable.