### PR TITLE
INTEGRATION [PR#1909 > development/8.2] BB-28 update werelogs to a tagged version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "prom-client": "^12.0.0",
     "uuid": "^3.1.0",
     "vaultclient": "scality/vaultclient#90762d2",
-    "werelogs": "scality/werelogs#4e0d97c",
+    "werelogs": "scality/werelogs#8.1.0",
     "yarn": "^1.17.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2617,6 +2617,12 @@ werelogs@scality/werelogs#4e0d97c:
   dependencies:
     safe-json-stringify "1.0.3"
 
+werelogs@scality/werelogs#8.1.0:
+  version "8.1.0"
+  resolved "https://codeload.github.com/scality/werelogs/tar.gz/e8f828725642c54c511cdbe580b18f43d3589313"
+  dependencies:
+    safe-json-stringify "1.0.3"
+
 wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1909.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/feature/BB-28-update-werelogs`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/feature/BB-28-update-werelogs
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/feature/BB-28-update-werelogs
```

Please always comment pull request #1909 instead of this one.