### PR TITLE
INTEGRATION [PR#1914 > development/8.2] bugfix: don't log entries in lifecycle queue populator

### DIFF
--- a/extensions/lifecycle/LifecycleQueuePopulator.js
+++ b/extensions/lifecycle/LifecycleQueuePopulator.js
@@ -129,8 +129,7 @@ class LifecycleQueuePopulator extends QueuePopulatorExtension {
         }
 
         if (this.extConfig.conductor.bucketSource !== 'zookeeper') {
-            this.log.info('bucket source is not zookeeper, skipping entry', {
-                entry,
+            this.log.debug('bucket source is not zookeeper, skipping entry', {
                 bucketSource: this.extConfig.conductor.bucketSource,
             });
             return undefined;


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1914.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/bugfix/BB-29-fix-entry-logging`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/bugfix/BB-29-fix-entry-logging
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/bugfix/BB-29-fix-entry-logging
```

Please always comment pull request #1914 instead of this one.