### PR TITLE
BB-32 fix replication status processor

### DIFF
--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -214,7 +214,7 @@ class ReplicationStatusProcessor {
                     concurrency:
                     this.repConfig.replicationStatusProcessor.concurrency,
                     queueProcessor: this.processKafkaEntry.bind(this),
-                    bootstrap: options && options.bootstrap,
+                    bootstrap: (options && options.bootstrap) || false,
                 });
                 this._consumer.on('error', () => {
                     if (!consumerReady) {


### PR DESCRIPTION
Backbeat consumer bootstrap is used for testing purposes only and has to be either a boolean type or undefined and in that case we will set to false (by default).
If `options` is `null`, `bootstrap` will be `null` and won't be set to false by default.

From joi documentation:

```
.default([value]) sets a default value if the original value is undefined
```

Other possible solutions:

- explicitly mentioning `{ bootstrap: false } ` instead of `null`.
- `joi.boolean().falsy(null).default(false)` or similar in our BackbeatConsumer.js.