### PR TITLE
BB-37 paused locations state is not set up properly

### DIFF
--- a/bin/ingestion.js
+++ b/bin/ingestion.js
@@ -168,7 +168,7 @@ function setupZkLocationNode(zkClient, location, done) {
                     return checkAndApplyScheduleResume(zkClient, d, location,
                         done);
                 }
-                if (data.paused === true) {
+                if (d.paused === true) {
                     ingestionPopulator.setPausedLocationState(location);
                 }
                 return done();


### PR DESCRIPTION
`data` is not JSON parsed so `data.paused` condition was always false.
That would lead to the application "ingestion state" not reflecting the zookeeper "ingestion state".
