### PR TITLE
bugfix: BB-31 skip metrics when using mongo log reader

### DIFF
--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -577,13 +577,16 @@ class LogReader {
 
     _processSaveLogOffset(batchState, done) {
         const { logRes, nextLogOffset, logger } = batchState;
-        if (nextLogOffset !== undefined && nextLogOffset !== this.logOffset
-            && (!logRes.log.reachedUnpublishedListing ||
-                logRes.log.reachedUnpublishedListing())) {
-            const logSize = batchState.logRes.info.cseq || batchState.logRes.info.end;
+        if (logRes.info && nextLogOffset !== undefined &&
+            nextLogOffset !== this.logOffset &&
+            (!logRes.log.reachedUnpublishedListing ||
+            logRes.log.reachedUnpublishedListing())) {
+
+            const logSize = logRes.info.cseq || logRes.info.end;
             this.logOffset = nextLogOffset;
             this._metricsHandler.logReadOffset(this.getMetricLabels(), this.logOffset);
             this._metricsHandler.logSize(this.getMetricLabels(), logSize);
+
             return this._writeLogOffset(logger, done);
         }
         return process.nextTick(() => done());


### PR DESCRIPTION
Mongo log reader has no value for the end of the log to use as the metric so just skip it for now