### PR TITLE
BB-40 stop retagging image on release pipeline

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -163,19 +163,18 @@ stages:
     worker: *docker_worker
     steps:
     - Git: *git
+    - ShellCommand:
+        name: Checkout tag
+        command: git checkout refs/tags/%(prop:tag)s
     - ShellCommand: *wait_docker_daemon
     - ShellCommand: *docker_login
-    - EvePropertyFromCommand:
-        name: get tag short revision
-        property: tag_revision
-        command: |
-          git checkout refs/tags/%(prop:tag)s 2&> /dev/null
-          git rev-parse --short HEAD
-        haltOnFailure: true
+    - ShellCommand:
+        name: docker build
+        command: >-
+          docker build .
+          --tag=${PRODUCTION_DOCKER_IMAGE_NAME}:%(prop:tag)s
+        env: *docker_env
     - ShellCommand:
         name: publish docker image to Scality Production OCI registry
-        command: |
-          docker pull ${DEVELOPMENT_DOCKER_IMAGE_NAME}:%(prop:tag_revision)s
-          docker tag ${DEVELOPMENT_DOCKER_IMAGE_NAME}:%(prop:tag_revision)s ${PRODUCTION_DOCKER_IMAGE_NAME}:%(prop:tag)s
-          docker push ${PRODUCTION_DOCKER_IMAGE_NAME}:%(prop:tag)s
+        command: docker push ${PRODUCTION_DOCKER_IMAGE_NAME}:%(prop:tag)s
         env: *docker_env


### PR DESCRIPTION
We currently faced multiple issues when trying to pull an existent
docker image in the dev namespace when releasing it:
* Race condition between two builds when the image is being built.
* Different git version return a different number on the commit hash

Now building the image from scratch instead of retagging it.
