### PR TITLE
bf: BB-46 ingestion producer crash

### DIFF
--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -51,7 +51,7 @@ class IngestionPopulator {
      * @param {Object} s3Config - configuration to connect to S3 Client
      */
     constructor(zkClient, zkConfig, kafkaConfig, qpConfig, mConfig, rConfig,
-                ingestionConfig, s3Config) {
+        ingestionConfig, s3Config) {
         this.zkClient = zkClient;
         this.zkConfig = zkConfig;
         this.kafkaConfig = kafkaConfig;
@@ -107,9 +107,9 @@ class IngestionPopulator {
                 if (err) {
                     this.log.error(
                         'error setting up ingestion extension', {
-                            method: 'IngestionPopulator.open',
-                            error: err,
-                        });
+                        method: 'IngestionPopulator.open',
+                        error: err,
+                    });
                 }
                 return next(err);
             }),
@@ -125,8 +125,10 @@ class IngestionPopulator {
         ], err => {
             if (err) {
                 this.log.error('error starting up ingestion populator',
-                    { method: 'IngestionPopulator.open',
-                        error: err });
+                    {
+                        method: 'IngestionPopulator.open',
+                        error: err
+                    });
                 return cb(err);
             }
             // setup redis for pause/resume
@@ -351,7 +353,7 @@ class IngestionPopulator {
             this._updateZkStateNode(location, 'scheduledResume', null, err => {
                 if (err) {
                     this.log.error('error occurred saving state to zookeeper ' +
-                    'to resume a scheduled resume. Retry again in 1 minute', {
+                        'to resume a scheduled resume. Retry again in 1 minute', {
                         method: 'IngestionPopulator.scheduleResume',
                         locationConstraint: location,
                         error: err,
@@ -431,7 +433,7 @@ class IngestionPopulator {
                     bufferedData = Buffer.from(JSON.stringify(state));
                 } catch (err) {
                     this.log.error('could not parse state data from ' +
-                    'zookeeper', {
+                        'zookeeper', {
                         method: 'IngestionPopulator._updateZkStateNode',
                         zookeeperPath: path,
                         error: err,
@@ -592,14 +594,19 @@ class IngestionPopulator {
     _setupUpdatedReaders(done) {
         const newReaders = this.logReadersUpdate;
         this.logReadersUpdate = [];
-        async.each(newReaders, (logReader, cb) => logReader.setup(cb),
-                   err => {
-                       if (err) {
-                           return done(err);
-                       }
-                       this.logReaders.push(...newReaders);
-                       return done();
-                   });
+        async.each(newReaders, (logReader, cb) => logReader.setup(err => {
+            if (err) {
+                // if setup fails for a log reader, don't add it to `logReaders`
+                // log the error and continue setting up others
+                this.log.fatal('error setting up log reader', {
+                    method: 'IngestionPopulator._setupUpdatedReaders',
+                    error: err,
+                });
+            } else {
+                this.logReaders.push(logReader);
+            }
+            return cb();
+        }), done);
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "8.2.8",
+  "version": "8.2.9",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {
@@ -74,3 +74,4 @@
     "zookeeper-mock": "^1.2.0"
   }
 }
+


### PR DESCRIPTION
Ingestion producer crashes when a non-existent bucket is set as ingestion source, for such configurations log reader will not be set until the bucket is created on the source.