### PR TITLE
bugfix: S3C-4457 workaround to catch duplicate callback

### DIFF
--- a/lib/tasks/BackbeatTask.js
+++ b/lib/tasks/BackbeatTask.js
@@ -31,11 +31,33 @@ class BackbeatTask {
         const startTime = Date.now();
         const self = this;
 
+        // FIXME workaround for S3C-4457:
+        //
+        // It seems the S3 client may call its callback multiple times
+        // in an unknown corner case (the callback passed to the
+        // send() function, like in ReplicateObject._setupRolesOnce()).
+        //
+        // Until we find the root cause, we catch duplicate calls and
+        // log them instead of crashing the process with an exception
+        // raised from the async module.
+        //
+        let cbCalled = false;
+        const doneOnce = function doneWrapper(...args) {
+            if (!cbCalled) {
+                cbCalled = true;
+                done.apply(done, args);
+            } else {
+                log.warn('callback was already called', Object.assign({
+                    method: 'BackbeatTask.retry',
+                }, logFields || {}));
+            }
+        };
+
         function _handleRes(...args) {
             const err = args[0];
             if (err) {
                 if (!shouldRetryFunc(err)) {
-                    return done(err);
+                    return doneOnce(err);
                 }
                 if (onRetryFunc) {
                     onRetryFunc(err);
@@ -49,7 +71,7 @@ class BackbeatTask {
                             nbRetries,
                             retryTotalMs: `${now - startTime}`,
                         }, logFields || {}), log);
-                    return done(err);
+                    return doneOnce(err);
                 }
                 const retryDelayMs = backoffCtx.duration();
                 log.info(`temporary failure to ${actionDesc}, scheduled retry`,
@@ -67,7 +89,7 @@ class BackbeatTask {
                              retryTotalMs: `${now - startTime}`,
                          }, logFields || {}));
             }
-            return done(...args);
+            return doneOnce(...args);
         }
         actionFunc(_handleRes);
     }

--- a/tests/unit/lib/tasks/BackbeatTask.spec.js
+++ b/tests/unit/lib/tasks/BackbeatTask.spec.js
@@ -1,0 +1,44 @@
+const assert = require('assert');
+
+const werelogs = require('werelogs');
+
+const BackbeatTask = require('../../../../lib/tasks/BackbeatTask');
+
+const logger = new werelogs.Logger('BackbeatTask:test');
+
+describe('BackbeatTask', () => {
+    // TODO S3C-4457: when the root cause of the issue is eventually
+    // found, the workaround can be removed and this associated test too.
+    it('BackbeatTask.retry() should handle and trace double callback', done => {
+        let cbCalled = false;
+        let inRetry = false;
+        const task = new BackbeatTask();
+        task.retry({
+            actionDesc: 'do test action',
+            actionFunc: cb => {
+                logger.info('actionFunc');
+                if (inRetry) {
+                    cb();
+                } else {
+                    cb(new Error('OOPS'));
+                    inRetry = true;
+                }
+                // trigger a double callback after 5 seconds, ending with success
+                setTimeout(cb, 2000);
+            },
+            shouldRetryFunc: () => true,
+            logFields: {
+                testLog: 'a log field',
+            },
+            log: logger,
+        }, err => {
+            assert.ifError(err);
+            assert(!cbCalled);
+            cbCalled = true;
+            // Wait to check that the callback does not get called
+            // again, to make sure the double callback is caught in
+            // the retry logic.
+            setTimeout(done, 2000);
+        });
+    }).timeout(10000);
+});


### PR DESCRIPTION
Add a workaround in BackbeatTask to catch duplicate callback calls and
avoid a process crash.

The suspicion is that the AWS SDK client may call its callback
multiple times from the send() method, but it was not reproduced so
far.

(cherry picked from commit 268777900872888925715e7ea40d7cab15803752)