### PR TITLE
INTEGRATION [PR#1936 > development/8.3] feature: BB-50 Probe server should return undefined

### DIFF
--- a/bin/ingestion.js
+++ b/bin/ingestion.js
@@ -3,7 +3,14 @@ const schedule = require('node-schedule');
 const zookeeper = require('node-zookeeper-client');
 
 const werelogs = require('werelogs');
-const { HealthProbeServer } = require('arsenal').network.probe;
+const { errors } = require('arsenal');
+const {
+    DEFAULT_LIVE_ROUTE,
+    DEFAULT_METRICS_ROUTE,
+    DEFAULT_READY_ROUTE,
+} = require('arsenal').network.probe.ProbeServer;
+const { sendSuccess, sendError } = require('arsenal').network.probe.Utils;
+const { ZenkoMetrics } = require('arsenal').metrics;
 const { reshapeExceptionError } = require('arsenal').errorUtils;
 
 const IngestionPopulator = require('../lib/queuePopulator/IngestionPopulator');
@@ -12,6 +19,7 @@ const { initManagement } = require('../lib/management/index');
 const zookeeperWrapper = require('../lib/clients/zookeeper');
 const { zookeeperNamespace, zkStatePath } =
     require('../extensions/ingestion/constants');
+const { startProbeServer } = require('../lib/util/probe');
 
 const zkConfig = config.zookeeper;
 const kafkaConfig = config.kafka;
@@ -27,11 +35,6 @@ const RESUME_NODE = 'scheduledResume';
 const log = new werelogs.Logger('Backbeat:IngestionPopulator');
 werelogs.configure({ level: config.log.logLevel,
     dump: config.log.dumpLevel });
-
-const healthServer = new HealthProbeServer({
-    bindAddress: config.healthcheckServer.bindAddress,
-    port: config.healthcheckServer.port,
-});
 
 let scheduler;
 let ingestionPopulator;
@@ -225,19 +228,6 @@ function updateProcessors(zkClient, bootstrapList) {
     });
 }
 
-function loadHealthcheck() {
-    healthServer.onReadyCheck(() => {
-        const state = ingestionPopulator.zkStatus();
-        if (state.code === zookeeper.State.SYNC_CONNECTED.code) {
-            return true;
-        }
-        log.error(`Zookeeper is not connected! ${state}`);
-        return false;
-    });
-    log.info('Starting health probe server');
-    healthServer.start();
-}
-
 function loadProcessors(zkClient) {
     let bootstrapList = config.getBootstrapList();
     updateProcessors(zkClient, bootstrapList);
@@ -246,6 +236,38 @@ function loadProcessors(zkClient) {
         bootstrapList = config.getBootstrapList();
         updateProcessors(zkClient, bootstrapList);
     });
+}
+
+/**
+ * Handle ProbeServer liveness check
+ *
+ * @param {http.HTTPServerResponse} res - HTTP Response to respond with
+ * @param {Logger} log - Logger
+ * @returns {undefined}
+ */
+ function handleLiveness(res, log) {
+    const state = ingestionPopulator.zkStatus();
+    if (state.code === zookeeper.State.SYNC_CONNECTED.code) {
+        sendSuccess(res, log);
+    } else {
+        log.error(`Zookeeper is not connected! ${state}`);
+        sendError(res, log, errors.ServiceUnavailable, 'unhealthy');
+    }
+}
+
+/**
+ * Handle ProbeServer metrics
+ *
+ * @param {http.HTTPServerResponse} res - HTTP Response to respond with
+ * @param {Logger} log - Logger
+ * @returns {undefined}
+ */
+function handleMetrics(res, log) {
+    log.debug('metrics requested');
+    res.writeHead(200, {
+        'Content-Type': ZenkoMetrics.asPrometheusContentType(),
+    });
+    res.end(ZenkoMetrics.asPrometheus());
 }
 
 function initAndStart(zkClient) {
@@ -272,8 +294,23 @@ function initAndStart(zkClient) {
             done => {
                 scheduler = schedule.scheduleJob(ingestionExtConfigs.cronRule,
                     () => queueBatch(ingestionPopulator, log));
-                done();
+                return done();
             },
+            done => startProbeServer(ingestionExtConfigs.probeServer, (err, probeServer) => {
+                if (err) {
+                    log.error('error starting probe server', { error: err });
+                    return done(err);
+                }
+                if (probeServer !== undefined) {
+                    // following the same pattern as other extensions, where liveness
+                    // and readiness are handled by the same handler
+                    probeServer.addHandler([DEFAULT_LIVE_ROUTE, DEFAULT_READY_ROUTE], handleLiveness);
+                    // retaining the old route and adding support to new route, until
+                    // metrics handling is consolidated
+                    probeServer.addHandler(['/_/monitoring/metrics', DEFAULT_METRICS_ROUTE], handleMetrics);
+                }
+                return done();
+            }),
         ], err => {
             if (err) {
                 log.fatal('error during ingestion populator initialization', {
@@ -282,7 +319,6 @@ function initAndStart(zkClient) {
                 });
                 process.exit(1);
             }
-            loadHealthcheck();
         });
     });
 }

--- a/extensions/gc/service.js
+++ b/extensions/gc/service.js
@@ -6,9 +6,10 @@ const {
     DEFAULT_LIVE_ROUTE,
     DEFAULT_READY_ROUTE,
 } = require('arsenal').network.probe.ProbeServer;
+const { sendSuccess, sendError } = require('arsenal').network.probe.ProbeServer;
 
 const GarbageCollector = require('./GarbageCollector');
-const { sendSuccess, sendError, startProbeServer } = require('../../lib/util/probe');
+const { startProbeServer } = require('../../lib/util/probe');
 const { initManagement } = require('../../lib/management');
 const config = require('../../lib/Config');
 
@@ -33,7 +34,7 @@ const logger = new werelogs.Logger('Backbeat:GC:service');
  *
  * @param {http.HTTPServerResponse} res - HTTP Response to respond with
  * @param {Logger} log - Logger
- * @returns {string} response
+ * @returns {undefined}
  */
  function handleLiveness(res, log) {
     if (garbageCollector.isReady()) {

--- a/extensions/lifecycle/bucketProcessor/task.js
+++ b/extensions/lifecycle/bucketProcessor/task.js
@@ -7,11 +7,12 @@ const {
     DEFAULT_LIVE_ROUTE,
     DEFAULT_READY_ROUTE,
 } = require('arsenal').network.probe.ProbeServer;
+const { sendSuccess, sendError } = require('arsenal').network.probe.Utils;
 
 const { initManagement } = require('../../../lib/management/index');
 const LifecycleBucketProcessor = require('./LifecycleBucketProcessor');
 const { applyBucketLifecycleWorkflows } = require('../management');
-const { sendSuccess, sendError, startProbeServer } = require('../../../lib/util/probe');
+const { startProbeServer } = require('../../../lib/util/probe');
 const config = require('../../../lib/Config');
 
 const { zookeeper, kafka, extensions, s3, log } = config;

--- a/extensions/lifecycle/conductor/service.js
+++ b/extensions/lifecycle/conductor/service.js
@@ -8,11 +8,12 @@ const {
     DEFAULT_METRICS_ROUTE,
     DEFAULT_READY_ROUTE,
 } = require('arsenal').network.probe.ProbeServer;
+const { sendSuccess, sendError } = require('arsenal').network.probe.Utils;
 const { ZenkoMetrics } = require('arsenal').metrics;
 
 const LifecycleConductor = require('./LifecycleConductor');
 const config = require('../../../lib/Config');
-const { sendSuccess, sendError, startProbeServer } = require('../../../lib/util/probe');
+const { startProbeServer } = require('../../../lib/util/probe');
 
 const zkConfig = config.zookeeper;
 const kafkaConfig = config.kafka;
@@ -59,7 +60,7 @@ function handleMetrics(res, log) {
 }
 
 async.waterfall([
-    done => startProbeServer(config.healthcheckServer, (err, probeServer) => {
+    done => startProbeServer(lcConfig.conductor.probeServer, (err, probeServer) => {
         if (err) {
             logger.error('error starting probe server', { error: err });
             return done(err);

--- a/extensions/lifecycle/objectProcessor/task.js
+++ b/extensions/lifecycle/objectProcessor/task.js
@@ -7,10 +7,11 @@ const {
     DEFAULT_LIVE_ROUTE,
     DEFAULT_READY_ROUTE,
 } = require('arsenal').network.probe.ProbeServer;
+const { sendSuccess, sendError } = require('arsenal').network.probe.Utils;
 
 const { initManagement } = require('../../../lib/management/index');
 const LifecycleObjectProcessor = require('./LifecycleObjectProcessor');
-const { sendSuccess, sendError, startProbeServer } = require('../../../lib/util/probe');
+const { startProbeServer } = require('../../../lib/util/probe');
 const config = require('../../../lib/Config');
 
 const zkConfig = config.zookeeper;

--- a/extensions/mongoProcessor/mongoProcessorTask.js
+++ b/extensions/mongoProcessor/mongoProcessorTask.js
@@ -1,11 +1,19 @@
 'use strict'; // eslint-disable-line
 
 const werelogs = require('werelogs');
-const { HealthProbeServer } = require('arsenal').network.probe;
+const { errors } = require('arsenal');
+const {
+    DEFAULT_LIVE_ROUTE,
+    DEFAULT_METRICS_ROUTE,
+    DEFAULT_READY_ROUTE,
+} = require('arsenal').network.probe.ProbeServer;
+const { sendSuccess, sendError } = require('arsenal').network.probe.Utils;
+const { ZenkoMetrics } = require('arsenal').metrics;
 
 const MongoQueueProcessor = require('./MongoQueueProcessor');
 const config = require('../../lib/Config');
 const { initManagement } = require('../../lib/management/index');
+const { startProbeServer } = require('../../lib/util/probe');
 
 const kafkaConfig = config.kafka;
 const mConfig = config.metrics;
@@ -14,11 +22,6 @@ const mongoProcessorConfig = config.extensions.mongoProcessor;
 // for the consumer side
 const mongoClientConfig = config.queuePopulator.mongo;
 
-const healthServer = new HealthProbeServer({
-    bindAddress: config.healthcheckServer.bindAddress,
-    port: config.healthcheckServer.port,
-});
-
 const log = new werelogs.Logger('Backbeat:MongoProcessor:task');
 werelogs.configure({ level: config.log.logLevel,
     dump: config.log.dumpLevel });
@@ -26,17 +29,35 @@ werelogs.configure({ level: config.log.logLevel,
 const mqp = new MongoQueueProcessor(kafkaConfig, mongoProcessorConfig,
     mongoClientConfig, mConfig);
 
-function loadHealthcheck() {
-    healthServer.onReadyCheck(() => {
-        let passed = true;
-        if (!mqp.isReady()) {
-            passed = false;
-            log.error('MongoQueueProcessor is not ready');
-        }
-        return passed;
+/**
+ * Handle ProbeServer liveness check
+ *
+ * @param {http.HTTPServerResponse} res - HTTP Response to respond with
+ * @param {Logger} log - Logger
+ * @returns {undefined}
+ */
+ function handleLiveness(res, log) {
+    if (mqp.isReady()) {
+        sendSuccess(res, log);
+    } else {
+        log.error('MongoQueueProcessor is not ready');
+        sendError(res, log, errors.ServiceUnavailable, 'unhealthy');
+    }
+}
+
+/**
+ * Handle ProbeServer metrics
+ *
+ * @param {http.HTTPServerResponse} res - HTTP Response to respond with
+ * @param {Logger} log - Logger
+ * @returns {undefined}
+ */
+function handleMetrics(res, log) {
+    log.debug('metrics requested');
+    res.writeHead(200, {
+        'Content-Type': ZenkoMetrics.asPrometheusContentType(),
     });
-    log.info('Starting HealthProbe server');
-    healthServer.start();
+    res.end(ZenkoMetrics.asPrometheus());
 }
 
 function loadManagementDatabase() {
@@ -51,14 +72,25 @@ function loadManagementDatabase() {
             return;
         }
         log.info('management init done');
-
         mqp.start();
-
-        loadHealthcheck();
     });
 }
 
-loadManagementDatabase();
+startProbeServer(mongoProcessorConfig.probeServer, (err, probeServer) => {
+    if (err) {
+        log.error('error starting probe server', { error: err });
+        process.exit(1);
+    }
+    if (probeServer !== undefined) {
+        // following the same pattern as other extensions, where liveness
+        // and readiness are handled by the same handler
+        probeServer.addHandler([DEFAULT_LIVE_ROUTE, DEFAULT_READY_ROUTE], handleLiveness);
+        // retaining the old route and adding support to new route, until
+        // metrics handling is consolidated
+        probeServer.addHandler(['/_/monitoring/metrics', DEFAULT_METRICS_ROUTE], handleMetrics);
+    }
+    loadManagementDatabase();
+});
 
 process.on('SIGTERM', () => {
     log.info('received SIGTERM, exiting');

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -16,6 +16,7 @@ const NotificationConfigManager
 const promClient = require('prom-client');
 const constants = require('../constants');
 const { wrapCounterInc, wrapGaugeSet } = require('../util/metrics');
+const { sendSuccess } = require('arsenal').network.probe.Utils;
 
 const metricLabels = ['origin', 'logName', 'logId', 'containerName'];
 promClient.register.setDefaultLabels({
@@ -457,7 +458,7 @@ class QueuePopulator {
      *
      * @param {http.HTTPServerResponse} res - HTTP Response to respond with
      * @param {Logger} log - Logger
-     * @returns {string} Error response string or undefined
+     * @returns {undefined}
      */
     handleLiveness(res, log) {
         // log verbose status for all checks
@@ -492,11 +493,19 @@ class QueuePopulator {
         log.debug('verbose liveness', verboseLiveness);
 
         if (responses.length > 0) {
-            return JSON.stringify(responses);
+            const message = JSON.stringify(responses);
+            log.debug('service unavailable',
+                {
+                    httpCode: 500,
+                    error: message,
+                }
+            );
+            res.writeHead(500);
+            res.end(message);
+            return undefined;
         }
 
-        res.writeHead(200);
-        res.end();
+        sendSuccess(res, log);
         return undefined;
     }
 
@@ -505,7 +514,7 @@ class QueuePopulator {
      *
      * @param {http.HTTPServerResponse} res - HTTP Response to respond with
      * @param {Logger} log - Logger
-     * @returns {string} Error response string or undefined
+     * @returns {undefined}
      */
     handleMetrics(res, log) {
         log.debug('metrics requested');

--- a/lib/util/probe.js
+++ b/lib/util/probe.js
@@ -33,30 +33,6 @@ function startProbeServer(config, callback) {
     probeServer.start();
 }
 
-function sendError(res, log, error, optMessage) {
-    res.writeHead(error.code);
-    let message;
-    if (optMessage) {
-        message = optMessage;
-    } else {
-        message = error.description || '';
-    }
-    log.debug('sending back error response', { httpCode: error.code,
-        errorType: error.message,
-        error: message });
-    res.end(`${JSON.stringify({ errorType: error.message,
-        errorMessage: message })}\n`);
-}
-
-function sendSuccess(res, log, msg) {
-    res.writeHead(200);
-    log.debug('replying with success');
-    const message = msg || 'OK';
-    res.end(message);
-}
-
 module.exports = {
     startProbeServer,
-    sendSuccess,
-    sendError,
 };

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@hapi/joi": "^15.1.0",
     "JSONStream": "^1.3.5",
-    "arsenal": "scality/Arsenal#8.1.1",
+    "arsenal": "scality/Arsenal#8.1.3",
     "async": "^2.3.0",
     "aws-sdk": "^2.938.0",
     "backo": "^1.1.0",

--- a/tests/unit/QueuePopulator.spec.js
+++ b/tests/unit/QueuePopulator.spec.js
@@ -34,11 +34,6 @@ describe('QueuePopulator', () => {
             };
             const response = qp.handleLiveness(mockRes, mockLog);
             assert.strictEqual(response, undefined);
-            sinon.assert.calledOnceWithExactly(
-                mockLog.debug,
-                sinon.match.any, // we don't care about the debug label
-                { zookeeper: zookeeper.State.SYNC_CONNECTED.code }
-            );
             sinon.assert.calledOnceWithExactly(mockRes.writeHead, 200);
             sinon.assert.calledOnce(mockRes.end);
         });
@@ -62,15 +57,6 @@ describe('QueuePopulator', () => {
             };
             const response = qp.handleLiveness(mockRes, mockLog);
             assert.strictEqual(response, undefined);
-            sinon.assert.calledOnceWithExactly(
-                mockLog.debug,
-                sinon.match.any, // we don't care about the debug label
-                {
-                    'zookeeper': zookeeper.State.SYNC_CONNECTED.code,
-                    'producer-topicA': true,
-                    'producer-topicB': true,
-                }
-            );
             sinon.assert.calledOnceWithExactly(mockRes.writeHead, 200);
             sinon.assert.calledOnce(mockRes.end);
         });
@@ -92,28 +78,18 @@ describe('QueuePopulator', () => {
             qp.zkClient = {
                 getState: () => zookeeper.State.SYNC_CONNECTED,
             };
-            const response = qp.handleLiveness(mockRes, mockLog);
-            assert.deepStrictEqual(
-                JSON.parse(response),
-                [
+            qp.handleLiveness(mockRes, mockLog);
+            sinon.assert.calledOnceWithExactly(mockRes.writeHead, 500);
+            sinon.assert.calledOnceWithExactly(
+                mockRes.end,
+                JSON.stringify([
                     {
                         component: 'log reader',
                         status: constants.statusNotReady,
                         topic: 'topicB',
                     },
-                ]
+                ])
             );
-            sinon.assert.calledOnceWithExactly(
-                mockLog.debug,
-                sinon.match.any, // we don't care about the debug label
-                {
-                    'zookeeper': zookeeper.State.SYNC_CONNECTED.code,
-                    'producer-topicA': true,
-                    'producer-topicB': false,
-                }
-            );
-            sinon.assert.notCalled(mockRes.writeHead);
-            sinon.assert.notCalled(mockRes.end);
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -531,9 +531,9 @@ arsenal@scality/Arsenal#32c895b:
   optionalDependencies:
     ioctl "2.0.0"
 
-arsenal@scality/Arsenal#8.1.1:
-  version "8.1.1"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/5aaec6a4e680c1330af910f65e05f76858f8887b"
+arsenal@scality/Arsenal#8.1.3:
+  version "8.1.3"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/a2b6846e2e7858fddc41cc6a09cd6148f9b5876b"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1936.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.3/feature/BB-50_ProbeServerShouldNotReturnString`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.3/feature/BB-50_ProbeServerShouldNotReturnString
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.3/feature/BB-50_ProbeServerShouldNotReturnString
```

Please always comment pull request #1936 instead of this one.