### PR TITLE
INTEGRATION [PR#1947 > development/8.3] BB-59 sendSuccess not imported correctly for garbage collector

### DIFF
--- a/extensions/gc/service.js
+++ b/extensions/gc/service.js
@@ -6,7 +6,7 @@ const {
     DEFAULT_LIVE_ROUTE,
     DEFAULT_READY_ROUTE,
 } = require('arsenal').network.probe.ProbeServer;
-const { sendSuccess, sendError } = require('arsenal').network.probe.ProbeServer;
+const { sendSuccess, sendError } = require('arsenal').network.probe.Utils;
 
 const GarbageCollector = require('./GarbageCollector');
 const { startProbeServer } = require('../../lib/util/probe');


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1947.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.3/bugfix/BB-59/prob`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.3/bugfix/BB-59/prob
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.3/bugfix/BB-59/prob
```

Please always comment pull request #1947 instead of this one.