### PR TITLE
INTEGRATION [PR#1955 > development/7.10] bugfix: BB-60 close LogReader on provisioning update

### DIFF
--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -90,6 +90,20 @@ class LogReader {
     }
 
     /**
+     * close the log reader, free any resources opened during the
+     * LogReader lifetime
+     *
+     * @param {function} cb - callback function
+     * @return {undefined}
+     */
+    close(cb) {
+        async.each(
+            Object.values(this._producers),
+            (producer, done) => producer.close(done),
+            cb);
+    }
+
+    /**
      * get the next offset to fetch from source log (aka. log sequence
      * number)
      *

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -296,8 +296,12 @@ class QueuePopulator {
                 if (err) {
                     return done(err);
                 }
-                this.logReaders = newReaders;
-                return done();
+                return async.each(
+                    this.logReaders, (logReader, cb) => logReader.close(cb),
+                    () => {
+                        this.logReaders = newReaders;
+                        return done();
+                    });
             }
         );
     }

--- a/tests/unit/QueuePopulator.spec.js
+++ b/tests/unit/QueuePopulator.spec.js
@@ -49,11 +49,22 @@ describe('QueuePopulator', () => {
 
     it('should stop processing old raft sessions after provisioning update', done => {
         const logReader1 = new MockLogReader(qp, 'raft_1');
+        let closeCalled = false;
+        logReader1.close = cb => {
+            assert(!closeCalled);
+            closeCalled = true;
+            process.nextTick(cb);
+        };
         qp.logReadersUpdate = [logReader1];
         qp.processAllLogEntries({}, err => {
             assert.ifError(err);
             assert.strictEqual(logReader1.processLogEntriesCallCount, 2);
-            done();
+            assert(!closeCalled);
+            qp.processAllLogEntries({}, err => {
+                assert.ifError(err);
+                assert(closeCalled);
+                done();
+            });
         });
     });
 


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1955.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/bugfix/BB-60-closeOldLogReaders`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/bugfix/BB-60-closeOldLogReaders
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/bugfix/BB-60-closeOldLogReaders
```

Please always comment pull request #1955 instead of this one.