### PR TITLE
improvement: BB-69 provisioning: no notify if provisions unchanged

### DIFF
--- a/lib/provisioning/ProvisionDispatcher.js
+++ b/lib/provisioning/ProvisionDispatcher.js
@@ -47,6 +47,7 @@ class ProvisionDispatcher {
         this._isLeader = false;
         this._owners = null;
         this._provisions = null;
+        this._myProvisions = null;
         this._redispatchInProgress = false;
         this._redoRedispatch = false;
         this._interval = -1;
@@ -364,10 +365,19 @@ class ProvisionDispatcher {
                 }
                 if (data !== undefined) {
                     const provisionList = JSON.parse(data);
-                    this._log.info('provisioning update',
-                                   { zkPath: this._zkEndpoint + myPath,
-                                     provisionList });
-                    return cb(null, provisionList);
+                    if (!this._myProvisions ||
+                        provisionList.length !== this._myProvisions.length ||
+                        provisionList.some(
+                            (provision, index) => provision !== this._myProvisions[index])) {
+                        this._log.info('provisioning update',
+                                       { zkPath: this._zkEndpoint + myPath,
+                                         provisionList });
+                        this._myProvisions = provisionList;
+                        return cb(null, provisionList);
+                    }
+                    this._log.debug('unchanged provisioning',
+                                    { zkPath: this._zkEndpoint + myPath,
+                                      provisionList });
                 }
                 return undefined;
             }


### PR DESCRIPTION
Do not send a provisioning update notification if provision list is
unchanged from before the notification.

This is an optimization that can also avoid possible side effects:

- unnecessary reinitialization of state (e.g. queue populator log
  reader) that can lead to extra CPU usage, duplicate work (replays),
  memory leaks etc.

- unnecessary logging when provisions are updated