### PR TITLE
INTEGRATION [PR#1965 > development/7.10] improvement: BB-69 provisioning: no notify if provisions unchanged

### DIFF
--- a/lib/provisioning/ProvisionDispatcher.js
+++ b/lib/provisioning/ProvisionDispatcher.js
@@ -47,6 +47,7 @@ class ProvisionDispatcher {
         this._isLeader = false;
         this._owners = null;
         this._provisions = null;
+        this._myProvisions = null;
         this._redispatchInProgress = false;
         this._redoRedispatch = false;
         this._interval = -1;
@@ -364,10 +365,19 @@ class ProvisionDispatcher {
                 }
                 if (data !== undefined) {
                     const provisionList = JSON.parse(data);
-                    this._log.info('provisioning update',
-                                   { zkPath: this._zkEndpoint + myPath,
-                                     provisionList });
-                    return cb(null, provisionList);
+                    if (!this._myProvisions ||
+                        provisionList.length !== this._myProvisions.length ||
+                        provisionList.some(
+                            (provision, index) => provision !== this._myProvisions[index])) {
+                        this._log.info('provisioning update',
+                                       { zkPath: this._zkEndpoint + myPath,
+                                         provisionList });
+                        this._myProvisions = provisionList;
+                        return cb(null, provisionList);
+                    }
+                    this._log.debug('unchanged provisioning',
+                                    { zkPath: this._zkEndpoint + myPath,
+                                      provisionList });
                 }
                 return undefined;
             }


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #1965.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/improvement/BB-69-noProvisioningUpdateOnZookeeperChecker`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/improvement/BB-69-noProvisioningUpdateOnZookeeperChecker
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/improvement/BB-69-noProvisioningUpdateOnZookeeperChecker
```

Please always comment pull request #1965 instead of this one.