### PR TITLE
bugfix: BB-70 upgrade node-rdkafka to 2.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "backo": "^1.1.0",
     "bucketclient": "scality/bucketclient#36e1279",
     "commander": "^2.11.0",
-    "node-rdkafka": "2.2.0",
+    "node-rdkafka": "2.10.1",
     "node-schedule": "^1.2.0",
     "node-zookeeper-client": "^0.2.2",
     "prom-client": "^12.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -344,7 +344,7 @@ better-assert@~1.0.0:
   dependencies:
     callsite "1.0.0"
 
-bindings@1.x, bindings@^1.1.1:
+bindings@^1.1.1, bindings@^1.3.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
   integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
@@ -1776,7 +1776,7 @@ mute-stream@0.0.5:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.5.tgz#8fbfabb0a98a253d3184331f9e8deb7372fac6c0"
   integrity sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=
 
-nan@2.x, nan@^2.14.0, nan@^2.3.2:
+nan@^2.14.0, nan@^2.3.2:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
@@ -1822,13 +1822,13 @@ node-gyp-build@~4.1.0:
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.1.0.tgz#3bc3dd7dd4aafecaf64a2e3729e785bc3cdea565"
   integrity sha512-rGLv++nK20BG8gc0MzzcYe1Nl3p3mtwJ74Q2QD0HTEDKZ6NvOFSelY6s2QBPWIHRR8h7hpad0LiwajfClBJfNg==
 
-node-rdkafka@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-2.2.0.tgz#a9d1928c7785897639898ed81a0aa4c5336736a2"
-  integrity sha1-qdGSjHeFiXY5iY7YGgqkxTNnNqI=
+node-rdkafka@2.10.1:
+  version "2.10.1"
+  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-2.10.1.tgz#de6055a8aed6315a68f5b401415e7d6b9bfcc631"
+  integrity sha512-yRb9Y90ipef4X+S/UbvQedUNtKZONa9RR6hCpAaGD83NqUga/uxTofdRQG8bm7SEh/DNuaifIJjRzLcoG9nUSQ==
   dependencies:
-    bindings "1.x"
-    nan "2.x"
+    bindings "^1.3.1"
+    nan "^2.14.0"
 
 node-schedule@^1.2.0:
   version "1.3.2"


### PR DESCRIPTION
More recent versions (2.9.0+) have fixed leaks that affected the queue
populator and required regular restarts to avoid OOM conditions.

The latest version to date is 2.11.0, however it is incompatible with
our current nodesvc-base image due to the GCC version not supporting
the flag "-std=c++14", hence upgrading to 2.10.1 until we have an
upgraded nodesvc-base image.