### PR TITLE
bugfix: BB-60 close LogReader on provisioning update

### DIFF
--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -87,6 +87,20 @@ class LogReader {
     }
 
     /**
+     * close the log reader, free any resources opened during the
+     * LogReader lifetime
+     *
+     * @param {function} cb - callback function
+     * @return {undefined}
+     */
+    close(cb) {
+        async.each(
+            Object.values(this._producers),
+            (producer, done) => producer.close(done),
+            cb);
+    }
+
+    /**
      * get the next offset to fetch from source log (aka. log sequence
      * number)
      *

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -219,14 +219,21 @@ class QueuePopulator {
     _setupUpdatedReaders(done) {
         const newReaders = this.logReadersUpdate;
         this.logReadersUpdate = null;
-        async.each(newReaders, (logReader, cb) => logReader.setup(cb),
-                   err => {
-                       if (err) {
-                           return done(err);
-                       }
-                       this.logReaders = newReaders;
-                       return done();
-                   });
+        async.each(
+            newReaders,
+            (logReader, cb) => logReader.setup(cb),
+            err => {
+                if (err) {
+                    return done(err);
+                }
+                return async.each(
+                    this.logReaders, (logReader, cb) => logReader.close(cb),
+                    () => {
+                        this.logReaders = newReaders;
+                        return done();
+                    });
+            }
+        );
     }
 
     _closeLogState(done) {


### PR DESCRIPTION
Make sure we close the LogReader instance properly when a raft session
provisioning update occurs. This LogReader.close() call closes the
Kafka producer instance if it has been opened, to fix the Kafka
connection leak.

(cherry picked from commit 3d8c1c0f9ff9bca03341ee0da43256526da8fb02)