### PR TITLE
bugfix: retry S3 calls from lifecycle processors

### DIFF
--- a/extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor.js
+++ b/extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor.js
@@ -7,6 +7,7 @@ const { Logger } = require('werelogs');
 const { errors } = require('arsenal');
 
 const BackbeatProducer = require('../../../lib/BackbeatProducer');
+const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
 const BackbeatConsumer = require('../../../lib/BackbeatConsumer');
 const KafkaBacklogMetrics = require('../../../lib/KafkaBacklogMetrics');
 const BackbeatMetadataProxy = require('../../../lib/BackbeatMetadataProxy');
@@ -90,12 +91,19 @@ class LifecycleBucketProcessor {
         this.s3Clients = {};
         this.backbeatClients = {};
         this.credentialsManager = new CredentialsManager('lifecycle', this._log);
+        this.retryWrapper = new BackbeatTask();
 
         // The task scheduler for processing lifecycle tasks concurrently.
         this._internalTaskScheduler = async.queue((ctx, cb) => {
             const { task, rules, value, s3target, backbeatMetadataProxy } = ctx;
-            return task.processBucketEntry(
-                rules, value, s3target, backbeatMetadataProxy, cb);
+            return this.retryWrapper.retry({
+                actionDesc: 'process bucket lifecycle entry',
+                logFields: { value },
+                actionFunc: done => task.processBucketEntry(
+                    rules, value, s3target, backbeatMetadataProxy, done),
+                shouldRetryFunc: err => err.retryable,
+                log: this._log,
+            }, cb);
         }, this._lcConfig.bucketProcessor.concurrency);
 
         // Listen for errors from any task being processed.
@@ -278,7 +286,7 @@ class LifecycleBucketProcessor {
         }
 
         const params = { Bucket: bucket };
-        return s3.getBucketLifecycleConfiguration(params, (err, config) => {
+        return this._getBucketLifecycleConfiguration(s3, params, (err, config) => {
             if (err) {
                 if (err.code === 'NoSuchLifecycleConfiguration') {
                     this._log.debug('skipping non-lifecycled bucket', { bucket });
@@ -310,6 +318,23 @@ class LifecycleBucketProcessor {
                 backbeatMetadataProxy,
             }, cb);
         });
+    }
+
+    /**
+     * Call AWS.S3.GetBucketLifecycleConfiguration in a retry wrapper.
+     * @param {AWS.S3} s3 - the s3 client
+     * @param {object} params - the parameters to pass to getBucketLifecycleConfiguration
+     * @param {Function} cb - The callback to call
+     * @return {undefined}
+     */
+    _getBucketLifecycleConfiguration(s3, params, cb) {
+        return this.retryWrapper.retry({
+            actionDesc: 'get bucket lifecycle',
+            logFields: { params },
+            actionFunc: done => s3.getBucketLifecycleConfiguration(params, done),
+            shouldRetryFunc: err => err.retryable,
+            log: this._log,
+        }, cb);
     }
 
     /**

--- a/tests/functional/lifecycle/LifecycleBucketProcessor.spec.js
+++ b/tests/functional/lifecycle/LifecycleBucketProcessor.spec.js
@@ -1,0 +1,137 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+const werelogs = require('werelogs');
+
+const LifecycleBucketProcessor = require(
+    '../../../extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor');
+
+const { S3ClientMock } = require('../../utils/S3ClientMock');
+
+const {
+    zkConfig,
+    kafkaConfig,
+    lcConfig,
+    repConfig,
+    s3Config,
+    bucketTasksTopic,
+    objectTasksTopic,
+    testTimeout,
+} = require('./configObjects');
+
+const bucketEntryMessage = {
+    key: '12345',
+    topic: bucketTasksTopic,
+    partition: 0,
+    offset: 0,
+    timestamp: 1633382688726,
+    value: `{
+        "action": "processObjects",
+        "target": {
+            "bucket": "bucket1",
+            "owner": "owner1",
+            "accountId": "acct1"
+        },
+        "details": {
+        }
+    }`,
+};
+
+werelogs.configure({ level: 'warn', dump: 'error' });
+
+describe('Lifecycle Bucket Processor', function lifecycleBucketProcessor() {
+    this.timeout(testTimeout);
+
+    function generateRetryTest(failures) {
+        return function testRetries() {
+            const lbp = new LifecycleBucketProcessor(
+                zkConfig, kafkaConfig, lcConfig, repConfig, s3Config);
+
+            const s3Client = new S3ClientMock(failures);
+            lbp._getS3Client = () => s3Client;
+            lbp._getBackbeatClient = () => ({});
+
+            const start = new Promise((resolve, reject) => {
+                lbp.start(err => {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        let messagesToConsume = [bucketEntryMessage];
+                        lbp._consumer._consumer.consume = (_, cb) => {
+                            process.nextTick(cb, null, messagesToConsume);
+                            messagesToConsume = [];
+                        };
+
+                        resolve();
+                    }
+                });
+            });
+
+            const destTopicSendAssert = new Promise((resolve, reject) => {
+                start
+                .then(() => {
+                    lbp._producer.sendToTopic = (topic, [{ message }]) => {
+                        const obj = JSON.parse(message);
+
+                        assert.strictEqual(topic, objectTasksTopic);
+                        assert.strictEqual(obj.action, 'deleteObject');
+                        assert.deepStrictEqual(obj.target, {
+                            owner: 'owner1',
+                            bucket: 'bucket1',
+                            accountId: 'acct1',
+                            key: 'obj1',
+                        });
+
+                        resolve();
+                    };
+                })
+                .catch(reject);
+            });
+
+            const sourceTopicCommitAssert = new Promise((resolve, reject) => {
+                start
+                .then(() => {
+                    lbp._consumer.onEntryCommittable = () => {
+                        s3Client.verifyRetries();
+                        resolve();
+                    };
+                })
+                .catch(reject);
+            });
+
+            return Promise.all([
+                sourceTopicCommitAssert,
+                destTopicSendAssert,
+            ]);
+        };
+    }
+
+    [
+        {
+            // S3 API call from inside the bucket processor's async queue
+            name: 'listObjects',
+            failures: {
+                listObjects: 2,
+            },
+        },
+        {
+            // S3 API call from inside the bucket processor's async queue
+            name: 'headObject',
+            failures: {
+                listObjects: 2,
+            },
+        },
+        {
+            // S3 API call from outside of the bucket processor's async queue,
+            // invoked indirectly by the `BackbeatConsumer` instance before
+            // dispatching to the async queue
+            name: 'getBucketLifecycleConfiguration',
+            failures: {
+                getBucketLifecycleConfiguration: 4,
+            },
+        },
+    ].forEach(testCase => {
+        it(`should retry bucket entries when ${testCase.name} fails`,
+            generateRetryTest(testCase.failures));
+    });
+});

--- a/tests/functional/lifecycle/LifecycleObjectProcessor.spec.js
+++ b/tests/functional/lifecycle/LifecycleObjectProcessor.spec.js
@@ -1,0 +1,106 @@
+'use strict'; // eslint-disable-line
+
+const werelogs = require('werelogs');
+
+const LifecycleObjectProcessor = require(
+    '../../../extensions/lifecycle/objectProcessor/LifecycleObjectProcessor');
+
+const { S3ClientMock } = require('../../utils/S3ClientMock');
+
+const {
+    zkConfig,
+    kafkaConfig,
+    lcConfig,
+    s3Config,
+    objectTasksTopic,
+    testTimeout,
+} = require('./configObjects');
+
+werelogs.configure({ level: 'warn', dump: 'error' });
+
+describe('Lifecycle Object Processor', function lifecycleObjectProcessor() {
+    this.timeout(testTimeout);
+
+    function generateRetryTest(failures, message) {
+        return function testRetries(done) {
+            const lop = new LifecycleObjectProcessor(
+                zkConfig, kafkaConfig, lcConfig, s3Config);
+
+            const s3Client = new S3ClientMock(failures);
+            lop._getS3Client = () => s3Client;
+
+            lop.start(err => {
+                if (err) {
+                    return done(err);
+                }
+
+                lop._consumer.onEntryCommittable = () => {
+                    s3Client.verifyRetries();
+                    done();
+                };
+
+                let messagesToConsume = [message];
+                lop._consumer._consumer.consume = (_, cb) => {
+                    process.nextTick(cb, null, messagesToConsume);
+                    messagesToConsume = [];
+                };
+
+                return undefined;
+            });
+        };
+    }
+
+    [
+        {
+            name: 'deleteObject',
+            failures: {
+                deleteObject: 2,
+            },
+            message: {
+                key: '12345',
+                topic: objectTasksTopic,
+                partition: 0,
+                offset: 0,
+                timestamp: 1633382688726,
+                value: `{
+                    "action": "deleteObject",
+                    "target": {
+                        "bucket": "bucket1",
+                        "key": "obj1",
+                        "owner": "owner1",
+                        "accountId": "acct1"
+                    },
+                    "details": {
+                    }
+                }`,
+            },
+        },
+        {
+            name: 'abortMultipartUpload',
+            failures: {
+                abortMultipartUpload: 2,
+            },
+            message: {
+                key: '12345',
+                topic: objectTasksTopic,
+                partition: 0,
+                offset: 0,
+                timestamp: 1633382688726,
+                value: `{
+                    "action": "deleteMPU",
+                    "target": {
+                        "bucket": "bucket1",
+                        "key": "obj1",
+                        "owner": "owner1",
+                        "accountId": "acct1"
+                    },
+                    "details": {
+                    }
+                }`,
+            },
+        },
+    ].forEach(testCase => {
+        it(`should retry object entries when ${testCase.name} fails`,
+            generateRetryTest(testCase.failures, testCase.message));
+    });
+});

--- a/tests/functional/lifecycle/configObjects.js
+++ b/tests/functional/lifecycle/configObjects.js
@@ -1,0 +1,52 @@
+const bucketTasksTopic = 'bucket-tasks';
+const objectTasksTopic = 'object-tasks';
+
+const zkConfig = {
+    connectionString: 'localhost:2181',
+};
+
+const kafkaConfig = {
+    hosts: 'localhost:9092',
+};
+
+const lcConfig = {
+    auth: {
+        type: 'assumeRole',
+        roleName: 'role',
+        sts: {},
+    },
+    bucketProcessor: {
+        groupId: `bucket-processor-test-${Math.random()}`,
+    },
+    objectProcessor: {
+        groupId: `object-processor-test-${Math.random()}`,
+    },
+    bucketTasksTopic,
+    objectTasksTopic,
+    rules: {
+        expiration: {
+            enabled: true,
+        },
+    },
+};
+
+const repConfig = {
+    destination: {
+        bootstrapList: [],
+    },
+};
+
+const s3Config = {};
+
+const testTimeout = 30000;
+
+module.exports = {
+    bucketTasksTopic,
+    objectTasksTopic,
+    zkConfig,
+    kafkaConfig,
+    lcConfig,
+    repConfig,
+    s3Config,
+    testTimeout,
+};

--- a/tests/utils/S3ClientMock.js
+++ b/tests/utils/S3ClientMock.js
@@ -1,0 +1,84 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+const { errors } = require('arsenal');
+
+class S3ClientMock {
+    constructor(failures) {
+        this.failures = failures;
+
+        this.calls = {};
+        this.stubMethod('deleteObject', {});
+        this.stubMethod('abortMultipartUpload', {});
+        this.stubMethod('getBucketVersioning', {});
+        this.stubMethod('listObjects', {
+            Contents: [
+                {
+                    Key: 'obj1',
+                },
+            ],
+        });
+        this.stubMethod('headObject', {
+            LastModified: '2021-10-04T21:46:49.157Z',
+        });
+        this.stubMethod('listMultipartUploads', {
+            Uploads: [],
+        });
+        this.stubMethod('getBucketLifecycleConfiguration', {
+            Rules: [
+                {
+                    Expiration: {
+                        Days: 1,
+                    },
+                    ID: 'id',
+                    Prefix: '',
+                    Status: 'Enabled',
+                },
+            ],
+        });
+    }
+
+    makeRetryableError() {
+        const err = errors.ServiceUnavailable.customizeDescription('failing on purpose');
+        err.retryable = true;
+        return err;
+    }
+
+    stubMethod(methodName, successResult) {
+        this.calls[methodName] = 0;
+
+        this[methodName] = (params, done) => {
+            this.calls[methodName]++;
+
+            if (this.failures[methodName] >= this.calls[methodName]) {
+                if (done) {
+                    return process.nextTick(done, this.makeRetryableError());
+                }
+                return {
+                    send: cb => process.nextTick(cb, this.makeRetryableError()),
+                    on: () => {},
+                };
+            }
+
+            if (done) {
+                return process.nextTick(done, null, successResult);
+            }
+
+            return {
+                send: cb => process.nextTick(cb, null, successResult),
+                on: () => {},
+            };
+        };
+    }
+
+    verifyRetries() {
+        Object.keys(this.failures).forEach(f => {
+            assert.strictEqual(this.calls[f], this.failures[f] + 1,
+                `did not retry ${this.failures[f]} times`);
+        });
+    }
+}
+
+module.exports = {
+    S3ClientMock,
+};


### PR DESCRIPTION
Only applies to retryable errors though, other errors will potentially
interrupt the scan, which will resume on the next lifecycle batch
trigger. This is on purpose, as fatal errors being retried over and over
again have the potential to increase the load to the point of causing
cascading failures, while not performing actual work.