### PR TITLE
feature: support mongodb sharding conf

### DIFF
--- a/lib/config.joi.js
+++ b/lib/config.joi.js
@@ -40,7 +40,14 @@ const joiSchema = {
             replicaSetHosts: joi.string().default('localhost:27017'),
             logName: joi.string().default('s3-recordlog'),
             writeConcern: joi.string().default('majority'),
-            replicaSet: joi.string().default('rs0'),
+            shardCollections: joi.boolean().default(false),
+            replicaSet: joi.when(
+                'shardCollections', {
+                    is: false,
+                    then: joi.string().default('rs0'),
+                    otherwise: joi.forbidden(),
+                },
+            ),
             readPreference: joi.string().default('primary'),
             database: joi.string().default('metadata'),
             authCredentials: joi.object({

--- a/lib/management/patchConfiguration.js
+++ b/lib/management/patchConfiguration.js
@@ -96,6 +96,7 @@ function buildMetadataParams(c) {
             writeConcern: mongo.writeConcern,
             replicaSet: mongo.replicaSet,
             readPreference: mongo.readPreference,
+            shardCollections: mongo.shardCollections,
             database: mongo.database,
             replicationGroupId: groupId,
             path: '',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "8.3.0",
+  "version": "8.3.1",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@hapi/joi": "^15.1.0",
     "JSONStream": "^1.3.5",
-    "arsenal": "scality/Arsenal#8.1.10",
+    "arsenal": "scality/Arsenal#8.1.16",
     "async": "^2.3.0",
     "aws-sdk": "^2.938.0",
     "backo": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -510,7 +510,6 @@ arsenal@scality/Arsenal#32c895b:
   version "7.4.3"
   resolved "https://codeload.github.com/scality/Arsenal/tar.gz/32c895b21a31eb67dacc6e76d7f58b8142bf3ad1"
   dependencies:
-    "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
     ajv "4.10.0"
     async "~2.1.5"
@@ -518,6 +517,7 @@ arsenal@scality/Arsenal#32c895b:
     diskusage "^1.1.1"
     ioredis "4.9.5"
     ipaddr.js "1.2.0"
+    joi "^10.6"
     level "~5.0.1"
     level-sublevel "~6.6.5"
     node-forge "^0.7.1"
@@ -569,9 +569,9 @@ arsenal@scality/Arsenal#8.1.1:
   optionalDependencies:
     ioctl "2.0.1"
 
-arsenal@scality/Arsenal#8.1.10:
-  version "8.1.10"
-  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/ed1d6c12c2e54bb6cfb747040d7b0711a21143c9"
+arsenal@scality/Arsenal#8.1.16:
+  version "8.1.15"
+  resolved "https://codeload.github.com/scality/Arsenal/tar.gz/6cdae52d572b979e250ee1fec220ebc461739235"
   dependencies:
     "@hapi/joi" "^15.1.0"
     JSONStream "^1.0.0"
@@ -1096,7 +1096,7 @@ bucketclient@scality/bucketclient#8.1.0:
   dependencies:
     agentkeepalive "^4.1.3"
     arsenal scality/Arsenal#8ed8478
-    werelogs scality/werelogs#8.1.0
+    werelogs scality/werelogs#351a2a3
 
 bucketclient@scality/bucketclient#949f11a:
   version "8.1.0"
@@ -2190,7 +2190,6 @@ fast-levenshtein@~2.0.6:
   dependencies:
     bindings "^1.1.1"
     nan "^2.3.2"
-    node-gyp "^8.0.0"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -5268,7 +5267,7 @@ sprintf-js@~1.0.2:
   resolved "https://codeload.github.com/scality/sproxydclient/tar.gz/e45c547833f03b1fa0409e0499433dcb386442f5"
   dependencies:
     async "^3.1.0"
-    werelogs scality/werelogs#8.1.0
+    werelogs scality/werelogs#351a2a3
 
 sql-where-parser@~2.2.1:
   version "2.2.1"
@@ -5806,7 +5805,8 @@ vaultclient@scality/vaultclient#478710c:
   version "7.5.1"
   resolved "https://codeload.github.com/scality/vaultclient/tar.gz/478710cbe2c479f35ba3f302f73b2932ec0716d9"
   dependencies:
-    arsenal scality/Arsenal#b03f5b8
+    agentkeepalive "^4.1.3"
+    arsenal scality/Arsenal#580e25a
     commander "2.20.0"
     werelogs scality/werelogs#4e0d97c
     xml2js "0.4.19"


### PR DESCRIPTION
In Backbeat's 8.3 branch, backbeat-api now connects to mongodb on startup and fails if a replicaset name is not provided (where 8.2 worked). We now need to add the `shardCollections` config param so that connection to mongo works at startup.