### PR TITLE
improvement: BB-122 pass "client.rack" property to kafka consumer

### DIFF
--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -19,6 +19,7 @@ const joiSchema = {
             zkPath: joi.string().default('/backbeat/run/kafka-backlog-metrics'),
             intervalS: joi.number().default(60),
         },
+        site: joi.string(),
     },
     s3: hostPortJoi.optional(),
     queuePopulator: {

--- a/extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor.js
+++ b/extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor.js
@@ -389,6 +389,7 @@ class LifecycleBucketProcessor {
             },
             kafka: {
                 hosts: this._kafkaConfig.hosts,
+                site: this._kafkaConfig.site,
                 backlogMetrics: this._kafkaConfig.backlogMetrics,
             },
             topic: this._lcConfig.bucketTasksTopic,

--- a/extensions/lifecycle/objectProcessor/LifecycleObjectProcessor.js
+++ b/extensions/lifecycle/objectProcessor/LifecycleObjectProcessor.js
@@ -94,6 +94,7 @@ class LifecycleObjectProcessor extends EventEmitter {
             },
             kafka: {
                 hosts: this._kafkaConfig.hosts,
+                site: this._kafkaConfig.site,
                 backlogMetrics: this._kafkaConfig.backlogMetrics,
             },
             topic: this._lcConfig.objectTasksTopic,

--- a/extensions/notification/queueProcessor/QueueProcessor.js
+++ b/extensions/notification/queueProcessor/QueueProcessor.js
@@ -117,7 +117,10 @@ class QueueProcessor extends EventEmitter {
                     = this.notifConfig.queueProcessor;
                 const consumerGroupId = `${groupId}-${this.destinationId}`;
                 this._consumer = new BackbeatConsumer({
-                    kafka: { hosts: this.kafkaConfig.hosts },
+                    kafka: {
+                        hosts: this.kafkaConfig.hosts,
+                        site: this.kafkaConfig.site,
+                    },
                     topic: this.notifConfig.topic,
                     groupId: consumerGroupId,
                     concurrency,

--- a/extensions/replication/failedCRR/FailedCRRConsumer.js
+++ b/extensions/replication/failedCRR/FailedCRRConsumer.js
@@ -36,7 +36,10 @@ class FailedCRRConsumer {
      */
     start(cb) {
         const consumer = new BackbeatConsumer({
-            kafka: { hosts: this._kafkaConfig.hosts },
+            kafka: {
+                hosts: this._kafkaConfig.hosts,
+                site: this._kafkaConfig.site,
+            },
             topic: this._topic,
             groupId: 'backbeat-retry-group',
             concurrency: CONCURRENCY,

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -408,7 +408,10 @@ class QueueProcessor extends EventEmitter {
             const groupId =
                 `${this.repConfig.queueProcessor.groupId}-${this.site}`;
             this._consumer = new BackbeatConsumer({
-                kafka: { hosts: this.kafkaConfig.hosts },
+                kafka: {
+                    hosts: this.kafkaConfig.hosts,
+                    site: this.kafkaConfig.site,
+                },
                 topic: this.repConfig.topic,
                 groupId,
                 concurrency: this.repConfig.queueProcessor.concurrency,

--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -164,7 +164,10 @@ class ReplicationStatusProcessor {
     start(options, cb) {
         this._FailedCRRProducer = new FailedCRRProducer(this.kafkaConfig);
         this._consumer = new BackbeatConsumer({
-            kafka: { hosts: this.kafkaConfig.hosts },
+            kafka: {
+                hosts: this.kafkaConfig.hosts,
+                site: this.kafkaConfig.site,
+            },
             topic: this.repConfig.replicationStatusTopic,
             groupId: this.repConfig.replicationStatusProcessor.groupId,
             concurrency:

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -42,6 +42,8 @@ class BackbeatConsumer extends EventEmitter {
      * @param {Object} config.kafka - kafka connection config
      * @param {string} config.kafka.hosts - kafka hosts list
      * as "host:port[,host:port...]"
+     * @param {object} [config.kafka.site] - name of site where this
+     * consumer runs, enables Kafka follower fetching when provided
      * @param {object} [config.kafka.backlogMetrics] - param object to
      * publish kafka topic metrics to zookeeper (disabled if param object
      * is not set)
@@ -75,6 +77,7 @@ class BackbeatConsumer extends EventEmitter {
                     zkPath: joi.string().required(),
                     intervalS: joi.number().default(60),
                 },
+                site: joi.string(),
             }).required(),
             topic: joi.string().required(),
             groupId: joi.string().required(),
@@ -95,6 +98,7 @@ class BackbeatConsumer extends EventEmitter {
         this._zookeeperEndpoint = zookeeper && zookeeper.connectionString;
         this._kafkaHosts = kafka.hosts;
         this._kafkaBacklogMetricsConfig = kafka.backlogMetrics;
+        this._site = kafka.site;
         this._fromOffset = fromOffset;
         this._log = new Logger(CLIENT_ID);
         this._topic = withTopicPrefix(topic);
@@ -162,6 +166,14 @@ class BackbeatConsumer extends EventEmitter {
         }
         if (this._logConsumerMetricsIntervalS !== undefined) {
             consumerParams['statistics.interval.ms'] = this._logConsumerMetricsIntervalS * 1000;
+        }
+        if (this._site) {
+            this._log.info('follower fetching enabled for topic/consumer group', {
+                site: this._site,
+                topic: this._topic,
+                groupId: this._groupId,
+            });
+            consumerParams['client.rack'] = this._site;
         }
         this._consumer = new kafka.KafkaConsumer(consumerParams);
         this._consumer.connect();

--- a/lib/MetricsConsumer.js
+++ b/lib/MetricsConsumer.js
@@ -40,7 +40,10 @@ class MetricsConsumer {
 
     start() {
         const consumer = new BackbeatConsumer({
-            kafka: { hosts: this.kafkaConfig.hosts },
+            kafka: {
+                hosts: this.kafkaConfig.hosts,
+                site: this.kafkaConfig.site,
+            },
             topic: this.mConfig.topic,
             groupId: 'backbeat-metrics-group',
             concurrency: CONCURRENCY,


### PR DESCRIPTION
To enable follower fetching on stretched configuration, pass the
"client.rack" property to kafka consumers from the "site" attribute
configured from Federation.

There is no unit test attached as this is barely passing a
configuration param to Kafka consumer client and would not check if
the param was applied all the way. The envisioned way to test this
properly (almost) end-to-end would be once Integration runs a 2-site
configuration to check if the backbeat and bucket notification logs
indeed contain the "follower fetching enabled" log line, asserting
that the configuration was applied for the relevant topics when on a
2-site config.

It does not look like an option either to check if the consumer is
always fetching from a local replica, because Kafka does not
systematically consume from a local replica but only when it sees fit
based on other considerations (load balancing etc.).

Note: to make it work, it also requires changes on Federation side to
set the replica selector class and to add the "site" property to
backbeat configuration.