### PR TITLE
Feature/bb 116 lc auth per component

### DIFF
--- a/conf/Config.js
+++ b/conf/Config.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const joi = require('@hapi/joi');
+const joi = require('joi');
 
 const extensions = require('../extensions');
 const backbeatConfigJoi = require('./config.joi.js');

--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -1,6 +1,6 @@
 'use strict'; // eslint-disable-line
 
-const joi = require('@hapi/joi');
+const joi = require('joi');
 const {
     hostPortJoi,
     transportJoi,

--- a/extensions/gc/GarbageCollectorConfigValidator.js
+++ b/extensions/gc/GarbageCollectorConfigValidator.js
@@ -1,4 +1,4 @@
-const joi = require('@hapi/joi');
+const joi = require('joi');
 const { authJoi, retryParamsJoi, probeServerJoi } = require('../../lib/config/configItems.joi.js');
 
 const joiSchema = joi.object({

--- a/extensions/ingestion/IngestionConfigValidator.js
+++ b/extensions/ingestion/IngestionConfigValidator.js
@@ -1,7 +1,7 @@
-const joi = require('@hapi/joi');
+const joi = require('joi');
 const { probeServerJoi } = require('../../lib/config/configItems.joi.js');
 
-const joiSchema = {
+const joiSchema = joi.object({
     auth: joi.object({
         type: joi.string().valid('service').required(),
         account: joi.string().required(),
@@ -12,7 +12,7 @@ const joiSchema = {
     maxParallelReaders: joi.number().greater(0).default(5),
     sources: joi.array().required(),
     probeServer: probeServerJoi.default(),
-};
+});
 
 function configValidator(backbeatConfig, extConfig) {
     const validatedConfig = joi.attempt(extConfig, joiSchema);

--- a/extensions/lifecycle/LifecycleConfigValidator.js
+++ b/extensions/lifecycle/LifecycleConfigValidator.js
@@ -1,13 +1,19 @@
-const { retryParamsJoi, authJoi, probeServerJoi, hostPortJoi } =
-    require('../../lib/config/configItems.joi.js');
 const joi = require('joi');
+const {
+    authJoi,
+    hostPortJoi,
+    inheritedAuthJoi,
+    probeServerJoi,
+    retryParamsJoi,
+} = require('../../lib/config/configItems.joi.js');
 
 const joiSchema = joi.object({
     zookeeperPath: joi.string().required(),
     bucketTasksTopic: joi.string().required(),
     objectTasksTopic: joi.string().required(),
-    auth: authJoi.required(),
+    auth: authJoi.optional(),
     conductor: {
+        auth: inheritedAuthJoi,
         bucketSource: joi.string().
             valid('bucketd', 'zookeeper').default('zookeeper'),
         bucketd: hostPortJoi.
@@ -20,6 +26,7 @@ const joiSchema = joi.object({
         probeServer: probeServerJoi.default(),
     },
     bucketProcessor: {
+        auth: inheritedAuthJoi,
         groupId: joi.string().required(),
         retry: retryParamsJoi,
         // a single producer task is already involving concurrency in
@@ -29,6 +36,7 @@ const joiSchema = joi.object({
         probeServer: probeServerJoi.default(),
     },
     objectProcessor: {
+        auth: inheritedAuthJoi,
         groupId: joi.string().required(),
         retry: retryParamsJoi,
         concurrency: joi.number().greater(0).default(10),

--- a/extensions/lifecycle/LifecycleConfigValidator.js
+++ b/extensions/lifecycle/LifecycleConfigValidator.js
@@ -1,8 +1,8 @@
-const joi = require('@hapi/joi');
 const { retryParamsJoi, authJoi, probeServerJoi, hostPortJoi } =
     require('../../lib/config/configItems.joi.js');
+const joi = require('joi');
 
-const joiSchema = {
+const joiSchema = joi.object({
     zookeeperPath: joi.string().required(),
     bucketTasksTopic: joi.string().required(),
     objectTasksTopic: joi.string().required(),
@@ -34,7 +34,7 @@ const joiSchema = {
         concurrency: joi.number().greater(0).default(10),
         probeServer: probeServerJoi.default(),
     },
-};
+});
 
 function configValidator(backbeatConfig, extConfig) {
     return joi.attempt(extConfig, joiSchema);

--- a/extensions/lifecycle/conductor/LifecycleConductor.js
+++ b/extensions/lifecycle/conductor/LifecycleConductor.js
@@ -64,6 +64,7 @@ class LifecycleConductor {
         this.zkConfig = zkConfig;
         this.kafkaConfig = kafkaConfig;
         this.lcConfig = lcConfig;
+        this._authConfig = lcConfig.conductor.auth || lcConfig.auth;
         this.repConfig = repConfig;
         this._cronRule =
             this.lcConfig.conductor.cronRule || DEFAULT_CRON_RULE;
@@ -95,7 +96,7 @@ class LifecycleConductor {
     _getAccountIds(canonicalIds, cb) {
         // if auth is not of type `assumeRole`, then
         // the accountId can be omitted from work queue messages
-        if (this.lcConfig.auth.type !== authTypeAssumeRole) {
+        if (this._authConfig.type !== authTypeAssumeRole) {
             return process.nextTick(cb, null, {});
         }
 
@@ -374,12 +375,12 @@ class LifecycleConductor {
     }
 
     _setupVaultClientCache() {
-        if (this.lcConfig.auth.type !== authTypeAssumeRole) {
+        if (this._authConfig.type !== authTypeAssumeRole) {
             return;
         }
 
         this._vaultClientCache = new VaultClientCache();
-        const { host, port } = this.lcConfig.auth.vault;
+        const { host, port } = this._authConfig.vault;
         this._vaultClientCache
             .setHost(LIFEYCLE_CONDUCTOR_CLIENT_ID, host)
             .setPort(LIFEYCLE_CONDUCTOR_CLIENT_ID, port);

--- a/extensions/lifecycle/objectProcessor/LifecycleObjectProcessor.js
+++ b/extensions/lifecycle/objectProcessor/LifecycleObjectProcessor.js
@@ -65,7 +65,7 @@ class LifecycleObjectProcessor extends EventEmitter {
         this._zkConfig = zkConfig;
         this._kafkaConfig = kafkaConfig;
         this._lcConfig = lcConfig;
-        this._authConfig = lcConfig.auth;
+        this._authConfig = lcConfig.objectProcessor.auth || lcConfig.auth;
         this._s3Config = s3Config;
         this._transport = transport;
         this._consumer = null;
@@ -140,8 +140,8 @@ class LifecycleObjectProcessor extends EventEmitter {
     }
 
     _initSTSConfig() {
-        if (this._lcConfig.auth.type === authTypeAssumeRole) {
-            const { sts } = this._lcConfig.auth;
+        if (this._authConfig.type === authTypeAssumeRole) {
+            const { sts } = this._authConfig;
             this._stsConfig = {
                 endpoint: `${this._transport}://${sts.host}:${sts.port}`,
                 credentials: {

--- a/extensions/mongoProcessor/MongoProcessorConfigValidator.js
+++ b/extensions/mongoProcessor/MongoProcessorConfigValidator.js
@@ -1,12 +1,12 @@
-const joi = require('@hapi/joi');
+const joi = require('joi');
 const { retryParamsJoi, probeServerJoi } = require('../../lib/config/configItems.joi.js');
 
-const joiSchema = {
+const joiSchema = joi.object({
     topic: joi.string().required(),
     groupId: joi.string().required(),
     retry: retryParamsJoi,
     probeServer: probeServerJoi.default(),
-};
+});
 
 function configValidator(backbeatConfig, extConfig) {
     const validatedConfig = joi.attempt(extConfig, joiSchema);

--- a/extensions/notification/NotificationConfigManager.js
+++ b/extensions/notification/NotificationConfigManager.js
@@ -1,7 +1,7 @@
 const async = require('async');
 const { EventEmitter } = require('events');
 const zookeeper = require('node-zookeeper-client');
-const joi = require('@hapi/joi');
+const joi = require('joi');
 
 const safeJsonParse = require('./utils/safeJsonParse');
 const constants = require('./constants');

--- a/extensions/notification/NotificationConfigValidator.js
+++ b/extensions/notification/NotificationConfigValidator.js
@@ -1,4 +1,4 @@
-const joi = require('@hapi/joi');
+const joi = require('joi');
 
 const joiSchema = {
     topic: joi.string(),

--- a/extensions/notification/destination/KafkaProducer.js
+++ b/extensions/notification/destination/KafkaProducer.js
@@ -1,6 +1,6 @@
 const { EventEmitter } = require('events');
 const { Producer } = require('node-rdkafka');
-const joi = require('@hapi/joi');
+const joi = require('joi');
 
 const errors = require('arsenal').errors;
 const jsutil = require('arsenal').jsutil;
@@ -32,7 +32,7 @@ class KafkaProducer extends EventEmitter {
     constructor(config) {
         super();
 
-        const configJoi = {
+        const configJoi = joi.object({
             kafka: joi.object({
                 hosts: joi.string().required(),
             }).required(),
@@ -40,7 +40,7 @@ class KafkaProducer extends EventEmitter {
             pollIntervalMs: joi.number().default(2000),
             messageMaxBytes: joi.number().default(PRODUCER_MESSAGE_MAX_BYTES),
             auth: joi.object().optional(),
-        };
+        });
         const validConfig = joi.attempt(config, configJoi,
             'invalid config params');
         const {

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-const joi = require('@hapi/joi');
+const joi = require('joi');
 const { hostPortJoi, transportJoi, bootstrapListJoi, adminCredsJoi,
         retryParamsJoi, probeServerJoi } =
     require('../../lib/config/configItems.joi.js');
@@ -13,7 +13,7 @@ const qpRetryJoi = joi.object({
 
 const CRR_FAILURE_EXPIRY = 24 * 60 * 60; // Expire Redis keys after 24 hours.
 
-const joiSchema = {
+const joiSchema = joi.object({
     source: {
         transport: transportJoi,
         s3: hostPortJoi.required(),
@@ -74,7 +74,7 @@ const joiSchema = {
         concurrency: joi.number().greater(0).default(10),
         probeServer: probeServerJoi.default(),
     },
-};
+});
 
 function _loadAdminCredentialsFromFile(filePath) {
     const adminCredsJSON = fs.readFileSync(filePath);

--- a/extensions/workflowEngine/WorkflowEngineConfigValidator.js
+++ b/extensions/workflowEngine/WorkflowEngineConfigValidator.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line
-const joi = require('@hapi/joi');
+const joi = require('joi');
 
 const { hostPortJoi } = require('../../lib/config/configItems.joi.js');
 

--- a/extensions/workflowEngineDataSource/WorkflowEngineDataSourceConfigValidator.js
+++ b/extensions/workflowEngineDataSource/WorkflowEngineDataSourceConfigValidator.js
@@ -1,11 +1,11 @@
 // eslint-disable-next-line
-const joi = require('@hapi/joi');
+const joi = require('joi');
 
-const joiSchema = {
+const joiSchema = joi.object({
     zookeeperPath: joi.string().required(),
     topic: joi.string().required(),
     groupId: joi.string().required(),
-};
+});
 
 function configValidator(backbeatConfig, extConfig) {
     return joi.attempt(extConfig, joiSchema);

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -2,7 +2,7 @@ const { EventEmitter } = require('events');
 const kafka = require('node-rdkafka');
 const assert = require('assert');
 const async = require('async');
-const joi = require('@hapi/joi');
+const joi = require('joi');
 const Logger = require('werelogs').Logger;
 
 const BackbeatProducer = require('./BackbeatProducer');
@@ -64,7 +64,7 @@ class BackbeatConsumer extends EventEmitter {
     constructor(config) {
         super();
 
-        const configJoi = {
+        const configJoi = joi.object({
             zookeeper: joi.object({
                 connectionString: joi.string().required(),
             }).when('kafka.backlogMetrics', { is: joi.exist(), then: joi.required() }),
@@ -83,7 +83,7 @@ class BackbeatConsumer extends EventEmitter {
             fetchMaxBytes: joi.number(),
             canary: joi.boolean().default(false),
             bootstrap: joi.boolean().default(false),
-        };
+        });
         const validConfig = joi.attempt(config, configJoi,
                                         'invalid config params');
 

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -1,6 +1,6 @@
 const { EventEmitter } = require('events');
 const { Producer } = require('node-rdkafka');
-const joi = require('@hapi/joi');
+const joi = require('joi');
 
 const { errors, jsutil } = require('arsenal');
 const Logger = require('werelogs').Logger;
@@ -42,7 +42,7 @@ class BackbeatProducer extends EventEmitter {
     constructor(config) {
         super();
 
-        const configJoi = {
+        const configJoi = joi.object({
             kafka: joi.object({
                 hosts: joi.string().required(),
             }).required(),
@@ -50,7 +50,7 @@ class BackbeatProducer extends EventEmitter {
             keyedPartitioner: joi.boolean().default(true),
             pollIntervalMs: joi.number().default(2000),
             messageMaxBytes: joi.number().default(PRODUCER_MESSAGE_MAX_BYTES),
-        };
+        });
         const validConfig = joi.attempt(config, configJoi,
                                         'invalid config params');
         const { kafka, topic, pollIntervalMs, messageMaxBytes } = validConfig;

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -4,7 +4,6 @@ const { EventEmitter } = require('events');
 
 const fs = require('fs');
 const path = require('path');
-const joi = require('@hapi/joi');
 const crypto = require('crypto');
 
 const extensions = require('../extensions');
@@ -49,8 +48,10 @@ class Config extends EventEmitter {
             throw new Error(`could not parse config file: ${err.message}`);
         }
 
-        const parsedConfig = joi.attempt(config, backbeatConfigJoi,
-                                         'invalid backbeat config');
+        const { value: parsedConfig, err } = backbeatConfigJoi.validate(config);
+        if (err) {
+            throw new Error(`could not validate config file: ${err.message}`);
+        }
 
         if (parsedConfig.extensions) {
             Object.keys(parsedConfig.extensions).forEach(extName => {

--- a/lib/config.joi.js
+++ b/lib/config.joi.js
@@ -1,13 +1,13 @@
 'use strict'; // eslint-disable-line
 
-const joi = require('@hapi/joi');
+const joi = require('joi');
 const { hostPortJoi, transportJoi, logJoi, certFilePathsJoi } =
       require('./config/configItems.joi.js');
 
 const logSourcesJoi = joi.string().valid('bucketd', 'mongo', 'ingestion',
     'dmd');
 
-const joiSchema = {
+const joiSchema = joi.object({
     replicationGroupId: joi.string().length(7).required(),
     zookeeper: {
         connectionString: joi.string().required(),
@@ -89,6 +89,6 @@ const joiSchema = {
     }).required(),
     certFilePaths: certFilePathsJoi,
     internalCertFilePaths: certFilePathsJoi,
-};
+});
 
 module.exports = joiSchema;

--- a/lib/config/configItems.joi.js
+++ b/lib/config/configItems.joi.js
@@ -77,6 +77,14 @@ const authJoi = joi.object({
         .when('type', { is: authTypeAssumeRole, then: joi.required() }),
 });
 
+const inheritedAuthJoi = authJoi
+    .when('...auth', {
+        is: joi.exist(),
+        then: joi.optional(),
+        otherwise: joi.required(),
+    }
+);
+
 const retryParamsJoi = joi.object({
     maxRetries: joi.number().default(5),
     timeoutS: joi.number().default(300),
@@ -106,6 +114,7 @@ module.exports = {
     logJoi,
     adminCredsJoi,
     authJoi,
+    inheritedAuthJoi,
     retryParamsJoi,
     certFilePathsJoi,
     probeServerJoi,

--- a/lib/config/configItems.joi.js
+++ b/lib/config/configItems.joi.js
@@ -1,6 +1,6 @@
 'use strict'; // eslint-disable-line
 
-const joi = require('@hapi/joi');
+const joi = require('joi');
 const constants = require('../../extensions/replication/constants');
 const {
     authTypeAccount,

--- a/lib/credentials/CredentialsManager.js
+++ b/lib/credentials/CredentialsManager.js
@@ -1,5 +1,5 @@
-const joi = require('@hapi/joi');
 const EventEmitter = require('events');
+const joi = require('joi');
 const AWS = require('aws-sdk');
 
 const {

--- a/lib/credentials/RoleCredentials.js
+++ b/lib/credentials/RoleCredentials.js
@@ -1,15 +1,15 @@
 const AWS = require('aws-sdk');
-const joi = require('@hapi/joi');
+const joi = require('joi');
 
 const errors = require('arsenal').errors;
 const { Logger } = require('werelogs');
 
-const configJoi = {
+const configJoi = joi.object({
     vaultclient: joi.object().required(),
     extension: joi.string().required(),
     roleArn: joi.string().required(),
     refreshCredsAnticipationSeconds: joi.number().greater(0).default(60),
-};
+});
 
 /**
 * Manages and refreshes credentials as needed through assuming a role.

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/scality/backbeat#readme",
   "dependencies": {
-    "@hapi/joi": "^15.1.0",
+    "joi": "^17.6.0",
     "JSONStream": "^1.3.5",
     "arsenal": "github:scality/arsenal#8.1.27",
     "async": "^2.3.0",

--- a/tests/unit/conf/Config.js
+++ b/tests/unit/conf/Config.js
@@ -1,10 +1,66 @@
 'use strict'; // eslint-disable-line
 
 const assert = require('assert');
+
+const joi = require('joi');
+
 const config = require('../../../lib/Config');
+const { authJoi, inheritedAuthJoi } = require('../../../lib/config/configItems.joi');
 
 describe('backbeat config parsing and validation', () => {
     it('should parse correctly the default config', () => {
         assert.notStrictEqual(config, undefined);
+    });
+
+    describe('inherited auth', () => {
+        const schema = joi.object({
+            auth: authJoi.optional(),
+            child: joi.object({
+                auth: inheritedAuthJoi,
+            }),
+        });
+
+        const authObject = {
+            type: 'service',
+            account: 'account1',
+        };
+
+        it('fail if auth missing in both parent and child', () => {
+            const obj = {
+                child: {},
+            };
+
+            assert(schema.validate(obj).error);
+        });
+
+        it('allow missing auth in child if defined in parent', () => {
+            const obj = {
+                auth: authObject,
+                child: {},
+            };
+
+            return schema.validateAsync(obj);
+        });
+
+        it('allow missing auth in parent if defined in child', () => {
+            const obj = {
+                child: {
+                    auth: authObject,
+                },
+            };
+
+            return schema.validateAsync(obj);
+        });
+
+        it('allow auth in both parent and child', () => {
+            const obj = {
+                auth: authObject,
+                child: {
+                    auth: authObject,
+                },
+            };
+
+            return schema.validateAsync(obj);
+        });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -208,6 +208,23 @@
   dependencies:
     dayjs "^1.10.5"
 
+"@sideway/address@^4.1.3":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.3.tgz#d93cce5d45c5daec92ad76db492cc2ee3c64ab27"
+  integrity sha512-8ncEUtmnTsMmL7z1YPB47kPUq7LpKWJNFPsRzHiIajGC5uXlWGn+AmkYPcHNl8S4tcEGx+cnORnNYaw2wvL+LQ==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
+  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
+
 "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.1":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.3.tgz#3802ddd21a50a949b6721ddd72da36e67e7f1b2d"
@@ -2908,6 +2925,17 @@ jmespath@0.16.0:
   version "0.16.0"
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
   integrity sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==
+
+joi@^17.6.0:
+  version "17.6.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.6.0.tgz#0bb54f2f006c09a96e75ce687957bd04290054b2"
+  integrity sha512-OX5dG6DTbcr/kbMFj0KGYxuew69HPcAE3K/sZpEV2nP6e/j/C0HV+HNiBPCASxdx5T7DMoa0s8UeHWMnb6n2zw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.3"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
 
 js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Change configuration schema to allow individual lifecycle components to provide their own `auth` block.

This required a `joi` update (for ancestor references), as `@hapi/joi` is deprecated and does not include the references API.