### PR TITLE
INTEGRATION [PR#2110 > development/7.10] feature: BB-133 add replay specific backlog metrics

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -45,8 +45,7 @@
             "destination": {
                 "transport": "http",
                 "bootstrapList": [
-                    { "site": "sf", "servers": ["127.0.0.1:9443"],
-                      "echo": false },
+                    { "site": "sf", "servers": ["127.0.0.1:9443"], "echo": false },
                     { "site": "aws-location", "type": "aws_s3" }
                 ],
                 "auth": {
@@ -106,7 +105,12 @@
                         "port": "4047"
                     }
                 ]
-            }
+            },
+            "objectSizeMetrics": [
+                66560,
+                8388608,
+                68157440
+            ]
         }
     },
     "log": {

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -87,6 +87,7 @@ const joiSchema = {
             })
         ),
     }),
+    objectSizeMetrics: joi.array().items(joi.number()),
 };
 
 function _loadAdminCredentialsFromFile(filePath) {

--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -18,7 +18,11 @@ const FailedCRRProducer = require('../failedCRR/FailedCRRProducer');
 const ReplayProducer = require('../replay/ReplayProducer');
 const promClient = require('prom-client');
 const constants = require('../../../lib/constants');
-const { wrapCounterInc, wrapGaugeSet } = require('../../../lib/util/metrics');
+const {
+    wrapCounterInc,
+    wrapGaugeSet,
+    wrapHistogramObserve,
+} = require('../../../lib/util/metrics');
 
 promClient.register.setDefaultLabels({
     origin: 'replication',
@@ -35,54 +39,6 @@ promClient.register.setDefaultLabels({
  * @property {string} [serviceName] - Name of our service to match generic metrics
  */
 
-const replicationStatusMetric = new promClient.Counter({
-    name: 'replication_status_changed_total',
-    help: 'Number of objects updated',
-    labelNames: ['origin', 'containerName', 'replicationStatus'],
-});
-
-const kafkaLagMetric = new promClient.Gauge({
-    name: 'kafka_lag',
-    help: 'Number of update entries waiting to be consumed from the Kafka topic',
-    labelNames: ['origin', 'containerName', 'partition', 'serviceName'],
-});
-
-const replayAttempts = new promClient.Counter({
-    name: 'replication_replay_attempts_total',
-    help: 'Number of total attempts made to replay replication',
-    labelNames: ['origin', 'containerName'],
-});
-
-const replaySuccess = new promClient.Counter({
-    name: 'replication_replay_success_total',
-    help: 'Number of times an object was replicated during a replay',
-    labelNames: ['origin', 'containerName'],
-});
-
-const replayQueuedObjects = new promClient.Counter({
-    name: 'replication_replay_objects_queued_total',
-    help: 'Number of objects added to replay queues',
-    labelNames: ['origin', 'containerName'],
-});
-
-const replayQueuedBytes = new promClient.Counter({
-    name: 'replication_replay_bytes_queued_total',
-    help: 'Number of bytes added to replay queues',
-    labelNames: ['origin', 'containerName'],
-});
-
-const replayCompletedObjects = new promClient.Counter({
-    name: 'replication_replay_objects_completed_total',
-    help: 'Number of objects completed from replay queues',
-    labelNames: ['origin', 'containerName'],
-});
-
-const replayCompletedBytes = new promClient.Counter({
-    name: 'replication_replay_bytes_completed_total',
-    help: 'Number of bytes completed from replay queues',
-    labelNames: ['origin', 'containerName'],
-});
-
 /**
  * Contains methods to incrememt different metrics
  * @typedef {Object} ReplicationStatusMetricsHandler
@@ -90,17 +46,94 @@ const replayCompletedBytes = new promClient.Counter({
  * @property {GaugeSet} lag - Set the kafka lag metric
  * @property {CounterInc} replayAttempts - Increments the replay attempts metric
  * @property {CounterInc} replaySuccess - Increments the replay success metric
+ * @property {CounterInc} replayQueuedObjects - Increments the replay queued objects metric
+ * @property {CounterInc} replayQueuedBytes - Increments the replay queued bytes metric
+ * @property {CounterInc} replayQueuedFileSizes - Increments the replay queued file sizes metric
+ * @property {CounterInc} replayCompletedObjects - Increments the replay completed objects metric
+ * @property {CounterInc} replayCompletedBytes - Increments the replay completed bytes metric
+ * @property {CounterInc} replayCompletedFileSizes - Increments the replay completed file sizes metric
  */
-const metricsHandler = {
-    status: wrapCounterInc(replicationStatusMetric),
-    lag: wrapGaugeSet(kafkaLagMetric),
-    replayAttempts: wrapCounterInc(replayAttempts),
-    replaySuccess: wrapCounterInc(replaySuccess),
-    replayQueuedObjects: wrapCounterInc(replayQueuedObjects),
-    replayQueuedBytes: wrapCounterInc(replayQueuedBytes),
-    replayCompletedObjects: wrapCounterInc(replayCompletedObjects),
-    replayCompletedBytes: wrapCounterInc(replayCompletedBytes),
-};
+
+/**
+ * @param {Object} repConfig - Replication configuration
+ * @returns {ReplicationStatusMetricsHandler} Metric handlers
+ */
+function loadMetricHandlers(repConfig) {
+    const replicationStatusMetric = new promClient.Counter({
+        name: 'replication_status_changed_total',
+        help: 'Number of objects updated',
+        labelNames: ['origin', 'containerName', 'replicationStatus'],
+    });
+
+    const kafkaLagMetric = new promClient.Gauge({
+        name: 'kafka_lag',
+        help: 'Number of update entries waiting to be consumed from the Kafka topic',
+        labelNames: ['origin', 'containerName', 'partition', 'serviceName'],
+    });
+
+    const replayAttempts = new promClient.Counter({
+        name: 'replication_replay_attempts_total',
+        help: 'Number of total attempts made to replay replication',
+        labelNames: ['origin', 'containerName'],
+    });
+
+    const replaySuccess = new promClient.Counter({
+        name: 'replication_replay_success_total',
+        help: 'Number of times an object was replicated during a replay',
+        labelNames: ['origin', 'containerName'],
+    });
+
+    const replayQueuedObjects = new promClient.Counter({
+        name: 'replication_replay_objects_queued_total',
+        help: 'Number of objects added to replay queues',
+        labelNames: ['origin', 'containerName'],
+    });
+
+    const replayQueuedBytes = new promClient.Counter({
+        name: 'replication_replay_bytes_queued_total',
+        help: 'Number of bytes added to replay queues',
+        labelNames: ['origin', 'containerName'],
+    });
+
+    const replayQueuedFileSizes = new promClient.Histogram({
+        name: 'replication_replay_file_sizes_queued',
+        help: 'Number of objects queued for replay by file size',
+        labelNames: ['origin', 'containerName'],
+        buckets: repConfig.objectSizeMetrics,
+    });
+
+    const replayCompletedObjects = new promClient.Counter({
+        name: 'replication_replay_objects_completed_total',
+        help: 'Number of objects completed from replay queues',
+        labelNames: ['origin', 'containerName'],
+    });
+
+    const replayCompletedBytes = new promClient.Counter({
+        name: 'replication_replay_bytes_completed_total',
+        help: 'Number of bytes completed from replay queues',
+        labelNames: ['origin', 'containerName'],
+    });
+
+    const replayCompletedFileSizes = new promClient.Histogram({
+        name: 'replication_replay_file_sizes_completed',
+        help: 'Number of objects completed from replay by file size',
+        labelNames: ['origin', 'containerName', 'replicationStatus'],
+        buckets: repConfig.objectSizeMetrics,
+    });
+
+    return {
+        status: wrapCounterInc(replicationStatusMetric),
+        lag: wrapGaugeSet(kafkaLagMetric),
+        replayAttempts: wrapCounterInc(replayAttempts),
+        replaySuccess: wrapCounterInc(replaySuccess),
+        replayQueuedObjects: wrapCounterInc(replayQueuedObjects),
+        replayQueuedBytes: wrapCounterInc(replayQueuedBytes),
+        replayQueuedFileSizes: wrapHistogramObserve(replayQueuedFileSizes),
+        replayCompletedObjects: wrapCounterInc(replayCompletedObjects),
+        replayCompletedBytes: wrapCounterInc(replayCompletedBytes),
+        replayCompletedFileSizes: wrapHistogramObserve(replayCompletedFileSizes),
+    };
+}
 
 /**
  * @class ReplicationStatusProcessor
@@ -163,6 +196,7 @@ class ReplicationStatusProcessor {
         }
 
         this._setupVaultclientCache();
+        this.metricsHandlers = loadMetricHandlers(repConfig);
 
         this._statsClient = new StatsModel(undefined);
         this.taskScheduler = new ReplicationTaskScheduler(
@@ -340,7 +374,7 @@ class ReplicationStatusProcessor {
         }
         let task;
         if (sourceEntry instanceof ObjectQueueEntry) {
-            task = new UpdateReplicationStatus(this, metricsHandler);
+            task = new UpdateReplicationStatus(this, this.metricsHandlers);
         }
         if (task) {
             return this.taskScheduler.push({ task, entry: sourceEntry },
@@ -415,7 +449,7 @@ class ReplicationStatusProcessor {
         // update the metrics when requested
         const lagStats = this._consumer.consumerStats.lag;
         Object.keys(lagStats).forEach(partition => {
-            metricsHandler.lag({ partition, serviceName }, lagStats[partition]);
+            this.metricsHandlers.lag({ partition, serviceName }, lagStats[partition]);
         });
 
         res.writeHead(200, {

--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -59,6 +59,30 @@ const replaySuccess = new promClient.Counter({
     labelNames: ['origin', 'containerName'],
 });
 
+const replayQueuedObjects = new promClient.Counter({
+    name: 'replication_replay_objects_queued_total',
+    help: 'Number of objects added to replay queues',
+    labelNames: ['origin', 'containerName'],
+});
+
+const replayQueuedBytes = new promClient.Counter({
+    name: 'replication_replay_bytes_queued_total',
+    help: 'Number of bytes added to replay queues',
+    labelNames: ['origin', 'containerName'],
+});
+
+const replayCompletedObjects = new promClient.Counter({
+    name: 'replication_replay_objects_completed_total',
+    help: 'Number of objects completed from replay queues',
+    labelNames: ['origin', 'containerName'],
+});
+
+const replayCompletedBytes = new promClient.Counter({
+    name: 'replication_replay_bytes_completed_total',
+    help: 'Number of bytes completed from replay queues',
+    labelNames: ['origin', 'containerName'],
+});
+
 /**
  * Contains methods to incrememt different metrics
  * @typedef {Object} ReplicationStatusMetricsHandler
@@ -72,6 +96,10 @@ const metricsHandler = {
     lag: wrapGaugeSet(kafkaLagMetric),
     replayAttempts: wrapCounterInc(replayAttempts),
     replaySuccess: wrapCounterInc(replaySuccess),
+    replayQueuedObjects: wrapCounterInc(replayQueuedObjects),
+    replayQueuedBytes: wrapCounterInc(replayQueuedBytes),
+    replayCompletedObjects: wrapCounterInc(replayCompletedObjects),
+    replayCompletedBytes: wrapCounterInc(replayCompletedBytes),
 };
 
 /**

--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -162,6 +162,8 @@ class ReplicationStatusProcessor {
      * @param {String} repConfig.replicationStatusProcessor.retryTimeoutS -
      *   number of seconds before giving up retries of an entry status
      *   update
+     * @param {Array<Number>} repConfig.objectSizeMetrics - Array of numbers
+     *   specifying the breakpoints in object size values for metrics
      * @param {Array.<{topicName: String, retries: Number}>}
      * repConfig.replayTopics - array of replay topics
      * @param {Object} [internalHttpsConfig] - internal HTTPS
@@ -447,10 +449,12 @@ class ReplicationStatusProcessor {
 
         // consumer stats lag is on a different update cycle so we need to
         // update the metrics when requested
-        const lagStats = this._consumer.consumerStats.lag;
-        Object.keys(lagStats).forEach(partition => {
-            this.metricsHandlers.lag({ partition, serviceName }, lagStats[partition]);
-        });
+        if (this._consumer) {
+            const lagStats = this._consumer.consumerStats.lag;
+            Object.keys(lagStats).forEach(partition => {
+                this.metricsHandlers.lag({ partition, serviceName }, lagStats[partition]);
+            });
+        }
 
         res.writeHead(200, {
             'Content-Type': promClient.register.contentType,

--- a/extensions/replication/tasks/UpdateReplicationStatus.js
+++ b/extensions/replication/tasks/UpdateReplicationStatus.js
@@ -167,6 +167,10 @@ class UpdateReplicationStatus extends BackbeatTask {
             }
             this.metricsHandler.replayCompletedObjects();
             this.metricsHandler.replayCompletedBytes(queueEntry.getContentLength());
+            this.metricsHandler.replayCompletedFileSizes(
+                { replicationStatus: 'FAILED' },
+                queueEntry.getContentLength(),
+            );
             return refreshedEntry.toFailedEntry(site);
         }
         if (count > 0) {
@@ -182,6 +186,7 @@ class UpdateReplicationStatus extends BackbeatTask {
             this._pushReplayEntry(queueEntry, site, log);
             this.metricsHandler.replayQueuedObjects();
             this.metricsHandler.replayQueuedBytes(queueEntry.getContentLength());
+            this.metricsHandler.replayQueuedFileSizes(queueEntry.getContentLength());
             return null;
         }
         log.error('count value is invalid',
@@ -208,6 +213,10 @@ class UpdateReplicationStatus extends BackbeatTask {
                     this.metricsHandler.replaySuccess();
                     this.metricsHandler.replayCompletedObjects();
                     this.metricsHandler.replayCompletedBytes(sourceEntry.getContentLength());
+                    this.metricsHandler.replayCompletedFileSizes(
+                        { replicationStatus: 'COMPLETED' },
+                        sourceEntry.getContentLength(),
+                    );
                 }
             } else if (status === 'FAILED') {
                 updatedSourceEntry = this._handleFailedReplicationEntry(refreshedEntry, sourceEntry, site, log);

--- a/extensions/replication/tasks/UpdateReplicationStatus.js
+++ b/extensions/replication/tasks/UpdateReplicationStatus.js
@@ -169,7 +169,7 @@ class UpdateReplicationStatus extends BackbeatTask {
             this.metricsHandler.replayCompletedBytes(queueEntry.getContentLength());
             this.metricsHandler.replayCompletedFileSizes(
                 { replicationStatus: 'FAILED' },
-                queueEntry.getContentLength(),
+                queueEntry.getContentLength()
             );
             return refreshedEntry.toFailedEntry(site);
         }
@@ -215,7 +215,7 @@ class UpdateReplicationStatus extends BackbeatTask {
                     this.metricsHandler.replayCompletedBytes(sourceEntry.getContentLength());
                     this.metricsHandler.replayCompletedFileSizes(
                         { replicationStatus: 'COMPLETED' },
-                        sourceEntry.getContentLength(),
+                        sourceEntry.getContentLength()
                     );
                 }
             } else if (status === 'FAILED') {

--- a/extensions/replication/tasks/UpdateReplicationStatus.js
+++ b/extensions/replication/tasks/UpdateReplicationStatus.js
@@ -165,6 +165,8 @@ class UpdateReplicationStatus extends BackbeatTask {
             if (this.repConfig.monitorReplicationFailures) {
                 this._pushFailedEntry(queueEntry);
             }
+            this.metricsHandler.replayCompletedObjects();
+            this.metricsHandler.replayCompletedBytes(queueEntry.getContentLength());
             return refreshedEntry.toFailedEntry(site);
         }
         if (count > 0) {
@@ -178,6 +180,8 @@ class UpdateReplicationStatus extends BackbeatTask {
             // If no replay count has been defined yet:
             queueEntry.setReplayCount(totalAttempts);
             this._pushReplayEntry(queueEntry, site, log);
+            this.metricsHandler.replayQueuedObjects();
+            this.metricsHandler.replayQueuedBytes(queueEntry.getContentLength());
             return null;
         }
         log.error('count value is invalid',
@@ -202,6 +206,8 @@ class UpdateReplicationStatus extends BackbeatTask {
                 updatedSourceEntry = refreshedEntry.toCompletedEntry(site);
                 if (sourceEntry.getReplayCount() >= 0) {
                     this.metricsHandler.replaySuccess();
+                    this.metricsHandler.replayCompletedObjects();
+                    this.metricsHandler.replayCompletedBytes(sourceEntry.getContentLength());
                 }
             } else if (status === 'FAILED') {
                 updatedSourceEntry = this._handleFailedReplicationEntry(refreshedEntry, sourceEntry, site, log);

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -726,6 +726,7 @@ describe('queue processor functional tests with mocking', () => {
                       groupId: 'backbeat-func-test-group-id',
                   },
                   monitorReplicationFailures: true,
+                  objectSizeMetrics: [100, 1000],
                 }, {
                 });
             replicationStatusProcessor.start({ bootstrap: true }, done);

--- a/tests/unit/replication/ReplicationStatusProcessor.js
+++ b/tests/unit/replication/ReplicationStatusProcessor.js
@@ -1,10 +1,6 @@
 const assert = require('assert');
 const promClient = require('prom-client');
 
-// Clear register to avoid:
-// Error: A metric with the name kafka_lag has already been registered.
-promClient.register.clear();
-
 const ReplicationStatusProcessor =
     require('../../../extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor');
 
@@ -16,11 +12,17 @@ function makeReplicationStatusProcessor(replayTopics) {
             s3: {},
             transport: 'http',
         },
-        { replayTopics },
+        { replayTopics, objectSizeMetrics: [100, 1000] },
         {});
 }
 
 describe('ReplicationStatusProcessor', () => {
+    beforeEach(() => {
+        // Clear register to avoid:
+        // Error: A metric with the name kafka_lag has already been registered.
+        promClient.register.clear();
+    });
+
     describe('::_reshapeReplayTopics', () => {
         it('should return undefined if the config replay topics is undefined', () => {
             const replayTopics = undefined;


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2110.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/7.10/feature/BB-133/replay-specific-object-and-byte-backlog`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/7.10/feature/BB-133/replay-specific-object-and-byte-backlog
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/7.10/feature/BB-133/replay-specific-object-and-byte-backlog
```

Please always comment pull request #2110 instead of this one.