### PR TITLE
BB-134 - Set zstd compression in producers

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -81,7 +81,7 @@ jobs:
     - name: Install build dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential
+        sudo apt-get install -y build-essential libzstd-dev
     - uses: actions/setup-go@v2
       with:
         go-version: '1.16.2'

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN apt-get update \
     libnss3-dev \
     libssl-dev \
     libreadline-dev \
-    libffi-dev
+    libffi-dev \
+    libzstd-dev
 
 ENV DOCKERIZE_VERSION v0.6.1
 ENV PYTHON=python3.9

--- a/extensions/notification/destination/KafkaProducer.js
+++ b/extensions/notification/destination/KafkaProducer.js
@@ -7,6 +7,7 @@ const jsutil = require('arsenal').jsutil;
 const Logger = require('werelogs').Logger;
 
 const authUtil = require('../utils/auth');
+const Constants = require('../../../lib/constants.js');
 
 // waits for an ack for messages
 const REQUIRE_ACKS = 1;
@@ -59,6 +60,7 @@ class KafkaProducer extends EventEmitter {
             'metadata.broker.list': this._kafkaHosts,
             'message.max.bytes': messageMaxBytes,
             'dr_cb': true,
+            'compression.type': Constants.compressionType,
         };
         Object.assign(producerOptions, authObject);
         // create a new producer instance

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -7,6 +7,7 @@ const Logger = require('werelogs').Logger;
 
 const { withTopicPrefix } = require('./util/topic');
 const KafkaBacklogMetrics = require('./KafkaBacklogMetrics');
+const Constants = require('./constants');
 
 // waits for an ack for messages
 const REQUIRE_ACKS = 'all';
@@ -65,6 +66,7 @@ class BackbeatProducer extends EventEmitter {
             'metadata.broker.list': this._kafkaHosts,
             'message.max.bytes': messageMaxBytes,
             'dr_cb': true,
+            'compression.type': Constants.compressionType,
         }, {
             'request.required.acks': REQUIRE_ACKS,
             'request.timeout.ms': ACK_TIMEOUT,

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -19,6 +19,7 @@ const constants = {
         replicationQueueProcessor: 'ReplicationQueueProcessor',
         replicationStatusProcessor: 'ReplicationStatusProcessor',
     },
+    compressionType: 'Zstd',
 };
 
 module.exports = constants;


### PR DESCRIPTION
Setting compression to `zstd` in producer configuration tackles one part of ZENKO-3223 - the other part is explicitly setting `producer` compression at the broker level.

Compression settings in Kafka are transparent: messages are sent in a compressed form by producers, or compressed at rest according to broker or topic configuration, but consumers receive the uncompressed message.

Additionally, brokers in Kafka are configured by default to `producer` compression, that is to say they match the compression setting of the producer sending the data and make no additional compression on their side.