### PR TITLE
BB-139: throttle conductor depending on bucket queue

### DIFF
--- a/.github/dockerfiles/syntheticbucketd/Dockerfile
+++ b/.github/dockerfiles/syntheticbucketd/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:10
+
+RUN mkdir /app
+COPY package.json /app
+COPY yarn.lock /app
+RUN cd /app && yarn install
+
+COPY tests/utils /app
+
+CMD ["node", "/app/syntheticbucketd.js", "200000", "1000"]

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,6 +42,16 @@ jobs:
         cache-from: type=local,src=/tmp/.buildx-cache
         cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
 
+    - name: Build and push syntheticbucketd
+      uses: docker/build-push-action@v2
+      with:
+        push: true
+        context: .
+        file: .github/dockerfiles/syntheticbucketd/Dockerfile
+        tags: "ghcr.io/scality/backbeat/syntheticbucketd:${{ github.sha }}"
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
     # Temp fix
     # https://github.com/docker/build-push-action/issues/252
     # https://github.com/moby/buildkit/issues/1896
@@ -58,6 +68,10 @@ jobs:
         image: redis:alpine
         ports:
         - 6379:6379
+      syntheticbucketd:
+        image: ghcr.io/scality/backbeat/syntheticbucketd:${{ github.sha }}
+        ports:
+        - 9001:9001
       kafka:
         image: ghcr.io/scality/backbeat/ci-kafka:${{ github.sha }}
         credentials:
@@ -119,3 +133,11 @@ jobs:
         BACKBEAT_CONFIG_FILE: "tests/config.json"
     - name: run backbeat notification feature tests
       run: yarn run ft_test:notification
+
+    - name: run ballooning tests for lifecycle conductor
+      run: yarn mocha tests/performance/lifecycle/conductor-with-bucketd-check-memory-balloon.js
+      env:
+        # Constrain heap long-lived heap size to 50MB, so that pushing 200K messages
+        # will crash if they end up in memory all at the same time (circuit breaking
+        # ineffective) while waiting to be committed to the kafka topic.
+        NODE_OPTIONS: '--max-old-space-size=50'

--- a/extensions/lifecycle/conductor/LifecycleConductor.js
+++ b/extensions/lifecycle/conductor/LifecycleConductor.js
@@ -69,6 +69,7 @@ class LifecycleConductor {
             this.lcConfig.conductor.cronRule || DEFAULT_CRON_RULE;
         this._concurrency =
             this.lcConfig.conductor.concurrency || DEFAULT_CONCURRENCY;
+        this._maxInFlightBatchSize = this._concurrency * 2;
         this._bucketSource = this.lcConfig.conductor.bucketSource;
         this._bucketdConfig = this.lcConfig.conductor.bucketd;
         this._producer = null;
@@ -109,7 +110,7 @@ class LifecycleConductor {
         });
     }
 
-    processBuckets() {
+    processBuckets(cb) {
         const log = this.logger.newRequestLogger();
         let nBucketsQueued = 0;
 
@@ -158,15 +159,24 @@ class LifecycleConductor {
         ], err => {
             if (err && err.Throttling) {
                 log.info('not starting new lifecycle batch', { reason: err });
+                if (cb) {
+                    cb(err);
+                }
                 return;
             }
 
             if (err) {
                 log.error('lifecycle batch failed', { error: err });
+                if (cb) {
+                    cb(err);
+                }
                 return;
             }
 
             log.info('finished pushing lifecycle batch', { nBucketsQueued });
+            if (cb) {
+                cb();
+            }
         });
     }
 
@@ -213,35 +223,48 @@ class LifecycleConductor {
         let isTruncated = false;
         let marker = null;
         let nEnqueued = 0;
+        const start = new Date();
 
         async.doWhilst(
-            next => this._bucketClient.listObject(
-                constants.usersBucket,
-                log.getSerializedUids(),
-                { marker, prefix: '', maxKeys: this._concurrency },
-                (err, resp) => {
-                    if (err) {
-                        return next(err);
-                    }
-
-                    const { error, result } = safeJsonParse(resp);
-                    if (error) {
-                        return next(error);
-                    }
-
-                    isTruncated = result.IsTruncated;
-                    nEnqueued += result.Contents.length;
-
-                    result.Contents.forEach(o => {
-                        marker = o.key;
-                        const [canonicalId, bucketName] = marker.split(constants.splitter);
-                        queue.push({ canonicalId, bucketName });
+            next => {
+                if (queue.length() > this._maxInFlightBatchSize) {
+                    log.info('delaying bucket pull', {
+                        nEnqueuedToDownstream: nEnqueued,
+                        inFlight: queue.length(),
+                        maxInFlight: this._maxInFlightBatchSize,
+                        enqueueRateHz: Math.round(nEnqueued * 1000 / (new Date() - start)),
                     });
 
-                    const delay = queue.length() > this._concurrency ? 0 : 500;
-                    return setTimeout(next, delay);
+                    return setTimeout(next, 10000);
                 }
-            ),
+
+                return this._bucketClient.listObject(
+                    constants.usersBucket,
+                    log.getSerializedUids(),
+                    { marker, prefix: '', maxKeys: this._concurrency },
+                    (err, resp) => {
+                        if (err) {
+                            return next(err);
+                        }
+
+                        const { error, result } = safeJsonParse(resp);
+                        if (error) {
+                            return next(error);
+                        }
+
+                        isTruncated = result.IsTruncated;
+                        nEnqueued += result.Contents.length;
+
+                        result.Contents.forEach(o => {
+                            marker = o.key;
+                            const [canonicalId, bucketName] = marker.split(constants.splitter);
+                            queue.push({ canonicalId, bucketName });
+                        });
+
+                        return next();
+                    }
+                );
+            },
             () => isTruncated,
             err => cb(err, nEnqueued));
     }

--- a/tests/performance/lifecycle/conductor-with-bucketd-check-memory-balloon.js
+++ b/tests/performance/lifecycle/conductor-with-bucketd-check-memory-balloon.js
@@ -1,0 +1,41 @@
+const baseConfig = require('../../../conf/Config');
+const LifecycleConductor = require('../../../extensions/lifecycle/conductor/LifecycleConductor');
+
+const lcConfig = {
+    ...baseConfig.extensions.lifecycle,
+    auth: {
+        type: '',
+    },
+    conductor: {
+        cronRule: '12 12 12 12 12',
+        concurrency: 10000,
+        bucketSource: 'bucketd',
+        bucketd: {
+            host: '127.0.0.1',
+            port: 9001,
+        },
+        backlogControl: {
+            enabled: true,
+        },
+    },
+};
+
+const lc = new LifecycleConductor(
+    baseConfig.zookeeper,
+    baseConfig.kafka,
+    lcConfig,
+    baseConfig.extensions.replication
+);
+
+describe('Lifecycle Conductor', function testBackpressure() {
+    this.timeout(10 * 60 * 1000);
+
+    it('should apply backpressure on bucket queue instead of ballooning', done => {
+        lc.init(() => {
+            lc.processBuckets(err => {
+                lc.stop();
+                done(err);
+            });
+        });
+    });
+});

--- a/tests/utils/syntheticbucketd.js
+++ b/tests/utils/syntheticbucketd.js
@@ -1,0 +1,90 @@
+const url = require('url');
+const http = require('http');
+const assert = require('assert');
+
+const werelogs = require('werelogs');
+const logger = new werelogs.Logger('Backbeat:syntheticbucketd');
+
+const bucketdPort = 9001;
+
+const bucketNumber = Number.parseInt(process.argv[2], 10);
+const accountsNumber = Number.parseInt(process.argv[3], 10);
+
+if (!Number.isSafeInteger(bucketNumber) ||
+    !Number.isSafeInteger(accountsNumber)) {
+    logger.error(`usage: ${process.argv[1]} <bucketNumber> <accountsNumber>`);
+    process.exit(1);
+}
+
+function getMarkerIndex(marker) {
+    if (marker) {
+        return Number.parseInt(marker.split('..|..')[1], 10) + 1;
+    }
+
+    return 0;
+}
+
+function generateAccountIds(accountsNumber) {
+    const accountPadding = '0'.repeat(64);
+    const ret = [];
+
+    for (let i = 0; i < accountsNumber; i++) {
+        ret.push((`${accountPadding}${i}`.slice(-20)));
+    }
+
+    ret.sort(() => Math.random() - 0.5);
+
+    return ret;
+}
+
+function makeListing(marker, maxKeys) {
+    const accountIds = generateAccountIds(accountsNumber);
+    const index = getMarkerIndex(marker);
+    const ret = [];
+
+    const upperBound = Math.min(index + maxKeys, bucketNumber);
+    const namePadding = '0'.repeat(24);
+
+    for (let i = index; i < upperBound; i += 1) {
+        const account = accountIds[i % accountsNumber];
+        const name = (`${namePadding}${i}`.slice(-24));
+        ret.push(`${account}..|..${name}`);
+    }
+
+    return ret;
+}
+
+const bucketdHandler = (req, res) => {
+    const { pathname, query } = url.parse(req.url, true);
+    const { maxKeys: maxKeysS, marker } = query;
+    const maxKeys = Number.parseInt(maxKeysS, 10);
+
+    assert.strictEqual(pathname, '/default/bucket/users..bucket');
+
+    const reqUid = req.headers['x-scal-request-uids'];
+    const log = reqUid ?
+        logger.newRequestLoggerFromSerializedUids(reqUid) :
+        logger.newRequestLogger();
+
+    const index = getMarkerIndex(marker);
+    const isTruncated = (index + maxKeys) < bucketNumber;
+
+    log.info('listing request', { marker, maxKeys, isTruncated, index });
+
+    res.end(JSON.stringify({
+        Contents: makeListing(marker, maxKeys).map(key => ({
+            key,
+            value: {},
+        })),
+        IsTruncated: isTruncated,
+    }));
+};
+
+http.createServer(bucketdHandler)
+    .listen(bucketdPort, () => {
+        logger.info('listening', {
+            bucketdPort,
+            bucketNumber,
+            accountsNumber,
+        });
+    });


### PR DESCRIPTION
- Fixes crash of lifecycle conductor when kafka is committing messages much slower than they're pulled from bucketd.
- Adds test that batches run in constant memory no matter the number of buckets (removing the circuit breaker causes the crash almost immediately).