### PR TITLE
BB-148: add processBuckets callback function type check

### DIFF
--- a/extensions/lifecycle/conductor/LifecycleConductor.js
+++ b/extensions/lifecycle/conductor/LifecycleConductor.js
@@ -433,7 +433,7 @@ class LifecycleConductor {
                              { cronRule: this._cronRule });
             this._cronJob = schedule.scheduleJob(
                 this._cronRule,
-                this.processBuckets.bind(this));
+                () => this.processBuckets(null));
         }
     }
 


### PR DESCRIPTION
add callback type check before invoking in processBuckets method.
cron scheduler does not pass a function type as a parameter to
processBuckets.