### PR TITLE
Feature: BB-161 add timestamp to object delete notification

### DIFF
--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -378,17 +378,31 @@ class LogReader {
     }
 
     _processLogEntry(batchState, record, entry) {
-        if (entry.value === undefined) {
-            return;
-        }
-        this._extensions.forEach(ext => ext.filter({
-            type: entry.type,
-            bucket: record.db,
-            // removing the v1 metadata prefix if it exists
-            key: transformKey(entry.key),
-            value: entry.value,
-            logReader: this,
-        }));
+        this._extensions.forEach(ext => {
+            /**
+             * object delete entries don't have a value field,
+             * those should not be skipped for the notification
+             * extension
+             */
+            if (entry.value === undefined) {
+                if (ext.constructor.name !== 'NotificationQueuePopulator') {
+                    return null;
+                } else {
+                    // adding timestamp to the value of the delete entry
+                    entry.value = {
+                        'last-modified': record.timestamp
+                    };
+                }
+            }
+            return ext.filter({
+                type: entry.type,
+                bucket: record.db,
+                // removing the v1 metadata prefix if it exists
+                key: transformKey(entry.key),
+                value: entry.value,
+                logReader: this,
+            });
+        });
     }
 
     _processPrepareEntries(batchState, done) {

--- a/tests/unit/lib/queuePopulator/LogReader.spec.js
+++ b/tests/unit/lib/queuePopulator/LogReader.spec.js
@@ -148,4 +148,106 @@ describe('LogReader', () => {
         assert(mockExtension.filter.secondCall.calledWith(expectedArgs));
         done();
     });
+
+    it('Should add time stamp if value not available and extesion is notification', done => {
+        const mockExtension = {
+            constructor: {
+                name: 'NotificationQueuePopulator'
+            },
+            filter: sinon.spy(),
+        };
+        const logReaderWithExtension = new LogReader({
+            logId: 'test-log-reader',
+            zkClient: zkMock.createClient('localhost:2181'),
+            logConsumer: new MockLogConsumer(),
+            logger: new Logger('test:logReaderWithExtension'),
+            extensions: [mockExtension]
+        });
+        const record = {
+            db: 'example-bucket',
+            timestamp: 'YYYY-MM-DD:HH-MM-SS',
+            entry: {
+                type: 'example-type',
+                key: 'fMexample-key',
+            }
+        };
+        logReaderWithExtension._processLogEntry({}, record, record.entry);
+        const expectedArgs = {
+            type: 'example-type',
+            bucket: 'example-bucket',
+            key: 'fMexample-key',
+            value: {
+                'last-modified': 'YYYY-MM-DD:HH-MM-SS',
+            },
+            logReader: logReaderWithExtension,
+        };
+        assert(mockExtension.filter.calledWith(expectedArgs));
+        done();
+    });
+
+    it('Should not modify entry value if already defined', done => {
+        const mockExtension = {
+            constructor: {
+                name: 'NotificationQueuePopulator'
+            },
+            filter: sinon.spy(),
+        };
+        const logReaderWithExtension = new LogReader({
+            logId: 'test-log-reader',
+            zkClient: zkMock.createClient('localhost:2181'),
+            logConsumer: new MockLogConsumer(),
+            logger: new Logger('test:logReaderWithExtension'),
+            extensions: [mockExtension]
+        });
+        const record = {
+            db: 'example-bucket',
+            timestamp: 'timestamp-value',
+            entry: {
+                type: 'example-type',
+                key: 'fMexample-key',
+                value: {
+                    'last-modified': 'YYYY-MM-DD:HH-MM-SS',
+                }
+            }
+        };
+        logReaderWithExtension._processLogEntry({}, record, record.entry);
+        const expectedArgs = {
+            type: 'example-type',
+            bucket: 'example-bucket',
+            key: 'fMexample-key',
+            value: {
+                'last-modified': 'YYYY-MM-DD:HH-MM-SS',
+            },
+            logReader: logReaderWithExtension,
+        };
+        assert(mockExtension.filter.calledWith(expectedArgs));
+        done();
+    });
+
+    it('Should skip filtering if value is undefined and extension not notification', done => {
+        const mockExtension = {
+            constructor: {
+                name: 'ReplicationQueuePopulator'
+            },
+            filter: sinon.spy(),
+        };
+        const logReaderWithExtension = new LogReader({
+            logId: 'test-log-reader',
+            zkClient: zkMock.createClient('localhost:2181'),
+            logConsumer: new MockLogConsumer(),
+            logger: new Logger('test:logReaderWithExtension'),
+            extensions: [mockExtension]
+        });
+        const record = {
+            db: 'example-bucket',
+            timestamp: 'YYYY-MM-DD:HH-MM-SS',
+            entry: {
+                type: 'example-type',
+                key: 'fMexample-key',
+            }
+        };
+        logReaderWithExtension._processLogEntry({}, record, record.entry);
+        assert(mockExtension.filter.notCalled);
+        done();
+    });
 });


### PR DESCRIPTION
…ication

Issue: (BB-161)[https://scality.atlassian.net/browse/BB-161]

Issue:
Oplog delete events don't have a value field, which makes the object deletion notifications have a null timestamp, as its value is extracted from the object metadata field `last-modified`.

Solution:
Manually add the required field in the entry value when filtering the oplog entries
The `last-modified` value used is the oplog record timestamp