### PR TITLE
BB-155 Do not fetch tags if object not eligible based on its date

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -130,6 +130,8 @@ jobs:
     - name: run feature lifecycle tests
       run: .github/scripts/run_ft_tests.bash ft_test:lifecycle
       env:
+        EXPIRE_ONE_DAY_EARLIER: "true"
+        TRANSITION_ONE_DAY_EARLIER: "true"
         BACKBEAT_CONFIG_FILE: "tests/config.json"
     - name: run backbeat notification feature tests
       run: yarn run ft_test:notification

--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -52,6 +52,7 @@ class LifecycleTask extends BackbeatTask {
             supportedLifecycleRules,
             this._lifecycleDateTime
         );
+        this._supportedRules = supportedLifecycleRules;
     }
 
     setSupportedRules(supportedRules) {
@@ -59,6 +60,7 @@ class LifecycleTask extends BackbeatTask {
             supportedRules,
             this._lifecycleDateTime
         );
+        this._supportedRules = supportedRules;
     }
 
     /**
@@ -534,6 +536,100 @@ class LifecycleTask extends BackbeatTask {
         });
     }
 
+    /**
+     * check if rule applies for a given date or calculed days.
+     * @param {array} rule - bucket lifecycle rule
+     * @param {number} daysSinceInitiated - Days passed since entity (object or version) last modified
+     * NOTE: entity is not an in-progress MPU or a delete marker.
+     * @param {number} currentDate - current date
+     * @return {boolean} true if rule applies - false otherwise.
+     */
+    _isRuleApplying(rule, daysSinceInitiated, currentDate) {
+        if (rule.Expiration && this._supportedRules.includes('expiration')) {
+            if (rule.Expiration.Days !== undefined && daysSinceInitiated >= rule.Expiration.Days) {
+                return true;
+            }
+
+            if (rule.Expiration.Date && rule.Expiration.Date < currentDate) {
+                return true;
+            }
+            // Expiration.ExpiredObjectDeleteMarker rule's action does not apply
+            // since object is not a delete marker.
+            // AbortIncompleteMultipartUpload.DaysAfterInitiation rule's action does not apply
+            // since in-progress MPUs are beeing handled separetly prior to this checks.
+        }
+
+        if (rule.Transitions && rule.Transitions.length > 0
+        && this._supportedRules.includes('transitions')) {
+            return rule.Transitions.some(t => {
+                if (t.Days !== undefined && daysSinceInitiated >= t.Days) {
+                    return true;
+                }
+                if (t.Date && t.Date < currentDate) {
+                    return true;
+                }
+                return false;
+            });
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if entity (object or version) is eligible for expiration or transition based on its date.
+     * This function was introduced to avoid having to go further into processing
+     * (call getObjectTagging, headObject...) if the entity was not eligible based on its date.
+     * @param {array} rules - array of bucket lifecycle rules
+     * @param {object} entity - object or object version
+     * NOTE: entity is not an in-progress MPU or a delete marker.
+     * @param {string} versioningStatus - 'Enabled', 'Suspended', or 'Disabled'
+     * @return {boolean} true if eligible - false otherwise.
+     */
+    _isEntityEligible(rules, entity, versioningStatus) {
+        const currentDate = this._lifecycleDateTime.getCurrentDate();
+        const daysSinceInitiated = this._lifecycleDateTime.findDaysSince(
+            new Date(entity.LastModified)
+        );
+        const { staleDate } = entity;
+        const daysSinceStaled = staleDate ?
+            this._lifecycleDateTime.findDaysSince(new Date(staleDate)) : null;
+
+        // Always eligible if object is a current version delete marker because
+        // it requires extra s3 call (list versions).
+        if (entity.IsLatest && this._isDeleteMarker(entity)) {
+            return true;
+        }
+
+        return rules.some(rule => {
+            if (rule.Status === 'Disabled') {
+                return false;
+            }
+
+            if (versioningStatus === 'Enabled' || versioningStatus === 'Suspended') {
+                if (entity.IsLatest) {
+                    return this._isRuleApplying(rule, daysSinceInitiated, currentDate);
+                }
+
+                if (!staleDate) {
+                    // NOTE: this should never happen. A non-current version should always have
+                    // a stale date. If it is the case, we will log later for debug purposes.
+                    return true;
+                }
+
+                if (rule.NoncurrentVersionExpiration
+                && this._supportedRules.includes('noncurrentVersionExpiration')) {
+                    if (rule.NoncurrentVersionExpiration.NoncurrentDays !== undefined &&
+                    daysSinceStaled >= rule.NoncurrentVersionExpiration.NoncurrentDays) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            return this._isRuleApplying(rule, daysSinceInitiated, currentDate);
+        });
+    }
+
 
     /**
      * Get rules and compare with each object or version
@@ -551,23 +647,30 @@ class LifecycleTask extends BackbeatTask {
             return done();
         }
         return async.eachLimit(contents, CONCURRENCY_DEFAULT, (obj, cb) => {
-            async.waterfall([
+            const eligible =
+                this._isEntityEligible(lcRules, obj, versioningStatus);
+            if (!eligible) {
+                log.debug('entity is not eligible for lifecycle', {
+                    bucket: bucketData.target.bucket,
+                    key: obj.Key,
+                    versionId: obj.VersionId,
+                    isLatest: obj.IsLatest,
+                    lastModified: obj.LastModified,
+                    staleDate: obj.staleDate,
+                    versioningStatus,
+                });
+                return process.nextTick(cb);
+            }
+
+            return async.waterfall([
                 next => this._getRules(bucketData, lcRules, obj, log, next),
                 (applicableRules, next) => {
-                    let rules = applicableRules;
-                    // Hijack for testing
-                    // Idea is to set any "Days" rule to `Days - 1`
-                    const testIsOn = process.env.CI === 'true';
-                    if (testIsOn) {
-                        rules = this._adjustRulesForTesting(rules);
-                    }
-
                     if (versioningStatus === 'Enabled'
                     || versioningStatus === 'Suspended') {
                         return this._compareVersion(bucketData, obj, contents,
-                            rules, versioningStatus, log, next);
+                            applicableRules, versioningStatus, log, next);
                     }
-                    return this._compareObject(bucketData, obj, rules, log,
+                    return this._compareObject(bucketData, obj, applicableRules, log,
                         next);
                 },
             ], cb);
@@ -980,37 +1083,6 @@ class LifecycleTask extends BackbeatTask {
     }
 
     /**
-     * Only to be used when testing (when process.env.CI is true).
-     * The idea is to adjust any "Days" or "NoncurrentDays" rules so that rules
-     * set with 1 day should expire, but any days set with 2+ days will not.
-     * Since Days/NoncurrentDays cannot be set to 0, this is a way to set the
-     * rule and test methods are working as intended.
-     * @param {object} rules - applicable rules
-     * @return {object} adjusted rules object
-     */
-    _adjustRulesForTesting(rules) {
-        /* eslint-disable no-param-reassign */
-        if (rules.Expiration
-        && rules.Expiration.Days) {
-            rules.Expiration.Days--;
-        }
-        const ncve = 'NoncurrentVersionExpiration';
-        const ncd = 'NoncurrentDays';
-        if (rules[ncve]
-        && rules[ncve][ncd]) {
-            rules[ncve][ncd]--;
-        }
-        const aimu = 'AbortIncompleteMultipartUpload';
-        const dai = 'DaysAfterInitiation';
-        if (rules[aimu]
-        && rules[aimu][dai]) {
-            rules[aimu][dai]--;
-        }
-        /* eslint-enable no-param-reassign */
-        return rules;
-    }
-
-    /**
      * Compare a version to most applicable rules
      * @param {object} bucketData - bucket data
      * @param {object} version - single version from `_getObjectVersions`
@@ -1110,14 +1182,7 @@ class LifecycleTask extends BackbeatTask {
             // Tags do not apply to UploadParts
             const noTags = { TagSet: [] };
             const filteredRules = this._lifecycleUtils.filterRules(bucketLCRules, upload, noTags);
-            let aRules = this._lifecycleUtils.getApplicableRules(filteredRules, {});
-
-            // Hijack for testing
-            // Idea is to set any "Days" rule to `Days - 1`
-            const testIsOn = process.env.CI === 'true';
-            if (testIsOn) {
-                aRules = this._adjustRulesForTesting(aRules);
-            }
+            const aRules = this._lifecycleUtils.getApplicableRules(filteredRules, {});
 
             const daysSinceInitiated = this._lifecycleDateTime.findDaysSince(
                 new Date(upload.Initiated)

--- a/tests/utils/S3ClientMock.js
+++ b/tests/utils/S3ClientMock.js
@@ -15,6 +15,7 @@ class S3ClientMock {
             Contents: [
                 {
                     Key: 'obj1',
+                    LastModified: '2021-10-04T21:46:49.157Z',
                 },
             ],
         });
@@ -92,6 +93,7 @@ class S3ClientMock {
             Contents: [
                 {
                     Key: 'obj1',
+                    LastModified: '2021-10-04T21:46:49.157Z',
                     ETag: '1:3749f52bb326ae96782b42dc0a97b4c1',
                     Size: 1,
                     StorageClass: 'site1',
@@ -112,7 +114,7 @@ class S3ClientMock {
                     Size: 1,
                     StorageClass: 'site1',
                     IsLatest: true,
-                    LastModified: '2021-04-18T21:46:49.157Z',
+                    LastModified: '2021-10-04T21:46:49.157Z',
                 },
             ],
         });
@@ -123,7 +125,7 @@ class S3ClientMock {
         this.stubMethod('listMultipartUploads', {
             IsTruncated: true,
             Uploads: [{
-                Initiated: '2021-04-18T21:46:49.157Z',
+                Initiated: '2021-10-04T21:46:49.157Z',
                 Key: 'mpu1',
             }],
             UploadIdMarker: 'id',


### PR DESCRIPTION
_Why is it not in Arsenal?_
Because of the urgent need for this improvement task and the latest version of Arsenal not yet being integrated as a Backbeat dependency (TypeScript work going on), we decided to introduce the functions directly in Backbeat.

Those functions will be moved to Backbeat lib/s3middleware/lifecycleHelpers/LifecycleUtils.js

JIRA ticket: https://scality.atlassian.net/browse/ARSN-166