### PR TITLE
Bugfix: BB-161 add timestamp to object deletion oplog entry in notification

### DIFF
--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -378,15 +378,21 @@ class LogReader {
     }
 
     async _processLogEntry(batchState, record, entry) {
-        // some extension's filter functions are async (notification)
         return Promise.all(this._extensions.map(ext => {
             /**
-             * object delete entries don't have a value field,
-             * those should not be skipped for the notification
-             * extension
+             * Delete entries don't have a value field.
+             * Value field normally contains the timestamp
+             * of the event, which is needed for the notification
+             * extension.
+             * That gets added here, we use the oplog event timestamp
              */
-            if (entry.value === undefined &&
-                ext.constructor.name !== 'NotificationQueuePopulator') {
+            if (entry.type === 'delete' &&
+                ext.constructor.name === 'NotificationQueuePopulator') {
+                entry.value = JSON.stringify({
+                    'last-modified': record.timestamp
+                });
+            // skipping entry for other extensions
+            } else if (entry.value === undefined) {
                 return null;
             }
             return ext.filter({

--- a/tests/unit/lib/queuePopulator/LogReader.spec.js
+++ b/tests/unit/lib/queuePopulator/LogReader.spec.js
@@ -148,4 +148,106 @@ describe('LogReader', () => {
         assert(mockExtension.filter.secondCall.calledWith(expectedArgs));
         done();
     });
+
+    it('Should add timestamp if got delete event and extension is notification', done => {
+        const mockExtension = {
+            constructor: {
+                name: 'NotificationQueuePopulator'
+            },
+            filter: sinon.spy(),
+        };
+        const logReaderWithExtension = new LogReader({
+            logId: 'test-log-reader',
+            zkClient: zkMock.createClient('localhost:2181'),
+            logConsumer: new MockLogConsumer(),
+            logger: new Logger('test:logReaderWithExtension'),
+            extensions: [mockExtension]
+        });
+        const record = {
+            db: 'example-bucket',
+            timestamp: 'YYYY-MM-DD:HH-MM-SS',
+            entry: {
+                type: 'delete',
+                key: 'fMexample-key',
+            }
+        };
+        logReaderWithExtension._processLogEntry({}, record, record.entry);
+        const expectedArgs = {
+            type: 'delete',
+            bucket: 'example-bucket',
+            key: 'fMexample-key',
+            value: JSON.stringify({
+                'last-modified': 'YYYY-MM-DD:HH-MM-SS',
+            }),
+            logReader: logReaderWithExtension,
+        };
+        assert(mockExtension.filter.calledWith(expectedArgs));
+        done();
+    });
+
+    it('Should not modify entry value if already defined', done => {
+        const mockExtension = {
+            constructor: {
+                name: 'NotificationQueuePopulator'
+            },
+            filter: sinon.spy(),
+        };
+        const logReaderWithExtension = new LogReader({
+            logId: 'test-log-reader',
+            zkClient: zkMock.createClient('localhost:2181'),
+            logConsumer: new MockLogConsumer(),
+            logger: new Logger('test:logReaderWithExtension'),
+            extensions: [mockExtension]
+        });
+        const record = {
+            db: 'example-bucket',
+            timestamp: 'timestamp-value',
+            entry: {
+                type: 'example-type',
+                key: 'fMexample-key',
+                value: {
+                    'last-modified': 'YYYY-MM-DD:HH-MM-SS',
+                }
+            }
+        };
+        logReaderWithExtension._processLogEntry({}, record, record.entry);
+        const expectedArgs = {
+            type: 'example-type',
+            bucket: 'example-bucket',
+            key: 'fMexample-key',
+            value: {
+                'last-modified': 'YYYY-MM-DD:HH-MM-SS',
+            },
+            logReader: logReaderWithExtension,
+        };
+        assert(mockExtension.filter.calledWith(expectedArgs));
+        done();
+    });
+
+    it('Should skip filtering if value is undefined and extension not notification', done => {
+        const mockExtension = {
+            constructor: {
+                name: 'ReplicationQueuePopulator'
+            },
+            filter: sinon.spy(),
+        };
+        const logReaderWithExtension = new LogReader({
+            logId: 'test-log-reader',
+            zkClient: zkMock.createClient('localhost:2181'),
+            logConsumer: new MockLogConsumer(),
+            logger: new Logger('test:logReaderWithExtension'),
+            extensions: [mockExtension]
+        });
+        const record = {
+            db: 'example-bucket',
+            timestamp: 'YYYY-MM-DD:HH-MM-SS',
+            entry: {
+                type: 'example-type',
+                key: 'fMexample-key',
+            }
+        };
+        logReaderWithExtension._processLogEntry({}, record, record.entry);
+        assert(mockExtension.filter.notCalled);
+        done();
+    });
 });


### PR DESCRIPTION
Issue: [BB-161](https://scality.atlassian.net/browse/BB-161)

Issue:
Oplog delete events don't have a value field, which makes the object deletion notifications have a `null` timestamp, as its value is directly extracted from the object metadata field `last-modified`.

Solution:
Manually add the required field in the entry value when filtering the oplog entries
The` last-modified` value used is the oplog record timestamp