### PR TITLE
Feature: BB-167 inject oplog for specific buckets

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -281,12 +281,7 @@
         "oplogPopulator": {
             "topic": "backbeat-oplog",
             "kafkaConnectHost": "127.0.0.1",
-            "kafkaConnectPort": 8083,
-            "connectors": [
-                {
-                    "name": "mongo-source"
-                }
-            ]
+            "kafkaConnectPort": 8083
         }
     },
     "log": {

--- a/extensions/notification/NotificationConfigManager.js
+++ b/extensions/notification/NotificationConfigManager.js
@@ -97,19 +97,19 @@ class NotificationConfigManager {
         // caching change stream resume token
         this._changeStreamResumeToken = change._id;
         // invalidating cached notification configs
-        const cachedConfig = this._cachedConfigs.get(change.fullDocument._id);
-        const bucketNotificationConfiguration = change.fullDocument.value.
-            notificationConfiguration;
+        const cachedConfig = this._cachedConfigs.get(change.documentKey._id);
+        const bucketNotificationConfiguration = change.fullDocument ? change.fullDocument.value.
+            notificationConfiguration : null;
         switch (change.operationType) {
             case 'delete':
                 // if no bucket config was cached, nothing is done
-                this._cachedConfigs.remove(change.fullDocument._id);
+                this._cachedConfigs.remove(change.documentKey._id);
                 break;
             case 'replace':
             case 'update':
                 if (cachedConfig) {
                     // add() replaces the value of an entry if it exists in cache
-                    this._cachedConfigs.add(change.fullDocument._id, bucketNotificationConfiguration);
+                    this._cachedConfigs.add(change.documentKey._id, bucketNotificationConfiguration);
                 }
                 break;
             default:
@@ -138,7 +138,7 @@ class NotificationConfigManager {
         if (!this._metastoreChangeStream.isClosed()) {
             await this._metastoreChangeStream.close();
         }
-        this._setMetastoreChangeStream(() => {});
+        this._setMetastoreChangeStream();
     }
 
     /**
@@ -170,6 +170,7 @@ class NotificationConfigManager {
                 $project: {
                     '_id': 1,
                     'operationType': 1,
+                    'documentKey._id': 1,
                     'fullDocument._id': 1,
                     'fullDocument.value.notificationConfiguration': 1
                 },

--- a/extensions/oplogPopulator/OplogPopulator.js
+++ b/extensions/oplogPopulator/OplogPopulator.js
@@ -1,10 +1,15 @@
 const joi = require('joi');
+const { errors } = require('arsenal');
+const { MongoClient } = require('mongodb');
 const constants = require('./constants');
-const KafkaConnectWrapper = require('./KafkaConnectWrapper');
+const { constructConnectionString } = require('../utils/MongoUtils');
+const KafkaConnectWrapper = require('../../lib/wrappers/KafkaConnectWrapper');
+const ChangeStream = require('../../lib/wrappers/ChangeStream');
 
 const paramsJoi = joi.object({
     config: joi.object().required(),
     mongoConfig: joi.object().required(),
+    activeExtensions: joi.array().required(),
     logger: joi.object().required(),
 }).required();
 
@@ -27,49 +32,75 @@ class OplogPopulator {
      * @param {Object} params.mongoConfig.replicaSet - mongo replica set
      * @param {Object} params.mongoConfig.readPreference - mongo read preference
      * @param {Object} params.mongoConfig.database - metadata database
+     * @param {string[]} params.activeExtensions - list of all active extension names
      * @param {Object} params.logger - logger
      */
     constructor(params) {
         joi.attempt(params, paramsJoi);
         this._config = params.config;
         this._mongoConfig = params.mongoConfig;
+        this._activeExtensions = params.activeExtensions;
         this._logger = params.logger;
         this._connectWrapper = new KafkaConnectWrapper({
             kafkaConnectHost: this._config.kafkaConnectHost,
             kafkaConnectPort: this._config.kafkaConnectPort,
             logger: this._logger,
         });
+        this._changeStreamWrapper = null;
+        // stores the set of buckets assigned to connector
+        this._bucketsForConnector = new Set();
+        // MongoDB related
+        this._mongoClient = null;
+        this._metastore = null;
+        // setup mongo connection data
+        this._mongoUrl = constructConnectionString(this._mongoConfig);
+        this._replicaSet = this._mongoConfig.replicaSet;
+        this._database = this._mongoConfig.database;
     }
 
     /**
-     * Sets default connector configuration
-     * @param {Object} connectorConfig custom connector configuration
-     * @param {string} connectorConfig.name connector name
+     * Connects to MongoDB using the MongoClientInterface
+     * and retreives the metastore collection
+     * @returns {Promise|undefined} undefined
+     * @throws {InternalError}
+     */
+    async _setupMongoClient() {
+        try {
+            const client = await MongoClient.connect(this._mongoUrl, {
+                 replicaSet: this._replicaSet,
+                 useNewUrlParser: true,
+            });
+            // connect to metadata DB
+            this._mongoClient = client.db(this._database, {
+                ignoreUndefined: true,
+            });
+            // get metastore collection
+            this._metastore = this._mongoClient.collection(constants.bucketMetastore);
+            this._logger.debug('Connected to MongoDB', {
+                method: 'OplogPopulator._setupMongoClient',
+            });
+            return undefined;
+        } catch (err) {
+            this._logger.error('Could not connect to MongoDB', {
+                method: 'OplogPopulator._setupMongoClient',
+                error: err.message,
+            });
+            throw errors.InternalError.customizeDescription(err.message);
+        }
+    }
+
+    /**
+     * get default connector configuration
+     * @param {string} connectorName connector name
      * @returns {Object} connector configuration
      */
-    getDefaultConnectorConfiguration(connectorConfig) {
-        const { authCredentials, replicaSetHosts, writeConcern, replicaSet,
-            readPreference, database } = this._mongoConfig;
+    _getDefaultConnectorConfiguration(connectorName) {
         // getting default connector config values
         const config = constants.defaultConnectorConfig;
         // connection and source configuration
-        config.name = connectorConfig.name;
-        config.database = database;
-        // get credentials
-        let cred = '';
-        if (authCredentials &&
-            authCredentials.username &&
-            authCredentials.password) {
-            const username = encodeURIComponent(authCredentials.username);
-            const password = encodeURIComponent(authCredentials.password);
-            cred = `${username}:${password}@`;
-        }
-        let connectionUrl = `mongodb://${cred}${replicaSetHosts}/` +
-            `?w=${writeConcern}&readPreference=${readPreference}`;
-        if (replicaSet) {
-            connectionUrl += `&replicaSet=${replicaSet}`;
-        }
-        config['connection.uri'] = connectionUrl;
+        config.name = connectorName;
+        config.database = this._database;
+        config['connection.uri'] = this._mongoUrl;
         // destination topic configuration
         config['topic.namespace.map'] = JSON.stringify({
             '*': this._config.topic,
@@ -78,29 +109,311 @@ class OplogPopulator {
     }
 
     /**
+     * Get buckets that have at least one extension active
+     * @returns {string[]} list of buckets to listen to
+     * @throws {InternalError}
+     */
+    async _getBackbeatEnabledBuckets() {
+        const filter = {
+            $or: [],
+        };
+        // notification filter
+        if (this._activeExtensions.includes('notification')) {
+            const field = constants.extensionConfigField.notification;
+            const extFilter = {};
+            // notification config should be an object
+            extFilter[`value.${field}`] = { $type: 3 };
+            filter.$or.push(extFilter);
+        }
+        // replication filter
+        if (this._activeExtensions.includes('replication')) {
+            const field = constants.extensionConfigField.replication;
+            const extFilter = {};
+            // processing buckets where at least one replication
+            // rule is enabled
+            extFilter[`value.${field}.rules`] = {
+                $elemMatch: {
+                    enabled: true,
+                },
+            };
+            filter.$or.push(extFilter);
+        }
+        // lifecycle filter
+        if (this._activeExtensions.includes('lifecycle')) {
+            const field = constants.extensionConfigField.lifecycle;
+            const extFilter = {};
+            // processing buckets where at least one lifecycle
+            // rule is enabled
+            extFilter[`value.${field}.rules`] = {
+                $elemMatch: {
+                    ruleStatus: 'Enabled',
+                },
+            };
+            filter.$or.push(extFilter);
+        }
+        // ingestion filter
+        if (this._activeExtensions.includes('ingestion')) {
+            const field = constants.extensionConfigField.ingestion;
+            const extFilter = {};
+            extFilter[`value.${field}.status`] = 'enabled';
+            filter.$or.push(extFilter);
+        }
+        try {
+            const buckets = await this._metastore.find(filter)
+                .project({ _id: 1 })
+                .map(bucket => bucket._id)
+                .toArray();
+            return buckets;
+        } catch (err) {
+            this._logger.error('Error querying buckets from MongoDB', {
+                method: 'OplogPopulator._getBackbeatEnabledBuckets',
+                error: err.message,
+            });
+            throw errors.InternalError.customizeDescription(err.message);
+        }
+    }
+
+    /**
+     * Makes new connector pipeline to listen to
+     * specified buckets
+     * @param {string[]} bucketNames list of buckets to listen to
+     * @returns {Object} new connector pipeline
+     */
+    _generateNewConnectorPipeline(bucketNames) {
+        const pipeline = [
+            {
+                $match: {
+                    'ns.coll': {
+                        $in: bucketNames,
+                    }
+                }
+            }
+        ];
+        return JSON.stringify(pipeline);
+    }
+
+    /**
+     * start listening to bucket
+     * @param {string} bucketName bucket name
+     * @returns {undefined}
+     */
+    _listenToBucket(bucketName) {
+        this._bucketsForConnector.add(bucketName);
+        this.updateConnectorPipeline(constants.defaultConnectorName, [...this._bucketsForConnector]);
+    }
+
+    /**
+     * stops listening to bucket
+     * @param {string} bucketName bucket name
+     * @returns {undefined}
+     */
+    _stopListeningToBucket(bucketName) {
+        this._bucketsForConnector.delete(bucketName);
+        this.updateConnectorPipeline(constants.defaultConnectorName, [...this._bucketsForConnector]);
+    }
+
+    /**
+     * Check if buckets has at least one backbeat extension active
+     * @param {BucketInfo} bucketMetadata bucket metadata
+     * @returns {boolean} is bucket backbeat enabled
+     */
+    _isBucketBackbeatEnabled(bucketMetadata) {
+        const areExtensionsEnabled = [];
+        // notification extension
+        if (this._activeExtensions.includes('notification')) {
+            const field = constants.extensionConfigField.notification;
+            areExtensionsEnabled.push(Boolean(bucketMetadata[field] !== null));
+        }
+        // replication extension
+        if (this._activeExtensions.includes('replication')) {
+            const field = constants.extensionConfigField.replication;
+            const rules = (bucketMetadata[field] && bucketMetadata[field].rules)
+                || null;
+            if (!rules || rules.length === 0) {
+                areExtensionsEnabled.push(false);
+            } else {
+                const areRulesActive = rules.some(rule =>
+                    rule.enabled === true);
+                areExtensionsEnabled.push(areRulesActive);
+            }
+        }
+        // lifecycle extension
+        if (this._activeExtensions.includes('lifecycle')) {
+            const field = constants.extensionConfigField.lifecycle;
+            const rules = (bucketMetadata[field] && bucketMetadata[field].rules)
+                || null;
+            if (!rules || rules.length === 0) {
+                areExtensionsEnabled.push(false);
+            } else {
+                const areRulesActive = rules.some(rule =>
+                    rule.ruleStatus === 'Enabled');
+                areExtensionsEnabled.push(areRulesActive);
+            }
+        }
+        // ingestion extension
+        if (this._activeExtensions.includes('ingestion')) {
+            const field = constants.extensionConfigField.ingestion;
+            const enabled = (bucketMetadata[field] && bucketMetadata[field].status)
+                || null;
+            areExtensionsEnabled.push(Boolean(enabled === 'enabled'));
+        }
+        return areExtensionsEnabled.some(ext => ext);
+    }
+
+    /**
+     * Handler for the change stream "change" event.
+     * Updates connector pipeline when change occurs
+     * @param {ChangeStreamDocument} change Change stream change object
+     * @returns {undefined}
+     */
+    _handleChangeStreamChangeEvent(change) {
+        const isListeningToBucket = this._bucketsForConnector.has(change.documentKey._id);
+        // no fullDocument field in delete events
+        const isBackbeatEnabled = change.fullDocument ?
+            this._isBucketBackbeatEnabled(change.fullDocument.value) : null;
+        switch (change.operationType) {
+            case 'delete':
+                if (isListeningToBucket) {
+                    this._stopListeningToBucket(change.documentKey._id);
+                }
+                break;
+            case 'replace':
+            case 'update':
+            case 'insert':
+                // remove bucket if no longer backbeat enabled
+                if (isListeningToBucket && !isBackbeatEnabled) {
+                    this._stopListeningToBucket(change.documentKey._id);
+                // add bucket if it is backbeat enabled
+                } else if (!isListeningToBucket && isBackbeatEnabled) {
+                    this._listenToBucket(change.documentKey._id);
+                }
+                break;
+            default:
+                this._logger.debug('Skipping unsupported change stream event', {
+                    method: 'OplogPopulator._handleChangeStreamChange',
+                    type: change.operationType,
+                    key: change.documentKey._id,
+                });
+                break;
+        }
+        this._logger.debug('Change stream event processed', {
+            method: 'OplogPopulator._handleChangeStreamChange',
+            type: change.operationType,
+            key: change.documentKey._id,
+        });
+    }
+
+    /**
+     * Initializes a change stream on the metastore collection
+     * @returns {undefined}
+     * @throws {InternalError}
+     */
+    _setMetastoreChangeStream() {
+        const changeStreamPipeline = [
+            {
+                $project: {
+                    '_id': 1,
+                    'operationType': 1,
+                    'documentKey._id': 1,
+                    'fullDocument.value': 1
+                },
+            },
+        ];
+        this._changeStreamWrapper = new ChangeStream({
+            logger: this._logger,
+            collection: this._metastore,
+            pipeline: changeStreamPipeline,
+            handler: this._handleChangeStreamChangeEvent.bind(this),
+            throwOnError: false,
+        });
+        // start watching metastore
+        this._changeStreamWrapper.start();
+    }
+
+    /**
+     * Updates connector pipeline
+     * @param {string} connectorName connector to update
+     * @param {array} buckets connector assigned buckets
+     * @returns {Promise|Object} connector config
+     * @throws {InternalError}
+     */
+    async updateConnectorPipeline(connectorName, buckets) {
+        // TODO: Add support for multiple connectors
+        const pipeline = this._generateNewConnectorPipeline(buckets);
+        try {
+            const config = await this._connectWrapper.updateConnectorPipeline(connectorName, pipeline);
+            return config;
+        } catch (err) {
+            this._logger.error('Error while updating connector', {
+                method: 'OplogPopulator.updateConnectorPipeline',
+                connector: connectorName,
+                buckets,
+                error: err.description,
+            });
+            throw errors.InternalError.customizeDescription(err.description);
+        }
+    }
+
+    /**
      * Creates and configures kafka connect
      * connectors based on the config
+     * @param {Object} connectorConfig Config of connector
      * @returns {Promise|Object} Updated connector configuration
      * @throws {InternalError}
      */
-    async setup() {
-        const activeConnectors = await this._connectWrapper.getConnectors();
-        await Promise.all(this._config.connectors.map(async connectorConfig => {
-            // getting default config
-            const defaultConfig = this.getDefaultConnectorConfiguration(connectorConfig);
+    async _configureConnector(connectorConfig) {
+        try {
+            const activeConnectors = await this._connectWrapper.getConnectors();
+            const connectorName = connectorConfig.name;
             // update the connector config if it already exist
-            if (activeConnectors.includes(connectorConfig.name)) {
-                return this._connectWrapper.updateConnectorConfig(connectorConfig.name, defaultConfig);
+            if (activeConnectors.includes(connectorName)) {
+                return this._connectWrapper.updateConnectorConfig(connectorName,
+                    connectorConfig.config);
             } else {
                 // otherwise create a new connector
                 return this._connectWrapper.createConnector({
-                    name: connectorConfig.name,
-                    config: defaultConfig,
+                    name: connectorName,
+                    config: connectorConfig.config,
                 });
             }
-        }));
+        } catch (err) {
+            this._logger.error('Error while initially configuring connectors', {
+                method: 'OplogPopulator._configureConnectors',
+                error: err.description,
+                config: connectorConfig,
+            });
+            throw errors.InternalError.customizeDescription(err.description);
+        }
     }
 
+    /**
+     * Sets up the OplogPopulator
+     * @returns {Promise|undefined} undefined
+     * @throws {InternalError}
+     */
+    async setup() {
+       try {
+           await this._setupMongoClient();
+           // getting buckets with at least one extension active
+           const backbeatEnabledBuckets = await this._getBackbeatEnabledBuckets();
+           this._bucketsForConnector = new Set(backbeatEnabledBuckets);
+           // TODO: add support for multiple connectors
+            const defaultConnectorConfig = this._getDefaultConnectorConfiguration(constants.defaultConnectorName);
+            defaultConnectorConfig.pipeline = this._generateNewConnectorPipeline(backbeatEnabledBuckets);
+            const connectorConfigs = {
+                name: constants.defaultConnectorName,
+                config: defaultConnectorConfig
+            };
+            await this._configureConnector(connectorConfigs);
+           this._setMetastoreChangeStream();
+       } catch (err) {
+            this._logger.error('An error occured when setting up the OplogPopulator', {
+                method: 'OplogPopulator.setup',
+                error: err.description,
+            });
+            throw errors.InternalError.customizeDescription(err.description);
+       }
+    }
 }
 
 module.exports = OplogPopulator;

--- a/extensions/oplogPopulator/OplogPopulatorConfigValidator.js
+++ b/extensions/oplogPopulator/OplogPopulatorConfigValidator.js
@@ -1,14 +1,9 @@
 const joi = require('joi');
 
-const connectorShema = joi.object({
-    name: joi.string().required(),
-});
-
 const joiSchema = joi.object({
     topic: joi.string().required(),
     kafkaConnectHost: joi.string().required(),
     kafkaConnectPort: joi.number().required(),
-    connectors: joi.array().items(connectorShema).length(1),
 });
 
 function configValidator(backbeatConfig, extConfig) {

--- a/extensions/oplogPopulator/OplogPopulatorTask.js
+++ b/extensions/oplogPopulator/OplogPopulatorTask.js
@@ -10,7 +10,8 @@ werelogs.configure({ level: config.log.logLevel,
 
 const mongoConfig = config.queuePopulator.mongo;
 const oplogPopulatorConfig = config.extensions.oplogPopulator;
-const activeExtensions = Object.keys(config.extensions);
+// Temporary as no extension uses the oplogPopulator for now
+const activeExtensions = [];
 
 const oplogPopulator = new OplogPopulator({
     config: oplogPopulatorConfig,

--- a/extensions/oplogPopulator/OplogPopulatorTask.js
+++ b/extensions/oplogPopulator/OplogPopulatorTask.js
@@ -10,10 +10,12 @@ werelogs.configure({ level: config.log.logLevel,
 
 const mongoConfig = config.queuePopulator.mongo;
 const oplogPopulatorConfig = config.extensions.oplogPopulator;
+const activeExtensions = Object.keys(config.extensions);
 
 const oplogPopulator = new OplogPopulator({
     config: oplogPopulatorConfig,
     mongoConfig,
+    activeExtensions,
     logger,
 });
 
@@ -23,13 +25,8 @@ const oplogPopulator = new OplogPopulator({
     } catch (error) {
         logger.error('Error when starting up the oplog populator', {
             method: 'OplogPopulatorTask.setup',
-            error,
+            error: error.description,
         });
-        process.emit('SIGTERM');
+        process.exit(0);
     }
 })();
-
-process.on('SIGTERM', () => {
-    logger.info('received SIGTERM, exiting');
-    process.exit(0);
-});

--- a/extensions/oplogPopulator/constants.js
+++ b/extensions/oplogPopulator/constants.js
@@ -1,11 +1,18 @@
 const constants = {
     bucketMetastore: '__metastore',
+    defaultConnectorName: 'source-connector',
     defaultConnectorConfig: {
         'connector.class': 'com.mongodb.kafka.connect.MongoSourceConnector',
         'change.stream.full.document': 'updateLookup',
         'pipeline': '[]',
         'collection': '',
-    }
+    },
+    extensionConfigField: {
+        notification: 'notificationConfiguration',
+        replication: 'replicationConfiguration',
+        lifecycle: 'lifecycleConfiguration',
+        ingestion: 'ingestion',
+    },
 };
 
 module.exports = constants;

--- a/extensions/utils/MongoUtils.js
+++ b/extensions/utils/MongoUtils.js
@@ -1,0 +1,34 @@
+/**
+ * Constructs mongo connection config
+ * @param {Object} mongoConfig mongo connection config
+ * @param {Object} mongoConfig.authCredentials mongo auth config
+ * @param {string} mongoConfig.authCredentials.username username
+ * @param {string} mongoConfig.authCredentials.password password
+ * @param {string} mongoConfig.replicaSetHosts replica set hosts
+ * @param {string} mongoConfig.replicaSet replica set name
+ * @param {string} mongoConfig.writeConcern write concern
+ * @param {string} mongoConfig.readPreference read preference
+ * @returns {string} mongo Connection config
+ */
+function constructConnectionString(mongoConfig) {
+    const { authCredentials, replicaSetHosts, writeConcern,
+        readPreference, replicaSet } = mongoConfig;
+    let cred = '';
+    if (authCredentials &&
+        authCredentials.username &&
+        authCredentials.password) {
+        const username = encodeURIComponent(authCredentials.username);
+        const password = encodeURIComponent(authCredentials.password);
+        cred = `${username}:${password}@`;
+    }
+    let url = `mongodb://${cred}${replicaSetHosts}/` +
+        `?w=${writeConcern}&readPreference=${readPreference}`;
+    if (replicaSet) {
+        url += `&replicaSet=${replicaSet}`;
+    }
+    return url;
+}
+
+module.exports = {
+    constructConnectionString
+};

--- a/lib/wrappers/ChangeStream.js
+++ b/lib/wrappers/ChangeStream.js
@@ -1,0 +1,95 @@
+const { errors } = require('arsenal');
+const joi = require('joi');
+
+const paramsJoi = joi.object({
+    logger: joi.object().required(),
+    collection: joi.object().required(),
+    handler: joi.function().required(),
+    pipeline: joi.array().required(),
+    throwOnError: joi.boolean().required(),
+}).required();
+
+/**
+ * @class ChangeStream
+ *
+ * @classdesc Wrapper arround MongoDB change stream API
+ */
+class ChangeStream {
+
+    /**
+     * @constructor
+     * @param {Object} params change stream wrapper config
+     * @param {Object} params.logger logger object
+     * @param {Collection} params.collection MongoDB collection to watch
+     * @param {Object[]} params.pipeline change stream pipeline
+     * @param {Function} params.handler change event handler function
+     * @param {Boolean} params.throwOnError throw error if got change stream error event
+     */
+    constructor(params) {
+        joi.attempt(params, paramsJoi);
+        this._logger = params.logger;
+        this._collection = params.collection;
+        this._changeHandler = params.handler;
+        this._pipeline = params.pipeline;
+        this._throwOnError = params.throwOnError;
+        this._resumeToken = null;
+        this._changeStream = null;
+    }
+
+    /**
+     * Handler for change stream error events
+     * @returns {undefined}
+     * @throws {InternalError}
+     */
+    async _handleChangeStreamErrorEvent() {
+        this._logger.error('An error occured when listening to the change stream', {
+            method: 'ChangeStream._handleChangeStreamErrorEvent',
+        });
+        // removing handlers for "change" and "error" events
+        this._changeStream.removeListener('change', this._changeHandler);
+        this._changeStream.removeListener('error', this._handleChangeStreamErrorEvent.bind(this));
+        // closing change stream if not closed
+        if (!this._changeStream.isClosed()) {
+            await this._changeStream.close();
+        }
+        if (this._throwOnError) {
+            throw errors.InternalError.customizeDescription('An error occured while reading the change stream');
+        }
+        // reseting change stream
+        this.start();
+    }
+
+    /**
+     * Establishes change stream and sets handlers for "change"
+     * and "error" events
+     * @returns {undefined}
+     * @throws {InternalError}
+     */
+    start() {
+        const changeStreamParams = { fullDocument: 'updateLookup' };
+        if (this._resumeToken) {
+            changeStreamParams.startAfter = this._resumeToken;
+        }
+        try {
+            this._changeStream = this._collection.watch(this._pipeline, changeStreamParams);
+            this._changeStream.on('change', change => {
+                // saving resume token
+                this._resumeToken = change._id;
+                // calling custom handler
+                this._changeHandler(change);
+            });
+            this._changeStream.on('error', this._handleChangeStreamErrorEvent.bind(this));
+            this._logger.debug('Change stream set', {
+                method: 'ChangeStream._setMetastoreChangeStream',
+            });
+        } catch (err) {
+            this._logger.error('Error while setting the change stream', {
+                method: 'ChangeStream._setMetastoreChangeStream',
+                error: err.message,
+            });
+            throw errors.InternalError.customizeDescription(err.message);
+        }
+    }
+}
+
+module.exports = ChangeStream;

--- a/lib/wrappers/KafkaConnectWrapper.js
+++ b/lib/wrappers/KafkaConnectWrapper.js
@@ -53,7 +53,8 @@ class KafkaConnectWrapper {
                 // resolve on end
                 res.on('end', () => {
                     try {
-                        body = JSON.parse(Buffer.concat(body).toString());
+                        body = params.method !== 'DELETE' ?
+                            JSON.parse(Buffer.concat(body).toString()) : {};
                     } catch (e) {
                         this._logger.error('Error occured while parsing request body', {
                             method: 'KafkaConnectManager.makeRequest',

--- a/tests/functional/notification/NotificationConfigManager.js
+++ b/tests/functional/notification/NotificationConfigManager.js
@@ -96,12 +96,9 @@ describe('NotificationConfigManager ::', () => {
         const changeStreamEvent = {
             _id: 'resumeToken',
             operationType: 'delete',
-            fullDocument: {
+            documentKey: {
                 _id: 'example-bucket-1',
-                value: {
-                    notificationConfiguration,
-                }
-            }
+            },
         };
         manager._metastoreChangeStream.emit('change', changeStreamEvent);
         // cached config for "example-bucket-1" should be invalidated
@@ -121,6 +118,9 @@ describe('NotificationConfigManager ::', () => {
         const changeStreamEvent = {
             _id: 'resumeToken',
             operationType: 'replace',
+            documentKey: {
+                _id: 'example-bucket-1',
+            },
             fullDocument: {
                 _id: 'example-bucket-1',
                 value: {
@@ -139,7 +139,7 @@ describe('NotificationConfigManager ::', () => {
         manager._metastoreChangeStream.emit('change', changeStreamEvent);
         assert.strictEqual(manager._cachedConfigs.count(), 2);
         assert.deepEqual(manager._cachedConfigs.get('example-bucket-2'),
-            notificationConfigurationVariant);
+            notificationConfiguration);
     });
 
     it('Change stream should resume from cached resumeToken', async () => {
@@ -151,6 +151,9 @@ describe('NotificationConfigManager ::', () => {
         const changeStreamEvent = {
             _id: 'resumeToken',
             operationType: 'update',
+            documentKey: {
+                _id: 'example-bucket-1',
+            },
             fullDocument: {
                 _id: 'example-bucket-1',
                 value: {

--- a/tests/unit/lib/wrappers/ChangeStream.js
+++ b/tests/unit/lib/wrappers/ChangeStream.js
@@ -1,0 +1,200 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const errors = require('arsenal').errors;
+const werelogs = require('werelogs');
+const events = require('events');
+
+const logger = new werelogs.Logger('connect-wrapper-logger');
+
+const ChangeStream =
+    require('../../../../lib/wrappers/ChangeStream');
+
+describe('ChangeStream', () => {
+    let wrapper;
+
+    beforeEach(() => {
+        wrapper = new ChangeStream({
+            logger,
+            collection: {
+                watch: () => new events.EventEmitter(),
+            },
+            handler: () => {},
+            pipeline: [],
+            throwOnError: false,
+        });
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    describe('constructor', () => {
+        it('should fail when params invalid', done => {
+            assert.throws(() => new ChangeStream({}));
+            assert.throws(() => new ChangeStream({
+                logger,
+            }));
+            assert.throws(() => new ChangeStream({
+                logger,
+                collection: {},
+                handler: () => {},
+            }));
+            assert.throws(() => new ChangeStream({
+                pipeline: [],
+                throwOnError: false,
+            }));
+            assert.throws(() => new ChangeStream({
+                logger,
+                collection: 'coll',
+                handler: () => {},
+                pipeline: [],
+                throwOnError: false,
+            }));
+            assert.throws(() => new ChangeStream({
+                logger,
+                collection: {},
+                handler: () => {},
+                pipeline: {},
+                throwOnError: false,
+            }));
+            const csw = new ChangeStream({
+                logger,
+                collection: {},
+                handler: () => {},
+                pipeline: [],
+                throwOnError: false,
+            });
+            assert(csw instanceof ChangeStream);
+            return done();
+        });
+    });
+
+    describe('_handleChangeStreamErrorEvent', () =>  {
+        it('should reset change stream on error without closing it (already closed)', async () => {
+            const removeListenerStub = sinon.stub();
+            const closeStub = sinon.stub();
+            const startStub = sinon.stub(wrapper, 'start');
+            const changehandler = sinon.stub().returns(true);
+            wrapper._changeStream = {
+                removeListener: removeListenerStub,
+                isClosed: () => true,
+                close: closeStub,
+            };
+            wrapper._changeHandler = changehandler;
+            await wrapper._handleChangeStreamErrorEvent()
+            .then(() => {
+                assert(startStub.calledOnce);
+                assert(closeStub.notCalled);
+                assert(removeListenerStub.getCall(0).calledWithMatch('change',
+                    changehandler));
+                assert(removeListenerStub.getCall(1).calledWithMatch('error',
+                    wrapper._handleChangeStreamErrorEvent.bind(wrapper)));
+            })
+            .catch(err => assert.ifError(err));
+        });
+
+        it('should close then reset the change steam on error', async () => {
+            const removeListenerStub = sinon.stub();
+            const closeStub = sinon.stub();
+            const startStub = sinon.stub(wrapper, 'start');
+            const changehandler = sinon.stub().returns(true);
+            wrapper._changeStream = {
+                removeListener: removeListenerStub,
+                isClosed: () => false,
+                close: closeStub,
+            };
+            wrapper._changeHandler = changehandler;
+            await wrapper._handleChangeStreamErrorEvent()
+            .then(() => {
+                assert(startStub.calledOnce);
+                assert(closeStub.calledOnce);
+                assert(removeListenerStub.getCall(0).calledWithMatch('change',
+                    changehandler));
+                assert(removeListenerStub.getCall(1).calledWithMatch('error',
+                    wrapper._handleChangeStreamErrorEvent.bind(wrapper)));
+            })
+            .catch(err => assert.ifError(err));
+        });
+
+        it('should throw error when throwOnError is set to true', async () => {
+            const startStub = sinon.stub(wrapper, 'start');
+            wrapper._changeStream = {
+                removeListener: () => {},
+                isClosed: () => true,
+                close: () => {},
+            };
+            wrapper._throwOnError = true;
+            await wrapper._handleChangeStreamErrorEvent()
+            .then(() => assert(startStub.notCalled))
+            .catch(err => assert.deepEqual(err, errors.InternalError));
+        });
+    });
+
+    describe('start', () =>  {
+        it('Should create and listen to the metastore change stream', done => {
+            const watchStub = sinon.stub().returns(new events.EventEmitter());
+            wrapper._collection = {
+                watch: watchStub,
+            };
+            assert.doesNotThrow(() => {
+                wrapper.start();
+                assert(wrapper._changeStream instanceof events.EventEmitter);
+                assert(watchStub.calledOnce);
+                const changeHandlers = events.getEventListeners(wrapper._changeStream, 'change');
+                const errorHandlers = events.getEventListeners(wrapper._changeStream, 'error');
+                assert.strictEqual(changeHandlers.length, 1);
+                assert.strictEqual(errorHandlers.length, 1);
+                return done();
+            });
+        });
+
+        it('Should set the change stream pipeline', done => {
+            const watchStub = sinon.stub().returns(new events.EventEmitter());
+            const changeStreamPipline = [
+                {
+                    $project: {
+                        '_id': 1,
+                        'operationType': 1,
+                        'documentKey._id': 1,
+                        'fullDocument.value': 1
+                    },
+                },
+            ];
+            const changeStreamParams = { fullDocument: 'updateLookup' };
+            wrapper._collection = {
+                watch: watchStub,
+            };
+            wrapper._pipeline = changeStreamPipline;
+            assert.doesNotThrow(() => {
+                wrapper.start();
+                assert(watchStub.calledOnceWith(changeStreamPipline, changeStreamParams));
+                return done();
+            });
+        });
+
+        it('Should resume change stream using resumeToken', done => {
+            const watchStub = sinon.stub().returns(new events.EventEmitter());
+            wrapper._collection = {
+                watch: watchStub,
+            };
+            wrapper._resumeToken = '1234';
+            const changeStreamParams = {
+                fullDocument: 'updateLookup',
+                startAfter: '1234',
+            };
+            assert.doesNotThrow(() => {
+                wrapper.start();
+                assert(watchStub.calledOnceWith([], changeStreamParams));
+                return done();
+            });
+        });
+
+        it('Should fail if it fails to create change stream', done => {
+            wrapper._collection = {
+                watch: sinon.stub().throws(errors.InternalError),
+            };
+            assert.throws(() => wrapper.start());
+            return done();
+        });
+    });
+});

--- a/tests/unit/lib/wrappers/kafkaConnectWrapper.js
+++ b/tests/unit/lib/wrappers/kafkaConnectWrapper.js
@@ -8,7 +8,7 @@ const events = require('events');
 const logger = new werelogs.Logger('connect-wrapper-logger');
 
 const KafkaConnectWrapper =
-    require('../../../extensions/oplogPopulator/KafkaConnectWrapper');
+    require('../../../../lib/wrappers/KafkaConnectWrapper');
 
 describe('KafkaConnectWrapper', () => {
     let wrapper;

--- a/tests/unit/notification/NotificationConfigManager.js
+++ b/tests/unit/notification/NotificationConfigManager.js
@@ -150,10 +150,13 @@ describe('NotificationConfigManager ::', () => {
     });
 
     describe('_handleChangeStreamChangeEvent ::', () => {
-        it('Should remove entry from cache', async () => {
+        it('Should remove entry from cache', () => {
             const changeStreamEvent = {
                 _id: 'resumeToken',
                 operationType: 'delete',
+                documentKey: {
+                    _id: 'example-bucket-1',
+                },
                 fullDocument: {
                     _id: 'example-bucket-1',
                     value: {
@@ -173,10 +176,13 @@ describe('NotificationConfigManager ::', () => {
             assert.strictEqual(manager._cachedConfigs.count(), 0);
         });
 
-        it('Should replace entry from cache', async () => {
+        it('Should replace entry from cache', () => {
             const changeStreamEvent = {
                 _id: 'resumeToken',
                 operationType: 'replace',
+                documentKey: {
+                    _id: 'example-bucket-1',
+                },
                 fullDocument: {
                     _id: 'example-bucket-1',
                     value: {
@@ -208,10 +214,13 @@ describe('NotificationConfigManager ::', () => {
             assert.strictEqual(manager._cachedConfigs.count(), 1);
         });
 
-        it('Should do nothing when config not in cache', async () => {
+        it('Should do nothing when config not in cache', () => {
             const changeStreamEvent = {
                 _id: 'resumeToken',
                 operationType: 'delete',
+                documentKey: {
+                    _id: 'example-bucket-2',
+                },
                 fullDocument: {
                     _id: 'example-bucket-2',
                     value: {
@@ -232,10 +241,13 @@ describe('NotificationConfigManager ::', () => {
             assert.strictEqual(manager._cachedConfigs.count(), 1);
         });
 
-        it('Should do nothing when operation is not supported', async () => {
+        it('Should do nothing when operation is not supported', () => {
             const changeStreamEvent = {
                 _id: 'resumeToken',
                 operationType: 'insert',
+                documentKey: {
+                    _id: 'example-bucket-1',
+                },
                 fullDocument: {
                     _id: 'example-bucket-2',
                     value: {
@@ -306,11 +318,11 @@ describe('NotificationConfigManager ::', () => {
             const closeStub = sinon.stub();
             const setMetastoreChangeStreamStub = sinon.stub(manager, '_setMetastoreChangeStream');
             manager._metastoreChangeStream = {
-                removeEventListener: removeEventListenerStub,
+                removeListener: removeEventListenerStub,
                 isClosed: () => true,
                 close: closeStub,
             };
-            manager._handleChangeStreamErrorEvent(err => {
+            await manager._handleChangeStreamErrorEvent(err => {
                 assert.ifError(err);
                 assert(setMetastoreChangeStreamStub.calledOnce);
                 assert(closeStub.notCalled);
@@ -327,11 +339,11 @@ describe('NotificationConfigManager ::', () => {
             const closeStub = sinon.stub();
             const setMetastoreChangeStreamStub = sinon.stub(manager, '_setMetastoreChangeStream');
             manager._metastoreChangeStream = {
-                removeEventListener: removeEventListenerStub,
+                removeListener: removeEventListenerStub,
                 isClosed: () => false,
                 close: closeStub,
             };
-            manager._handleChangeStreamErrorEvent(err => {
+            await manager._handleChangeStreamErrorEvent(err => {
                 assert.ifError(err);
                 assert(setMetastoreChangeStreamStub.calledOnce);
                 assert(closeStub.called);

--- a/tests/unit/oplogPopulator/oplogPopulator.js
+++ b/tests/unit/oplogPopulator/oplogPopulator.js
@@ -2,23 +2,23 @@ const assert = require('assert');
 const sinon = require('sinon');
 const errors = require('arsenal').errors;
 const werelogs = require('werelogs');
+const events = require('events');
+const MongoClient = require('mongodb').MongoClient;
+
 
 const logger = new werelogs.Logger('connect-wrapper-logger');
 
 const OplogPopulator =
     require('../../../extensions/oplogPopulator/OplogPopulator');
 const KafkaConnectWrapper =
-    require('../../../extensions/oplogPopulator/KafkaConnectWrapper');
+    require('../../../lib/wrappers/KafkaConnectWrapper');
+const ChangeStream =
+    require('../../../lib/wrappers/ChangeStream');
 
 const oplogPopulatorConfig = {
     topic: 'oplog',
     kafkaConnectHost: '127.0.0.1',
-    kafkaConnectPort: 8083,
-    connectors: [
-        {
-            name: 'mongo-source'
-        }
-    ]
+    kafkaConnectPort: 8083
 };
 
 const mongoConfig = {
@@ -27,20 +27,26 @@ const mongoConfig = {
     writeConcern: 'majority',
     replicaSet: 'rs0',
     readPreference: 'primary',
-    database: 'metadata'
+    database: 'metadata',
+    authCredentials: {
+        username: 'user',
+        password: 'password'
+    }
 };
 
 const connectorConfig = {
-    'name': 'mongo-source',
+    'name': 'source-connector',
     'database': 'metadata',
-    'connection.uri': 'mongodb://localhost:27017,localhost:27018,localhost:27019' +
-        '/?w=majority&readPreference=primary&replicaSet=rs0',
+    'connection.uri': 'mongodb://user:password@localhost:27017,localhost:27018,' +
+        'localhost:27019/?w=majority&readPreference=primary&replicaSet=rs0',
     'topic.namespace.map': '{\"*\":\"oplog\"}',
     'connector.class': 'com.mongodb.kafka.connect.MongoSourceConnector',
     'change.stream.full.document': 'updateLookup',
     'pipeline': '[]',
     'collection': '',
 };
+
+const activeExtensions = ['ingestion', 'replication', 'notification', 'lifecycle'];
 
 describe('OplogPopulator', () => {
     let oplogPopulator;
@@ -49,6 +55,7 @@ describe('OplogPopulator', () => {
         oplogPopulator = new OplogPopulator({
             config: oplogPopulatorConfig,
             mongoConfig,
+            activeExtensions,
             logger,
         });
     });
@@ -67,6 +74,9 @@ describe('OplogPopulator', () => {
                 mongoConfig,
             }));
             assert.throws(() => new OplogPopulator({
+                activeExtensions,
+            }));
+            assert.throws(() => new OplogPopulator({
                 logger,
             }));
             assert.throws(() => new OplogPopulator({
@@ -75,15 +85,28 @@ describe('OplogPopulator', () => {
             }));
             assert.throws(() => new OplogPopulator({
                 config: oplogPopulatorConfig,
+                activeExtensions,
+            }));
+            assert.throws(() => new OplogPopulator({
+                config: oplogPopulatorConfig,
                 logger,
             }));
             assert.throws(() => new OplogPopulator({
-                mongoConfig,
+                mongoConfig: oplogPopulatorConfig,
+                activeExtensions,
+            }));
+            assert.throws(() => new OplogPopulator({
+                mongoConfig: oplogPopulatorConfig,
+                logger,
+            }));
+            assert.throws(() => new OplogPopulator({
+                activeExtensions,
                 logger,
             }));
             const op = new OplogPopulator({
                 config: oplogPopulatorConfig,
                 mongoConfig,
+                activeExtensions,
                 logger,
             });
             assert(op instanceof OplogPopulator);
@@ -91,106 +114,110 @@ describe('OplogPopulator', () => {
         });
 
         it('should initialize kafka wrapper', done => {
-            const op = new OplogPopulator({
-                config: oplogPopulatorConfig,
-                mongoConfig,
-                logger,
-            });
-            assert(op._connectWrapper instanceof KafkaConnectWrapper);
+            assert(oplogPopulator._connectWrapper instanceof KafkaConnectWrapper);
+            return done();
+        });
+
+        it('should set mongo connection info', done => {
+            const mongoUrl = 'mongodb://user:password@localhost:27017,' +
+                'localhost:27018,localhost:27019/?w=majority&readPreference=primary&replicaSet=rs0';
+            assert.strictEqual(oplogPopulator._mongoUrl, mongoUrl);
+            assert.strictEqual(oplogPopulator._replicaSet, 'rs0');
+            assert.strictEqual(oplogPopulator._database, 'metadata');
             return done();
         });
     });
 
-    describe('setup', () => {
-        it('should update a connector', () => {
-            const getConnectorsStub = sinon.stub(oplogPopulator._connectWrapper, 'getConnectors')
-                .resolves(['mongo-source']);
-            const getConf = sinon.stub(oplogPopulator, 'getDefaultConnectorConfiguration').returns(connectorConfig);
-            const updateConfStub = sinon.stub(oplogPopulator._connectWrapper, 'updateConnectorConfig').resolves(null);
-            const createConnectorStub = sinon.stub(oplogPopulator._connectWrapper, 'createConnector').resolves(null);
-            oplogPopulator.setup()
+    describe('_setupMongoClient', () => {
+        it('should connect to mongo and setup client', async () => {
+            const collectionStub = sinon.stub();
+            const dbStub = sinon.stub().returns({
+                collection: collectionStub,
+            });
+            const mongoConnectStub = sinon.stub(MongoClient, 'connect')
+                .resolves({ db: dbStub });
+            await oplogPopulator._setupMongoClient()
             .then(() => {
-                assert(getConnectorsStub.calledOnce);
-                assert(getConf.calledOnceWith(oplogPopulatorConfig.connectors[0]));
-                assert(updateConfStub.calledOnceWith(connectorConfig));
-                assert(createConnectorStub.notCalled);
-            })
-            .catch(err => assert.ifError(err));
+                const mongoUrl = 'mongodb://user:password@localhost:27017,localhost:27018,' +
+                    'localhost:27019/?w=majority&readPreference=primary&replicaSet=rs0';
+                assert(mongoConnectStub.calledOnceWith(
+                    mongoUrl,
+                    {
+                        replicaSet: 'rs0',
+                        useNewUrlParser: true
+                    }
+                ));
+                assert(dbStub.calledOnceWith('metadata', { ignoreUndefined: true }));
+                assert(collectionStub.calledOnceWith('__metastore'));
+            }).catch(err => assert.ifError(err));
         });
 
-        it('should create a connector', () => {
-            const getConnectorsStub = sinon.stub(oplogPopulator._connectWrapper, 'getConnectors').resolves([]);
-            const getConf = sinon.stub(oplogPopulator, 'getDefaultConnectorConfiguration').returns(connectorConfig);
-            const updateConfStub = sinon.stub(oplogPopulator._connectWrapper, 'updateConnectorConfig').resolves(null);
-            const createConnectorStub = sinon.stub(oplogPopulator._connectWrapper, 'createConnector').resolves(null);
-            oplogPopulator.setup()
-            .then(() => {
-                assert(getConnectorsStub.calledOnce);
-                assert(getConf.calledOnceWith(oplogPopulatorConfig.connectors[0]));
-                assert(updateConfStub.notCalled);
-                assert(createConnectorStub.calledWith({
-                    name: 'mongo-source',
-                    config: connectorConfig,
-                }));
-            })
-            .catch(err => assert.ifError(err));
-        });
-
-        it('should throw error if it fails to get connectors', () => {
-            const getConnectorsStub = sinon.stub(oplogPopulator._connectWrapper, 'getConnectors')
+        it('should fail when mongo connection fails', async () => {
+            const mongoConnectStub = sinon.stub(MongoClient, 'connect')
                 .rejects(errors.InternalError);
-            const getConf = sinon.stub(oplogPopulator, 'getDefaultConnectorConfiguration').returns(null);
-            const updateConfStub = sinon.stub(oplogPopulator._connectWrapper, 'updateConnectorConfig').resolves(null);
-            const createConnectorStub = sinon.stub(oplogPopulator._connectWrapper, 'createConnector').resolves(null);
-            oplogPopulator.setup()
+            await oplogPopulator._setupMongoClient()
             .then(() => {
-                assert(getConnectorsStub.calledOnce);
-                assert(getConf.notCalled);
-                assert(updateConfStub.notCalled);
-                assert(createConnectorStub.notCalled);
-            })
-            .catch(err => assert.deepEqual(err, errors.InternalError));
+                const mongoUrl = 'mongodb://user:password@localhost:27017,' +
+                    'localhost:27018,localhost:27019/?w=majority&readPreference=primary';
+                assert(mongoConnectStub.calledOnceWith(
+                    mongoUrl,
+                    {
+                        replicaSet: 'rs0',
+                        useNewUrlParser: true
+                    }
+                ));
+            }).catch(err => assert.deepEqual(err, errors.InternalError));
         });
 
-        it('should throw error if it fails to update connector', () => {
-            const getConnectorsStub = sinon.stub(oplogPopulator._connectWrapper, 'getConnectors')
-                .resolves(['mongo-source']);
-            const getConf = sinon.stub(oplogPopulator, 'getDefaultConnectorConfiguration').returns(connectorConfig);
-            const updateConfStub = sinon.stub(oplogPopulator._connectWrapper, 'updateConnectorConfig')
-                .rejects(errors.InternalError);
-            const createConnectorStub = sinon.stub(oplogPopulator._connectWrapper, 'createConnector').resolves(null);
-            oplogPopulator.setup()
+        it('should fail if it can\'t get metadata db', async () => {
+            const dbStub = sinon.stub().returns({
+                collection: sinon.stub().throws(errors.InternalError),
+            });
+            const mongoConnectStub = sinon.stub(MongoClient, 'connect')
+                .resolves({ db: dbStub });
+            await oplogPopulator._setupMongoClient()
             .then(() => {
-                assert(getConnectorsStub.calledOnce);
-                assert(getConf.calledOnce);
-                assert(updateConfStub.calledOnce);
-                assert(createConnectorStub.notCalled);
-            })
-            .catch(err => assert.deepEqual(err, errors.InternalError));
+                const mongoUrl = 'mongodb://user:password@localhost:27017,' +
+                    'localhost:27018,localhost:27019/?w=majority&readPreference=primary';
+                assert(mongoConnectStub.calledOnceWith(
+                    mongoUrl,
+                    {
+                        replicaSet: 'rs0',
+                        useNewUrlParser: true
+                    }
+                ));
+                assert(dbStub.calledOnceWith('metadata', { ignoreUndefined: true }));
+            }).catch(err => assert.deepEqual(err, errors.InternalError));
         });
 
-        it('should throw error if it fails to create connector', () => {
-            const getConnectorsStub = sinon.stub(oplogPopulator._connectWrapper, 'getConnectors')
-                .resolves(['mongo-source']);
-            const getConf = sinon.stub(oplogPopulator, 'getDefaultConnectorConfiguration').returns(connectorConfig);
-            const updateConfStub = sinon.stub(oplogPopulator._connectWrapper, 'updateConnectorConfig').resolves(null);
-            const createConnectorStub = sinon.stub(oplogPopulator._connectWrapper, 'createConnector')
-                .rejects(errors.InternalError);
-            oplogPopulator.setup()
+        it('should fail if it can\'t get metastore collection', async () => {
+            const collectionStub = sinon.stub().throws(errors.InternalError);
+            const dbStub = sinon.stub().returns({
+                collection: collectionStub,
+            });
+            const mongoConnectStub = sinon.stub(MongoClient, 'connect')
+                .resolves({ db: dbStub });
+            await oplogPopulator._setupMongoClient()
             .then(() => {
-                assert(getConnectorsStub.calledOnce);
-                assert(getConf.calledOnce);
-                assert(updateConfStub.notCalled);
-                assert(createConnectorStub.calledOnce);
-            })
-            .catch(err => assert.deepEqual(err, errors.InternalError));
+                const mongoUrl = 'mongodb://user:password@localhost:27017,' +
+                    'localhost:27018,localhost:27019/?w=majority&readPreference=primary';
+                assert(mongoConnectStub.calledOnceWith(
+                    mongoUrl,
+                    {
+                        replicaSet: 'rs0',
+                        useNewUrlParser: true
+                    }
+                ));
+                assert(dbStub.calledOnceWith('metadata', { ignoreUndefined: true }));
+                assert(collectionStub.calledOnceWith('__metastore'));
+            }).catch(err => assert.deepEqual(err, errors.InternalError));
         });
     });
 
     describe('getDefaultConnectorConfiguration', () => {
         it('should return default configuration (relica set)', done => {
-            const config = oplogPopulator.getDefaultConnectorConfiguration(
-                oplogPopulatorConfig.connectors[0]);
+            const config = oplogPopulator._getDefaultConnectorConfiguration(
+                'source-connector');
             assert.deepEqual(config, connectorConfig);
             return done();
         });
@@ -199,16 +226,605 @@ describe('OplogPopulator', () => {
             // making config without replica set
             const shardedMongoConfig = Object.assign({}, mongoConfig);
             shardedMongoConfig.replicaSet = '';
-            oplogPopulator._mongoConfig = shardedMongoConfig;
+            const op = new OplogPopulator({
+                config: oplogPopulatorConfig,
+                mongoConfig: shardedMongoConfig,
+                activeExtensions,
+                logger,
+            });
             // getting default config
-            const config = oplogPopulator.getDefaultConnectorConfiguration(
-                oplogPopulatorConfig.connectors[0]);
+            const config = op._getDefaultConnectorConfiguration(
+                'source-connector');
             // removing replica set from expected default config
             const shardedConnectorConfig = Object.assign({}, connectorConfig);
-            shardedConnectorConfig['connection.uri'] = 'mongodb://localhost:27017,' +
+            shardedConnectorConfig['connection.uri'] = 'mongodb://user:password@localhost:27017,' +
                 'localhost:27018,localhost:27019/?w=majority&readPreference=primary';
             assert.deepEqual(config, shardedConnectorConfig);
             return done();
+        });
+    });
+
+    describe('_getBackbeatEnabledBuckets', () => {
+        [
+            {
+                extensions: ['notification'],
+                filter: [
+                    { 'value.notificationConfiguration': { $type: 3 } },
+                ],
+            },
+            {
+                extensions: ['replication'],
+                filter: [
+                    {
+                        'value.replicationConfiguration.rules': {
+                            $elemMatch: {
+                                enabled: true,
+                            },
+                        },
+                    },
+                ],
+            },
+            {
+                extensions: ['lifecycle'],
+                filter: [
+                    {
+                        'value.lifecycleConfiguration.rules': {
+                            $elemMatch: {
+                                ruleStatus: 'Enabled',
+                            },
+                        },
+                    },
+                ],
+            },
+            {
+                extensions: ['ingestion'],
+                filter: [
+                    {
+                        'value.ingestion.status': 'enabled',
+                    }
+                ],
+            },
+            {
+                extensions: ['gc'],
+                filter: [],
+            },
+            {
+                extensions: ['mongoProcessor'],
+                filter: [],
+            },
+            {
+                extensions: ['notification', 'replication', 'ingestion', 'lifecycle'],
+                filter: [
+                    { 'value.notificationConfiguration': { $type: 3 } },
+                    {
+                        'value.replicationConfiguration.rules': {
+                            $elemMatch: {
+                                enabled: true,
+                            },
+                        },
+                    },
+                    {
+                        'value.lifecycleConfiguration.rules': {
+                            $elemMatch: {
+                                ruleStatus: 'Enabled',
+                            },
+                        },
+                    },
+                    {
+                        'value.ingestion.status': 'enabled',
+                    }
+                ],
+            }
+        ].forEach(scenario => {
+            const { extensions, filter } = scenario;
+            it(`should correctly set filter (${extensions})`, async () => {
+                const findStub = sinon.stub().returns({
+                    project: () => ({
+                        map: () => ({
+                            toArray: () => ['example-bucket-1'],
+                        }),
+                    })
+                });
+                oplogPopulator._metastore = { find: findStub };
+                oplogPopulator._activeExtensions = extensions;
+                await oplogPopulator._getBackbeatEnabledBuckets()
+                .then(buckets => {
+                    assert(findStub.calledOnceWith({
+                        $or: filter,
+                    }));
+                    assert.deepEqual(buckets, ['example-bucket-1']);
+                })
+                .catch(err => assert.ifError(err));
+            });
+        });
+
+        it('should return fail when toArray operation fails', async () => {
+            const findStub = sinon.stub().returns({
+                project: () => ({
+                    map: () => ({
+                        toArray: sinon.stub().throws(errors.InternalError),
+                    }),
+                })
+            });
+            oplogPopulator._metastore = { find: findStub };
+            await oplogPopulator._getBackbeatEnabledBuckets()
+            .then(buckets => {
+                assert.strict(buckets, undefined);
+            })
+            .catch(err => assert.deepEqual(err, errors.InternalError));
+        });
+
+        it('should return fail when map operation fails', async () => {
+            const findStub = sinon.stub().returns({
+                project: () => ({
+                    map: () => sinon.stub().throws(errors.InternalError),
+                })
+            });
+            oplogPopulator._metastore = { find: findStub };
+            await oplogPopulator._getBackbeatEnabledBuckets()
+            .then(buckets => {
+                assert.strict(buckets, undefined);
+            })
+            .catch(err => assert.deepEqual(err, errors.InternalError));
+        });
+
+        it('should return fail when project operation fails', async () => {
+            const findStub = sinon.stub().returns({
+                project: () => sinon.stub().throws(errors.InternalError),
+            });
+            oplogPopulator._metastore = { find: findStub };
+            await oplogPopulator._getBackbeatEnabledBuckets()
+            .then(buckets => {
+                assert.strict(buckets, undefined);
+            })
+            .catch(err => assert.deepEqual(err, errors.InternalError));
+        });
+
+        it('should return fail when find operation fails', async () => {
+            const findStub = sinon.stub().throws(errors.InternalError);
+            oplogPopulator._metastore = { find: findStub };
+            await oplogPopulator._getBackbeatEnabledBuckets()
+            .then(buckets => {
+                assert.strict(buckets, undefined);
+            })
+            .catch(err => assert.deepEqual(err, errors.InternalError));
+        });
+    });
+
+    describe('_generateNewConnectorPipeline', () => {
+        it('should return new pipeline', done => {
+            const buckets = ['example-bucket-1', 'example-bucket-2'];
+            const pipeline = oplogPopulator._generateNewConnectorPipeline(buckets);
+            assert.strictEqual(pipeline, JSON.stringify([
+                {
+                    $match: {
+                        'ns.coll': {
+                            $in: buckets,
+                        }
+                    }
+                }
+            ]));
+            return done();
+        });
+    });
+
+    describe('_listenToBucket', () => {
+        it('Should update connector pipeline', done => {
+            const updateStub = sinon.stub(oplogPopulator, 'updateConnectorPipeline');
+            oplogPopulator._listenToBucket('example-bucket');
+            assert(oplogPopulator._bucketsForConnector.has('example-bucket'));
+            assert(updateStub.calledOnceWith('source-connector', ['example-bucket']));
+            return done();
+        });
+    });
+
+    describe('_stopListeningToBucket', () => {
+        it('Should update connector pipeline', done => {
+            const updateStub = sinon.stub(oplogPopulator, 'updateConnectorPipeline');
+            oplogPopulator._bucketsForConnector.add('example-bucket');
+            oplogPopulator._stopListeningToBucket('example-bucket');
+            assert.strictEqual(oplogPopulator._bucketsForConnector.has('example-bucket'), false);
+            assert(updateStub.calledOnceWith('source-connector', []));
+            return done();
+        });
+    });
+
+    describe('_isBucketBackbeatEnabled', () => {
+        [
+            {
+                exts: 'all extensions active',
+                metadata: {
+                    notificationConfiguration: {},
+                    lifecycleConfiguration: {
+                        rules: [
+                            {
+                                ruleStatus: 'Enabled',
+                            }
+                        ]
+                    },
+                    replicationConfiguration: {
+                        rules: [
+                            {
+                                enabled: true,
+                            },
+                        ]
+                    },
+                    ingestion: {
+                        status: 'enabled',
+                    },
+                },
+                result: true,
+            },
+            {
+                exts: 'notification active',
+                metadata: {
+                    notificationConfiguration: {},
+                    replicationConfiguration: null,
+                    lifecycleConfiguration: null,
+                    ingestion: null,
+                },
+                result: true,
+            },
+            {
+                exts: 'replication active',
+                metadata: {
+                    notificationConfiguration: null,
+                    lifecycleConfiguration: null,
+                    ingestion: null,
+                    replicationConfiguration: {
+                        rules: [
+                            {
+                                enabled: false,
+                            },
+                            {
+                                enabled: true,
+                            },
+                        ]
+                    },
+                },
+                result: true,
+            },
+            {
+                exts: 'replication disabled',
+                metadata: {
+                    notificationConfiguration: null,
+                    lifecycleConfiguration: null,
+                    ingestion: null,
+                    replicationConfiguration: {
+                        rules: [
+                            {
+                                enabled: false,
+                            },
+                        ]
+                    },
+                },
+                result: false,
+            },
+            {
+                exts: 'replication no rules',
+                metadata: {
+                    notificationConfiguration: null,
+                    lifecycleConfiguration: null,
+                    ingestion: null,
+                    replicationConfiguration: {
+                        rules: []
+                    },
+                },
+                result: false,
+            },
+            {
+                exts: 'lifecycle active',
+                metadata: {
+                    notificationConfiguration: null,
+                    replicationConfiguration: null,
+                    ingestion: null,
+                    lifecycleConfiguration: {
+                        rules: [
+                            {
+                                ruleStatus: 'Disabled',
+                            },
+                            {
+                                ruleStatus: 'Enabled',
+                            }
+                        ]
+                    },
+                },
+                result: true,
+            },
+            {
+                exts: 'lifecycle no rules',
+                metadata: {
+                    notificationConfiguration: null,
+                    replicationConfiguration: null,
+                    ingestion: null,
+                    lifecycleConfiguration: {
+                        rules: []
+                    },
+                },
+                result: false,
+            },
+            {
+                exts: 'lifecycle no rules active',
+                metadata: {
+                    notificationConfiguration: null,
+                    replicationConfiguration: null,
+                    ingestion: null,
+                    lifecycleConfiguration: {
+                        rules: [
+                            {
+                                ruleStatus: 'Disabled',
+                            },
+                        ]
+                    },
+                },
+                result: false,
+            },
+            {
+                exts: 'ingestion active',
+                metadata: {
+                    notificationConfiguration: null,
+                    replicationConfiguration: null,
+                    lifecycleConfiguration: null,
+                    ingestion: {
+                        status: 'enabled',
+                    },
+                },
+                result: true,
+            },
+            {
+                exts: 'ingestion disabled',
+                metadata: {
+                    notificationConfiguration: null,
+                    replicationConfiguration: null,
+                    lifecycleConfiguration: null,
+                    ingestion: {
+                        status: 'disabled',
+                    },
+                },
+                result: false,
+            },
+            {
+                exts: 'no extension active',
+                metadata: {
+                    notificationConfiguration: null,
+                    replicationConfiguration: null,
+                    lifecycleConfiguration: null,
+                },
+                result: false,
+            },
+        ].forEach(scenario => {
+            const { exts, metadata, result } = scenario;
+            it(`Should validate bucket if at least one extension active (${exts})`, done => {
+                const valid = oplogPopulator._isBucketBackbeatEnabled(metadata);
+                assert.strictEqual(valid, result);
+                return done();
+            });
+        });
+    });
+
+    describe.skip('_handleChangeStreamChangeEvent', () => {
+        // TODO: tests will be written in BB-164
+        // as function will change
+    });
+
+    describe('_setMetastoreChangeStream ::', () =>  {
+        it('Should create and listen to the metastore change stream', done => {
+            const changeStreamPipeline = [
+                {
+                    $project: {
+                        '_id': 1,
+                        'operationType': 1,
+                        'documentKey._id': 1,
+                        'fullDocument.value': 1
+                    },
+                },
+            ];
+            oplogPopulator._metastore = {
+                watch: sinon.stub().returns(new events.EventEmitter()),
+            };
+            oplogPopulator._setMetastoreChangeStream();
+            assert(oplogPopulator._changeStreamWrapper instanceof ChangeStream);
+            assert.deepEqual(oplogPopulator._changeStreamWrapper._pipeline, changeStreamPipeline);
+            return done();
+        });
+    });
+
+    describe.skip('updateConnectorConfig', () => {
+        // TODO: tests will be written in BB-164
+        // as function will change
+    });
+
+    describe('_configureConnector', () => {
+        it('should update a connector', async () => {
+            const getConnectorsStub = sinon.stub(oplogPopulator._connectWrapper, 'getConnectors')
+                .resolves(['source-connector']);
+            const updateConfStub = sinon.stub(oplogPopulator._connectWrapper, 'updateConnectorConfig')
+                .resolves(null);
+            const createConnectorStub = sinon.stub(oplogPopulator._connectWrapper, 'createConnector')
+                .resolves(null);
+            await oplogPopulator._configureConnector({
+                name: 'source-connector',
+                config: {},
+            })
+            .then(() => {
+                assert(getConnectorsStub.calledOnce);
+                assert(updateConfStub.calledOnceWith('source-connector', {}));
+                assert(createConnectorStub.notCalled);
+            })
+            .catch(err => assert.ifError(err));
+        });
+
+        it('should create a connector', async () => {
+            const getConnectorsStub = sinon.stub(oplogPopulator._connectWrapper, 'getConnectors')
+                .resolves([]);
+            const updateConfStub = sinon.stub(oplogPopulator._connectWrapper, 'updateConnectorConfig')
+                .resolves(null);
+            const createConnectorStub = sinon.stub(oplogPopulator._connectWrapper, 'createConnector')
+                .resolves(null);
+            await oplogPopulator._configureConnector({
+                name: 'source-connector',
+                config: {},
+            })
+            .then(() => {
+                assert(getConnectorsStub.calledOnce);
+                assert(updateConfStub.notCalled);
+                assert(createConnectorStub.calledWithMatch({
+                    name: 'source-connector',
+                    config: {},
+                }));
+            })
+            .catch(err => assert.ifError(err));
+        });
+
+        it('should throw error if it fails to get connectors', async () => {
+            const getConnectorsStub = sinon.stub(oplogPopulator._connectWrapper, 'getConnectors')
+                .rejects(errors.InternalError);
+            const updateConfStub = sinon.stub(oplogPopulator._connectWrapper, 'updateConnectorConfig')
+                .resolves(null);
+            const createConnectorStub = sinon.stub(oplogPopulator._connectWrapper, 'createConnector')
+                .resolves(null);
+            await oplogPopulator._configureConnector({
+                name: 'source-connector',
+                config: {},
+            })
+            .then(() => {
+                assert(getConnectorsStub.calledOnce);
+                assert(updateConfStub.notCalled);
+                assert(createConnectorStub.notCalled);
+            })
+            .catch(err => assert.deepEqual(err, errors.InternalError));
+        });
+
+        it('should throw error if it fails to update connector', async () => {
+            const getConnectorsStub = sinon.stub(oplogPopulator._connectWrapper, 'getConnectors')
+                .resolves(['source-connector']);
+            const updateConfStub = sinon.stub(oplogPopulator._connectWrapper, 'updateConnectorConfig')
+                .rejects(errors.InternalError);
+            const createConnectorStub = sinon.stub(oplogPopulator._connectWrapper, 'createConnector')
+                .resolves(null);
+            await oplogPopulator._configureConnector({
+                name: 'source-connector',
+                config: {},
+            })
+            .then(() => {
+                assert(getConnectorsStub.calledOnce);
+                assert(updateConfStub.calledOnce);
+                assert(createConnectorStub.notCalled);
+            })
+            .catch(err => assert.deepEqual(err, errors.InternalError));
+        });
+
+        it('should throw error if it fails to create connector', async () => {
+            const getConnectorsStub = sinon.stub(oplogPopulator._connectWrapper, 'getConnectors')
+                .resolves([]);
+            const updateConfStub = sinon.stub(oplogPopulator._connectWrapper, 'updateConnectorConfig')
+                .resolves(null);
+            const createConnectorStub = sinon.stub(oplogPopulator._connectWrapper, 'createConnector')
+                .rejects(errors.InternalError);
+            await oplogPopulator._configureConnector({
+                name: 'source-connector',
+                config: {},
+            })
+            .then(() => {
+                assert(getConnectorsStub.calledOnce);
+                assert(updateConfStub.notCalled);
+                assert(createConnectorStub.calledOnce);
+            })
+            .catch(err => assert.deepEqual(err, errors.InternalError));
+        });
+    });
+
+    describe('setup', () => {
+        it('should setup the OplogPopulator', async () => {
+            const setupMongoStub = sinon.stub(oplogPopulator, '_setupMongoClient')
+                .resolves();
+            const setupMetastore = sinon.stub(oplogPopulator, '_setMetastoreChangeStream')
+                .resolves();
+            const getbucketStub = sinon.stub(oplogPopulator, '_getBackbeatEnabledBuckets')
+                .resolves([]);
+            const getDefaultConfigStub = sinon.stub(oplogPopulator, '_getDefaultConnectorConfiguration')
+                .returns(connectorConfig);
+            const generatePipelineStub = sinon.stub(oplogPopulator, '_generateNewConnectorPipeline')
+                .returns('[]');
+            const configureConnectorsStub = sinon.stub(oplogPopulator, '_configureConnector')
+                .resolves();
+            await oplogPopulator.setup()
+            .then(() => {
+                assert(setupMongoStub.calledOnce);
+                assert(getbucketStub.calledOnce);
+                assert(getDefaultConfigStub.calledOnceWithMatch('source-connector'));
+                assert(generatePipelineStub.calledOnceWithMatch([]));
+                assert(configureConnectorsStub.calledOnceWithMatch({
+                    name: 'source-connector',
+                    config: connectorConfig,
+                }));
+                assert(setupMetastore.calledOnce);
+            })
+            .catch(err => assert.ifError(err));
+        });
+
+        it('should fail if it can\'t connect to mongo', async () => {
+            const setupMongoStub = sinon.stub(oplogPopulator, '_setupMongoClient')
+                .rejects(errors.InternalError);
+            await oplogPopulator.setup()
+            .then(() => {
+                assert(setupMongoStub.calledOnce);
+            })
+            .catch(err => assert.deepEqual(err, errors.InternalError));
+        });
+
+        it('should fail if it can\'t establish change stream', async () => {
+            const setupMongoStub = sinon.stub(oplogPopulator, '_setupMongoClient')
+                .resolves();
+            const setupMetastore = sinon.stub(oplogPopulator, '_setMetastoreChangeStream')
+                .rejects(errors.InternalError);
+            await oplogPopulator.setup()
+            .then(() => {
+                assert(setupMongoStub.calledOnce);
+                assert(setupMetastore.calledOnce);
+            })
+            .catch(err => assert.deepEqual(err, errors.InternalError));
+        });
+
+        it('should fail if it can\'t get backbeat enabled buckets', async () => {
+            const setupMongoStub = sinon.stub(oplogPopulator, '_setupMongoClient')
+                .resolves();
+            const setupMetastore = sinon.stub(oplogPopulator, '_setMetastoreChangeStream')
+                .resolves();
+            const getbucketStub = sinon.stub(oplogPopulator, '_getBackbeatEnabledBuckets')
+                .rejects(errors.InternalError);
+            await oplogPopulator.setup()
+            .then(() => {
+                assert(setupMongoStub.calledOnce);
+                assert(setupMetastore.calledOnce);
+                assert(getbucketStub.calledOnce);
+            })
+            .catch(err => assert.deepEqual(err, errors.InternalError));
+        });
+
+        it('should fail if connector configuration fails', async () => {
+            const setupMongoStub = sinon.stub(oplogPopulator, '_setupMongoClient')
+                .resolves();
+            const setupMetastore = sinon.stub(oplogPopulator, '_setMetastoreChangeStream')
+                .resolves();
+            const getbucketStub = sinon.stub(oplogPopulator, '_getBackbeatEnabledBuckets')
+                .resolves([]);
+            const getDefaultConfigStub = sinon.stub(oplogPopulator, '_getDefaultConnectorConfiguration')
+                .returns(connectorConfig);
+            const generatePipelineStub = sinon.stub(oplogPopulator, '_generateNewConnectorPipeline')
+                .returns('[]');
+            const configureConnectorsStub = sinon.stub(oplogPopulator, '_configureConnector')
+                .rejects(errors.InternalError);
+            await oplogPopulator.setup()
+            .then(() => {
+                assert(setupMongoStub.calledOnce);
+                assert(setupMetastore.calledOnce);
+                assert(getbucketStub.calledOnce);
+                assert(getDefaultConfigStub.calledOnceWithMatch(oplogPopulatorConfig.connectors[0]));
+                assert(generatePipelineStub.calledOnceWithMatch([]));
+                assert(configureConnectorsStub.calledOnce);
+            })
+            .catch(err => assert.deepEqual(err, errors.InternalError));
         });
     });
 });

--- a/tests/unit/utils/MongoUtils.js
+++ b/tests/unit/utils/MongoUtils.js
@@ -1,0 +1,43 @@
+const assert = require('assert');
+const MongoUtils = require('../../../extensions/utils/MongoUtils');
+
+const mongoConfRepl = {
+    replicaSetHosts:
+    'localhost:27017,localhost:27018,localhost:27019',
+    writeConcern: 'majority',
+    replicaSet: 'rs0',
+    readPreference: 'primary',
+    database: 'metadata',
+    authCredentials: {
+        username: 'user',
+        password: 'pass',
+    }
+};
+
+const mongoConfShard = {
+    replicaSetHosts:
+    'localhost:27017,localhost:27018,localhost:27019',
+    writeConcern: 'majority',
+    readPreference: 'primary',
+    database: 'metadata',
+    authCredentials: {
+        username: 'user',
+        password: 'pass',
+    }
+};
+
+describe('constructConnectionString', () => {
+    it('Should construct correct mongo connection string', done => {
+        const url = MongoUtils.constructConnectionString(mongoConfRepl);
+        assert.strictEqual(url, 'mongodb://user:pass@localhost:27017,localhost:27018,localhost:27019' +
+            '/?w=majority&readPreference=primary&replicaSet=rs0');
+        return done();
+    });
+
+    it('Should construct correct mongo connection string (replica)', done => {
+        const url = MongoUtils.constructConnectionString(mongoConfShard);
+        assert.strictEqual(url, 'mongodb://user:pass@localhost:27017,localhost:27018,localhost:27019' +
+            '/?w=majority&readPreference=primary');
+        return done();
+    });
+});


### PR DESCRIPTION
Issue: [BB-167](https://scality.atlassian.net/browse/BB-167)

**Changes:**

NotificationConfigManager:
- Mongo changeStream delete events don't have the `fullDocument` field, which throws an error when trying to get the object id from it. Switched to the `documentKey` field instead as it is always provided

OplogPopulator:
- Now configures Kafka-connect mongo connector to only listen to specific buckets (collections) that have at least one backbeat extension active.
- A Mongo change stream is established to listen to `__metastore` changes and reconfigure the Kafka-connect connector accordingly.

ChangeStreamWrapper:
- Created simple class to handle change streams

KafkaConnectWrapper:
- Changed location of file
