### PR TITLE
Feature: BB-164 support multiple connectors in oplog populator

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -281,7 +281,8 @@
         "oplogPopulator": {
             "topic": "backbeat-oplog",
             "kafkaConnectHost": "127.0.0.1",
-            "kafkaConnectPort": 8083
+            "kafkaConnectPort": 8083,
+            "numberOfConnectors": 1
         }
     },
     "log": {

--- a/extensions/oplogPopulator/OplogPopulator.js
+++ b/extensions/oplogPopulator/OplogPopulator.js
@@ -3,8 +3,9 @@ const { errors } = require('arsenal');
 const { MongoClient } = require('mongodb');
 const constants = require('./constants');
 const { constructConnectionString } = require('../utils/MongoUtils');
-const KafkaConnectWrapper = require('../../lib/wrappers/KafkaConnectWrapper');
 const ChangeStream = require('../../lib/wrappers/ChangeStream');
+const Allocator = require('./modules/Allocator');
+const ConnectorsManager = require('./modules/ConnectorsManager');
 
 const paramsJoi = joi.object({
     config: joi.object().required(),
@@ -41,14 +42,9 @@ class OplogPopulator {
         this._mongoConfig = params.mongoConfig;
         this._activeExtensions = params.activeExtensions;
         this._logger = params.logger;
-        this._connectWrapper = new KafkaConnectWrapper({
-            kafkaConnectHost: this._config.kafkaConnectHost,
-            kafkaConnectPort: this._config.kafkaConnectPort,
-            logger: this._logger,
-        });
         this._changeStreamWrapper = null;
-        // stores the set of buckets assigned to connector
-        this._bucketsForConnector = new Set();
+        this._allocator = null;
+        this._connectorsManager  = null;
         // MongoDB related
         this._mongoClient = null;
         this._metastore = null;
@@ -87,25 +83,6 @@ class OplogPopulator {
             });
             throw errors.InternalError.customizeDescription(err.message);
         }
-    }
-
-    /**
-     * get default connector configuration
-     * @param {string} connectorName connector name
-     * @returns {Object} connector configuration
-     */
-    _getDefaultConnectorConfiguration(connectorName) {
-        // getting default connector config values
-        const config = constants.defaultConnectorConfig;
-        // connection and source configuration
-        config.name = connectorName;
-        config.database = this._database;
-        config['connection.uri'] = this._mongoUrl;
-        // destination topic configuration
-        config['topic.namespace.map'] = JSON.stringify({
-            '*': this._config.topic,
-        });
-        return config;
     }
 
     /**
@@ -158,6 +135,10 @@ class OplogPopulator {
             extFilter[`value.${field}.status`] = 'enabled';
             filter.$or.push(extFilter);
         }
+        // return empty list if no extension active
+        if (filter.$or.length === 0) {
+            return [];
+        }
         try {
             const buckets = await this._metastore.find(filter)
                 .project({ _id: 1 })
@@ -174,46 +155,7 @@ class OplogPopulator {
     }
 
     /**
-     * Makes new connector pipeline to listen to
-     * specified buckets
-     * @param {string[]} bucketNames list of buckets to listen to
-     * @returns {Object} new connector pipeline
-     */
-    _generateNewConnectorPipeline(bucketNames) {
-        const pipeline = [
-            {
-                $match: {
-                    'ns.coll': {
-                        $in: bucketNames,
-                    }
-                }
-            }
-        ];
-        return JSON.stringify(pipeline);
-    }
-
-    /**
-     * start listening to bucket
-     * @param {string} bucketName bucket name
-     * @returns {undefined}
-     */
-    _listenToBucket(bucketName) {
-        this._bucketsForConnector.add(bucketName);
-        this.updateConnectorPipeline(constants.defaultConnectorName, [...this._bucketsForConnector]);
-    }
-
-    /**
-     * stops listening to bucket
-     * @param {string} bucketName bucket name
-     * @returns {undefined}
-     */
-    _stopListeningToBucket(bucketName) {
-        this._bucketsForConnector.delete(bucketName);
-        this.updateConnectorPipeline(constants.defaultConnectorName, [...this._bucketsForConnector]);
-    }
-
-    /**
-     * Check if buckets has at least one backbeat extension active
+     * Checks if buckets has at least one backbeat extension active
      * @param {BucketInfo} bucketMetadata bucket metadata
      * @returns {boolean} is bucket backbeat enabled
      */
@@ -266,15 +208,15 @@ class OplogPopulator {
      * @param {ChangeStreamDocument} change Change stream change object
      * @returns {undefined}
      */
-    _handleChangeStreamChangeEvent(change) {
-        const isListeningToBucket = this._bucketsForConnector.has(change.documentKey._id);
+    async _handleChangeStreamChangeEvent(change) {
+        const isListeningToBucket = this._allocator.has(change.documentKey._id);
         // no fullDocument field in delete events
         const isBackbeatEnabled = change.fullDocument ?
             this._isBucketBackbeatEnabled(change.fullDocument.value) : null;
         switch (change.operationType) {
             case 'delete':
                 if (isListeningToBucket) {
-                    this._stopListeningToBucket(change.documentKey._id);
+                    await this._allocator.stopListeningToBucket(change.documentKey._id);
                 }
                 break;
             case 'replace':
@@ -282,10 +224,10 @@ class OplogPopulator {
             case 'insert':
                 // remove bucket if no longer backbeat enabled
                 if (isListeningToBucket && !isBackbeatEnabled) {
-                    this._stopListeningToBucket(change.documentKey._id);
-                // add bucket if it is backbeat enabled
+                    await this._allocator.stopListeningToBucket(change.documentKey._id);
+                // add bucket if it became backbeat enabled
                 } else if (!isListeningToBucket && isBackbeatEnabled) {
-                    this._listenToBucket(change.documentKey._id);
+                    await this._allocator.listenToBucket(change.documentKey._id);
                 }
                 break;
             default:
@@ -331,85 +273,44 @@ class OplogPopulator {
     }
 
     /**
-     * Updates connector pipeline
-     * @param {string} connectorName connector to update
-     * @param {array} buckets connector assigned buckets
-     * @returns {Promise|Object} connector config
-     * @throws {InternalError}
-     */
-    async updateConnectorPipeline(connectorName, buckets) {
-        // TODO: Add support for multiple connectors
-        const pipeline = this._generateNewConnectorPipeline(buckets);
-        try {
-            const config = await this._connectWrapper.updateConnectorPipeline(connectorName, pipeline);
-            return config;
-        } catch (err) {
-            this._logger.error('Error while updating connector', {
-                method: 'OplogPopulator.updateConnectorPipeline',
-                connector: connectorName,
-                buckets,
-                error: err.description,
-            });
-            throw errors.InternalError.customizeDescription(err.description);
-        }
-    }
-
-    /**
-     * Creates and configures kafka connect
-     * connectors based on the config
-     * @param {Object} connectorConfig Config of connector
-     * @returns {Promise|Object} Updated connector configuration
-     * @throws {InternalError}
-     */
-    async _configureConnector(connectorConfig) {
-        try {
-            const activeConnectors = await this._connectWrapper.getConnectors();
-            const connectorName = connectorConfig.name;
-            // update the connector config if it already exist
-            if (activeConnectors.includes(connectorName)) {
-                return this._connectWrapper.updateConnectorConfig(connectorName,
-                    connectorConfig.config);
-            } else {
-                // otherwise create a new connector
-                return this._connectWrapper.createConnector({
-                    name: connectorName,
-                    config: connectorConfig.config,
-                });
-            }
-        } catch (err) {
-            this._logger.error('Error while initially configuring connectors', {
-                method: 'OplogPopulator._configureConnectors',
-                error: err.description,
-                config: connectorConfig,
-            });
-            throw errors.InternalError.customizeDescription(err.description);
-        }
-    }
-
-    /**
-     * Sets up the OplogPopulator
+     * Sets the OplogPopulator
      * @returns {Promise|undefined} undefined
      * @throws {InternalError}
      */
     async setup() {
        try {
-           await this._setupMongoClient();
-           // getting buckets with at least one extension active
-           const backbeatEnabledBuckets = await this._getBackbeatEnabledBuckets();
-           this._bucketsForConnector = new Set(backbeatEnabledBuckets);
-           // TODO: add support for multiple connectors
-            const defaultConnectorConfig = this._getDefaultConnectorConfiguration(constants.defaultConnectorName);
-            defaultConnectorConfig.pipeline = this._generateNewConnectorPipeline(backbeatEnabledBuckets);
-            const connectorConfigs = {
-                name: constants.defaultConnectorName,
-                config: defaultConnectorConfig
-            };
-            await this._configureConnector(connectorConfigs);
-           this._setMetastoreChangeStream();
+           this._connectorsManager = new ConnectorsManager({
+               nbConnectors: this._config.numberOfConnectors,
+               database: this._database,
+               mongoUrl: this._mongoUrl,
+               oplogTopic: this._config.topic,
+               prefix: this._config.prefix,
+               kafkaConnectHost: this._config.kafkaConnectHost,
+               kafkaConnectPort: this._config.kafkaConnectPort,
+               logger: this._logger,
+            });
+            await this._connectorsManager.initializeConnectors();
+            this._allocator = new Allocator({
+                connectorsManager: this._connectorsManager,
+                logger: this._logger,
+            });
+            // initialize mongo client
+            await this._setupMongoClient();
+            // get currently valid buckets from mongo
+            const validBuckets = await this._getBackbeatEnabledBuckets();
+            // listen to valid buckets
+            await Promise.all(validBuckets.map(bucket => this._allocator.listenToBucket(bucket)));
+            // establish change stream
+            this._setMetastoreChangeStream();
+            // remove no longer valid buckets from old connectors
+            await this._connectorsManager.removeInvalidBuckets(validBuckets);
+            this._logger.debug('OplogPopulator setup complete', {
+                method: 'OplogPopulator.setup',
+            });
        } catch (err) {
             this._logger.error('An error occured when setting up the OplogPopulator', {
                 method: 'OplogPopulator.setup',
-                error: err.description,
+                error: err.description || err.message,
             });
             throw errors.InternalError.customizeDescription(err.description);
        }

--- a/extensions/oplogPopulator/OplogPopulatorConfigValidator.js
+++ b/extensions/oplogPopulator/OplogPopulatorConfigValidator.js
@@ -4,6 +4,8 @@ const joiSchema = joi.object({
     topic: joi.string().required(),
     kafkaConnectHost: joi.string().required(),
     kafkaConnectPort: joi.number().required(),
+    numberOfConnectors: joi.number().required().min(1),
+    prefix: joi.string().optional(),
 });
 
 function configValidator(backbeatConfig, extConfig) {

--- a/extensions/oplogPopulator/OplogPopulatorTask.js
+++ b/extensions/oplogPopulator/OplogPopulatorTask.js
@@ -4,7 +4,7 @@ const werelogs = require('werelogs');
 const config = require('../../lib/Config');
 const OplogPopulator = require('./OplogPopulator');
 
-const logger = new werelogs.Logger('Backbeat:OplogPopulator:task');
+const logger = new werelogs.Logger('Backbeat:OplogPopulator');
 werelogs.configure({ level: config.log.logLevel,
     dump: config.log.dumpLevel });
 
@@ -26,7 +26,7 @@ const oplogPopulator = new OplogPopulator({
     } catch (error) {
         logger.error('Error when starting up the oplog populator', {
             method: 'OplogPopulatorTask.setup',
-            error: error.description,
+            error: error.description || error.message,
         });
         process.exit(0);
     }

--- a/extensions/oplogPopulator/allocationStrategy/AllocationStrategy.js
+++ b/extensions/oplogPopulator/allocationStrategy/AllocationStrategy.js
@@ -1,0 +1,24 @@
+const { errors } = require('arsenal');
+
+class AllocationStrategy {
+
+    /**
+     * @constructor
+     * @param {Logger} logger logger object
+     */
+    constructor(logger) {
+        this._logger = logger;
+    }
+
+    /**
+     * Get best connector for assigning a bucket
+     * @param {Connector[]} connectors available connectors
+     * @returns {Connector} connector
+     */
+    getConnector(connectors) { // eslint-disable-line no-unused-vars
+        throw errors.NotImplemented;
+    }
+
+}
+
+module.exports = AllocationStrategy;

--- a/extensions/oplogPopulator/allocationStrategy/LeastFullConnector.js
+++ b/extensions/oplogPopulator/allocationStrategy/LeastFullConnector.js
@@ -1,0 +1,32 @@
+const AllocationStrategy = require('./AllocationStrategy');
+
+/**
+ * @class LeastFullConnector
+ *
+ * @classdesc LeastFullConnector is an allocation
+ * strategy that assigns buckets to connectors based
+ * on the number of buckets assigned to each connector.
+ * Connectors with the fewest buckets are filled first
+ */
+class LeastFullConnector extends AllocationStrategy {
+
+    /**
+     * @constructor
+     * @param {Object} params params
+     * @param {Logger} params.logger logger object
+     */
+    constructor(params) {
+        super(params.logger);
+    }
+
+    /**
+     * Get best connector for assigning a bucket
+     * @param {Connector[]} connectors available connectors
+     * @returns {Connector} connector
+     */
+    getConnector(connectors) {
+        return connectors.reduce((prev, elt) => (elt.bucketCount < prev.bucketCount ? elt : prev));
+    }
+}
+
+module.exports = LeastFullConnector;

--- a/extensions/oplogPopulator/modules/Allocator.js
+++ b/extensions/oplogPopulator/modules/Allocator.js
@@ -1,0 +1,124 @@
+const joi = require('joi');
+const async = require('async');
+const { errors } = require('arsenal');
+const LeastFullConnector = require('../allocationStrategy/LeastFullConnector');
+
+const paramsJoi = joi.object({
+    connectorsManager: joi.object().required(),
+    logger: joi.object().required(),
+}).required();
+
+// Number of times the allocator should try to update
+// a connector
+const MAX_RETRIES = process.env.OPLOG_POPULATOR_ALLOCATOR_RETRY || 3;
+
+/**
+ * @class Allocator
+ *
+ * @classdesc Allocator handles listening to buckets by assigning
+ * a connector to them.
+ */
+class Allocator {
+
+    /**
+     * @constructor
+     * @param {Object} params Allocator param
+     * @param {ConnectorsManager} params.connectorsManager connectorsManager
+     * @param {Logger} params.logger logger object
+     */
+    constructor(params) {
+        joi.attempt(params, paramsJoi);
+        this._connectorsManager = params.connectorsManager;
+        this._logger = params.logger;
+        this._allocationStrategy = new LeastFullConnector({
+            logger: params.logger,
+        });
+        // Stores connector assigned for each bucket
+        this._bucketsToConnectors = new Map();
+        this._initConnectorToBucketMap();
+    }
+
+    /**
+     * Initializes connectorsManager map
+     * @returns {undefined}
+     */
+    _initConnectorToBucketMap() {
+        const connectors = this._connectorsManager.connectors;
+        connectors.forEach(connector => {
+            connector.buckets
+                .forEach(bucket => this._bucketsToConnectors.set(bucket, connector));
+        });
+    }
+
+    /**
+     * Is bucket already added to a connector
+     * @param {string} bucket bucket name
+     * @returns {boolean} true if a connector is
+     * listening to the bucket
+     */
+    has(bucket) {
+        return this._bucketsToConnectors.has(bucket);
+    }
+
+    /**
+     * Starts listening to bucket by
+     * adding and assigning a connector to it
+     * @param {string} bucket bucket name
+     * @returns {Promise|undefined} undefined
+     * @throws {InternalError}
+     */
+    async listenToBucket(bucket) {
+        try {
+            if (!this._bucketsToConnectors.has(bucket)) {
+                const connectors = this._connectorsManager.connectors;
+                const connector = this._allocationStrategy.getConnector(connectors);
+                await async.retry(MAX_RETRIES, async () => connector.addBucket(bucket));
+                this._bucketsToConnectors.set(bucket, connector);
+                this._logger.debug('Started listening to bucket', {
+                    method: 'Allocator.listenToBucket',
+                    bucket,
+                    connector: connector.name,
+                });
+            }
+        } catch (err) {
+            this._logger.error('Error when starting to listen to bucket', {
+                method: 'Allocator.listenToBucket',
+                bucket,
+                error: err.description,
+            });
+            throw errors.InternalError.customizeDescription(err.description);
+        }
+    }
+
+    /**
+     * Stops listening to bucket by removing
+     * the bucket from the connector assigned
+     * to it
+     * @param {string} bucket bucket name
+     * @returns {Promise|undefined} undefined
+     * @throws {InternalError}
+     */
+    async stopListeningToBucket(bucket) {
+        try {
+            const connector = this._bucketsToConnectors.get(bucket);
+            if (connector) {
+                await async.retry(MAX_RETRIES, async () => connector.removeBucket(bucket));
+                this._bucketsToConnectors.delete(bucket);
+                this._logger.debug('Stoped listening to bucket', {
+                    method: 'Allocator.listenToBucket',
+                    bucket,
+                    connector: connector.name,
+                });
+            }
+        } catch (err) {
+            this._logger.error('Error when stopping listening to bucket', {
+                method: 'Allocator.stopListeningToBucket',
+                bucket,
+                error: err.description,
+            });
+            throw errors.InternalError.customizeDescription(err.description);
+        }
+    }
+}
+
+module.exports = Allocator;

--- a/extensions/oplogPopulator/modules/Connector.js
+++ b/extensions/oplogPopulator/modules/Connector.js
@@ -1,0 +1,200 @@
+const joi = require('joi');
+const { errors } = require('arsenal');
+const KafkaConnectWrapper = require('../../../lib/wrappers/KafkaConnectWrapper');
+
+const connectorParams = joi.object({
+    name: joi.string().required(),
+    config: joi.object().required(),
+    buckets: joi.array().required(),
+    logger: joi.object().required(),
+    kafkaConnectHost: joi.string().required(),
+    kafkaConnectPort: joi.number().required(),
+});
+
+/**
+ * @class Connector
+ *
+ * @classdesc The connector class manages the state of
+ * a Kafka-Connect MongoDB source connector, it can spawn,
+ * destroy and update the config of the connector when adding
+ * or removing buckets from it
+ */
+class Connector {
+
+    /**
+     * @constructor
+     * @param {Object} params connector config
+     * @param {string} params.name connector name
+     * @param {Object} params.config Kafka-connect MongoDB source
+     * connector config
+     * @param {string[]} params.buckets buckets assigned to this connector
+     * @param {Logger} params.logger logger object
+     * @param {string} params.kafkaConnectHost kafka connect host
+     * @param {number} params.kafkaConnectPort kafka connect port
+     */
+    constructor(params) {
+        joi.attempt(params, connectorParams);
+        this._name = params.name;
+        this._config = params.config;
+        this._buckets = new Set(params.buckets);
+        this._logger = params.logger;
+        this._kafkaConnect = new KafkaConnectWrapper({
+            kafkaConnectHost: params.kafkaConnectHost,
+            kafkaConnectPort: params.kafkaConnectPort,
+            logger: this._logger,
+        });
+    }
+
+    /**
+     * Getter for connector name
+     * @returns {string} connector name
+     */
+    get name() { return this._name; }
+
+    /**
+     * Getter for connector buckets
+     * @returns {string[]} buckets assigned to this connector
+     */
+    get buckets() { return [...this._buckets]; }
+
+    /**
+     * Get number of buckets assigned to this
+     * connector
+     * @returns {Number} number of buckets
+     */
+    get bucketCount() { return this._buckets.size; }
+
+    /**
+     * Creates the Kafka-connect mongo connector
+     * @returns {Promise|undefined} undefined
+     * @throws {InternalError}
+     */
+    async spawn() {
+        const connectorConfig = { ...this._config };
+        try {
+            await this._kafkaConnect.createConnector({
+                name: this._name,
+                config: this._config,
+            });
+        } catch (err) {
+            this._logger.error('Error while spawning connector', {
+                method: 'Connector.spawn',
+                connector: this._name,
+                config: connectorConfig,
+                error: err.description || err.message,
+            });
+            throw errors.InternalError.customizeDescription(err.description);
+        }
+    }
+
+    /**
+     * Destroys the Kafka-connect mongo connector
+     * @returns {Promise|undefined} undefined
+     * @throws {InternalError}
+     */
+    async destroy() {
+        try {
+            await this._kafkaConnect.deleteConnector(this._name);
+        } catch (err) {
+            this._logger.error('Error while destroying connector', {
+                method: 'Connector.destroy',
+                connector: this._name,
+                error: err.description || err.message,
+            });
+            throw errors.InternalError.customizeDescription(err.description);
+        }
+    }
+
+    /**
+     * Add bucket to this connector
+     * Connector is updated with the new bucket list
+     * @param {string} bucket bucket to add
+     * @param {boolean} [doUpdate=true] updates connector if true
+     * @returns {Promise|undefined} undefined
+     * @throws {InternalError}
+     */
+    async addBucket(bucket, doUpdate = true) {
+        try {
+            this._buckets.add(bucket);
+            await this.updatePipeline(doUpdate);
+        } catch (err) {
+            this._logger.error('Error while adding bucket to connector', {
+                method: 'Connector.addBucket',
+                connector: this._name,
+                bucket,
+                error: err.description || err.message,
+            });
+            throw errors.InternalError.customizeDescription(err.description);
+        }
+    }
+
+    /**
+     * Remove bucket from this connector
+     * Connector is updated with new bucket list
+     * @param {string} bucket bucket to add
+     * @param {boolean} [doUpdate=true] updates connector if true
+     * @returns {Promise|undefined} undefined
+     * @throws {InternalError}
+     */
+    async removeBucket(bucket, doUpdate = true) {
+        try {
+            this._buckets.delete(bucket);
+            await this.updatePipeline(doUpdate);
+        } catch (err) {
+            this._logger.error('Error while removing bucket from connector', {
+                method: 'Connector.removeBucket',
+                connector: this._name,
+                bucket,
+                error: err.description || err.message,
+            });
+            throw errors.InternalError.customizeDescription(err.description);
+        }
+    }
+
+    /**
+     * Makes new connector pipeline that includes
+     * buckets assigned to this connector
+     * @param {string[]} buckets list of bucket names
+     * @returns {string} new connector pipeline
+     */
+    _generateConnectorPipeline(buckets) {
+        const pipeline = [
+            {
+                $match: {
+                    'ns.coll': {
+                        $in: buckets,
+                    }
+                }
+            }
+        ];
+        return JSON.stringify(pipeline);
+    }
+
+    /**
+     * Updates connector pipeline with
+     * buckets assigned to this connector
+     * @param {boolean} [doUpdate=true] updates connector if true
+     * @returns {Promise|undefined} undefined
+     * @throws {InternalError}
+     */
+    async updatePipeline(doUpdate = true) {
+        this._config.pipeline = this._generateConnectorPipeline([...this._buckets]);
+        try {
+            if (doUpdate) {
+                await this._kafkaConnect.updateConnectorPipeline(this._name, this._config.pipeline);
+            }
+        } catch (err) {
+            this._logger.error('Error while updating connector pipeline', {
+                method: 'Connector.updatePipeline',
+                connector: this._name,
+                buckets: [...this._buckets],
+                pipeline: this._config.pipeline,
+                error: err.description || err.message,
+            });
+            throw errors.InternalError.customizeDescription(err.description);
+        }
+    }
+
+}
+
+module.exports = Connector;

--- a/extensions/oplogPopulator/modules/ConnectorsManager.js
+++ b/extensions/oplogPopulator/modules/ConnectorsManager.js
@@ -1,0 +1,255 @@
+const joi = require('joi');
+const async = require('async');
+const uuid = require('uuid');
+const { errors } = require('arsenal');
+const constants = require('../constants');
+const KafkaConnectWrapper = require('../../../lib/wrappers/KafkaConnectWrapper');
+const Connector = require('./Connector');
+
+const paramsJoi = joi.object({
+    nbConnectors: joi.number().required(),
+    database: joi.string().required(),
+    mongoUrl: joi.string().required(),
+    oplogTopic: joi.string().required(),
+    prefix: joi.string(),
+    kafkaConnectHost: joi.string().required(),
+    kafkaConnectPort: joi.number().required(),
+    logger: joi.object().required(),
+}).required();
+
+/**
+ * @class ConnectorsManager
+ *
+ * @classdesc ConnectorsManager handles connector logic
+ * for spawning connectors and retreiving old ones
+ */
+class ConnectorsManager {
+
+    /**
+     * @constructor
+     * @param {Object} params params
+     * @param {number} params.nbConnectors number of connectors to have
+     * @param {string} params.database MongoDB database to use (for connector)
+     * @param {string} params.mongoUrl MongoDB connection url
+     * @param {string} params.oplogTopic topic to use for oplog
+     * @param {string} params.kafkaConnectHost kafka connect host
+     * @param {number} params.kafkaConnectPort kafka connect port
+     * @param {Logger} params.logger logger object
+     */
+    constructor(params) {
+        joi.attempt(params, paramsJoi);
+        this._nbConnectors = params.nbConnectors;
+        this._logger = params.logger;
+        this._kafkaConnectHost = params.kafkaConnectHost;
+        this._kafkaConnectPort = params.kafkaConnectPort;
+        this._kafkaConnect = new KafkaConnectWrapper({
+            kafkaConnectHost: this._kafkaConnectHost,
+            kafkaConnectPort: this._kafkaConnectPort,
+            logger: this._logger,
+        });
+        this._database = params.database;
+        this._mongoUrl = params.mongoUrl;
+        this._oplogTopic = params.oplogTopic;
+        this._prefix = params.prefix || '';
+        this._connectors = [];
+        // used for initial clean up of old connector pipelines
+        this._oldConnectors = [];
+    }
+
+    /**
+     * get default connector configuration
+     * @param {string} connectorName connector name
+     * @returns {Object} connector configuration
+     */
+    _getDefaultConnectorConfiguration(connectorName) {
+        const connectorConfig = {
+            'name': connectorName,
+            'database': this._database,
+            'connection.uri': this._mongoUrl,
+            'topic.namespace.map': JSON.stringify({
+                '*': this._oplogTopic,
+            })
+        };
+        return {
+            ...constants.defaultConnectorConfig,
+            ...connectorConfig
+        };
+    }
+
+    /**
+     * generates a random connector name
+     * @returns {string} generated connector name
+     */
+    _generateConnectorName() {
+        return `${this._prefix}${constants.defaultConnectorName}-${uuid.v4()}`;
+    }
+
+    /**
+     * Creates a connector
+     * @param {boolean} spawn should connector be spawned
+     * @returns {Promise|Connector} created connector
+     * @throws {InternalError}
+     */
+    async addConnector(spawn = true) {
+        try {
+            // generate connector name
+            const connectorName = this._generateConnectorName();
+            // get connector config
+            const config = this._getDefaultConnectorConfiguration(connectorName);
+            // initialize connector
+            const connector = new Connector({
+                name: connectorName,
+                config,
+                buckets: [],
+                logger: this._logger,
+                kafkaConnectHost: this._kafkaConnectHost,
+                kafkaConnectPort: this._kafkaConnectPort,
+            });
+            if (spawn) {
+                await connector.spawn();
+            }
+            return connector;
+        } catch (err) {
+            this._logger.error('An error occurred while creating connector', {
+                method: 'ConnectorsManager.addConnector',
+                error: err.description || err.message,
+            });
+            throw errors.InternalError.customizeDescription(err.description);
+        }
+    }
+
+    /**
+     * Extracts buckets from a connector config pipeline
+     * @param {Object} connectorConfig connector config
+     * @returns {string[]} list of buckets
+     */
+     _extractBucketsFromConfig(connectorConfig) {
+        const pipeline = connectorConfig.pipeline ?
+            JSON.parse(connectorConfig.pipeline) : null;
+        if (!pipeline || pipeline.length === 0) {
+            return [];
+        }
+        return pipeline[0].$match['ns.coll'].$in;
+    }
+
+    /**
+     * Gets old connector configs and initializes connector
+     * instances
+     * @param {string[]} connectorNames connector names
+     * @returns {Promise|Connector[]} list of connectors
+     */
+    async _getOldConnectors(connectorNames) {
+        try {
+            const connectors = Promise.all(connectorNames.map(async connectorName => {
+                // get old connector config
+                const config = await this._kafkaConnect.getConnectorConfig(connectorName);
+                // extract buckets from old connector config and filter them
+                // only leaving currently valid buckets
+                const buckets = this._extractBucketsFromConfig(config);
+                // initializing connector
+                const connector = new Connector({
+                    name: connectorName,
+                    config,
+                    buckets,
+                    logger: this._logger,
+                    kafkaConnectHost: this._kafkaConnectHost,
+                    kafkaConnectPort: this._kafkaConnectPort,
+                });
+                return connector;
+            }));
+            return connectors;
+        } catch (err) {
+            this._logger.error('An error occurred while getting old connectors', {
+                method: 'ConnectorsManager._getOldConnectors',
+                error: err.description || err.message,
+            });
+            throw errors.InternalError.customizeDescription(err.description);
+        }
+    }
+
+    /**
+     * Initialize previously created connector instances and
+     * creates new connectors based on configuration
+     * @returns {Promise|Connector[]} list connectors
+     * @throws {InternalError}
+     */
+    async initializeConnectors() {
+        try {
+            // get and initialize old connectors
+            const oldConnectorNames = await this._kafkaConnect.getConnectors();
+            if (oldConnectorNames) {
+                const oldConnectors = await this._getOldConnectors(oldConnectorNames);
+                this._connectors.push(...oldConnectors);
+                this._oldConnectors.push(...oldConnectors);
+            }
+            // Add connectors if required number of connectors not reached
+            const nbConnectorsToAdd = this._nbConnectors - this._connectors.length;
+            for (let i = 0; i < nbConnectorsToAdd; i++) {
+                // eslint-disable-next-line no-await-in-loop
+                const newConnector = await this.addConnector();
+                this._connectors.push(newConnector);
+            }
+            return this._connectors;
+        } catch (err) {
+            this._logger.error('An error occurred while initializing connectors', {
+                method: 'ConnectorsManager.initializeConnectors',
+                error: err.description || err.message,
+            });
+            throw errors.InternalError.customizeDescription(err.description);
+        }
+    }
+
+    /**
+     * Removes invalid buckets from connector config
+     * @param {Connector} connector connector
+     * @param {string[]} buckets valid bucket names
+     * @returns {Promise|undefined} undefined
+     * @throws {InternalError}
+     */
+    async removeConnectorInvalidBuckets(connector, buckets) {
+        try {
+            // getting connector's invalid buckets
+            const invalidBuckets = connector.buckets.filter(bucket =>
+                !buckets.includes(bucket));
+            // removing invalid buckets
+            await async.eachLimit(invalidBuckets, 10, async bucket =>
+                connector.removeBucket(bucket, false));
+            // updating connector pipeline
+            await connector.updatePipeline(true);
+        } catch (err) {
+            this._logger.error('An error occurred while removing invalid buckets from a connector', {
+                method: 'ConnectorsManager.removeConnectorInvalidBuckets',
+                error: err.description || err.message,
+                connector: connector.name,
+            });
+            throw errors.InternalError.customizeDescription(err.description);
+        }
+    }
+
+    /**
+     * Removes invalid buckets from old connectors
+     * @param {string[]} buckets valid bucket names
+     * @returns {Promise|undefined} undefined
+     * @throws {InternalError}
+     */
+    async removeInvalidBuckets(buckets) {
+        try {
+            await Promise.all(this._oldConnectors.map(connector =>
+                this.removeConnectorInvalidBuckets(connector, buckets)));
+        } catch (err) {
+            this._logger.error('An error occurred while removing invalid buckets from connectors', {
+                method: 'ConnectorsManager.removeInvalidBuckets',
+                error: err.description || err.message,
+            });
+            throw errors.InternalError.customizeDescription(err.description);
+        }
+    }
+
+    /**
+     * Get currently active connectors
+     * @returns {Connectors[]} list of connectors
+     */
+    get connectors() { return this._connectors; }
+}
+
+module.exports = ConnectorsManager;

--- a/tests/unit/oplogPopulator/Allocator.js
+++ b/tests/unit/oplogPopulator/Allocator.js
@@ -1,0 +1,127 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const werelogs = require('werelogs');
+
+const Allocator =
+    require('../../../extensions/oplogPopulator/modules/Allocator');
+const Connector =
+    require('../../../extensions/oplogPopulator/modules/Connector');
+
+const logger = new werelogs.Logger('Allocator');
+
+const defaultConnectorParams = {
+    config: {},
+    logger,
+    kafkaConnectHost: '127.0.0.1',
+    kafkaConnectPort: 8083,
+};
+
+const connector1 = new Connector({
+    name: 'example-connector-1',
+    buckets: ['example-bucket-1'],
+    ...defaultConnectorParams,
+});
+
+describe('Allocator', () => {
+    let allocator;
+    beforeEach(() => {
+        allocator = new Allocator({
+            connectorsManager: {
+                connectors: [],
+            },
+            logger,
+        });
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    describe('_initConnectorToBucketMap', () => {
+        it('Should initialize map', () => {
+            allocator._connectorsManager.connectors = [connector1];
+            allocator._initConnectorToBucketMap();
+            const connector = allocator._bucketsToConnectors.get('example-bucket-1');
+            assert.strictEqual(connector.name, 'example-connector-1');
+            assert.strictEqual(allocator._bucketsToConnectors.size, 1);
+        });
+    });
+
+    describe('has', () => {
+        it('Should return true if bucket exist', () => {
+            allocator._bucketsToConnectors.set('example-bucket-1', connector1);
+            const exists = allocator.has('example-bucket-1');
+            assert.strictEqual(exists, true);
+        });
+
+        it('Should return false if bucket doesn\'t exist', () => {
+            const exists = allocator.has('example-bucket-2');
+            assert.strictEqual(exists, false);
+        });
+    });
+
+    describe('listenToBucket', () => {
+        it('Should listen to bucket if it wasn\'t assigned before', async () => {
+            allocator._connectorsManager.connectors = [connector1];
+            const getConnectorStub = sinon.stub(allocator._allocationStrategy, 'getConnector')
+                .returns(connector1);
+            const addBucketStub = sinon.stub(connector1, 'addBucket').resolves();
+            await allocator.listenToBucket('example-bucket-1');
+            assert(getConnectorStub.calledOnceWith([connector1]));
+            assert(addBucketStub.calledOnceWith('example-bucket-1'));
+            const assignedConnector = allocator._bucketsToConnectors.get('example-bucket-1');
+            assert.deepEqual(assignedConnector, connector1);
+        });
+
+        it('Should not listen to bucket it was assigned before', async () => {
+            allocator._bucketsToConnectors.set('example-bucket-1', connector1);
+            const getConnectorStub = sinon.stub(allocator._allocationStrategy, 'getConnector')
+                .returns(connector1);
+            const addBucketStub = sinon.stub(connector1, 'addBucket').resolves();
+            await allocator.listenToBucket('example-bucket-1');
+            assert(getConnectorStub.notCalled);
+            assert(addBucketStub.notCalled);
+        });
+
+        it('Should allow retries', async () => {
+            allocator._connectorsManager.connectors = [connector1];
+            const getConnectorStub = sinon.stub(allocator._allocationStrategy, 'getConnector')
+                .returns(connector1);
+            const addBucketStub = sinon.stub(connector1, 'addBucket');
+            addBucketStub.onCall(0).rejects();
+            addBucketStub.onCall(1).resolves();
+            await allocator.listenToBucket('example-bucket-1');
+            assert(getConnectorStub.calledOnce);
+            const assignedConnector = allocator._bucketsToConnectors.get('example-bucket-1');
+            assert.deepEqual(assignedConnector, connector1);
+        });
+    });
+
+    describe('stopListeningToBucket', () => {
+        it('Should stop listening to bucket if it was assigned a connector', async () => {
+            allocator._bucketsToConnectors.set('example-bucket-1', connector1);
+            const removeBucketStub = sinon.stub(connector1, 'removeBucket').resolves();
+            await allocator.stopListeningToBucket('example-bucket-1');
+            assert(removeBucketStub.calledOnceWith('example-bucket-1'));
+            const exists = allocator._bucketsToConnectors.has('example-bucket-1');
+            assert.strictEqual(exists, false);
+        });
+
+        it('Should do nothing if bucket has no connector assigned', async () => {
+            const removeBucketStub = sinon.stub(connector1, 'removeBucket').resolves();
+            await allocator.stopListeningToBucket('example-bucket-1');
+            assert(removeBucketStub.notCalled);
+        });
+
+        it('Should allow retries', async () => {
+            allocator._bucketsToConnectors.set('example-bucket-1', connector1);
+            const removeBucketStub = sinon.stub(connector1, 'removeBucket');
+            removeBucketStub.onCall(0).rejects();
+            removeBucketStub.onCall(1).resolves();
+            await allocator.stopListeningToBucket('example-bucket-1');
+            assert(removeBucketStub.calledOnce);
+            const exists = allocator._bucketsToConnectors.has('example-bucket-1');
+            assert.strictEqual(exists, false);
+        });
+    });
+});

--- a/tests/unit/oplogPopulator/Connector.js
+++ b/tests/unit/oplogPopulator/Connector.js
@@ -1,0 +1,123 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const werelogs = require('werelogs');
+
+const Connector =
+    require('../../../extensions/oplogPopulator/modules/Connector');
+
+const logger = new werelogs.Logger('Connector');
+
+const connectorConfig = {
+    'name': 'example-connector',
+    'database': 'metadata',
+    'connection.uri': 'mongodb://user:password@localhost:27017,localhost:27018,' +
+        'localhost:27019/?w=majority&readPreference=primary&replicaSet=rs0',
+    'topic.namespace.map': '{*:"oplogTopic"}',
+    'connector.class': 'com.mongodb.kafka.connect.MongoSourceConnector',
+    'change.stream.full.document': 'updateLookup',
+    'pipeline': '[]',
+    'collection': '',
+};
+
+describe('Connector', () => {
+    let connector;
+
+    beforeEach(() => {
+        connector = new Connector({
+            name: 'example-connector',
+            config: connectorConfig,
+            buckets: [],
+            kafkaConnectHost: '127.0.0.1',
+            kafkaConnectPort: 8083,
+            logger,
+        });
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    describe('spawn', () => {
+        it('Should spawn connector with correct pipeline', async () => {
+            const createStub = sinon.stub(connector._kafkaConnect, 'createConnector')
+                .resolves();
+            await connector.spawn();
+            assert(createStub.calledOnceWith({
+                name: 'example-connector',
+                config: connectorConfig
+            }));
+        });
+    });
+
+    describe('destroy', () => {
+        it('Should destroy connector', async () => {
+            const deleteStub = sinon.stub(connector._kafkaConnect, 'deleteConnector')
+                .resolves();
+            await connector.destroy();
+            assert(deleteStub.calledOnceWith('example-connector'));
+        });
+    });
+
+    describe('addBucket', () => {
+        it('Should add bucket and update connector', async () => {
+            const connectorUpdateStub = sinon.stub(connector, 'updatePipeline')
+                .resolves();
+            await connector.addBucket('example-bucket');
+            assert(connectorUpdateStub.calledOnce);
+            assert.strictEqual(connector._buckets.has('example-bucket'), true);
+        });
+
+        it('Should add bucket without updating connector', async () => {
+            const connectorUpdateStub = sinon.stub(connector, 'updatePipeline')
+                .resolves();
+            await connector.addBucket('example-bucket', false);
+            assert(connectorUpdateStub.calledWith(false));
+        });
+    });
+
+    describe('removeBucket', () => {
+        it('Should remove bucket and update connector', async () => {
+            const connectorUpdateStub = sinon.stub(connector, 'updatePipeline')
+                .resolves();
+            connector._buckets.add('example-bucket');
+            await connector.removeBucket('example-bucket');
+            assert(connectorUpdateStub.calledOnce);
+            assert.strictEqual(connector._buckets.has('example-bucket'), false);
+        });
+
+        it('Should remove bucket without updating connector', async () => {
+            const connectorUpdateStub = sinon.stub(connector, 'updatePipeline')
+                .resolves();
+            await connector.removeBucket('example-bucket', false);
+            assert(connectorUpdateStub.calledWith(false));
+        });
+    });
+
+    describe('_generateConnectorPipeline', () => {
+        it('should return new pipeline', () => {
+            const buckets = ['example-bucket-1', 'example-bucket-2'];
+            const pipeline = connector._generateConnectorPipeline(buckets);
+            assert.strictEqual(pipeline, JSON.stringify([
+                {
+                    $match: {
+                        'ns.coll': {
+                            $in: buckets,
+                        }
+                    }
+                }
+            ]));
+        });
+    });
+
+    describe('updatePipeline', () => {
+        it('Should update connector pipeline', async () => {
+            const pipelineStub = sinon.stub(connector, '_generateConnectorPipeline')
+                .returns('example-pipeline');
+            const updateStub = sinon.stub(connector._kafkaConnect, 'updateConnectorPipeline')
+                .resolves();
+            await connector.updatePipeline();
+            assert(pipelineStub.calledOnceWith([]));
+            assert(updateStub.calledOnceWith('example-connector', 'example-pipeline'));
+        });
+    });
+});

--- a/tests/unit/oplogPopulator/ConnectorsManager.js
+++ b/tests/unit/oplogPopulator/ConnectorsManager.js
@@ -1,0 +1,161 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const werelogs = require('werelogs');
+
+const Connector =
+    require('../../../extensions/oplogPopulator/modules/Connector');
+const ConnectorsManager =
+    require('../../../extensions/oplogPopulator/modules/ConnectorsManager');
+
+const logger = new werelogs.Logger('ConnectorsManager');
+
+const connectorConfig = {
+    'name': 'source-connector',
+    'database': 'metadata',
+    'connection.uri': 'mongodb://localhost:27017/?w=majority&readPreference=primary',
+    'topic.namespace.map': '{\"*\":\"oplog\"}',
+    'connector.class': 'com.mongodb.kafka.connect.MongoSourceConnector',
+    'change.stream.full.document': 'updateLookup',
+    'pipeline': '[]',
+    'collection': '',
+};
+
+const connector1 = new Connector({
+    name: 'source-connector',
+    buckets: [],
+    config: connectorConfig,
+    logger,
+    kafkaConnectHost: '127.0.0.1',
+    kafkaConnectPort: 8083,
+});
+
+describe('ConnectorsManager', () => {
+    let connectorsManager;
+    beforeEach(() => {
+        connectorsManager = new ConnectorsManager({
+            nbConnectors: 1,
+            database: 'metadata',
+            mongoUrl: 'mongodb://localhost:27017/?w=majority&readPreference=primary',
+            oplogTopic: 'oplog',
+            kafkaConnectHost: '127.0.0.1',
+            kafkaConnectPort: 8083,
+            logger,
+        });
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    describe('_getDefaultConnectorConfiguration', () => {
+        it('should return default configuration', () => {
+            const config = connectorsManager._getDefaultConnectorConfiguration(
+                'source-connector');
+            assert.deepEqual(config, connectorConfig);
+        });
+    });
+
+    describe('_generateConnectorName', () => {
+        it('Should generate a random name', () => {
+            const connectorName = connectorsManager._generateConnectorName();
+            assert(connectorName.startsWith('source-connector-'));
+        });
+
+        it('Should add prefix to connector name', () => {
+            connectorsManager._prefix = 'pfx-';
+            const connectorName = connectorsManager._generateConnectorName();
+            assert(connectorName.startsWith('pfx-source-connector-'));
+        });
+    });
+
+    describe('addConnector', () => {
+        it('should create a connector', async () => {
+            sinon.stub(connectorsManager, '_generateConnectorName')
+                .returns('source-connector');
+            sinon.stub(connectorsManager, '_getDefaultConnectorConfiguration')
+                .returns(connectorConfig);
+            const connector = await connectorsManager.addConnector(false);
+            assert(connector instanceof Connector);
+            assert.strictEqual(connector.name, 'source-connector');
+        });
+    });
+
+    describe('_extractBucketsFromConfig', () => {
+        it('should extract buckets from connector config', () => {
+            const config = {
+                pipeline: JSON.stringify([{
+                    $match: {
+                        'ns.coll': {
+                            $in: ['example-bucket-1, example-bucket-2'],
+                        }
+                    }
+                }])
+            };
+            const buckets = connectorsManager._extractBucketsFromConfig(config);
+            assert.deepEqual(buckets, ['example-bucket-1, example-bucket-2']);
+        });
+    });
+
+    describe('_getOldConnectors', () => {
+        it('Should return old connector', async () => {
+            sinon.stub(connectorsManager._kafkaConnect, 'getConnectorConfig')
+                .resolves(connectorConfig);
+            sinon.stub(connectorsManager, '_extractBucketsFromConfig').returns([]);
+            const connectors = await connectorsManager._getOldConnectors(['source-connector']);
+            assert.strictEqual(connectors.length, 1);
+            assert.strictEqual(connectors[0].name, 'source-connector');
+        });
+    });
+
+    describe('initializeConnectors', () => {
+        it('Should initialize old connector', async () => {
+            connectorsManager._nbConnectors = 1;
+            sinon.stub(connectorsManager._kafkaConnect, 'getConnectors')
+                .resolves(['source-connector']);
+            sinon.stub(connectorsManager, '_getOldConnectors')
+                .resolves([connector1]);
+            const connectors = await connectorsManager.initializeConnectors();
+            assert.deepEqual(connectors, [connector1]);
+            assert.deepEqual(connectorsManager._connectors, [connector1]);
+            assert.deepEqual(connectorsManager._oldConnectors, [connector1]);
+        });
+
+        it('Should add more connectors', async () => {
+            connectorsManager._nbConnectors = 1;
+            sinon.stub(connectorsManager._kafkaConnect, 'getConnectors')
+                .resolves([]);
+            sinon.stub(connectorsManager, 'addConnector')
+                .resolves(connector1);
+            const connectors = await connectorsManager.initializeConnectors();
+            assert.deepEqual(connectors, [connector1]);
+            assert.deepEqual(connectorsManager._connectors, [connector1]);
+            assert.deepEqual(connectorsManager._oldConnectors, []);
+        });
+    });
+
+    describe('removeConnectorInvalidBuckets', () => {
+        it('Should remove invalid buckets from connector', async () => {
+            connector1._buckets = new Set(['valid-bucket-1', 'invalid-bucket-1', 'invalid-bucket-2']);
+            const removeStub = sinon.stub(connector1, 'removeBucket')
+                .resolves();
+            sinon.stub(connector1, 'updatePipeline')
+                .resolves();
+            await connectorsManager.removeConnectorInvalidBuckets(connector1, [
+                'valid-bucket-1',
+            ]);
+            assert(removeStub.getCall(0).calledWith('invalid-bucket-1', false));
+            assert(removeStub.getCall(1).calledWith('invalid-bucket-2', false));
+        });
+    });
+
+    describe('removeInvalidBuckets', () => {
+        it('Should remove invalid buckets from old connectors', async () => {
+            connectorsManager._oldConnectors = [connector1];
+            const removeBucketsStub = sinon.stub(connectorsManager, 'removeConnectorInvalidBuckets')
+                .resolves();
+            await connectorsManager.removeInvalidBuckets(['valid-bucket-1']);
+            assert(removeBucketsStub.calledOnceWith(connector1, ['valid-bucket-1']));
+        });
+    });
+});
+

--- a/tests/unit/oplogPopulator/allocationStrategy/LeastFullConnector.js
+++ b/tests/unit/oplogPopulator/allocationStrategy/LeastFullConnector.js
@@ -1,0 +1,44 @@
+const assert = require('assert');
+const werelogs = require('werelogs');
+
+const Connector =
+    require('../../../../extensions/oplogPopulator/modules/Connector');
+const LeastFullConnector =
+    require('../../../../extensions/oplogPopulator/allocationStrategy/LeastFullConnector');
+
+const logger = new werelogs.Logger('LeastFullConnector');
+
+const defaultConnectorParams = {
+    config: {},
+    logger,
+    kafkaConnectHost: '127.0.0.1',
+    kafkaConnectPort: 8083,
+};
+
+const connector1 = new Connector({
+    name: 'example-connector-1',
+    buckets: [],
+    ...defaultConnectorParams,
+});
+
+const connector2 = new Connector({
+    name: 'example-connector-2',
+    buckets: ['bucket1', 'bucket2'],
+    ...defaultConnectorParams,
+});
+
+describe('LeastFullConnector', () => {
+    let strategy;
+    beforeEach(() => {
+        strategy = new LeastFullConnector({
+            logger,
+        });
+    });
+
+    describe('getConnector', () => {
+        it('Should return connector with fewest buckets', () => {
+            const connector = strategy.getConnector([connector1, connector2]);
+            assert.strictEqual(connector.name, connector1.name);
+        });
+    });
+});


### PR DESCRIPTION
Issue: [BB-164](https://scality.atlassian.net/browse/BB-164)

Added support for the use of multiple connectors by the oplogPopulator

--------
**Connector Class**
This class manages the state of a kafka-connect mongodb source connectors.
The class contains the connector's config and can assign or unassign buckets from it

--------
**ConnectorsManager Class**
A ConnectorsManager keeps a list of active connectors

It is also used to spawn and configure connectors.

At startup, old connectors are first retreived and reconfigured*, then if more
connectors are required it creates them.

*Old connectors are reconfigured where buckets that are no longer valid
are removed from the connectors' config

--------
**Allocator Class**
The Allocator handles assigning buckets to connectors using
an allocation strategy.

--------
**Allocation Strategy Class**
Allocation strategy is what decides what connector should be assigned
to a bucket next

The allocation strategy implemented for now, returns the connector with the
fewest buckets assigned

--------
**OplogPopulator**
The OplogPopulator dynamically configures kafka-connect MongoDB source connectors to watch over changes in relevant buckets in MongoDB

At startup, the OplogPopulator first initializes connectors following its config.
If we have old connectors, these are reconfigured as explained above. More connectors are created if needed
The allocator is then instantiated, and used to start listening to valid buckets that don't have an assigned connector yet
A change stream is then established with the `__metastore` db to watch for changes of bucket configs, this is used to decide if we should listen to object operations in a bucket or not.
We start listening to a bucket if it uses at least one of the active backbeat extensions (ex. replication, notification...)