### PR TITLE
INTEGRATION [PR#2174 > development/8.2] BB-177: lifecycle delete object task - handle 404 response

### DIFF
--- a/extensions/lifecycle/tasks/LifecycleDeleteObjectTask.js
+++ b/extensions/lifecycle/tasks/LifecycleDeleteObjectTask.js
@@ -106,6 +106,11 @@ class LifecycleDeleteObjectTask extends BackbeatTask {
             next => this._checkDate(entry, log, next),
             next => this._executeDelete(entry, log, next),
         ], err => {
+            if (err && err.statusCode === 404) {
+                log.debug('Unable to find object to delete, skipping',
+                    entry.getLogInfo());
+                return done();
+            }
             if (err && err.statusCode === 412) {
                 log.info('Object was modified after delete entry ' +
                          'created so object was not deleted',

--- a/tests/unit/lifecycle/LifecycleDeleteObjectTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleDeleteObjectTask.spec.js
@@ -1,0 +1,73 @@
+const assert = require('assert');
+const { errors } = require('arsenal');
+const werelogs = require('werelogs');
+
+const ActionQueueEntry = require('../../../lib/models/ActionQueueEntry');
+const LifecycleDeleteObjectTask = require(
+    '../../../extensions/lifecycle/tasks/LifecycleDeleteObjectTask');
+
+const {
+    S3ClientMock,
+    LifecycleObjectProcessorMock,
+} = require('./mocks');
+
+describe('LifecycleDeleteObjectTask', () => {
+    let s3Client;
+    let objectProcessor;
+    let task;
+
+    beforeEach(() => {
+        s3Client = new S3ClientMock();
+        objectProcessor = new LifecycleObjectProcessorMock(
+            s3Client,
+            null,
+            null,
+            new werelogs.Logger('test:LifecycleDeleteObjectTask'));
+        task = new LifecycleDeleteObjectTask(objectProcessor);
+    });
+
+    it('should not return error for 404s', (done) => {
+        const entry = ActionQueueEntry.create('deleteObject')
+            .setAttribute('target.owner', 'testowner')
+            .setAttribute('target.bucket', 'testbucket')
+            .setAttribute('target.accountId', 'testid')
+            .setAttribute('target.key', 'testkey')
+            .setAttribute('details.lastModified', '2022-05-13T17:51:31.261Z');
+        const error = errors.NoSuchKey;
+        error.statusCode = error.code;
+
+        s3Client.setResponse(error, null);
+        task.processActionEntry(entry, done);
+    });
+
+    it('should return error non-404 errors', (done) => {
+        const entry = ActionQueueEntry.create('deleteObject')
+            .setAttribute('target.owner', 'testowner')
+            .setAttribute('target.bucket', 'testbucket')
+            .setAttribute('target.accountId', 'testid')
+            .setAttribute('target.key', 'testkey')
+            .setAttribute('details.lastModified', '2022-05-13T17:51:31.261Z');
+        const error = errors.PreconditionFailed;
+        error.statusCode = error.code;
+
+        s3Client.setResponse(error, null);
+        task.processActionEntry(entry, err => {
+            assert(err);
+            done();
+        });
+    });
+
+    it('successful request', (done) => {
+        const entry = ActionQueueEntry.create('deleteObject')
+            .setAttribute('target.owner', 'testowner')
+            .setAttribute('target.bucket', 'testbucket')
+            .setAttribute('target.accountId', 'testid')
+            .setAttribute('target.key', 'testkey')
+            .setAttribute('details.lastModified', '2022-05-13T17:51:31.261Z');
+        s3Client.setResponse(null, {});
+        task.processActionEntry(entry, err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+});

--- a/tests/unit/lifecycle/LifecycleUpdateTransitionTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleUpdateTransitionTask.spec.js
@@ -6,61 +6,11 @@ const ActionQueueEntry = require('../../../lib/models/ActionQueueEntry');
 const LifecycleUpdateTransitionTask = require(
     '../../../extensions/lifecycle/tasks/LifecycleUpdateTransitionTask');
 
-class GarbageCollectorProducerMock {
-    constructor() {
-        this.receivedEntry = null;
-    }
-
-    publishActionEntry(gcEntry) {
-        this.receivedEntry = gcEntry;
-    }
-
-    getReceivedEntry() {
-        return this.receivedEntry;
-    }
-}
-
-
-class BackbeatClientMock {
-    constructor() {
-        this.mdObj = null;
-        this.receivedMd = null;
-    }
-
-    setMdObj(mdObj) {
-        this.mdObj = mdObj;
-    }
-
-    getMetadata(params, log, cb) {
-        return cb(null, { Body: this.mdObj.getSerialized() });
-    }
-
-    putMetadata(params, log, cb) {
-        this.receivedMd = JSON.parse(params.mdBlob);
-        return cb();
-    }
-
-    getReceivedMd() {
-        return this.receivedMd;
-    }
-}
-
-class LifecycleObjectProcessorMock {
-    constructor(backbeatClient, gcProducer) {
-        this.backbeatClient = backbeatClient;
-        this.gcProducer = gcProducer;
-        this.logger = new werelogs.Logger('test:LifecycleUpdateTransitionTask');
-    }
-
-    getStateVars() {
-        return {
-            backbeatClient: this.backbeatClient,
-            gcProducer: this.gcProducer,
-            logger: this.logger,
-            getBackbeatClient: () => this.backbeatClient,
-        };
-    }
-}
+const {
+    GarbageCollectorProducerMock,
+    BackbeatClientMock,
+    LifecycleObjectProcessorMock,
+} = require('./mocks');
 
 describe('LifecycleUpdateTransitionTask', () => {
     let backbeatClient;
@@ -94,7 +44,10 @@ describe('LifecycleUpdateTransitionTask', () => {
         backbeatClient = new BackbeatClientMock();
         gcProducer = new GarbageCollectorProducerMock();
         objectProcessor = new LifecycleObjectProcessorMock(
-            backbeatClient, gcProducer);
+            null,
+            backbeatClient,
+            gcProducer,
+            new werelogs.Logger('test:LifecycleUpdateTransitionTask'));
         mdObj = new ObjectMD();
         mdObj.setLocation(oldLocation)
             .setContentMd5('1ccc7006b902a4d30ec26e9ddcf759d8')

--- a/tests/unit/lifecycle/mocks.js
+++ b/tests/unit/lifecycle/mocks.js
@@ -1,0 +1,111 @@
+const assert = require('assert');
+const { EventEmitter } = require('events');
+
+class GarbageCollectorProducerMock {
+    constructor() {
+        this.receivedEntry = null;
+    }
+
+    publishActionEntry(gcEntry) {
+        this.receivedEntry = gcEntry;
+    }
+
+    getReceivedEntry() {
+        return this.receivedEntry;
+    }
+}
+
+class BackbeatClientMock {
+    constructor() {
+        this.mdObj = null;
+        this.receivedMd = null;
+    }
+
+    setMdObj(mdObj) {
+        this.mdObj = mdObj;
+    }
+
+    getMetadata(params, log, cb) {
+        return cb(null, { Body: this.mdObj.getSerialized() });
+    }
+
+    putMetadata(params, log, cb) {
+        this.receivedMd = JSON.parse(params.mdBlob);
+        return cb();
+    }
+
+    getReceivedMd() {
+        return this.receivedMd;
+    }
+}
+
+class LifecycleObjectProcessorMock {
+    constructor(s3Client, backbeatClient, gcProducer, logger) {
+        this.s3Client = s3Client;
+        this.backbeatClient = backbeatClient;
+        this.gcProducer = gcProducer;
+        this.logger = logger;
+    }
+
+    getStateVars() {
+        return {
+            backbeatClient: this.backbeatClient,
+            gcProducer: this.gcProducer,
+            logger: this.logger,
+            getBackbeatClient: () => this.backbeatClient,
+            getS3Client: () => this.s3Client,
+        };
+    }
+}
+
+class S3RequestMock extends EventEmitter {
+    constructor(error, data) {
+        super();
+        this.error = error;
+        this.data = data;
+    }
+
+    send(cb) {
+        cb(this.error, this.data);
+    }
+}
+
+class S3ClientMock {
+    constructor() {
+        this.response = null;
+    }
+
+    setResponse(error, data) {
+        this.response = { error, data };
+    }
+
+    unsetResponse() {
+        this.response = null;
+    }
+
+    assertRespIsSet() {
+        assert(typeof this.response === 'object');
+    }
+
+    headObject() {
+        this.assertRespIsSet();
+        return new S3RequestMock(this.response.error, this.response.data);
+    }
+
+    deleteObject() {
+        this.assertRespIsSet();
+        return new S3RequestMock(this.response.error, this.response.data);
+    }
+
+    deleteMultipartObject() {
+        this.assertRespIsSet();
+        return new S3RequestMock(this.response.error, this.response.data);
+    }
+}
+
+module.exports = {
+    LifecycleObjectProcessorMock,
+    GarbageCollectorProducerMock,
+    BackbeatClientMock,
+    S3ClientMock,
+};


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2174.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.2/bugfix/BB-177/lifecycleTaskHandle404s`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.2/bugfix/BB-177/lifecycleTaskHandle404s
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.2/bugfix/BB-177/lifecycleTaskHandle404s
```

Please always comment pull request #2174 instead of this one.