### PR TITLE
BB-183 Lifecycle transition entry is missing target.accountId

### DIFF
--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -818,6 +818,7 @@ class LifecycleTask extends BackbeatTask {
             fromLocation: objectMD.getDataStoreName(),
             contentLength: objectMD.getContentLength(),
             resultsTopic: this.objectTasksTopic,
+            accountId: params.accountId,
         });
         entry.addContext({
             origin: 'lifecycle',
@@ -1087,6 +1088,7 @@ class LifecycleTask extends BackbeatTask {
             if (rules.Transition) {
                 this._applyTransitionRule({
                     owner: bucketData.target.owner,
+                    accountId: bucketData.target.accountId,
                     bucket: bucketData.target.bucket,
                     objectKey: obj.Key,
                     eTag: obj.ETag,
@@ -1167,6 +1169,7 @@ class LifecycleTask extends BackbeatTask {
         if (rules.Transition) {
             this._applyTransitionRule({
                 owner: bucketData.target.owner,
+                accountId: bucketData.target.accountId,
                 bucket: bucketData.target.bucket,
                 objectKey: version.Key,
                 eTag: version.ETag,

--- a/extensions/replication/ReplicationAPI.js
+++ b/extensions/replication/ReplicationAPI.js
@@ -16,6 +16,7 @@ class ReplicationAPI {
      * @param {object} params - params object
      * @param {string} params.bucketName - bucket name
      * @param {string} params.objectKey - object key
+     * @param {string} params.accountId - object's bucket's account id
      * @param {string} [params.versionId] - encoded version ID
      * @param {string} [params.eTag] - ETag of object
      * @param {string} [params.lastModified] - object last modification date
@@ -34,6 +35,7 @@ class ReplicationAPI {
         const action = ActionQueueEntry.create('copyLocation');
         action
             .setAttribute('target', {
+                accountId: params.accountId,
                 owner: params.owner,
                 bucket: params.bucketName,
                 key: params.objectKey,


### PR DESCRIPTION
This accountId is needed to get temporary credentials from `assumeRole()` call.