### PR TITLE
bugfix: BB-187 misused Kafka keyed partitioning

### DIFF
--- a/extensions/notification/queueProcessor/QueueProcessor.js
+++ b/extensions/notification/queueProcessor/QueueProcessor.js
@@ -204,7 +204,9 @@ class QueueProcessor extends EventEmitter {
                     const message
                         = messageUtil.transformToSpec(sourceEntry);
                     const msg = {
-                        key: this.destinationId,
+                        // for Kafka keyed partitioning, to map a
+                        // particular bucket and key to a partition
+                        key: `${bucket}/${key}`,
                         message,
                     };
                     const msgDesc = 'sending message to external destination';


### PR DESCRIPTION
Fix keyed partitioning for bucket notifications: instead of passing
the destination ID as key to be hashed, pass "bucket/objectKey", in
order to preserve the ordering of operations per object key while
spreading notifications across all partitions overall.

The fix has been tested on lab: it now spreads notifications across
partitions, and notifications for the same object key go to the same
partition.