### PR TITLE
bugfix: BB-159 fix unauthorized notification type getting produced

### DIFF
--- a/extensions/notification/utils/config.js
+++ b/extensions/notification/utils/config.js
@@ -54,8 +54,11 @@ function validateEntryWithFilter(filterRules, entry) {
 function filterConfigsByEvent(bnConfigs, event) {
     return bnConfigs.filter(config => config.events.some(evt => {
         // support wildcard events
-        const starts = evt.endsWith('*') ? evt.replace('*', '') : evt;
-        return event.toLowerCase().startsWith(starts.toLowerCase());
+        if (evt.endsWith('*')) {
+            const starts = evt.replace('*', '');
+            return event.toLowerCase().startsWith(starts.toLowerCase());
+        }
+        return event.toLowerCase() === evt.toLowerCase();
     }));
 }
 

--- a/tests/unit/notification/utils/config.js
+++ b/tests/unit/notification/utils/config.js
@@ -127,6 +127,19 @@ const testConfigs = [
             ],
         },
     },
+    {
+        bucket: 'bucket8',
+        notificationConfiguration: {
+            queueConfig: [
+                {
+                    events: ['s3:ObjectRemoved:Delete'],
+                    queueArn: 'q8',
+                    filterRules: [],
+                    id: 'config8',
+                },
+            ],
+        },
+    },
 ];
 
 const tests = [
@@ -190,6 +203,15 @@ const tests = [
             eventType: 's3:ObjectCreated:Post',
             bucket: 'bucket1',
             key: 'test.png',
+        },
+        pass: false,
+    },
+    {
+        desc: 'fail if the event type does not match config',
+        entry: {
+            eventType: 's3:ObjectRemoved:DeleteMarkerCreated',
+            bucket: 'bucket8',
+            key: 'abcd.png',
         },
         pass: false,
     },


### PR DESCRIPTION
When the notification config allows "s3:ObjectRemoved:Delete" notifications
and the event being processed is of type "s3:ObjectRemoved:DeleteMarkerCreated",
the event gets validated even if it is not autorized in the config.

This is caused by the way events are compared, as the string
"s3:ObjectRemoved:DeleteMarkerCreated" starts with "s3:ObjectRemoved:Delete"