### PR TITLE
Feature: BB-190 implement kafka log reader

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -37,6 +37,10 @@
             "readPreference": "primary",
             "database": "metadata"
         },
+        "kafka": {
+            "topic": "backbeat-oplog",
+            "consumerGroupId": "backbeat-qp-oplog-group"
+        },
         "probeServer": {
             "bindAddress": "0.0.0.0",
             "port": 4042

--- a/lib/config.joi.js
+++ b/lib/config.joi.js
@@ -6,11 +6,12 @@ const {
     hostPortJoi,
     logJoi,
     mongoJoi,
+    qpKafkaJoi,
     transportJoi,
 } = require('./config/configItems.joi.js');
 
 const logSourcesJoi = joi.string().valid('bucketd', 'mongo', 'ingestion',
-    'dmd');
+    'dmd', 'kafka');
 
 const joiSchema = joi.object({
     replicationGroupId: joi.string().length(7).required(),
@@ -42,6 +43,7 @@ const joiSchema = joi.object({
             logName: joi.string().default('s3-recordlog'),
         }).when('logSource', { is: 'dmd', then: joi.required() }),
         mongo: mongoJoi,
+        kafka: qpKafkaJoi.when('logSource', { is: 'kafka', then: joi.required() }),
         probeServer: joi.object({
             bindAddress: joi.string().default('localhost'),
             port: joi.number().required(),

--- a/lib/config/configItems.joi.js
+++ b/lib/config/configItems.joi.js
@@ -132,6 +132,12 @@ const mongoJoi = joi.object({
     }),
 });
 
+const qpKafkaJoi = joi.object({
+    topic: joi.string().default('backbeat-oplog'),
+    consumerGroupId: joi.string().default('backbeat-oplog-consumer-id'),
+    logName: joi.string().default('s3-recordlog'),
+});
+
 module.exports = {
     hostPortJoi,
     transportJoi,
@@ -145,4 +151,5 @@ module.exports = {
     probeServerJoi,
     stsConfigJoi,
     mongoJoi,
+    qpKafkaJoi,
 };

--- a/lib/queuePopulator/KafkaLogConsumer/ListRecordStream.js
+++ b/lib/queuePopulator/KafkaLogConsumer/ListRecordStream.js
@@ -1,0 +1,85 @@
+const stream = require('stream');
+
+class ListRecordStream extends stream.Transform {
+    /**
+     * @constructor
+     * @param {Logger} logger logger
+     */
+    constructor(logger) {
+        super({ objectMode: true });
+        this._logger = logger;
+    }
+
+    /**
+     * Maps change stream operation type to
+     * backbeat supported types
+     * @param {string} operationType mongo opetation type
+     * @returns {string|undefined} supported operation type
+     */
+    _getType(operationType) {
+        switch (operationType) {
+            case 'insert':
+            case 'update':
+            case 'replace':
+                return 'put';
+            case 'delete':
+                return 'delete';
+            default:
+                this._logger.warn('Got unsupported operation', {
+                    method: 'ListRecordStream._getType',
+                    operationType,
+                });
+                return undefined;
+        }
+    }
+
+    /**
+     * Parse kafka message's value field twice, as the Kafka-connect MongoDB
+     * source connector will double stringify the value field
+     * @param {string} blob sringified json
+     * @returns {Object} parsed json
+     */
+    _parseKafkaMessageValue(blob) {
+        try {
+            const parsed = JSON.parse(JSON.parse(blob));
+            return parsed;
+        } catch (err) {
+            this._logger.warn('Got invalid kafka message value field format', {
+                method: 'ListRecordStream._parseJson',
+                value: blob,
+            });
+            return {};
+        }
+     }
+
+    /**
+     * Formats change stream entries
+     * @param {Object} data chunk of data
+     * @param {Buffer} data.value message contents as a Buffer
+     * In our case this contains the changeStreamDocument data
+     * @param {Number} data.size size of the message, in bytes
+     * @param {string} data.topic topic the message comes from
+     * @param {Number} data.offset  offset the message was read from
+     * @param {Number} data.partition partition the message was on
+     * @param {string} data.key key of the message if present
+     * @param {Number} data.timestamp timestamp of message creation
+     * @param {string} encoding enconding of data
+     * @param {Function} callback callback
+     * @returns {undefined}
+     */
+    _transform(data, encoding, callback) {
+        const changeStreamDocument = this._parseKafkaMessageValue(data.value);
+        const streamObject = {
+            timestamp: new Date(data.timestamp),
+            db: changeStreamDocument.ns && changeStreamDocument.ns.coll,
+            entries: [{
+                key: changeStreamDocument.documentKey && changeStreamDocument.documentKey._id,
+                type: this._getType(changeStreamDocument.operationType),
+                value: changeStreamDocument.fullDocument && changeStreamDocument.fullDocument.value,
+            }],
+        };
+        callback(null, streamObject);
+    }
+}
+
+module.exports = ListRecordStream;

--- a/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
+++ b/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
@@ -1,0 +1,169 @@
+const kafka = require('node-rdkafka');
+const async = require('async');
+const ListRecordStream = require('./ListRecordStream');
+
+// maximum time to wait for consumer group to rebalance (ms)
+const maxDelayRebalanceMs = 120000;
+
+class LogConsumer {
+
+    /**
+     * @constructor
+     * @param {Object} kafkaConfig queue populator kafka config
+     * @param {string} kafkaConfig.hosts kafka hosts
+     * @param {string} kafkaConfig.topic kafka oplog topic
+     * @param {string} kafkaConfig.consumerGroupId consumer group id
+     * @param {Logger} logger logger
+     */
+    constructor(kafkaConfig, logger) {
+        const { hosts, topic, consumerGroupId } = kafkaConfig;
+        this._kafkaHosts = hosts;
+        this._topic = topic;
+        this._consumerGroupId = consumerGroupId;
+        this._log = logger;
+        this._offsets = {};
+    }
+
+    /**
+     * Get partition offsets
+     * @returns {string} stored partition offsets
+     */
+    _getOffset() {
+        // Format: [{ topic: 'oplog-topic', partition: 0, offset: 0 }]
+        return JSON.stringify(this._offsets);
+    }
+
+    /**
+     * Connects consumer to kafka and subscribes
+     * to oplog topic
+     * @param {Function} done callback
+     * @returns {undefined}
+     */
+    setup(done) {
+        // partition offsets will be managed by kafka
+        const consumerParams = {
+            'enable.auto.offset.store': true,
+            'metadata.broker.list': this._kafkaHosts,
+            'group.id': this._consumerGroupId,
+        };
+        const topicParams = {
+            'auto.offset.reset': 'earliest',
+            'enable.auto.commit': true,
+        };
+        this._consumer = new kafka.KafkaConsumer(consumerParams, topicParams);
+        this._consumer.connect();
+        this._consumer.on('ready', () => {
+            this._consumer.subscribe([this._topic]);
+            return done();
+        });
+    }
+
+    /**
+     * Waits for consumer group to rebalance
+     * @param {number} wait amount of time to wait already waited for, in milliseconds
+     * @param {Function} cb callback
+     * @returns {undefined}
+     */
+    _waitForAssignment(wait, cb) {
+        setTimeout(() => {
+            // assignements contain the partitions
+            // assigned to this consumer, they are only
+            // set once consumer group is balanced
+            const assignments = this._consumer.assignments();
+            if (assignments.length === 0) {
+                if (wait > maxDelayRebalanceMs) {
+                    this._log.error('Timeout waiting for consumer to be assigned to partitions', {
+                        method: 'LogConsumer._waitForAssignment',
+                        topic: this._topic,
+                        consumerGroupId: this._consumerGroupId,
+                    });
+                    return cb(true);
+                }
+                return this._waitForAssignment(wait + 2000, cb);
+            }
+            return cb();
+        }, 2000);
+    }
+
+    /**
+     * Queries last commited partition offsets
+     * and stores them
+     * @param {Function} cb callback
+     * @returns {undefined}
+     */
+    _storeCurrentOffsets(cb) {
+        this._consumer.committed(5000, (err, topicPartitions) => {
+            if (err) {
+                this._log.error('Error while getting offsets', {
+                    method: 'LogConsumer._storeCurrentOffsets',
+                    topic: this._topic,
+                    consumerGroupId: this._consumerGroupId,
+                });
+                return cb(err);
+            }
+            // saving offsets
+            this._offsets = topicPartitions;
+            return cb();
+        });
+    }
+
+    /**
+     * Inintializes record stream
+     * @returns {undefined}
+     */
+    _resetRecordStream() {
+        this._listRecordStream = new ListRecordStream(this._log);
+        this._listRecordStream.getOffset = this._getOffset.bind(this);
+    }
+
+    /**
+     * Consumes kafka messages and writes them to record
+     * stream
+     * @param {Number} limit maximum messages to consume
+     * @param {Function} cb callback
+     * @returns {undefined}
+     */
+    _consumeKafkaMessages(limit, cb) {
+        this._resetRecordStream();
+        this._consumer.consume(limit, (err, messages) => {
+            if (err) {
+                this._log.error('An error occured while consuming messages', {
+                    method: 'LogConsumer.readRecords',
+                    topic: this._topic,
+                    consumerGroupId: this._consumerGroupId,
+                });
+                return cb(err);
+            }
+            // writing consumed messages to the stream
+            messages.forEach(message => this._listRecordStream.write(message));
+            return cb();
+        });
+    }
+
+    /**
+     * Reads a certain number of messages from oplog kafka topic
+     * The caller of this function expects a stream to be returned
+     * in the callback
+     * @param {Object} params reading params
+     * @param {number} params.limit maximum number of elements to fetch
+     * @param {Function} cb callback
+     * @returns {undefined}
+     */
+    readRecords(params, cb) {
+        async.series([
+            // waiting for the consumer group to rebalance
+            next => this._waitForAssignment(0, next),
+            // saving last commited offset
+            next => this._storeCurrentOffsets(next),
+            // consuming the desired number of messages at most
+            next => this._consumeKafkaMessages(params.limit, next),
+            next => {
+                // ending and returning the stream
+                this._listRecordStream.end();
+                return next(null, { log: this._listRecordStream, tailable: false });
+            }
+        ], (err, res) => cb(err, res[3]));
+    }
+}
+
+module.exports = LogConsumer;

--- a/lib/queuePopulator/KafkaLogReader.js
+++ b/lib/queuePopulator/KafkaLogReader.js
@@ -1,0 +1,76 @@
+const LogConsumer = require('./KafkaLogConsumer/LogConsumer');
+const LogReader = require('./LogReader');
+
+class KafkaLogReader extends LogReader {
+    /**
+     * @constructor
+     * @param {Object} params - constructor params
+     * @param {Object} params.zkClient - zookeeper client object
+     * @param {Object} params.zkConfig - zookeeper config
+     * @param {Object} params.kafkaConfig - kafka configuration object
+     * @param {Logger} params.logger - logger object
+     * @param {Object} params.qpKafkaConfig - queue populator kafka configuration
+     * @param {QueuePopulatorExtension[]} params.extensions - array of
+     *   queue populator extension modules
+     * @param {MetricsProducer} params.metricsProducer - instance of metrics
+     *   producer
+     * @param {MetricsHandler} params.metricsHandler - instance of metrics
+     *   handler
+     */
+    constructor(params) {
+        const { zkClient, kafkaConfig, zkConfig, qpKafkaConfig,
+            logger, extensions, metricsProducer, metricsHandler } = params;
+        // conf contains global kafka and queuePoplator kafka configs
+        const conf = {
+            hosts: kafkaConfig.hosts,
+            ...qpKafkaConfig
+        };
+        logger.info('initializing kafka log reader',
+            { method: 'KafkaLogReader.constructor',
+            kafkaConfig: conf });
+        const logConsumer = new LogConsumer(conf, logger);
+        super({ zkClient, kafkaConfig, zkConfig, logConsumer,
+                logId: `kafka_${qpKafkaConfig.logName}`, logger, extensions,
+                metricsProducer, metricsHandler });
+        this._kafkaConfig = conf;
+    }
+
+    /**
+    * Setup log consumer
+    * @param {object} done callback function
+    * @return {undefined}
+    */
+     setup(done) {
+        this.logConsumer.setup(err => {
+            if (err) {
+                this.log.error('error setting up log consumer', {
+                    method: 'KafkaLogReader.setup',
+                    kafkaConfig: this._kafkaConfig,
+                });
+                return done(err);
+            }
+            return super.setup(done);
+        });
+    }
+
+    /**
+     * Get kakfa log info
+     * @return {object} logName
+     */
+    getLogInfo() {
+        return { logName: this._kafkaConfig.logName };
+    }
+
+    /**
+     * Get metric label
+     * @returns {object} metric labels
+     */
+    getMetricLabels() {
+        return {
+            logName: 'kafka-log',
+            logId: this._kafkaConfig.logName,
+        };
+    }
+}
+
+module.exports = KafkaLogReader;

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -10,6 +10,7 @@ const MetricsConsumer = require('../MetricsConsumer');
 const FailedCRRConsumer =
     require('../../extensions/replication/failedCRR/FailedCRRConsumer');
 const MongoLogReader = require('./MongoLogReader');
+const KafkaLogReader = require('./KafkaLogReader');
 const { metricsExtension } = require('../../extensions/replication/constants');
 const NotificationConfigManager
     = require('../../extensions/notification/NotificationConfigManager');
@@ -264,6 +265,20 @@ class QueuePopulator {
                         kafkaConfig: this.kafkaConfig,
                         zkConfig: this.zkConfig,
                         mongoConfig: this.qpConfig.mongo,
+                        logger: this.log,
+                        extensions: this._extensions,
+                        metricsProducer: this._mProducer,
+                        metricsHandler,
+                    }),
+                ];
+                break;
+            case 'kafka':
+                this.logReadersUpdate = [
+                    new KafkaLogReader({
+                        zkClient: this.zkClient,
+                        kafkaConfig: this.kafkaConfig,
+                        zkConfig: this.zkConfig,
+                        qpKafkaConfig: this.qpConfig.kafka,
                         logger: this.log,
                         extensions: this._extensions,
                         metricsProducer: this._mProducer,

--- a/tests/unit/lib/queuePopulator/kafkaLogConsumer/ListRecordStream.js
+++ b/tests/unit/lib/queuePopulator/kafkaLogConsumer/ListRecordStream.js
@@ -1,0 +1,126 @@
+const assert = require('assert');
+const werelogs = require('werelogs');
+const logger = new werelogs.Logger('ListRecordStream');
+const ListRecordStream =
+    require('../../../../../lib/queuePopulator/KafkaLogConsumer/ListRecordStream');
+
+const changeStreamDocument = {
+    ns: {
+        db: 'metadata',
+        coll: 'example-bucket',
+    },
+    documentKey: {
+        _id: 'example-key',
+    },
+    operationType: 'insert',
+    fullDocument: {
+        value: {
+            field: 'value'
+        }
+    }
+};
+const kafkaMessage = {
+    // kafka-connect double stringifies the message
+    value: Buffer.from(JSON.stringify(JSON.stringify(changeStreamDocument))),
+    timestamp: Date.now(),
+    size: 2,
+    topic: 'oplog-topic',
+    offset: 1337,
+    partition: 0,
+    key: Buffer.from('key'),
+};
+
+const InvalidKafkaMessage = {
+    value: Buffer.from(''),
+    timestamp: Date.now(),
+    size: 2,
+    topic: 'oplog-topic',
+    offset: 1337,
+    partition: 0,
+    key: Buffer.from('key'),
+};
+
+describe('ListRecordStream', () => {
+    let listRecordStream;
+    beforeEach(() => {
+        listRecordStream = new ListRecordStream(logger);
+    });
+
+    describe('_getType', () => {
+        [
+            {
+                opType: 'insert',
+                expected: 'put'
+            },
+            {
+                opType: 'update',
+                expected: 'put'
+            },
+            {
+                opType: 'replace',
+                expected: 'put'
+            },
+            {
+                opType: 'delete',
+                expected: 'delete'
+            },
+            {
+                opType: 'unsupported',
+                expected: undefined
+            }].forEach(params => {
+                const { opType, expected } = params;
+                it(`Should return correct operation type (${opType})`, done => {
+                    const type = listRecordStream._getType(opType);
+                    assert.strictEqual(type, expected);
+                    return done();
+                });
+            });
+    });
+
+    describe('_transform', () => {
+        it('Should correct format entry', done => {
+            listRecordStream.write(kafkaMessage);
+            listRecordStream.once('data', data => {
+                assert.deepEqual(data, {
+                    timestamp: new Date(kafkaMessage.timestamp),
+                    db: 'example-bucket',
+                    entries: [{
+                        key: 'example-key',
+                        type: 'put',
+                        value: {
+                            field: 'value'
+                        },
+                    }],
+                });
+                return done();
+            });
+        });
+        it('Should not fail if format is invalid', done => {
+            listRecordStream.write(InvalidKafkaMessage);
+            listRecordStream.once('data', data => {
+                assert.deepEqual(data, {
+                    timestamp: new Date(InvalidKafkaMessage.timestamp),
+                    db: undefined,
+                    entries: [{
+                        key: undefined,
+                        type: undefined,
+                        value: undefined,
+                    }],
+                });
+                return done();
+            });
+        });
+    });
+
+    describe('_parseKafkaMessageValue', () => {
+        it('Should parse doubly stringified object', () => {
+            const objStr = JSON.stringify(JSON.stringify(changeStreamDocument));
+            const parsed = listRecordStream._parseKafkaMessageValue(objStr);
+            assert.deepEqual(parsed, changeStreamDocument);
+        });
+        it('Should return empty object when format is invalid', () => {
+            const parsed = listRecordStream._parseKafkaMessageValue('');
+            assert.deepEqual(parsed, {});
+        });
+    });
+});

--- a/tests/unit/lib/queuePopulator/kafkaLogConsumer/LogConsumer.js
+++ b/tests/unit/lib/queuePopulator/kafkaLogConsumer/LogConsumer.js
@@ -1,0 +1,199 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const werelogs = require('werelogs');
+const { errors } = require('arsenal');
+const logger = new werelogs.Logger('KafkaLogConsumer');
+const ListRecordStream =
+    require('../../../../../lib/queuePopulator/KafkaLogConsumer/ListRecordStream');
+const LogConsumer =
+    require('../../../../../lib/queuePopulator/KafkaLogConsumer/LogConsumer');
+
+const kafkaConfig = {
+    hosts: 'localhost:9092',
+    topic: 'backbeat-oplog-topic',
+    groupId: 'backbeat-oplog-group',
+};
+
+const changeStreamDocument = {
+    ns: {
+        db: 'metadata',
+        coll: 'example-bucket',
+    },
+    documentKey: {
+        _id: 'example-key',
+    },
+    operationType: 'insert',
+    fullDocument: {
+        value: {
+            field: 'value'
+        }
+    }
+};
+const kafkaMessage = {
+    // kafka-connect double stringifies the message
+    value: Buffer.from(JSON.stringify(JSON.stringify(changeStreamDocument))),
+    timestamp: Date.now(),
+    size: 2,
+    topic: 'oplog-topic',
+    offset: 1337,
+    partition: 0,
+    key: Buffer.from('key'),
+};
+
+describe('LogConsumer', () => {
+    let logConsumer;
+    beforeEach(() => {
+        logConsumer = new LogConsumer(kafkaConfig, logger);
+    });
+
+    describe('_waitForAssignment', () => {
+        it('Should wait for consumer group to balance', done => {
+            const waitAssignementSpy = sinon.spy(logConsumer, '_waitForAssignment');
+            const getAssignemntsStub = sinon.stub();
+            getAssignemntsStub.onCall(0).returns([]);
+            getAssignemntsStub.onCall(1).returns([{
+                topic: 'backbeat-oplog-topic',
+                partition: 0,
+            }]);
+            logConsumer._consumer = {
+                assignments: getAssignemntsStub,
+            };
+            logConsumer._waitForAssignment(0, () => {
+                assert.strictEqual(waitAssignementSpy.getCall(1).args.at(0), 2000);
+                return done();
+            });
+        }).timeout(5000);
+
+        it('Should timeout', done => {
+            const getAssignemntsStub = sinon.stub();
+            getAssignemntsStub.returns([]);
+            logConsumer._consumer = {
+                assignments: getAssignemntsStub,
+            };
+            logConsumer._waitForAssignment(120001, err => {
+                assert.strict(err, true);
+                return done();
+            });
+        }).timeout(5000);
+    });
+
+    describe('_storeCurrentOffsets', () => {
+        it('Should store offsets', done => {
+            const committedStub = sinon.stub();
+            committedStub.callsArgWith(1, null, [{
+                topic: 'backbeat-oplog-topic',
+                partition: 0,
+                offset: 0
+            }]);
+            logConsumer._consumer = {
+                committed: committedStub,
+            };
+            logConsumer._storeCurrentOffsets(err => {
+                assert.ifError(err);
+                assert.deepEqual(logConsumer._offsets, [{
+                    topic: 'backbeat-oplog-topic',
+                    partition: 0,
+                    offset: 0
+                }]);
+                return done();
+            });
+        });
+    });
+
+    describe('_resetRecordStream', () => {
+        it('Should initialize record stream', () => {
+            logConsumer._resetRecordStream();
+            assert(logConsumer._listRecordStream instanceof ListRecordStream);
+            assert.strictEqual(typeof(logConsumer._listRecordStream.getOffset), 'function');
+        });
+    });
+
+    describe('_consumeKafkaMessages', () => {
+        it('Should consume kafka messages', done => {
+            const consumeStub = sinon.stub();
+            consumeStub.callsArgWith(1, null, [kafkaMessage]);
+            logConsumer._consumer = {
+                consume: consumeStub,
+            };
+            logConsumer._consumeKafkaMessages(1, err => {
+                assert.ifError(err);
+                assert.strictEqual(consumeStub.getCall(0).args.at(0), 1);
+                logConsumer._listRecordStream.once('data', msg => {
+                    assert.deepEqual(msg, {
+                        timestamp: new Date(kafkaMessage.timestamp),
+                        db: 'example-bucket',
+                        entries: [{
+                            key: 'example-key',
+                            type: 'put',
+                            value: {
+                                field: 'value'
+                            },
+                        }],
+                    });
+                    return done();
+                });
+            });
+        });
+    });
+
+    describe('readRecords', () => {
+        it('Should return stream', done => {
+            const waitAssignementStub = sinon.stub(logConsumer, '_waitForAssignment')
+                .callsArg(1);
+            const storeOffsetsStub = sinon.stub(logConsumer, '_storeCurrentOffsets')
+                .callsArg(0);
+            const consumeKafkaStub = sinon.stub(logConsumer, '_consumeKafkaMessages')
+                .callsArg(1);
+            logConsumer._resetRecordStream();
+            logConsumer.readRecords({ limit: 1 }, (err, res) => {
+                assert(waitAssignementStub.called);
+                assert(storeOffsetsStub.called);
+                assert(consumeKafkaStub.called);
+                assert.ifError(err);
+                assert(res.log instanceof ListRecordStream);
+                assert.strictEqual(res.tailable, false);
+                assert.strictEqual(typeof(res.log.getOffset), 'function');
+                return done();
+            });
+        });
+
+        it('Should fail if consumer group failed to stabilize', done => {
+            const waitAssignementStub = sinon.stub(logConsumer, '_waitForAssignment')
+                .callsArgWith(1, errors.InternalError);
+            logConsumer.readRecords({ limit: 1 }, err => {
+                assert(waitAssignementStub.called);
+                assert.deepEqual(err, errors.InternalError);
+                return done();
+            });
+        });
+
+        it('Should fail if it can\'t store offsets', done => {
+            const waitAssignementStub = sinon.stub(logConsumer, '_waitForAssignment')
+                .callsArg(1);
+            const storeOffsetsStub = sinon.stub(logConsumer, '_storeCurrentOffsets')
+                .callsArgWith(0, errors.InternalError);
+            logConsumer.readRecords({ limit: 1 }, err => {
+                assert(waitAssignementStub.called);
+                assert(storeOffsetsStub.called);
+                assert.deepEqual(err, errors.InternalError);
+                return done();
+            });
+        });
+
+        it('Should fail if it can\'t consume kafka messages', done => {
+            const waitAssignementStub = sinon.stub(logConsumer, '_waitForAssignment')
+                .callsArg(1);
+            const storeOffsetsStub = sinon.stub(logConsumer, '_storeCurrentOffsets')
+                .callsArg(0);
+            const consumeKafkaStub = sinon.stub(logConsumer, '_consumeKafkaMessages')
+                .callsArgWith(1, errors.InternalError);
+            logConsumer.readRecords({ limit: 1 }, err => {
+                assert(waitAssignementStub.called);
+                assert(storeOffsetsStub.called);
+                assert(consumeKafkaStub.called);
+                assert.deepEqual(err, errors.InternalError);
+                return done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Issue: [BB-190](https://scality.atlassian.net/browse/BB-190)

The Kafka LogReader consumes messages from the kafka topic used by the kafka-connect mongo connector to mongo publish change stream events.

The Kafka LogReader uses consumer groups and the partition offsets are managed by kafka.