### PR TITLE
Feature: BB-146 support different internal topics for notification targets

### DIFF
--- a/conf/config.joi.js
+++ b/conf/config.joi.js
@@ -56,7 +56,6 @@ const joiSchema = {
     },
     certFilePaths: certFilePathsJoi,
     internalCertFilePaths: certFilePathsJoi,
-    bucketNotificationDestinations: joi.array().items(joi.object()).default([]),
 };
 
 module.exports = joiSchema;

--- a/extensions/notification/NotificationConfigValidator.js
+++ b/extensions/notification/NotificationConfigValidator.js
@@ -1,5 +1,15 @@
 const joi = require('joi');
 
+const destinationSchema = joi.object({
+    resource: joi.string().required(),
+    type: joi.string().required(),
+    host: joi.string().required(),
+    port: joi.number().required(),
+    internalTopic: joi.string(),
+    topic: joi.string().required(),
+    auth: joi.object().default({}),
+});
+
 const joiSchema = joi.object({
     topic: joi.string(),
     monitorNotificationFailures: joi.boolean().default(true),
@@ -8,6 +18,7 @@ const joiSchema = joi.object({
         groupId: joi.string().required(),
         concurrency: joi.number().greater(0).default(10),
     },
+    destinations: joi.array().items(destinationSchema).default([]),
 });
 
 function configValidator(backbeatConfig, extConfig) {

--- a/extensions/notification/queueProcessor/task.js
+++ b/extensions/notification/queueProcessor/task.js
@@ -7,7 +7,6 @@ const config = require('../../../lib/Config');
 const kafkaConfig = config.kafka;
 const notifConfig = config.extensions.notification;
 const mongoConfig = config.queuePopulator.mongo;
-const notificationDestinations = config.bucketNotificationDestinations;
 
 const log = new werelogs.Logger('Backbeat:NotificationProcessor:task');
 werelogs.configure({
@@ -18,12 +17,8 @@ werelogs.configure({
 try {
     const destination = process.argv[2];
     assert(destination, 'task must be started with a destination as argument');
-    const destinationConfig
-        = notificationDestinations.find(dest => dest.resource === destination);
-    assert(destinationConfig, 'Invalid destination argument. Destination ' +
-        'could not be found in destinations defined');
     const queueProcessor = new QueueProcessor(
-        mongoConfig, kafkaConfig, notifConfig, destinationConfig, destination);
+        mongoConfig, kafkaConfig, notifConfig, destination);
     queueProcessor.start();
 } catch (err) {
     log.error('error starting notification queue processor task', {

--- a/extensions/replication/tasks/MultipleBackendTask.js
+++ b/extensions/replication/tasks/MultipleBackendTask.js
@@ -1192,7 +1192,7 @@ class MultipleBackendTask extends ReplicateObject {
                 kafkaEntry,
             });
         if (this.notificationConfig) {
-            this._publishFailedReplicationStatusNotification(sourceEntry, log);
+            return this._publishFailedReplicationStatusNotification(sourceEntry, log, done);
         }
         return done(null, { committable: false });
     }

--- a/tests/config.notification.json
+++ b/tests/config.notification.json
@@ -25,7 +25,27 @@
             "queueProcessor": {
                 "groupId": "backbeat-bucket-notification-group",
                 "concurrency": 10
-            }
+            },
+            "destinations": [
+                {
+                    "resource": "destination1",
+                    "type": "kafka",
+                    "host": "localhost:9092",
+                    "port": 9092,
+                    "topic": "destination-topic-1",
+                    "internalTopic": "internal-notification-topic-destination1",
+                    "auth": {}
+                },
+                {
+                    "resource": "destination2",
+                    "type": "kafka",
+                    "host": "localhost:9092",
+                    "port": 9092,
+                    "topic": "destination-topic-2",
+                    "internalTopic": "internal-notification-topic-destination2",
+                    "auth": {}
+                }
+            ]
         }
     },
     "log": {
@@ -74,16 +94,6 @@
             }
         ],
         "sentinelPassword": ""
-    },
-    "bucketNotificationDestinations": [
-        {
-            "resource": "destination1",
-            "type": "kafka",
-            "host": "localhost:9092",
-            "port": 9092,
-            "topic": "destination-topic",
-            "auth": {}
-        }
-    ]
+    }
 }
 

--- a/tests/unit/replication/MultipleBackendTask.js
+++ b/tests/unit/replication/MultipleBackendTask.js
@@ -55,6 +55,9 @@ describe('MultipleBackendTask', function test() {
                 sourceConfig: config.extensions.replication.source,
                 destConfig: config.extensions.replication.destination,
                 site: 'test-site-2',
+                notificationConfigManager: {
+                    getConfig: () => null
+                }
             }),
         });
     });


### PR DESCRIPTION
Issue: [BB-146](https://scality.atlassian.net/browse/BB-146)

**Changes**:

NotificationQueuePopulator:
- Now pushes notification messages onto specific internal Kafka topics of destinations for which the object validates their notification config.

NotificationQueueProcessor:
- Now consumes messages form internal Kafka topic specific to their destination
- Made processKafkaEntry use callbacks to fix an async bug where we get the following error `done is not a function`

Config
- Added fields in the notification config to specify the internal topic to use for each destination

ReplicationProcessor:
- Now supports pushing replication failed messages to specific internal topic of destinations