### PR TITLE
bugfix: BB-187 BN: add object key to keyed partitioning

### DIFF
--- a/extensions/notification/NotificationQueuePopulator.js
+++ b/extensions/notification/NotificationQueuePopulator.js
@@ -165,7 +165,7 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
                     eventTime: message.dateTime,
                 });
                 this.publish(this.notificationConfig.topic,
-                    bucket,
+                    `${bucket}/${key}`,
                     JSON.stringify(message));
             }
             return undefined;


### PR DESCRIPTION
When pushing to the internal backbeat-bucket-notification topic, use
"bucket/key" string instead of just "bucket" for keyed
partitioning. This allows multiple objects belonging to the same
bucket to go to different notification partitions. It retains the
order of operations on a single object, or multiple versions of that
object, by pushing those operations to the same partition.

This complements the previous commit that fixed keyed partitioning for
the Kafka destination.