### PR TITLE
Feature: BB-194 move extension specific code out from oplog populator

### DIFF
--- a/extensions/lifecycle/LifecycleOplogPopulatorUtils.js
+++ b/extensions/lifecycle/LifecycleOplogPopulatorUtils.js
@@ -1,0 +1,42 @@
+const OplogPopulatorUtils = require('../../lib/util/OplogPopulatorUtils');
+
+class LifecycleOplogPopulatorUtils extends OplogPopulatorUtils {
+    /**
+     * Get extension specific MongoDB filter
+     * to get buckets with that have the lifecycle
+     * extension enabled
+     * @returns {Object} MongoDB filter
+     */
+     static getExtensionMongoDBFilter() {
+        // getting buckets with at least one lifecycle
+        // rule enabled
+        return {
+            'value.lifecycleConfiguration.rules': {
+                $elemMatch: {
+                    ruleStatus: 'Enabled',
+                },
+            }
+        };
+    }
+
+    /**
+     * Check if bucket has the lifecycle extension
+     * active
+     * @param {Object} bucketMD bucket metadata
+     * @returns {boolean} true if the bucket has the
+     * current extension enabled
+     */
+    static isBucketExtensionEnabled(bucketMD) {
+        const rules = bucketMD.lifecycleConfiguration
+            && bucketMD.lifecycleConfiguration.rules;
+        if (!rules || rules.length === 0) {
+            return false;
+        } else {
+            // return true if at least one lifecycle
+            // rule is enabled
+            return rules.some(rule =>
+                rule.ruleStatus === 'Enabled');
+        }
+    }
+}
+module.exports = LifecycleOplogPopulatorUtils;

--- a/extensions/lifecycle/index.js
+++ b/extensions/lifecycle/index.js
@@ -1,4 +1,5 @@
 const LifecycleConfigValidator = require('./LifecycleConfigValidator');
+const LifecycleOplogPopulatorUtils = require('./LifecycleOplogPopulatorUtils');
 
 module.exports = {
     name: 'lifecycle',
@@ -6,4 +7,5 @@ module.exports = {
     configValidator: LifecycleConfigValidator,
     // we need a dynamic require to avoid a circular dependency
     queuePopulatorExtension: () => require('./LifecycleQueuePopulator'),
+    oplogPopulatorUtils: LifecycleOplogPopulatorUtils,
 };

--- a/extensions/notification/NotificationOplogPopulatorUtils.js
+++ b/extensions/notification/NotificationOplogPopulatorUtils.js
@@ -1,0 +1,29 @@
+const OplogPopulatorUtils = require('../../lib/util/OplogPopulatorUtils');
+
+class NotificationOplogPopulatorUtils extends OplogPopulatorUtils {
+    /**
+     * Get extension specific MongoDB filter
+     * to get buckets with that have the notification
+     * extension enabled
+     * @returns {Object} MongoDB filter
+     */
+     static getExtensionMongoDBFilter() {
+        return {
+            'value.notificationConfiguration': {
+                $type: 3
+            }
+        };
+    }
+
+    /**
+     * Check if bucket has the notification extension
+     * active
+     * @param {Object} bucketMD bucket metadata
+     * @returns {boolean} true if the bucket has the
+     * current extension enabled
+     */
+    static isBucketExtensionEnabled(bucketMD) {
+        return Boolean(bucketMD.notificationConfiguration !== null);
+    }
+}
+module.exports = NotificationOplogPopulatorUtils;

--- a/extensions/notification/index.js
+++ b/extensions/notification/index.js
@@ -1,9 +1,11 @@
 const NotificationConfigValidator = require('./NotificationConfigValidator');
 const NotificationQueuePopulator = require('./NotificationQueuePopulator');
+const NotificationOplogPopulatorUtils = require('./NotificationOplogPopulatorUtils');
 
 module.exports = {
     name: 'notification',
     version: '1.0.0',
     configValidator: NotificationConfigValidator,
     queuePopulatorExtension: NotificationQueuePopulator,
+    oplogPopulatorUtils: NotificationOplogPopulatorUtils,
 };

--- a/extensions/oplogPopulator/constants.js
+++ b/extensions/oplogPopulator/constants.js
@@ -7,12 +7,6 @@ const constants = {
         'pipeline': '[]',
         'collection': '',
     },
-    extensionConfigField: {
-        notification: 'notificationConfiguration',
-        replication: 'replicationConfiguration',
-        lifecycle: 'lifecycleConfiguration',
-        ingestion: 'ingestion',
-    },
 };
 
 module.exports = constants;

--- a/extensions/replication/ReplicationOplogPopulatorUtils.js
+++ b/extensions/replication/ReplicationOplogPopulatorUtils.js
@@ -1,0 +1,42 @@
+const OplogPopulatorUtils = require('../../lib/util/OplogPopulatorUtils');
+
+class ReplicationOplogPopulatorUtils extends OplogPopulatorUtils {
+    /**
+     * Get extension specific MongoDB filter
+     * to get buckets with that have the replication
+     * extension enabled
+     * @returns {Object} MongoDB filter
+     */
+     static getExtensionMongoDBFilter() {
+        // getting buckets with at least one replication
+        // rule enabled
+        return {
+            'value.replicationConfiguration.rules': {
+                $elemMatch: {
+                    enabled: true,
+                },
+            }
+        };
+    }
+
+    /**
+     * Check if bucket has the replication extension
+     * active
+     * @param {Object} bucketMD bucket metadata
+     * @returns {boolean} true if the bucket has the
+     * current extension enabled
+     */
+    static isBucketExtensionEnabled(bucketMD) {
+        const rules = bucketMD.replicationConfiguration
+            && bucketMD.replicationConfiguration.rules;
+        if (!rules || rules.length === 0) {
+            return false;
+        } else {
+            // return true if at least one replication
+            // rule is enabled
+            return rules.some(rule =>
+                rule.enabled === true);
+        }
+    }
+}
+module.exports = ReplicationOplogPopulatorUtils;

--- a/extensions/replication/index.js
+++ b/extensions/replication/index.js
@@ -1,8 +1,10 @@
 const ReplicationConfigValidator = require('./ReplicationConfigValidator');
+const ReplicationOplogPopulatorUtils = require('./ReplicationOplogPopulatorUtils');
 
 module.exports = {
     name: 'replication',
     version: '1.0.0',
     configValidator: ReplicationConfigValidator,
     queuePopulatorExtension: () => require('./ReplicationQueuePopulator'),
+    oplogPopulatorUtils: ReplicationOplogPopulatorUtils,
 };

--- a/lib/util/OplogPopulatorUtils.js
+++ b/lib/util/OplogPopulatorUtils.js
@@ -1,0 +1,26 @@
+const { errors } = require('arsenal');
+
+class OplogPopulatorUtils {
+    /**
+     * Get extension specific MongoDB filter
+     * to get buckets with that have the current
+     * extension enabled
+     * @returns {Object} MongoDB filter
+     */
+    static getExtensionMongoDBFilter() {
+        throw errors.NotImplemented;
+    }
+
+    /**
+     * Check if bucket has the current extension
+     * active
+     * @param {Object} bucketMD bucket metadata
+     * @returns {boolean} true if the bucket has the
+     * current extension enabled
+     */
+    static isBucketExtensionEnabled(bucketMD) { // eslint-disable-line no-unused-vars
+        throw errors.NotImplemented;
+    }
+}
+
+module.exports = OplogPopulatorUtils;


### PR DESCRIPTION
Moving extension specific code from the OplogPopulator to the extensions
The code moved is used for :
- Checking a bucket's metadata to see if it uses a backbeat extension
- Getting MongoDB filters that get buckets that use the extensions