### PR TITLE
Save logOffset for all backends

### DIFF
--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -603,15 +603,19 @@ class LogReader {
 
     _processSaveLogOffset(batchState, done) {
         const { logRes, nextLogOffset, logger } = batchState;
-        if (logRes.info && nextLogOffset !== undefined &&
+        if (nextLogOffset !== undefined &&
             nextLogOffset !== this.logOffset &&
             (!logRes.log.reachedUnpublishedListing ||
-            logRes.log.reachedUnpublishedListing())) {
+             logRes.log.reachedUnpublishedListing())) {
 
-            const logSize = logRes.info.cseq || logRes.info.end;
             this.logOffset = nextLogOffset;
-            this._metricsHandler.logReadOffset(this.getMetricLabels(), this.logOffset);
-            this._metricsHandler.logSize(this.getMetricLabels(), logSize);
+
+            // Skip metrics if we are not using Raft backend
+            if (logRes.info) {
+                const logSize = logRes.info.cseq || logRes.info.end;
+                this._metricsHandler.logReadOffset(this.getMetricLabels(), this.logOffset);
+                this._metricsHandler.logSize(this.getMetricLabels(), logSize);
+            }
 
             return this._writeLogOffset(logger, done);
         }


### PR DESCRIPTION
We still skip metrics when using mongo log reader.

Issue: BB-201
