### PR TITLE
BB-138 - deduplicate producer code

### DIFF
--- a/extensions/notification/destination/KafkaProducer.js
+++ b/extensions/notification/destination/KafkaProducer.js
@@ -1,185 +1,39 @@
-const { EventEmitter } = require('events');
-const { Producer } = require('node-rdkafka');
 const joi = require('joi');
 
-const errors = require('arsenal').errors;
-const jsutil = require('arsenal').jsutil;
-const Logger = require('werelogs').Logger;
-
+const BackbeatProducer = require('../../../lib/BackbeatProducer');
 const authUtil = require('../utils/auth');
-const Constants = require('../../../lib/constants');
 
-// waits for an ack for messages
-const REQUIRE_ACKS = 1;
-// time in ms. to wait for acks from Kafka
-const ACK_TIMEOUT = 5000;
-// max time in ms. to wait for flush to complete
-const FLUSH_TIMEOUT = 5000;
+class KafkaProducer extends BackbeatProducer {
 
-const PRODUCER_MESSAGE_MAX_BYTES = 5000020;
+    getConfigJoi() {
+        return super.getConfigJoi().append(
+            { auth: joi.object().optional() }
+        ).keys(
+            { topic: joi.string() }
+        );
+    }
 
-const CLIENT_ID = 'KafkaNotificationProducer';
+    getClientId() {
+        return 'NotificationProducer';
+    }
 
-class KafkaProducer extends EventEmitter {
+    getRequireAcks() {
+        return 1;
+    }
 
-    /**
-    * constructor
-    * @param {Object} config - config
-    * @param {string} config.topic - Kafka topic to write to
-    * @param {string} config.auth - kafka auth configuration
-    * @param {Object} config.kafka - kafka connection config
-    * @param {string} config.kafka.hosts - kafka hosts list
-    */
-    constructor(config) {
-        super();
+    setFromConfig(joiResult) {
+        super.setFromConfig(joiResult);
+        this._auth = joiResult.auth ? authUtil.generateKafkaAuthObject(joiResult.auth) : {};
+    }
 
-        const configJoi = joi.object({
-            kafka: joi.object({
-                hosts: joi.string().required(),
-            }).required(),
-            topic: joi.string().required(),
-            pollIntervalMs: joi.number().default(2000),
-            messageMaxBytes: joi.number().default(PRODUCER_MESSAGE_MAX_BYTES),
-            auth: joi.object().optional(),
-        });
-        const validConfig = joi.attempt(config, configJoi,
-            'invalid config params');
-        const {
-            kafka,
-            topic,
-            pollIntervalMs,
-            messageMaxBytes,
-            auth,
-        } = validConfig;
-        this._kafkaHosts = kafka.hosts;
-        this._log = new Logger(CLIENT_ID);
-        this._topic = topic;
-        this._ready = false;
-        const authObject = auth ? authUtil.generateKafkaAuthObject(auth) : {};
-        const producerOptions = {
-            'metadata.broker.list': this._kafkaHosts,
-            'message.max.bytes': messageMaxBytes,
-            'dr_cb': true,
-            'compression.type': Constants.compressionType,
+    get producerConfig() {
+        const base = super.producerConfig;
+        return {
+            ...base,
+            ...this._auth
         };
-        Object.assign(producerOptions, authObject);
-        // create a new producer instance
-        this._producer = new Producer(producerOptions, {
-            'request.required.acks': REQUIRE_ACKS,
-            'request.timeout.ms': ACK_TIMEOUT,
-        });
-        this._ready = false;
-        this._producer.connect({}, error => {
-            if (error) {
-                this._log.info('error connecting to broker', {
-                    error,
-                    method: 'KafkaProducer.constructor',
-                });
-            }
-        });
-        this._producer.on('ready', () => {
-            this._ready = true;
-            this.emit('ready');
-            this._producer.setPollInterval(pollIntervalMs);
-            this._producer.on('delivery-report',
-                this._onDeliveryReport.bind(this));
-        });
-        this._producer.on('event.error', error => {
-            this._log.error('error with producer', {
-                error: error.message,
-                method: 'KakfaProducer.constructor',
-            });
-            this.emit('error', error);
-        });
-        return this;
     }
 
-    _onDeliveryReport(error, report) {
-        const sendCtx = report.opaque;
-        const cbOnce = sendCtx.cbOnce;
-        --sendCtx.pendingReportsCount;
-        if (error) {
-            this._log.error('error in delivery report retrieval', {
-                error: error.message,
-                method: 'KakfaProducer._onDeliveryReport',
-            });
-            this.emit('error', error);
-            return cbOnce(error);
-        }
-        this._log.debug('delivery report received', { report });
-        if (sendCtx.pendingReportsCount === 0) {
-            cbOnce();
-        }
-        return undefined;
-    }
-
-    /**
-    * sends entries/messages to the given topic
-    * @param {Object[]} entries - array of entries objects with properties
-    * key and message ([{ key: 'foo', message: 'hello world'}, ...])
-    * @param {callback} cb - cb(err)
-    * @return {this} current instance
-    */
-    send(entries, cb) {
-        this._log.debug('publishing entries',
-            { method: 'KakfaProducer.send' });
-        if (!this._ready) {
-            return process.nextTick(() => {
-                this._log.error('producer is not ready yet', {
-                    method: 'KakfaProducer.send',
-                    ready: this._ready,
-                });
-                cb(errors.InternalError);
-            });
-        }
-        if (entries.length === 0) {
-            return process.nextTick(cb);
-        }
-        const sendCtx = {
-            cbOnce: jsutil.once(cb),
-            pendingReportsCount: entries.length,
-        };
-        try {
-            // TODO: try to avoid stringify operation
-            entries.forEach(item => this._producer.produce(
-                this._topic,
-                null, // partition
-                Buffer.from(JSON.stringify(item.message)), // value
-                item.key, // key (for keyed partitioning)
-                Date.now(), // timestamp
-                sendCtx // opaque
-            ));
-        } catch (err) {
-            this._log.error('error publishing entries', {
-                error: err,
-                method: 'KakfaProducer.send',
-            });
-            return process.nextTick(
-                () => sendCtx.cbOnce(errors.InternalError.
-                    customizeDescription(err.message)));
-        }
-        return this;
-    }
-
-    /**
-    * close client connection
-    * @param {callback} cb - cb()
-    * @return {object} this - current class instance
-    */
-    close(cb) {
-        this._producer.flush(FLUSH_TIMEOUT, err => {
-            this._ready = false;
-            if (err) {
-                this._log.error('error flushing entries', {
-                    error: err,
-                    method: 'KakfaProducer.close',
-                });
-            }
-            this._producer.disconnect();
-            return cb(err);
-        });
-        return this;
-    }
 }
 
 module.exports = KafkaProducer;

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -9,107 +9,73 @@ const { withTopicPrefix } = require('./util/topic');
 const KafkaBacklogMetrics = require('./KafkaBacklogMetrics');
 const Constants = require('./constants');
 
-// waits for an ack for messages
-const REQUIRE_ACKS = 'all';
-// time in ms. to wait for acks from Kafka
-const ACK_TIMEOUT = 5000;
-// max time in ms. to wait for flush to complete
+const DEFAULT_POLL_INTERVAL = 2000;
+const PRODUCER_MESSAGE_MAX_BYTES = 5000020;
 const FLUSH_TIMEOUT = 5000;
 
-/**
-* Backbeat replication topic is currently setup with a config
-* max.message.bytes of 5MB. Producers need to update their
-* messageMaxBytes to get at least 5MB put in the Kafka topic, adding a
-* little extra bytes of padding for approximation.
-*/
-const PRODUCER_MESSAGE_MAX_BYTES = 5000020;
-
-const CLIENT_ID = 'BackbeatProducer';
 
 class BackbeatProducer extends EventEmitter {
 
-    /**
-    * constructor
-    * @param {Object} config - config
-    * @param {string} [config.topic] - Kafka topic to write to when
-    * using BackbeatProducer.send() calls
-    * @param {boolean} [config.keyedPartitioner=true] - if no
-    * partition is set, tell whether the producer should use keyed
-    * partitioning or the default partitioning of the kafka client
-    * @param {Object} config.kafka - kafka connection config
-    * @param {string} config.kafka.hosts - kafka hosts list
-    * as "host:port[,host:port...]"
-    */
     constructor(config) {
         super();
 
-        const configJoi = joi.object({
-            kafka: joi.object({
-                hosts: joi.string().required(),
-            }).required(),
-            topic: joi.string(),
-            keyedPartitioner: joi.boolean().default(true),
-            pollIntervalMs: joi.number().default(2000),
-            messageMaxBytes: joi.number().default(PRODUCER_MESSAGE_MAX_BYTES),
-        });
-        const validConfig = joi.attempt(config, configJoi,
-                                        'invalid config params');
-        const { kafka, topic, pollIntervalMs, messageMaxBytes } = validConfig;
+        const validConfig = joi.attempt(
+            config,
+            this.getConfigJoi(),
+            'invalid config params'
+        );
+        this._config = validConfig;
+        this.setFromConfig(validConfig);
 
-        this._kafkaHosts = kafka.hosts;
-        this._log = new Logger(CLIENT_ID);
-        this._topic = topic && withTopicPrefix(topic);
         this._ready = false;
+        this._log = new Logger(this.getClientId());
 
-        // create a new producer instance
-        this._producer = new Producer({
+        this._producer = new Producer(this.producerConfig, this.topicConfig);
+
+        this.connect();
+        this.setListeners();
+        return this;
+    }
+
+    getConfigJoi() {
+        return joi.object(
+            {
+                kafka: joi.object({
+                    hosts: joi.string().required(),
+                }).required(),
+                topic: joi.string(),
+                pollIntervalMs: joi.number().default(DEFAULT_POLL_INTERVAL),
+                messageMaxBytes: joi.number().default(PRODUCER_MESSAGE_MAX_BYTES),
+            }
+        );
+    }
+
+    getClientId() {
+        return 'BackbeatProducer';
+    }
+
+    getRequireAcks() {
+        return 'all';
+    }
+
+    getAckTimeout() {
+        return 5000;
+    }
+
+    get producerConfig() {
+        return {
             'metadata.broker.list': this._kafkaHosts,
-            'message.max.bytes': messageMaxBytes,
+            'message.max.bytes': this._messageMaxBytes,
             'dr_cb': true,
             'compression.type': Constants.compressionType,
-        }, {
-            'request.required.acks': REQUIRE_ACKS,
-            'request.timeout.ms': ACK_TIMEOUT,
-        });
-        this._ready = false;
-        this._producer.connect({ timeout: 30000 }, () => {
-            const opts = {
-                topic: withTopicPrefix('backbeat-sanitycheck'),
-                timeout: 10000,
-            };
-            this._producer.getMetadata(opts, err => {
-                if (err) {
-                    this.emit('error', err);
-                }
-            });
-        });
-        this._producer.on('ready', () => {
-            this._ready = true;
-            this.emit('ready');
-            this._producer.setPollInterval(pollIntervalMs);
-            this._producer.on('delivery-report',
-                              this._onDeliveryReport.bind(this));
-        });
-        this._producer.on('event.error', error => {
-            // This is a bit hacky: the "broker transport failure"
-            // error occurs when the kafka broker reaps the idle
-            // connections every few minutes, and librdkafka handles
-            // reconnection automatically anyway, so we ignore those
-            // harmless errors (moreover with the current
-            // implementation there's no way to access the original
-            // error code, so we match the message instead).
-            if (!['broker transport failure',
-                  'all broker connections are down']
-                .includes(error.message)) {
-                this._log.error('error with producer', {
-                    config,
-                    error: error.message,
-                    method: 'BackbeatProducer.constructor',
-                });
-                this.emit('error', error);
-            }
-        });
-        return this;
+        };
+    }
+
+    get topicConfig() {
+        return {
+            'request.required.acks': this.getRequireAcks(),
+            'request.timeout.ms': this.getAckTimeout(),
+        };
     }
 
     getKafkaProducer() {
@@ -124,11 +90,47 @@ class BackbeatProducer extends EventEmitter {
      * @param {function} cb - callback: cb(err, response)
      * @return {undefined}
      */
-    getMetadata(params, cb) {
+     getMetadata(params, cb) {
         this._producer.getMetadata(params, cb);
     }
 
-    _onDeliveryReport(error, report) {
+    isReady() {
+        return this._ready;
+    }
+
+    setFromConfig(joiResult) {
+        const {
+            kafka,
+            topic,
+            pollIntervalMs,
+            messageMaxBytes,
+        } = joiResult;
+        this._kafkaHosts = kafka.hosts;
+        this._topic = topic && withTopicPrefix(topic);
+        this._pollIntervalMs = pollIntervalMs;
+        this._messageMaxBytes = messageMaxBytes;
+    }
+
+    connect() {
+        this._producer.connect({ timeout: 30000 }, () => {
+            const opts = {
+                topic: withTopicPrefix('backbeat-sanitycheck'),
+                timeout: 10000,
+            };
+            this._producer.getMetadata(opts, err => {
+                if (err) {
+                    this.emit('error', err);
+                }
+            });
+        });
+    }
+
+    setListeners() {
+        this._producer.on('ready', this.onReady.bind(this));
+        this._producer.on('event.error', this.onEventError.bind(this));
+    }
+
+    onDeliveryReport(error, report) {
         const sendCtx = report.opaque;
         const cbOnce = sendCtx.cbOnce;
         sendCtx.receivedReports.push(report);
@@ -145,7 +147,7 @@ class BackbeatProducer extends EventEmitter {
         const { topic, partition, offset, timestamp } = report;
         const key = report.key && report.key.toString();
         this._log.debug('delivery report received',
-                        { topic, partition, offset, timestamp, key });
+            { topic, partition, offset, timestamp, key });
         KafkaBacklogMetrics.onMessagePublished(
             topic, partition, timestamp / 1000);
         if (sendCtx.pendingReportsCount === 0) {
@@ -157,12 +159,32 @@ class BackbeatProducer extends EventEmitter {
         return undefined;
     }
 
-    /**
-    * synchronous check for producer's status
-    * @return {bool} - check result
-    */
-    isReady() {
-        return this._ready;
+    onReady() {
+        this._ready = true;
+        this.emit('ready');
+        this._producer.setPollInterval(this._pollIntervalMs);
+        this._producer.on('delivery-report', this.onDeliveryReport.bind(this));
+    }
+
+    onEventError(error) {
+        // This is a bit hacky: the "broker transport failure"
+        // error occurs when the kafka broker reaps the idle
+        // connections every few minutes, and librdkafka handles
+        // reconnection automatically anyway, so we ignore those
+        // harmless errors (moreover with the current
+        // implementation there's no way to access the original
+        // error code, so we match the message instead).
+        const config = this._config;
+        if (!['broker transport failure',
+            'all broker connections are down']
+            .includes(error.message)) {
+            this._log.error('error with producer', {
+                config,
+                error: error.message,
+                method: `${this.getClientId()}.constructor`,
+            });
+            this.emit('error', error);
+        }
     }
 
     /**
@@ -209,14 +231,14 @@ class BackbeatProducer extends EventEmitter {
 
     _sendToTopic(topic, entries, cb) {
         this._log.debug('publishing entries', {
-            method: 'BackbeatProducer._sendToTopic',
+            method: `${this.getClientId()}._sendToTopic`,
             topic,
             entryCount: entries.length,
         });
         if (!this._ready) {
             process.nextTick(() => {
                 this._log.error('producer is not ready yet', {
-                    method: 'BackbeatProducer._sendToTopic',
+                    method: `${this.getClientId()}._sendToTopic`,
                     ready: this._ready,
                 });
                 cb(errors.InternalError);
@@ -227,9 +249,11 @@ class BackbeatProducer extends EventEmitter {
             process.nextTick(cb);
             return this;
         }
-        const sendCtx = { cbOnce: jsutil.once(cb),
-                          pendingReportsCount: entries.length,
-                          receivedReports: [] };
+        const sendCtx = {
+            cbOnce: jsutil.once(cb),
+            pendingReportsCount: entries.length,
+            receivedReports: []
+        };
         try {
             entries.forEach(item => {
                 let partition = null;
@@ -247,13 +271,13 @@ class BackbeatProducer extends EventEmitter {
             });
         } catch (err) {
             this._log.error('error publishing entries', {
-                method: 'BackbeatProducer._sendToTopic',
+                method: `${this.getClientId()}._sendToTopic`,
                 topic,
                 error: err.message,
             });
             process.nextTick(
                 () => sendCtx.cbOnce(errors.InternalError.
-                                     customizeDescription(err.message)));
+                    customizeDescription(err.message)));
         }
         return this;
     }
@@ -269,7 +293,7 @@ class BackbeatProducer extends EventEmitter {
             if (err) {
                 this._log.error('error flushing entries', {
                     error: err,
-                    method: 'BackbeatProducer.close',
+                    method: `${this.getClientId()}.close`,
                 });
             }
             this._producer.disconnect();

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,27 +9,27 @@
   dependencies:
     "@babel/highlight" "^7.18.6"
 
-"@babel/generator@^7.18.7":
-  version "7.18.7"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.18.7.tgz#2aa78da3c05aadfc82dbac16c99552fc802284bd"
-  integrity sha512-shck+7VLlY72a2w9c3zYWuE1pwOKEiQHV7GTUbSnhyl5eu3i04t30tBY82ZRWrDfo3gkakCFtevExnxbkf2a3A==
+"@babel/generator@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.18.9.tgz#68337e9ea8044d6ddc690fb29acae39359cca0a5"
+  integrity sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==
   dependencies:
-    "@babel/types" "^7.18.7"
+    "@babel/types" "^7.18.9"
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
-"@babel/helper-environment-visitor@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.6.tgz#b7eee2b5b9d70602e59d1a6cad7dd24de7ca6cd7"
-  integrity sha512-8n6gSfn2baOY+qlp+VSzsosjCVGFqWKmDF0cCWOybh52Dw3SEyoWR1KrhMJASjLwIEkkAufZ0xvr+SxLHSpy2Q==
+"@babel/helper-environment-visitor@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz#0c0cee9b35d2ca190478756865bb3528422f51be"
+  integrity sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==
 
-"@babel/helper-function-name@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.18.6.tgz#8334fecb0afba66e6d87a7e8c6bb7fed79926b83"
-  integrity sha512-0mWMxV1aC97dhjCah5U5Ua7668r5ZmSC2DLfH2EZnf9c3/dHZKiFa5pRLMH5tjSl471tY6496ZWk/kjNONBxhw==
+"@babel/helper-function-name@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz#940e6084a55dee867d33b4e487da2676365e86b0"
+  integrity sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==
   dependencies:
     "@babel/template" "^7.18.6"
-    "@babel/types" "^7.18.6"
+    "@babel/types" "^7.18.9"
 
 "@babel/helper-hoist-variables@^7.18.6":
   version "7.18.6"
@@ -59,15 +59,15 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.18.6", "@babel/parser@^7.18.8", "@babel/parser@^7.7.0":
-  version "7.18.8"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.8.tgz#822146080ac9c62dac0823bb3489622e0bc1cbdf"
-  integrity sha512-RSKRfYX20dyH+elbJK2uqAkVyucL+xXzhqlMD5/ZXx+dAAwpyB7HsvnHe/ZUGOF+xLr5Wx9/JoXVTj6BQE2/oA==
+"@babel/parser@^7.18.6", "@babel/parser@^7.18.9", "@babel/parser@^7.7.0":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.18.9.tgz#f2dde0c682ccc264a9a8595efd030a5cc8fd2539"
+  integrity sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==
 
 "@babel/runtime@^7.16.0":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.6.tgz#6a1ef59f838debd670421f8c7f2cbb8da9751580"
-  integrity sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
+  integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -81,25 +81,25 @@
     "@babel/types" "^7.18.6"
 
 "@babel/traverse@^7.7.0":
-  version "7.18.8"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.18.8.tgz#f095e62ab46abf1da35e5a2011f43aee72d8d5b0"
-  integrity sha512-UNg/AcSySJYR/+mIcJQDCv00T+AqRO7j/ZEJLzpaYtgM48rMg5MnkJgyNqkzo88+p4tfRvZJCEiwwfG6h4jkRg==
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.18.9.tgz#deeff3e8f1bad9786874cb2feda7a2d77a904f98"
+  integrity sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==
   dependencies:
     "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.18.7"
-    "@babel/helper-environment-visitor" "^7.18.6"
-    "@babel/helper-function-name" "^7.18.6"
+    "@babel/generator" "^7.18.9"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.18.9"
     "@babel/helper-hoist-variables" "^7.18.6"
     "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/parser" "^7.18.8"
-    "@babel/types" "^7.18.8"
+    "@babel/parser" "^7.18.9"
+    "@babel/types" "^7.18.9"
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.18.6", "@babel/types@^7.18.7", "@babel/types@^7.18.8", "@babel/types@^7.7.0":
-  version "7.18.8"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.8.tgz#c5af199951bf41ba4a6a9a6d0d8ad722b30cd42f"
-  integrity sha512-qwpdsmraq0aJ3osLJRApsc2ouSJCdnMeZwB0DhbtHAtRpZNZCdlbRnHIgcRKzdE1g0iOGg644fzjOBcdOz9cPw==
+"@babel/types@^7.18.6", "@babel/types@^7.18.9", "@babel/types@^7.7.0":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.9.tgz#7148d64ba133d8d73a41b3172ac4b83a1452205f"
+  integrity sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.18.6"
     to-fast-properties "^2.0.0"
@@ -298,9 +298,9 @@
     type-detect "^4.0.8"
 
 "@sinonjs/text-encoding@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
-  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz#5981a8db18b56ba38ef0efb7d995b12aa7b51918"
+  integrity sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -809,9 +809,9 @@ aws-sdk@2.905.0:
     xml2js "0.4.19"
 
 aws-sdk@^2.1005.0, aws-sdk@^2.938.0:
-  version "2.1175.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1175.0.tgz#127662834445154e63aec4e75f7a5eb295e427b6"
-  integrity sha512-iv4SL2yn9DJzuqbzSbBNi3iI6Mehrqo2CUbsLEsEnIuiTf0uBR1Hp4061whgQOj2RxOuEPe4yKEsGWURkc8X6A==
+  version "2.1182.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1182.0.tgz#7364e3e104f62b61018a00f19f2ffc989b1780ed"
+  integrity sha512-iemVvLTc2iy0rz3xTp8zc/kD27gIfDF/mk6bxY8/35xMulKCVANWUkAH8jWRKReHh5F/gX4bp33dnfG63ny1Ww==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -1478,9 +1478,9 @@ dashdash@^1.12.0:
     assert-plus "^1.0.0"
 
 dayjs@^1.10.5:
-  version "1.11.3"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.3.tgz#4754eb694a624057b9ad2224b67b15d552589258"
-  integrity sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A==
+  version "1.11.4"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.4.tgz#3b3c10ca378140d8917e06ebc13a4922af4f433e"
+  integrity sha512-Zj/lPM5hOvQ1Bf7uAvewDaUcsJoI6JmNqmHhHl3nyumwe0XHwt8sWdOVAPACJzCebL8gQCi+K49w7iKWnGwX9g==
 
 debug@2.6.8:
   version "2.6.8"
@@ -2838,10 +2838,10 @@ ioredis@^4.28.0, ioredis@^4.28.5, ioredis@^4.9.5:
     redis-parser "^3.0.0"
     standard-as-callback "^2.1.0"
 
-ip@^1.1.5:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.8.tgz#ae05948f6b075435ed3307acce04629da8cdbf48"
-  integrity sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==
+ip@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.0.tgz#4cf4ab182fee2314c75ede1276f8c80b479936da"
+  integrity sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==
 
 ipaddr.js@1.9.1:
   version "1.9.1"
@@ -5133,11 +5133,11 @@ socks-proxy-agent@^6.0.0:
     socks "^2.6.2"
 
 socks@^2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/socks/-/socks-2.6.2.tgz#ec042d7960073d40d94268ff3bb727dc685f111a"
-  integrity sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.7.0.tgz#f9225acdb841e874dca25f870e9130990f3913d0"
+  integrity sha512-scnOe9y4VuiNUULJN72GrM26BNOjVsfPXI+j+98PkyEfsIXroa5ofyjT+FzGvn/xHs73U2JtoBYAVx9Hl4quSA==
   dependencies:
-    ip "^1.1.5"
+    ip "^2.0.0"
     smart-buffer "^4.2.0"
 
 sorted-array-functions@^1.3.0:
@@ -5810,6 +5810,7 @@ webidl-conversions@^3.0.0:
 
 "werelogs@git+https://github.com/scality/werelogs#8.1.0":
   version "8.1.0"
+  uid e8f828725642c54c511cdbe580b18f43d3589313
   resolved "git+https://github.com/scality/werelogs#e8f828725642c54c511cdbe580b18f43d3589313"
   dependencies:
     safe-json-stringify "1.0.3"
@@ -5956,9 +5957,9 @@ ws@^5.1.0:
     async-limiter "~1.0.0"
 
 ws@^7.1.2:
-  version "7.5.8"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.8.tgz#ac2729881ab9e7cbaf8787fe3469a48c5c7f636a"
-  integrity sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==
+  version "7.5.9"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
+  integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
 
 ws@~6.1.0:
   version "6.1.4"


### PR DESCRIPTION
Producer code was more or less replicated between the canonical `BackbeatProducer` code and the bucket notification extension `KafkaProducer` code.

This PR concentrates logic in `BackbeatProducer`, of which `KafkaProducer` is essentially a Kafka configuration superset at startup.

Since the 2 had diverged between the creation of `KafkaProducer` as a duplicate with slightly different configuration, we get the following enhancements made in `BackbeatProducer` that `KafkaProducer` did not receive:

* 265cffe5 (ZENKO-1420) canary message filtering
* f1daedc4 (ZENKO-1520) receivedReport counting
* 51a9c539 (ZENKO-1643) filtering out broker transport failures

Additionally, we finish the non-keyed partitioner update (`7e863860` - S3C-1154) by removing `keyedPartitioner` from joi configuration schema in `BackbeatProducer`, since it's not used anywhere any more.

Note: this code would be better served by using `static` members for a lot of the configuration "variables", but this means pulling on a big ball of yarn until reaching the fact that the linter doesn't accept this if we remain in default (i.e. ES6) parser mode for eslint.

:heavy_check_mark: Green Zenko smoke tests - https://eve.devsca.com/github/scality/zenko/#/builders/4/builds/22418