### PR TITLE
BB-212: use accountId as credentials key

### DIFF
--- a/extensions/gc/tasks/GarbageCollectorTask.js
+++ b/extensions/gc/tasks/GarbageCollectorTask.js
@@ -20,16 +20,12 @@ class GarbageCollectorTask extends BackbeatTask {
         log.debug('action execution starts', entry.getLogInfo());
         const {
             locations,
-            owner: canonicalId,
             accountId
         } = entry.getAttribute('target');
-        const backbeatClient = this.getBackbeatClient(canonicalId, accountId);
+        const backbeatClient = this.getBackbeatClient(accountId);
 
         if (!backbeatClient) {
-            log.error('failed to get backbeat client', {
-                canonicalId,
-                accountId,
-            });
+            log.error('failed to get backbeat client', { accountId });
             return done(errors.InternalError
                 .customizeDescription('Unable to obtain client'));
         }

--- a/extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor.js
+++ b/extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor.js
@@ -190,14 +190,14 @@ class LifecycleBucketProcessor {
             accountId,
         });
 
-        const s3 = this.clientManager.getS3Client(owner, accountId);
+        const s3 = this.clientManager.getS3Client(accountId);
         if (!s3) {
             return cb(errors.InternalError
                 .customizeDescription('failed to obtain a s3 client'));
         }
 
         const backbeatMetadataProxy =
-            this.clientManager.getBackbeatMetadataProxy(owner, accountId);
+            this.clientManager.getBackbeatMetadataProxy(accountId);
         if (!backbeatMetadataProxy) {
             return cb(errors.InternalError
                 .customizeDescription('failed to obtain a backbeat client'));

--- a/extensions/lifecycle/tasks/LifecycleDeleteObjectTask.js
+++ b/extensions/lifecycle/tasks/LifecycleDeleteObjectTask.js
@@ -20,10 +20,10 @@ class LifecycleDeleteObjectTask extends BackbeatTask {
     }
 
     _checkDate(entry, log, done) {
-        const { owner: canonicalId, accountId } = entry.getAttribute('target');
-        const s3Client = this.getS3Client(canonicalId, accountId);
+        const { accountId } = entry.getAttribute('target');
+        const s3Client = this.getS3Client(accountId);
         if (!s3Client) {
-            log.error('failed to get S3 client', { canonicalId, accountId });
+            log.error('failed to get S3 client', { accountId });
             return done(errors.InternalError
                 .customizeDescription('Unable to obtain client'));
         }
@@ -50,10 +50,10 @@ class LifecycleDeleteObjectTask extends BackbeatTask {
     }
 
     _executeDelete(entry, log, done) {
-        const { owner: canonicalId, accountId } = entry.getAttribute('target');
-        const s3Client = this.getS3Client(canonicalId, accountId);
+        const { accountId } = entry.getAttribute('target');
+        const s3Client = this.getS3Client(accountId);
         if (!s3Client) {
-            log.error('failed to get S3 client', { canonicalId, accountId });
+            log.error('failed to get S3 client', { accountId });
             return done(errors.InternalError
                 .customizeDescription('Unable to obtain client'));
         }

--- a/extensions/lifecycle/tasks/LifecycleUpdateExpirationTask.js
+++ b/extensions/lifecycle/tasks/LifecycleUpdateExpirationTask.js
@@ -20,19 +20,15 @@ class LifecycleUpdateExpirationTask extends BackbeatTask {
 
     _getMetadata(entry, log, done) {
         const {
-            owner: canonicalId,
             accountId,
             bucket,
             key,
             version,
         } = entry.getAttribute('target');
 
-        const backbeatClient = this.getBackbeatMetadataProxy(canonicalId, accountId);
+        const backbeatClient = this.getBackbeatMetadataProxy(accountId);
         if (!backbeatClient) {
-            log.error('failed to get backbeat client', {
-                canonicalId,
-                accountId,
-            });
+            log.error('failed to get backbeat client', { accountId });
             done(errors.InternalError.customizeDescription(
                 'Unable to obtain client',
             ));
@@ -70,19 +66,15 @@ class LifecycleUpdateExpirationTask extends BackbeatTask {
 
     _putMetadata(entry, objMD, log, done) {
         const {
-            owner: canonicalId,
             accountId,
             bucket,
             key,
             version,
         } = entry.getAttribute('target');
 
-        const backbeatClient = this.getBackbeatMetadataProxy(canonicalId, accountId);
+        const backbeatClient = this.getBackbeatMetadataProxy(accountId);
         if (!backbeatClient) {
-            log.error('failed to get backbeat client', {
-                canonicalId,
-                accountId,
-            });
+            log.error('failed to get backbeat client', { accountId });
             done(errors.InternalError.customizeDescription(
                 'Unable to obtain client',
             ));

--- a/extensions/lifecycle/tasks/LifecycleUpdateTransitionTask.js
+++ b/extensions/lifecycle/tasks/LifecycleUpdateTransitionTask.js
@@ -22,13 +22,10 @@ class LifecycleUpdateTransitionTask extends BackbeatTask {
     }
 
     _getMetadata(entry, log, done) {
-        const { owner: canonicalId, accountId } = entry.getAttribute('target');
-        const backbeatClient = this.getBackbeatMetadataProxy(canonicalId, accountId);
+        const { accountId } = entry.getAttribute('target');
+        const backbeatClient = this.getBackbeatMetadataProxy(accountId);
         if (!backbeatClient) {
-            log.error('failed to get backbeat client', {
-                canonicalId,
-                accountId,
-            });
+            log.error('failed to get backbeat client', { accountId });
             return done(errors.InternalError
                 .customizeDescription('Unable to obtain client'));
         }
@@ -74,13 +71,10 @@ class LifecycleUpdateTransitionTask extends BackbeatTask {
     }
 
     _putMetadata(entry, objMD, log, done) {
-        const { owner: canonicalId, accountId } = entry.getAttribute('target');
-        const backbeatClient = this.getBackbeatMetadataProxy(canonicalId, accountId);
+        const { accountId } = entry.getAttribute('target');
+        const backbeatClient = this.getBackbeatMetadataProxy(accountId);
         if (!backbeatClient) {
-            log.error('failed to get backbeat client', {
-                canonicalId,
-                accountId,
-            });
+            log.error('failed to get backbeat client', { accountId });
             return done(errors.InternalError
                 .customizeDescription('Unable to obtain client'));
         }

--- a/lib/clients/ClientManager.js
+++ b/lib/clients/ClientManager.js
@@ -76,13 +76,12 @@ class ClientManager {
 
     /**
      * Return an S3 client instance
-     * @param {String} canonicalId - The canonical ID of the bucket owner.
      * @param {String} accountId - The account ID of the bucket owner .
      * @return {AWS.S3} The S3 client instance to make requests with
      */
-    getS3Client(canonicalId, accountId) {
+    getS3Client(accountId) {
         const credentials = this.credentialsManager.getCredentials({
-            id: canonicalId,
+            id: accountId,
             accountId,
             stsConfig: this._stsConfig,
             authConfig: this._authConfig,
@@ -92,14 +91,13 @@ class ClientManager {
             return null;
         }
 
-        const clientId = canonicalId;
-        const client = this.s3Clients[clientId];
+        const client = this.s3Clients[accountId];
 
         if (client) {
             return client;
         }
 
-        this.s3Clients[clientId] = createS3Client({
+        this.s3Clients[accountId] = createS3Client({
             transport: this._transport,
             port: this._s3Config.port,
             host: this._s3Config.host,
@@ -107,18 +105,17 @@ class ClientManager {
             agent: this.s3Agent,
         });
 
-        return this.s3Clients[clientId];
+        return this.s3Clients[accountId];
     }
 
 
     /**
      * Return an backbeat metadata proxy
-     * @param {String} canonicalId - The canonical ID of the bucket owner.
      * @param {String} accountId - The account ID of the bucket owner .
      * @return {BackbeatMetadataProxy} The S3 client instance to make requests with
      */
-    getBackbeatMetadataProxy(canonicalId, accountId) {
-        const client = this.getBackbeatClient(canonicalId, accountId);
+    getBackbeatMetadataProxy(accountId) {
+        const client = this.getBackbeatClient(accountId);
 
         if (client === null) {
             return null;
@@ -131,13 +128,12 @@ class ClientManager {
 
     /**
      * Return an backbeat client instance
-     * @param {String} canonicalId - The canonical ID of the bucket owner.
      * @param {String} accountId - The account ID of the bucket owner .
      * @return {BackbeatClient} The S3 client instance to make requests with
      */
-    getBackbeatClient(canonicalId, accountId) {
+    getBackbeatClient(accountId) {
         const credentials = this.credentialsManager.getCredentials({
-            id: canonicalId,
+            id: accountId,
             accountId,
             stsConfig: this._stsConfig,
             authConfig: this._authConfig,
@@ -147,14 +143,13 @@ class ClientManager {
             return null;
         }
 
-        const clientId = canonicalId;
-        const client = this.backbeatClients[clientId];
+        const client = this.backbeatClients[accountId];
 
         if (client) {
             return client;
         }
 
-        this.backbeatClients[clientId] = createBackbeatClient({
+        this.backbeatClients[accountId] = createBackbeatClient({
             transport: this._transport,
             port: this._s3Config.port,
             host: this._s3Config.host,
@@ -162,7 +157,7 @@ class ClientManager {
             agent: this.s3Agent,
         });
 
-        return this.backbeatClients[clientId];
+        return this.backbeatClients[accountId];
     }
 }
 

--- a/lib/credentials/CredentialsManager.js
+++ b/lib/credentials/CredentialsManager.js
@@ -69,14 +69,28 @@ class CredentialsManager extends EventEmitter {
     getCredentials(params) {
         const { authConfig, id } = params;
 
-        if (!id || !authConfig) {
-            this._logger.error('missing required params', {
+        if (!authConfig) {
+            this._logger.error('missing authConfig params', {
                 method: 'CredentialsManager::getCredentials',
                 extension: this._extension,
                 id,
                 authConfig,
             });
             return null;
+        }
+
+        if (authConfig.type === authTypeAccount ||
+            authConfig.type === authTypeService) {
+            return getAccountCredentials(authConfig, this._logger);
+        }
+
+        if (!id) {
+            this._logger.error('missing id params for assume role', {
+                method: 'CredentialsManager::getCredentials',
+                extension: this._extension,
+                id,
+                authConfig,
+            });
         }
 
         if (this._accountCredsCache[id]) {
@@ -86,11 +100,6 @@ class CredentialsManager extends EventEmitter {
         if (authConfig.type === authTypeAssumeRole) {
             const paramsWithKeys = this.resolveExternalFileSync(params);
             return this._addAssumeRoleCredentials(paramsWithKeys);
-        }
-
-        if (authConfig.type === authTypeAccount ||
-            authConfig.type === authTypeService) {
-            return getAccountCredentials(authConfig, this._logger);
         }
 
         this._logger.error(`auth type "${authConfig.type}" not supported`, {
@@ -143,9 +152,9 @@ class CredentialsManager extends EventEmitter {
      */
     removeInactiveCredentials(maxInactiveDuration) {
         Object.keys(this._accountCredsCache)
-            .forEach(canonicalId => {
+            .forEach(accountId => {
                 const expiration =
-                    this._accountCredsCache[canonicalId].expireTime;
+                    this._accountCredsCache[accountId].expireTime;
 
                 if (!expiration) {
                     return;
@@ -153,11 +162,11 @@ class CredentialsManager extends EventEmitter {
 
                 if (Date.now() - expiration >= maxInactiveDuration) {
                     this._logger.debug('deleting stale credentials', {
-                        canonicalId,
+                        accountId,
                         extension: this._extension,
                     });
-                    delete this._accountCredsCache[canonicalId];
-                    this.emit('deleteCredentials', canonicalId);
+                    delete this._accountCredsCache[accountId];
+                    this.emit('deleteCredentials', accountId);
                 }
             });
     }


### PR DESCRIPTION
use `accountId` as key over for retrieving credentials/clients from cache instead of `canonicalId`
* reduces size of messages that are sent to sorbet topics
* removes duplicate clients that are kept in cache for users under the  same account