### PR TITLE
Feature: BB-213 fix oplog populator race condition

### DIFF
--- a/extensions/oplogPopulator/OplogPopulator.js
+++ b/extensions/oplogPopulator/OplogPopulator.js
@@ -228,6 +228,7 @@ class OplogPopulator {
                database: this._database,
                mongoUrl: this._mongoUrl,
                oplogTopic: this._config.topic,
+               cronRule: this._config.connectorsUpdateCronRule,
                prefix: this._config.prefix,
                kafkaConnectHost: this._config.kafkaConnectHost,
                kafkaConnectPort: this._config.kafkaConnectPort,
@@ -248,7 +249,8 @@ class OplogPopulator {
             this._setMetastoreChangeStream();
             // remove no longer valid buckets from old connectors
             await this._connectorsManager.removeInvalidBuckets(validBuckets);
-            this._logger.debug('OplogPopulator setup complete', {
+            // start scheduler for updating connectors
+            this._connectorsManager.scheduleConnectorUpdates();
                 method: 'OplogPopulator.setup',
             });
        } catch (err) {

--- a/extensions/oplogPopulator/OplogPopulator.js
+++ b/extensions/oplogPopulator/OplogPopulator.js
@@ -74,7 +74,7 @@ class OplogPopulator {
             });
             // get metastore collection
             this._metastore = this._mongoClient.collection(constants.bucketMetastore);
-            this._logger.debug('Connected to MongoDB', {
+            this._logger.info('Connected to MongoDB', {
                 method: 'OplogPopulator._setupMongoClient',
             });
             return undefined;
@@ -174,14 +174,14 @@ class OplogPopulator {
                 }
                 break;
             default:
-                this._logger.debug('Skipping unsupported change stream event', {
+                this._logger.info('Skipping unsupported change stream event', {
                     method: 'OplogPopulator._handleChangeStreamChange',
                     type: change.operationType,
                     key: change.documentKey._id,
                 });
                 break;
         }
-        this._logger.debug('Change stream event processed', {
+        this._logger.info('Change stream event processed', {
             method: 'OplogPopulator._handleChangeStreamChange',
             type: change.operationType,
             key: change.documentKey._id,
@@ -251,6 +251,7 @@ class OplogPopulator {
             await this._connectorsManager.removeInvalidBuckets(validBuckets);
             // start scheduler for updating connectors
             this._connectorsManager.scheduleConnectorUpdates();
+            this._logger.info('OplogPopulator setup complete', {
                 method: 'OplogPopulator.setup',
             });
        } catch (err) {

--- a/extensions/oplogPopulator/OplogPopulatorConfigValidator.js
+++ b/extensions/oplogPopulator/OplogPopulatorConfigValidator.js
@@ -8,6 +8,7 @@ const joiSchema = joi.object({
     numberOfConnectors: joi.number().required().min(1),
     prefix: joi.string().optional(),
     probeServer: probeServerJoi.default(),
+    connectorsUpdateCronRule: joi.string().default('*/1 * * * * *'),
 });
 
 function configValidator(backbeatConfig, extConfig) {

--- a/extensions/oplogPopulator/modules/Allocator.js
+++ b/extensions/oplogPopulator/modules/Allocator.js
@@ -69,7 +69,7 @@ class Allocator {
                 const connector = this._allocationStrategy.getConnector(connectors);
                 await connector.addBucket(bucket);
                 this._bucketsToConnectors.set(bucket, connector);
-                this._logger.debug('Started listening to bucket', {
+                this._logger.info('Started listening to bucket', {
                     method: 'Allocator.listenToBucket',
                     bucket,
                     connector: connector.name,
@@ -99,7 +99,7 @@ class Allocator {
             if (connector) {
                 await connector.removeBucket(bucket);
                 this._bucketsToConnectors.delete(bucket);
-                this._logger.debug('Stoped listening to bucket', {
+                this._logger.info('Stopped listening to bucket', {
                     method: 'Allocator.listenToBucket',
                     bucket,
                     connector: connector.name,

--- a/extensions/oplogPopulator/modules/ConnectorsManager.js
+++ b/extensions/oplogPopulator/modules/ConnectorsManager.js
@@ -118,6 +118,10 @@ class ConnectorsManager {
             if (spawn) {
                 await connector.spawn();
             }
+            this._logger.debug('Successfully created connector', {
+                method: 'ConnectorsManager.addConnector',
+                connector: connector.name
+            });
             return connector;
         } catch (err) {
             this._logger.error('An error occurred while creating connector', {
@@ -165,8 +169,16 @@ class ConnectorsManager {
                     kafkaConnectHost: this._kafkaConnectHost,
                     kafkaConnectPort: this._kafkaConnectPort,
                 });
+                this._logger.debug('Successfully retreived old connector', {
+                    method: 'ConnectorsManager._getOldConnectors',
+                    connector: connector.name
+                });
                 return connector;
             }));
+            this._logger.info('Successfully retreived old connectors', {
+                method: 'ConnectorsManager._getOldConnectors',
+                numberOfConnectors: connectors.length
+            });
             return connectors;
         } catch (err) {
             this._logger.error('An error occurred while getting old connectors', {
@@ -232,6 +244,11 @@ class ConnectorsManager {
                 connector: connector.name,
                 numberOfBucketsRemoved: invalidBuckets.length
             });
+            this._logger.debug('Successfully removed invalid buckets from connector', {
+                method: 'ConnectorsManager.removeConnectorInvalidBuckets',
+                connector: connector.name,
+                numberOfBucketsRemoved: invalidBuckets.length
+            });
         } catch (err) {
             this._logger.error('An error occurred while removing invalid buckets from a connector', {
                 method: 'ConnectorsManager.removeConnectorInvalidBuckets',
@@ -252,6 +269,9 @@ class ConnectorsManager {
         try {
             await eachLimit(this._oldConnectors, 10, async connector =>
                 this.removeConnectorInvalidBuckets(connector, buckets));
+            this._logger.info('Successfully removed invalid buckets from old connectors', {
+                method: 'ConnectorsManager.removeInvalidBuckets',
+            });
             this._logger.info('Successfully removed invalid buckets from old connectors', {
                 method: 'ConnectorsManager.removeInvalidBuckets',
             });

--- a/tests/unit/oplogPopulator/Allocator.js
+++ b/tests/unit/oplogPopulator/Allocator.js
@@ -82,19 +82,6 @@ describe('Allocator', () => {
             assert(getConnectorStub.notCalled);
             assert(addBucketStub.notCalled);
         });
-
-        it('Should allow retries', async () => {
-            allocator._connectorsManager.connectors = [connector1];
-            const getConnectorStub = sinon.stub(allocator._allocationStrategy, 'getConnector')
-                .returns(connector1);
-            const addBucketStub = sinon.stub(connector1, 'addBucket');
-            addBucketStub.onCall(0).rejects();
-            addBucketStub.onCall(1).resolves();
-            await allocator.listenToBucket('example-bucket-1');
-            assert(getConnectorStub.calledOnce);
-            const assignedConnector = allocator._bucketsToConnectors.get('example-bucket-1');
-            assert.deepEqual(assignedConnector, connector1);
-        });
     });
 
     describe('stopListeningToBucket', () => {
@@ -111,17 +98,6 @@ describe('Allocator', () => {
             const removeBucketStub = sinon.stub(connector1, 'removeBucket').resolves();
             await allocator.stopListeningToBucket('example-bucket-1');
             assert(removeBucketStub.notCalled);
-        });
-
-        it('Should allow retries', async () => {
-            allocator._bucketsToConnectors.set('example-bucket-1', connector1);
-            const removeBucketStub = sinon.stub(connector1, 'removeBucket');
-            removeBucketStub.onCall(0).rejects();
-            removeBucketStub.onCall(1).resolves();
-            await allocator.stopListeningToBucket('example-bucket-1');
-            assert(removeBucketStub.calledOnce);
-            const exists = allocator._bucketsToConnectors.has('example-bucket-1');
-            assert.strictEqual(exists, false);
         });
     });
 });

--- a/tests/unit/oplogPopulator/ConnectorsManager.js
+++ b/tests/unit/oplogPopulator/ConnectorsManager.js
@@ -73,6 +73,7 @@ describe('ConnectorsManager', () => {
             database: 'metadata',
             mongoUrl: 'mongodb://localhost:27017/?w=majority&readPreference=primary',
             oplogTopic: 'oplog',
+            cronRule: '*/5 * * * * *',
             kafkaConnectHost: '127.0.0.1',
             kafkaConnectPort: 8083,
             logger,
@@ -179,8 +180,8 @@ describe('ConnectorsManager', () => {
             await connectorsManager.removeConnectorInvalidBuckets(connector1, [
                 'valid-bucket-1',
             ]);
-            assert(removeStub.getCall(0).calledWith('invalid-bucket-1', false));
-            assert(removeStub.getCall(1).calledWith('invalid-bucket-2', false));
+            assert(removeStub.getCall(0).calledWith('invalid-bucket-1'));
+            assert(removeStub.getCall(1).calledWith('invalid-bucket-2'));
         });
     });
 


### PR DESCRIPTION
A race condition occurs when multiple events are processed at the same time
and that affect the same connector, in which case the connector is not configured
correctly.

For example when two buckets are being added to the same connector at the same time,
only one of them gets added, this is caused by the two operations getting and updating
the list of buckets assigned to the connector at the same time, which results in one of
them overwriting the other.

The solution is using a scheduler that periodically updates all of the connectors.
Connectors are no longer updated on an event basis