### PR TITLE
Feature: BB-219 update mongo connector config

### DIFF
--- a/extensions/oplogPopulator/OplogPopulatorTask.js
+++ b/extensions/oplogPopulator/OplogPopulatorTask.js
@@ -10,8 +10,8 @@ werelogs.configure({ level: config.log.logLevel,
 
 const mongoConfig = config.queuePopulator.mongo;
 const oplogPopulatorConfig = config.extensions.oplogPopulator;
-// Temporary as no extension uses the oplogPopulator for now
-const activeExtensions = [];
+// Notification extension is the only one using OplogPopulator for now
+const activeExtensions = config.extensions.notification ? ['notification'] : [];
 
 const oplogPopulator = new OplogPopulator({
     config: oplogPopulatorConfig,

--- a/extensions/oplogPopulator/constants.js
+++ b/extensions/oplogPopulator/constants.js
@@ -6,6 +6,43 @@ const constants = {
         'change.stream.full.document': 'updateLookup',
         'pipeline': '[]',
         'collection': '',
+        // Kafka message key config
+        // The message key is set to only contain the bucket where the event happend.
+        // This will make events of the same bucket always land in the same partition
+        // as they will have the same key
+        'output.format.key': 'schema',
+        'output.schema.key': JSON.stringify({
+            type: 'record',
+            name: 'keySchema',
+            fields: [{
+                name: 'ns',
+                type: [{
+                        name: 'ns',
+                        type: 'record',
+                        fields: [{
+                            name: 'coll',
+                            type: ['string', 'null'],
+                        }],
+                    }, 'null'],
+            }, {
+                name: 'fullDocument',
+                type: [{
+                   type: 'record',
+                   name: 'fullDocumentRecord',
+                   fields: [{
+                        name: 'value',
+                        type: [{
+                            type: 'record',
+                            name: 'valueRecord',
+                            fields: [{
+                                name: 'key',
+                                type: ['string', 'null'],
+                            }],
+                        }, 'null'],
+                   }],
+                }, 'null'],
+            }],
+        }),
     },
     extensionConfigField: {
         notification: 'notificationConfiguration',

--- a/extensions/oplogPopulator/constants.js
+++ b/extensions/oplogPopulator/constants.js
@@ -6,6 +6,12 @@ const constants = {
         'change.stream.full.document': 'updateLookup',
         'pipeline': '[]',
         'collection': '',
+        // JSON output converter config
+        // Using a string converter to avoid getting an over-stringified
+        // JSON that is returned by default
+        'output.format.value': 'json',
+        'value.converter.schemas.enable': false,
+        'value.converter': 'org.apache.kafka.connect.storage.StringConverter',
         // Kafka message key config
         // The message key is set to only contain the bucket where the event happend.
         // This will make events of the same bucket always land in the same partition

--- a/lib/queuePopulator/KafkaLogConsumer/ListRecordStream.js
+++ b/lib/queuePopulator/KafkaLogConsumer/ListRecordStream.js
@@ -34,25 +34,6 @@ class ListRecordStream extends stream.Transform {
     }
 
     /**
-     * Parse kafka message's value field twice, as the Kafka-connect MongoDB
-     * source connector will double stringify the value field
-     * @param {string} blob sringified json
-     * @returns {Object} parsed json
-     */
-    _parseKafkaMessageValue(blob) {
-        try {
-            const parsed = JSON.parse(JSON.parse(blob));
-            return parsed;
-        } catch (err) {
-            this._logger.warn('Got invalid kafka message value field format', {
-                method: 'ListRecordStream._parseJson',
-                value: blob,
-            });
-            return {};
-        }
-     }
-
-    /**
      * Formats change stream entries
      * @param {Object} data chunk of data
      * @param {Buffer} data.value message contents as a Buffer
@@ -68,7 +49,16 @@ class ListRecordStream extends stream.Transform {
      * @returns {undefined}
      */
     _transform(data, encoding, callback) {
-        const changeStreamDocument = this._parseKafkaMessageValue(data.value);
+        let changeStreamDocument;
+        try {
+            changeStreamDocument = JSON.parse(data.value.toString());
+        } catch (error) {
+            this._logger.warn('Got invalid kafka message value format', {
+                method: 'ListRecordStream._transform',
+                data,
+            });
+            changeStreamDocument = {};
+        }
         const streamObject = {
             timestamp: new Date(data.timestamp),
             db: changeStreamDocument.ns && changeStreamDocument.ns.coll,

--- a/tests/unit/lib/queuePopulator/kafkaLogConsumer/ListRecordStream.js
+++ b/tests/unit/lib/queuePopulator/kafkaLogConsumer/ListRecordStream.js
@@ -20,8 +20,7 @@ const changeStreamDocument = {
     }
 };
 const kafkaMessage = {
-    // kafka-connect double stringifies the message
-    value: Buffer.from(JSON.stringify(JSON.stringify(changeStreamDocument))),
+    value: Buffer.from(JSON.stringify(changeStreamDocument)),
     timestamp: Date.now(),
     size: 2,
     topic: 'oplog-topic',
@@ -109,18 +108,6 @@ describe('ListRecordStream', () => {
                 });
                 return done();
             });
-        });
-    });
-
-    describe('_parseKafkaMessageValue', () => {
-        it('Should parse doubly stringified object', () => {
-            const objStr = JSON.stringify(JSON.stringify(changeStreamDocument));
-            const parsed = listRecordStream._parseKafkaMessageValue(objStr);
-            assert.deepEqual(parsed, changeStreamDocument);
-        });
-        it('Should return empty object when format is invalid', () => {
-            const parsed = listRecordStream._parseKafkaMessageValue('');
-            assert.deepEqual(parsed, {});
         });
     });
 });

--- a/tests/unit/lib/queuePopulator/kafkaLogConsumer/LogConsumer.js
+++ b/tests/unit/lib/queuePopulator/kafkaLogConsumer/LogConsumer.js
@@ -30,8 +30,7 @@ const changeStreamDocument = {
     }
 };
 const kafkaMessage = {
-    // kafka-connect double stringifies the message
-    value: Buffer.from(JSON.stringify(JSON.stringify(changeStreamDocument))),
+    value: Buffer.from(JSON.stringify(changeStreamDocument)),
     timestamp: Date.now(),
     size: 2,
     topic: 'oplog-topic',

--- a/tests/unit/oplogPopulator/ConnectorsManager.js
+++ b/tests/unit/oplogPopulator/ConnectorsManager.js
@@ -18,6 +18,42 @@ const connectorConfig = {
     'change.stream.full.document': 'updateLookup',
     'pipeline': '[]',
     'collection': '',
+    'output.format.value': 'json',
+    'value.converter.schemas.enable': false,
+    'value.converter': 'org.apache.kafka.connect.storage.StringConverter',
+    'output.format.key': 'schema',
+    'output.schema.key': JSON.stringify({
+        type: 'record',
+        name: 'keySchema',
+        fields: [{
+            name: 'ns',
+            type: [{
+                    name: 'ns',
+                    type: 'record',
+                    fields: [{
+                        name: 'coll',
+                        type: ['string', 'null'],
+                    }],
+                }, 'null'],
+        }, {
+            name: 'fullDocument',
+            type: [{
+               type: 'record',
+               name: 'fullDocumentRecord',
+               fields: [{
+                    name: 'value',
+                    type: [{
+                        type: 'record',
+                        name: 'valueRecord',
+                        fields: [{
+                            name: 'key',
+                            type: ['string', 'null'],
+                        }],
+                    }, 'null'],
+               }],
+            }, 'null'],
+        }],
+    }),
 };
 
 const connector1 = new Connector({


### PR DESCRIPTION
Issue: [BB-219](https://scality.atlassian.net/browse/BB-219)
- Configure Kafka-connect MongoDB connector to only include bucket name in the Kafka message key. This will make events of the same bucket always land in the same partition as they will have the same key
- Configure Kafka-connect MongoDB connector to use an output string converter to avoid getting an over stringified JSON