### PR TITLE
feature: BB-243 ignore notification extension in queue populator bin …

### DIFF
--- a/bin/notification.js
+++ b/bin/notification.js
@@ -11,7 +11,8 @@ const mConfig = config.metrics;
 const rConfig = config.redis;
 const vConfig = config.vaultAdmin;
 const qpConfig = config.queuePopulator;
-const extConfigs = config.extensions;
+// Only consider the notification extension
+const extConfigs = config.extensions.notification ? { notification: config.extensions.notification } : {};
 const QueuePopulator = require('../lib/queuePopulator/QueuePopulator');
 const { startProbeServer } = require('../lib/util/probe');
 const { DEFAULT_LIVE_ROUTE, DEFAULT_METRICS_ROUTE, DEFAULT_READY_ROUTE } =

--- a/bin/queuePopulator.js
+++ b/bin/queuePopulator.js
@@ -6,7 +6,10 @@ const werelogs = require('werelogs');
 const config = require('../lib/Config');
 const zkConfig = config.zookeeper;
 const kafkaConfig = config.kafka;
-const extConfigs = config.extensions;
+// removing notification extension config as it needs to
+// be run in a separate instance of the queue populator
+// as it uses a different log consumer
+const { notification, ...extConfigs } = config.extensions;
 const qpConfig = config.queuePopulator;
 const httpsConfig = config.internalHttps;
 const mConfig = config.metrics;


### PR DESCRIPTION
…script

Notification extension needs to be run in a separate queue populator instance as it uses the kafka log consumer different from other extensions that use the mongo log consumer.

Changes:
- Ignore the notification extension in /bin/queuePopulator.js
- Only consider notification extension in /bin/notification.js