### PR TITLE
bugfix: BB-245 fix invalid value of dataStoreVersionId in non version…

### DIFF
--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -8,7 +8,6 @@ const { replicationBackends, emptyFileMd5 } = require('arsenal').constants;
 const MongoClient = require('arsenal').storage
     .metadata.mongoclient.MongoClientInterface;
 const ObjectMD = require('arsenal').models.ObjectMD;
-const { encode } = require('arsenal').versioning.VersionID;
 
 const Config = require('../../lib/Config');
 const BackbeatConsumer = require('../../lib/BackbeatConsumer');
@@ -274,7 +273,7 @@ class MongoQueueProcessor {
         // To hold reference to this null object, we need to encode "null"
         // as its dataStoreVersionId
         const dataStoreVersionId = entry.getVersionId() ?
-            entry.getEncodedVersionId() : encode('null');
+            entry.getEncodedVersionId() : 'null';
         let zenkoDataLocations;
         if (!locations || locations.length === 0) {
             zenkoDataLocations = [{


### PR DESCRIPTION
…ed OOB objects

Issue: [BB-245](https://scality.atlassian.net/browse/BB-245)

When the source bucket of an OOB in RING has non versioned objects that were created before enabling versioning, these objects can not be downloaded in the ARTESCA UI and all GET operations using AWS CLI or SDK fail with the following error

```
<Error>
<Code>LocationNotFound</Code>
<Message>The object data location does not exist.</Message>
<Resource/>
<RequestId>23cc9258dd499fde3746</RequestId>
</Error>
```

The issue is cause by the `location.dataStoreVersionId` field of the object metadata containing the wrong value (encoding of the string "null"). 

That field is used by Cloudserver to GET the object on the Ring side using AWS SDK as it is considered an AWS S3 location. The value of the field should be the string `"null"` as that's how we GET a null version using AWS SDK

This fix only affects non versioned OOB objects, and was tested in ARTESCA 1.4.2