### PR TITLE
Feature: BB-246 allow replication of non versioned objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "8.4.12",
+  "version": "8.4.14",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Issue: [BB-246](https://scality.atlassian.net/browse/BB-246)

Source OOB buckets can have non versioned objects with only master keys that were created before versioning was enabled, we allow replication of those objects.

- [x] Tested in Zenko CI [Build Link](https://eve.devsca.com/github/scality/zenko/#/builders/12/builds/5627)
- [x] Tested in Local Artesca cluster the behaviour of replication with zero byte objects, normal non MPU objects, MPU objects. the objects where also tested as versioned, non versioned and versioning suspended