### PR TITLE
BB-252 Oras fails pushing dashboard and policies

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      
+      # TODO: remove the following step once Oras CLI 0.13.0 bug https://github.com/oras-project/oras/issues/447 is fixed. 
+      - name: Downgrade Oras to 0.12.0 
+        run: |
+          curl -LO https://github.com/oras-project/oras/releases/download/v0.12.0/oras_0.12.0_linux_amd64.tar.gz
+          mkdir -p oras-install/
+          tar -zxf oras_0.12.0_*.tar.gz -C oras-install/
+          mv oras-install/oras /usr/local/bin/
+          rm -rf oras_0.12.0_*.tar.gz oras-install/
 
       - name: Set up Docker Buildk
         uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
**Context:** 

A new ubuntu-latest virtual environment was released a few days ago with a new Oras version 1.13.0. 

This Oras version seems to have a bug  

**Potential fixes:**

1. If doable, use the previous fixed ubuntu version instead of ubuntu-latest
2. or, add an extra GitHub action step to install the older Oras version 1.12.0
3. or, push an extra customize config file:  that includes the release tag. The blob would be different for each release which will make push possible even if dashboards/policies have not changed. With this solution, some changes might be needed when we pull the images at the Zenko operator level (https://github.com/scality/zenko-operator/blob/development/1.4/pkg/controller/zenko/generic_image_reconciler.go#L208)

**Fix picked:** 2 - because it does not require much change and can be removed once the issue is fixed.