### PR TITLE
BB-257 Backbeat client requests never time out

### DIFF
--- a/lib/clients/utils.js
+++ b/lib/clients/utils.js
@@ -1,6 +1,8 @@
 const S3 = require('aws-sdk/clients/s3');
 const BackbeatClient = require('./BackbeatClient');
 
+const TIMEOUT_MS = 1000 * 60 * 2; // 2 minutes in ms
+
 function attachReqUids(s3req, log) {
     s3req.on('build', () => {
         // eslint-disable-next-line no-param-reassign
@@ -29,7 +31,7 @@ function createBackbeatClient(params) {
         endpoint,
         credentials,
         sslEnabled: transport === 'https',
-        httpOptions: { agent, timeout: 0 },
+        httpOptions: { agent, timeout: TIMEOUT_MS },
         maxRetries: 0,
     });
 }


### PR DESCRIPTION
Today, “backbeat client” requests never timeout blocking the transition object processor flow when a response is never received.

This might happen due to a software bug (an error is thrown).

I set the timeout to 2 minutes (default AWS SDK value).

Also, the retry logic timeout after 5 minutes so it will retry a couple of times before giving up.
