### PR TITLE
bugfix: BB-260 fix S3C delete events not correctly deleting Zenko obj…

### DIFF
--- a/lib/util/versioning.js
+++ b/lib/util/versioning.js
@@ -1,6 +1,17 @@
 const VID_SEP = require('arsenal').versioning.VersioningConstants
           .VersionId.Separator;
 
+/**
+ * @param {string} key full object key (_id in metadata)
+ * @returns {string | null} version id
+ */
+function extractVersionId(key) {
+    if (key.includes(VID_SEP)) {
+        return key.split(VID_SEP)[1];
+    }
+    return null;
+}
+
 module.exports = {
-    isMasterKey: key => !key.includes(VID_SEP),
+    extractVersionId,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "8.4.17",
+  "version": "8.4.18",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
…ect in OOB buckets

When receiving a delete event in RAFT log, OOB calls the generic deleteObject function of
the MongoClient with undefined options so that it calls the deleteObjectNoVer function to
directly delete the object without any further manipulation.

The behaviour of this function changed with the introduction of the v1 metadata in Zenko,
the function now adds a prefix to the object name before performing the deletion. Since the
function was intended for deletion of non versioned objects (objects that only have a master
key) it adds a master version prefix \x7fM.

This introduces an issue where deleted objects in S3C are not deleted in Zenko, as the function
only deletes the master keys and not the version. This creates an issue when listing objects either
in the UI or using the CLI, where the object is not visible in the normal listing function but is
when listing the versions.