### PR TITLE
BB-258 Need to send at least one of versionid and etag to DMF

### DIFF
--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -1300,6 +1300,7 @@ class LifecycleTask extends BackbeatTask {
                 accountId: bucketData.target.accountId,
                 bucket: bucketData.target.bucket,
                 objectKey: version.Key,
+                versionId: version.VersionId,
                 eTag: version.ETag,
                 lastModified: version.LastModified,
                 site: rules.Transition.StorageClass,

--- a/extensions/replication/ReplicationAPI.js
+++ b/extensions/replication/ReplicationAPI.js
@@ -68,7 +68,7 @@ class ReplicationAPI {
      * @return {undefined}
      */
     static sendDataMoverAction(producer, action, log, cb) {
-        const { accountId, bucket, key, version } = action.getAttribute('target');
+        const { accountId, bucket, key, version, eTag } = action.getAttribute('target');
         const { origin, fromLocation, contentLength } = action.getAttribute('metrics');
         const kafkaEntry = {
             key: `${bucket}/${key}`,
@@ -93,6 +93,7 @@ class ReplicationAPI {
                 requestId: reqId,
                 // TODO: BB-217 do not use contentLength from metrics
                 size: contentLength,
+                eTag,
             };
             kafkaEntry.message = JSON.stringify(message);
         }

--- a/lib/models/ColdStorageStatusQueueEntry.js
+++ b/lib/models/ColdStorageStatusQueueEntry.js
@@ -12,6 +12,7 @@ const entrySchema = joi.object({
     originalMessage: joi.object(),
     reason: joi.optional(),
     date: joi.date().optional(),
+    eTag: joi.string().optional(),
 }).unknown(true);
 
 class ColdStorageStatusQueueEntry {

--- a/tests/unit/replication/ReplicationAPI.spec.js
+++ b/tests/unit/replication/ReplicationAPI.spec.js
@@ -1,0 +1,77 @@
+const ReplicationAPI =
+      require('../../../extensions/replication/ReplicationAPI');
+
+const assert = require('assert');
+const ActionQueueEntry = require('../../../lib/models/ActionQueueEntry');
+
+const fakeLogger = require('../../utils/fakeLogger');
+const bucketName = 'transition-to-dmf';
+const owner = '4f5a1a4bd769fd6e4ebca87b96c86a621ebb9c8be0c012f291757410c55a36f7';
+const objectKey = 'n2bv20';
+const versionId = '39383334313437353030313233353939393939395247303031202038393336382e38';
+const eTag = '"f611f77f57aa931a6475ae3fbb8e6d33"';
+const lastModified = '2022-07-22T21:23:18.761Z';
+const toLocation = 'location-dmf-v1';
+const originLabel = 'lifecycle';
+const fromLocation = 'aws-location';
+const contentLength = 315;
+const resultsTopic = 'backbeat-lifecycle-object-tasks';
+const accountId = '507132247041';
+
+describe('ReplicationAPI', () => {
+    let messages;
+    const mockProducer = {
+        sendToTopic: (topic, [{ message }], cb) => {
+            const entry = JSON.parse(message);
+            messages.push({ topic, entry });
+            process.nextTick(() => cb(null, [{}]));
+            return;
+        },
+    };
+
+    beforeEach(() => {
+        messages = [];
+    });
+
+    describe('::sendDataMoverAction ', () => {
+        it('should publish to archive topic', done => {
+            const action = ActionQueueEntry.create('copyLocation');
+            action
+                .setAttribute('target', {
+                    accountId,
+                    owner,
+                    bucket: bucketName,
+                    key: objectKey,
+                    version: versionId,
+                    eTag,
+                    lastModified,
+                })
+                .setAttribute('toLocation', toLocation)
+                .setAttribute('metrics', {
+                    origin: originLabel,
+                    fromLocation,
+                    contentLength,
+                })
+                .setResultsTopic(resultsTopic);
+            ReplicationAPI.sendDataMoverAction(mockProducer, action, fakeLogger, err => {
+                assert.ifError(err);
+                const expectedMessage = [
+                    {
+                        topic: 'cold-archive-req-location-dmf-v1',
+                        entry: {
+                            accountId,
+                            bucketName,
+                            objectKey,
+                            objectVersion: versionId,
+                            size: contentLength,
+                            eTag,
+                        },
+                    },
+                ];
+                assert.deepStrictEqual(messages, expectedMessage);
+                done();
+                return;
+            });
+        });
+    });
+});


### PR DESCRIPTION
Messages sent to sorbet to trigger archive will always include the object's ETag.
Additionally, we will send version id when transitioning the current version of a versioned bucket.
