### PR TITLE
bugfix: BB-262 fix replication failures of objects with tags

### DIFF
--- a/extensions/replication/tasks/MultipleBackendTask.js
+++ b/extensions/replication/tasks/MultipleBackendTask.js
@@ -1117,10 +1117,14 @@ class MultipleBackendTask extends ReplicateObject {
                     return next(errors.InvalidObjectState.customizeDescription(
                         errMessage));
                 }
-                if (content.includes('PUT_TAGGING')) {
+                // Only put/delete tags if object was previously
+                // replicated. Otherwise we replicate the whole object
+                // which should also replicate the updated tags.
+                const dataStoreVersionId = sourceEntry.getReplicationSiteDataStoreVersionId(this.site);
+                if (content.includes('PUT_TAGGING') && dataStoreVersionId) {
                     return this._putObjectTagging(sourceEntry, log, next);
                 }
-                if (content.includes('DELETE_TAGGING')) {
+                if (content.includes('DELETE_TAGGING') && dataStoreVersionId) {
                     return this._deleteObjectTagging(sourceEntry, log, next);
                 }
                 // Do a multipart upload when either the size is above

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "8.4.18",
+  "version": "8.4.19",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/utils/fakeLogger.js
+++ b/tests/utils/fakeLogger.js
@@ -3,6 +3,7 @@ const fakeLogger = {
     error: console.error, // eslint-disable-line no-console
     info: console.log,    // eslint-disable-line no-console
     debug: console.debug, // eslint-disable-line no-console
+    warn: console.warn,    // eslint-disable-line no-console
     getSerializedUids: () => {},
     end: () => fakeLogger,
 };


### PR DESCRIPTION
Issue: [BB-262](https://scality.atlassian.net/browse/BB-262)

when putting or deleting tags from an object that has a FAILED replication status, all future replication attempts fail due to the replication processor directly putting/deleting tags and assuming that the object was replicated before which is not the case.