### PR TITLE
BB-265 Set client timeout to free up consumer slots when connection idle

### DIFF
--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -716,7 +716,7 @@ class ReplicateObject extends BackbeatTask {
                 `${sourceS3.host}:${sourceS3.port}`,
             credentials: this.s3sourceCredentials,
             sslEnabled: this.sourceConfig.transport === 'https',
-            httpOptions: { agent: this.sourceHTTPAgent, timeout: TIMEOUT_MS },
+            httpOptions: { agent: this.sourceHTTPAgent, timeout: TIMEOUT_MS, connectTimeout: TIMEOUT_MS },
             maxRetries: 0,
         });
         this.backbeatSourceProxy = new BackbeatMetadataProxy(
@@ -724,7 +724,7 @@ class ReplicateObject extends BackbeatTask {
                 `${sourceS3.host}:${sourceS3.port}`,
             this.sourceConfig.auth, this.sourceHTTPAgent);
         this.backbeatSourceProxy.setSourceRole(sourceRole);
-        this.backbeatSourceProxy.setSourceClient(log);
+        this.backbeatSourceProxy.setBackbeatClient(this.backbeatSource);
     }
 
     _setupDestClients(targetRole, log) {

--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -10,7 +10,7 @@ const BackbeatClient = require('../../../lib/clients/BackbeatClient');
 const BackbeatMetadataProxy = require('../../../lib/BackbeatMetadataProxy');
 
 const mapLimitWaitPendingIfError = require('../../../lib/util/mapLimitWaitPendingIfError');
-const { attachReqUids } = require('../../../lib/clients/utils');
+const { attachReqUids, TIMEOUT_MS } = require('../../../lib/clients/utils');
 const getExtMetrics = require('../utils/getExtMetrics');
 const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
 const { getAccountCredentials } = require('../../../lib/credentials/AccountCredentials');
@@ -29,8 +29,6 @@ function _extractAccountIdFromRole(role) {
 // When set, the value is the target percentage of errors.
 const BACKBEAT_INJECT_REPLICATION_ERROR_RATE =
     process.env.BACKBEAT_INJECT_REPLICATION_ERROR_RATE / 100;
-
-const BACKBEAT_CLIENT_TIMEOUT_MS = 120000; // 2 minutes is the default AWS S3 Javascript SDK timeout.
 
 class ReplicateObject extends BackbeatTask {
     /**
@@ -718,7 +716,7 @@ class ReplicateObject extends BackbeatTask {
                 `${sourceS3.host}:${sourceS3.port}`,
             credentials: this.s3sourceCredentials,
             sslEnabled: this.sourceConfig.transport === 'https',
-            httpOptions: { agent: this.sourceHTTPAgent, timeout: BACKBEAT_CLIENT_TIMEOUT_MS },
+            httpOptions: { agent: this.sourceHTTPAgent, timeout: TIMEOUT_MS },
             maxRetries: 0,
         });
         this.backbeatSourceProxy = new BackbeatMetadataProxy(

--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -30,6 +30,8 @@ function _extractAccountIdFromRole(role) {
 const BACKBEAT_INJECT_REPLICATION_ERROR_RATE =
     process.env.BACKBEAT_INJECT_REPLICATION_ERROR_RATE / 100;
 
+const BACKBEAT_CLIENT_TIMEOUT_MS = 120000; // 2 minutes is the default AWS S3 Javascript SDK timeout.
+
 class ReplicateObject extends BackbeatTask {
     /**
      * Process a single replication entry
@@ -716,7 +718,7 @@ class ReplicateObject extends BackbeatTask {
                 `${sourceS3.host}:${sourceS3.port}`,
             credentials: this.s3sourceCredentials,
             sslEnabled: this.sourceConfig.transport === 'https',
-            httpOptions: { agent: this.sourceHTTPAgent, timeout: 0 },
+            httpOptions: { agent: this.sourceHTTPAgent, timeout: BACKBEAT_CLIENT_TIMEOUT_MS },
             maxRetries: 0,
         });
         this.backbeatSourceProxy = new BackbeatMetadataProxy(

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -457,6 +457,7 @@ class BackbeatConsumer extends EventEmitter {
             entry: { topic, partition, offset,
                      key: key && key.toString(), timestamp },
             committableOffset,
+            offsetLedger: this._offsetLedger.toString(),
         });
         // ensure consumer is active when calling offsetsStore() on
         // it, to avoid raising an exception (invalid state)

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -338,6 +338,7 @@ class BackbeatConsumer extends EventEmitter {
                     this._log.debug('marked consumed entry', {
                         entry: { topic, partition, offset,
                                  key: key && key.toString(), timestamp },
+                        offsetLedger: this._offsetLedger.toString(),
                     });
                     if (topic === undefined ||
                         partition === undefined ||

--- a/lib/BackbeatMetadataProxy.js
+++ b/lib/BackbeatMetadataProxy.js
@@ -253,7 +253,7 @@ class BackbeatMetadataProxy extends BackbeatTask {
             endpoint: this._s3Endpoint,
             credentials: this._createCredentials(log),
             sslEnabled: this._s3Endpoint.startsWith('https:'),
-            httpOptions: { agent: this._sourceHTTPAgent, timeout: TIMEOUT_MS },
+            httpOptions: { agent: this._sourceHTTPAgent, timeout: TIMEOUT_MS, connectTimeout: TIMEOUT_MS },
             maxRetries: 0, // Disable retries, use our own retry policy
         });
         return this;

--- a/lib/BackbeatMetadataProxy.js
+++ b/lib/BackbeatMetadataProxy.js
@@ -1,6 +1,7 @@
 const http = require('http');
 const errors = require('arsenal').errors;
 const jsutil = require('arsenal').jsutil;
+const { TIMEOUT_MS } = require('./clients/utils');
 const VaultClientCache = require('./clients/VaultClientCache');
 const BackbeatClient = require('./clients/BackbeatClient');
 const BackbeatTask = require('./tasks/BackbeatTask');
@@ -252,7 +253,7 @@ class BackbeatMetadataProxy extends BackbeatTask {
             endpoint: this._s3Endpoint,
             credentials: this._createCredentials(log),
             sslEnabled: this._s3Endpoint.startsWith('https:'),
-            httpOptions: { agent: this._sourceHTTPAgent, timeout: 0 },
+            httpOptions: { agent: this._sourceHTTPAgent, timeout: TIMEOUT_MS },
             maxRetries: 0, // Disable retries, use our own retry policy
         });
         return this;

--- a/lib/clients/utils.js
+++ b/lib/clients/utils.js
@@ -40,4 +40,5 @@ module.exports = {
     attachReqUids,
     createS3Client,
     createBackbeatClient,
+    TIMEOUT_MS,
 };


### PR DESCRIPTION
Sets the socket to timeout after 120000 milliseconds of inactivity on the socket. It is the default AWS S3 JavaScript SDK.

The current value of 0 means infinity and for multiple reasons (server, network, internet connection) the server can stop sending data and leave the connection open and idle “forever“.

That will lead to:
- one consumer slot being taken “forever”
- “the consumer group offset” not committed and lag never decreased.

Note: we are only updating the `this.backbeatSource` client's timeout since it is the one responsible for getting and putting data. We also don't want to change too much the logic that has been working for years. 

TODO: Test that large files (> 1GB) are being replicated correctly and do not timeout. If it times out, we could increase the client timeout on replay processors.