### PR TITLE
Add replication metrics

### DIFF
--- a/bin/queuePopulator.js
+++ b/bin/queuePopulator.js
@@ -63,14 +63,9 @@ async.waterfall([
             probeServer.addHandler([DEFAULT_LIVE_ROUTE, DEFAULT_READY_ROUTE],
                 (res, log) => queuePopulator.handleLiveness(res, log)
             );
-            // TODO: set this variable during deployment
-            // enable metrics route only when it is enabled
-            if (process.env.ENABLE_METRICS_PROBE === 'true') {
-                probeServer.addHandler(
-                    DEFAULT_METRICS_ROUTE,
-                    (res, log) => queuePopulator.handleMetrics(res, log)
-                );
-            }
+            probeServer.addHandler(DEFAULT_METRICS_ROUTE,
+                (res, log) => queuePopulator.handleMetrics(res, log)
+            );
         }
         done();
     }),

--- a/conf/config.json
+++ b/conf/config.json
@@ -208,7 +208,12 @@
                     "bindAddress": "localhost",
                     "port": 4045
                 }
-            }
+            },
+            "objectSizeMetrics": [
+                66560,
+                8388608,
+                68157440
+            ]
         },
         "lifecycle": {
             "auth": {

--- a/docs/replication-metrics.md
+++ b/docs/replication-metrics.md
@@ -11,14 +11,8 @@ Under `conf/config.json` you can specify the probe server settings.
 
 > Currently SSL/TLS is not supported
 
-When starting processes you can enable/disable metrics handling by setting an
-environment variable. It is disabled by default.
-
-```sh
-export ENABLE_METRICS_PROBE=true
-```
-
-After you start the process you can view prometheus metrics at `http://{bindAddress}:{port}/metrics`.
+After you start the process you can view prometheus metrics at
+`http://{bindAddress}:{port}/metrics`.
 
 ## Connecting to Prometheus
 

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -78,6 +78,7 @@ const joiSchema = joi.object({
         concurrency: joi.number().greater(0).default(10),
         probeServer: probeServerJoi.default(),
     },
+    objectSizeMetrics: joi.array().items(joi.number()),
 });
 
 function _loadAdminCredentialsFromFile(filePath) {

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -12,6 +12,7 @@ const qpRetryJoi = joi.object({
 });
 
 const CRR_FAILURE_EXPIRY = 24 * 60 * 60; // Expire Redis keys after 24 hours.
+const OBJECT_SIZE_METRICS = [66560, 8388608, 68157440];
 
 const joiSchema = joi.object({
     source: {
@@ -78,7 +79,7 @@ const joiSchema = joi.object({
         concurrency: joi.number().greater(0).default(10),
         probeServer: probeServerJoi.default(),
     },
-    objectSizeMetrics: joi.array().items(joi.number()),
+    objectSizeMetrics: joi.array().items(joi.number()).default(OBJECT_SIZE_METRICS),
 });
 
 function _loadAdminCredentialsFromFile(filePath) {

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -1014,7 +1014,7 @@ class QueueProcessor extends EventEmitter {
      * @param {Logger} log - Logger
      * @returns {string} Error response string or undefined
      */
-    handleMetrics(res, log) {
+    static handleMetrics(res, log) {
         log.debug('metrics requested');
 
         res.writeHead(200, {

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -32,7 +32,7 @@ const BucketQueueEntry = require('../../../lib/models/BucketQueueEntry');
 const ActionQueueEntry = require('../../../lib/models/ActionQueueEntry');
 const MetricsProducer = require('../../../lib/MetricsProducer');
 const libConstants = require('../../../lib/constants');
-const { wrapCounterInc, wrapGaugeSet, wrapHistogramObserve } = require('../../../lib/util/metrics');
+const { wrapCounterInc, wrapHistogramObserve } = require('../../../lib/util/metrics');
 
 const {
     zookeeperNamespace,
@@ -70,13 +70,6 @@ const metadataReplicationStatusMetric = new promClient.Counter({
     name: 'replication_metadata_status_changed_total',
     help: 'Number of status updates',
     labelNames: ['origin', 'location', 'replicationStatus'],
-});
-
-// TODO: Kafka lag is not set in 8.x branches see BB-1
-const kafkaLagMetric = new promClient.Gauge({           // NEVER USED
-    name: 'kafka_lag',
-    help: 'Number of update entries waiting to be consumed from the Kafka topic',
-    labelNames: ['origin', 'partition', 'serviceName', 'site'],
 });
 
 const dataReplicationBytesMetric = new promClient.Counter({
@@ -124,7 +117,6 @@ const timeElapsedMetric = new promClient.Histogram({
  * @property {CounterInc} dataReplicationBytes - Increments the replication bytes metric for data operation
  * @property {CounterInc} metadataReplicationBytes - Increments the replication bytes metric for metadata operation
  * @property {CounterInc} sourceDataBytes - Increments the source data bytes metric
- * @property {GaugeSet} lag - Set the kafka lag metric
  * @property {CounterInc} reads - Increments the read metric
  * @property {CounterInc} writes - Increments the write metric
  * @property {HistogramObserve} timeElapsed - Observes the time elapsed metric
@@ -135,7 +127,6 @@ const metricsHandler = {
     dataReplicationBytes: wrapCounterInc(dataReplicationBytesMetric),
     metadataReplicationBytes: wrapCounterInc(metadataReplicationBytesMetric),
     sourceDataBytes: wrapCounterInc(sourceDataBytesMetric),
-    lag: wrapGaugeSet(kafkaLagMetric),
     reads: wrapCounterInc(readMetric),
     writes: wrapCounterInc(writeMetric),
     timeElapsed: wrapHistogramObserve(timeElapsedMetric),

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -46,7 +46,6 @@ const {
 
 promClient.register.setDefaultLabels({
     origin: 'replication',
-    containerName: process.env.CONTAINER_NAME || '',
 });
 
 /**
@@ -64,56 +63,56 @@ promClient.register.setDefaultLabels({
 const dataReplicationStatusMetric = new promClient.Counter({
     name: 'replication_data_status_changed_total',
     help: 'Number of status updates',
-    labelNames: ['origin', 'containerName', 'replicationStatus'],
+    labelNames: ['origin', 'replicationStatus'],
 });
 
 const metadataReplicationStatusMetric = new promClient.Counter({
     name: 'replication_metadata_status_changed_total',
     help: 'Number of status updates',
-    labelNames: ['origin', 'containerName', 'replicationStatus'],
+    labelNames: ['origin', 'replicationStatus'],
 });
 
 // TODO: Kafka lag is not set in 8.x branches see BB-1
-const kafkaLagMetric = new promClient.Gauge({
+const kafkaLagMetric = new promClient.Gauge({           // NEVER USED
     name: 'kafka_lag',
     help: 'Number of update entries waiting to be consumed from the Kafka topic',
-    labelNames: ['origin', 'containerName', 'partition', 'serviceName'],
+    labelNames: ['origin', 'partition', 'serviceName'],
 });
 
 const dataReplicationBytesMetric = new promClient.Counter({
     name: 'replication_data_bytes',
     help: 'Total number of bytes replicated for data operation',
-    labelNames: ['origin', 'containerName', 'serviceName'],
+    labelNames: ['origin', 'serviceName'],
 });
 
 const metadataReplicationBytesMetric = new promClient.Counter({
     name: 'replication_metadata_bytes',
     help: 'Total number of bytes replicated for metadata operation',
-    labelNames: ['origin', 'containerName', 'serviceName'],
+    labelNames: ['origin', 'serviceName'],
 });
 
 const sourceDataBytesMetric = new promClient.Counter({
     name: 'replication_source_data_bytes',
     help: 'Total number of data bytes read from replication source',
-    labelNames: ['origin', 'containerName', 'serviceName'],
+    labelNames: ['origin', 'serviceName'],
 });
 
 const readMetric = new promClient.Counter({
     name: 'replication_data_read',
     help: 'Number of read operations',
-    labelNames: ['origin', 'containerName', 'serviceName'],
+    labelNames: ['origin', 'serviceName'],
 });
 
 const writeMetric = new promClient.Counter({
     name: 'replication_data_write',
     help: 'Number of write operations',
-    labelNames: ['origin', 'containerName', 'serviceName', 'replicationContent'],
+    labelNames: ['origin', 'serviceName', 'replicationContent'],
 });
 
 const timeElapsedMetric = new promClient.Histogram({
     name: 'replication_stage_time_elapsed',
     help: 'Elapsed time of a specific stage in replication',
-    labelNames: ['origin', 'containerName', 'serviceName', 'replicationStage'],
+    labelNames: ['origin', 'serviceName', 'replicationStage'],
 });
 
 /**

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -63,56 +63,57 @@ promClient.register.setDefaultLabels({
 const dataReplicationStatusMetric = new promClient.Counter({
     name: 'replication_data_status_changed_total',
     help: 'Number of status updates',
-    labelNames: ['origin', 'replicationStatus'],
+    labelNames: ['origin', 'location', 'replicationStatus'],
 });
 
 const metadataReplicationStatusMetric = new promClient.Counter({
     name: 'replication_metadata_status_changed_total',
     help: 'Number of status updates',
-    labelNames: ['origin', 'replicationStatus'],
+    labelNames: ['origin', 'location', 'replicationStatus'],
 });
 
 // TODO: Kafka lag is not set in 8.x branches see BB-1
 const kafkaLagMetric = new promClient.Gauge({           // NEVER USED
     name: 'kafka_lag',
     help: 'Number of update entries waiting to be consumed from the Kafka topic',
-    labelNames: ['origin', 'partition', 'serviceName'],
+    labelNames: ['origin', 'partition', 'serviceName', 'site'],
 });
 
 const dataReplicationBytesMetric = new promClient.Counter({
     name: 'replication_data_bytes',
     help: 'Total number of bytes replicated for data operation',
-    labelNames: ['origin', 'serviceName'],
+    labelNames: ['origin', 'serviceName', 'location'],
 });
 
 const metadataReplicationBytesMetric = new promClient.Counter({
     name: 'replication_metadata_bytes',
     help: 'Total number of bytes replicated for metadata operation',
-    labelNames: ['origin', 'serviceName'],
+    labelNames: ['origin', 'serviceName', 'location'],
 });
 
 const sourceDataBytesMetric = new promClient.Counter({
     name: 'replication_source_data_bytes',
     help: 'Total number of data bytes read from replication source',
-    labelNames: ['origin', 'serviceName'],
+    labelNames: ['origin', 'serviceName', 'location'],
 });
 
 const readMetric = new promClient.Counter({
     name: 'replication_data_read',
     help: 'Number of read operations',
-    labelNames: ['origin', 'serviceName'],
+    labelNames: ['origin', 'serviceName', 'location'],
 });
 
 const writeMetric = new promClient.Counter({
     name: 'replication_data_write',
     help: 'Number of write operations',
-    labelNames: ['origin', 'serviceName', 'replicationContent'],
+    labelNames: ['origin', 'serviceName', 'location', 'replicationContent'],
 });
 
 const timeElapsedMetric = new promClient.Histogram({
     name: 'replication_stage_time_elapsed',
     help: 'Elapsed time of a specific stage in replication',
-    labelNames: ['origin', 'serviceName', 'replicationStage'],
+    labelNames: ['origin', 'serviceName', 'location', 'replicationStage'],
+    buckets: [0.01, 0.1, 1, 10, 30, 60, 120, 300],
 });
 
 /**

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -275,13 +275,9 @@ function initAndStart(zkClient) {
                             return undefined;
                         }
                     );
-                    // TODO: set this variable during deployment
-                    // enable metrics route only when it is enabled
-                    if (process.env.ENABLE_METRICS_PROBE === 'true') {
-                        probeServer.addHandler(DEFAULT_METRICS_ROUTE,
-                            (res, log) => QueueProcessor.handleMetrics(res, log)
-                        );
-                    }
+                    probeServer.addHandler(DEFAULT_METRICS_ROUTE,
+                        (res, log) => QueueProcessor.handleMetrics(res, log)
+                    );
                 }
             }
         );

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -278,11 +278,9 @@ function initAndStart(zkClient) {
                     // TODO: set this variable during deployment
                     // enable metrics route only when it is enabled
                     if (process.env.ENABLE_METRICS_PROBE === 'true') {
-                        // TODO: implement metrics route for multi site setup, BB-23
-                        probeServer.addHandler(DEFAULT_METRICS_ROUTE, (res, log) => {
-                            log.info('queue processor metrics route not implemented');
-                            sendSuccess(res, log);
-                        });
+                        probeServer.addHandler(DEFAULT_METRICS_ROUTE,
+                            (res, log) => QueueProcessor.handleMetrics(res, log)
+                        );
                     }
                 }
             }

--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -69,6 +69,30 @@ const replaySuccess = new promClient.Counter({
     labelNames: ['origin'],
 });
 
+const replayQueuedObjects = new promClient.Counter({
+    name: 'replication_replay_objects_queued_total',
+    help: 'Number of objects added to replay queues',
+    labelNames: ['origin', 'containerName'],
+});
+
+const replayQueuedBytes = new promClient.Counter({
+    name: 'replication_replay_bytes_queued_total',
+    help: 'Number of bytes added to replay queues',
+    labelNames: ['origin', 'containerName'],
+});
+
+const replayCompletedObjects = new promClient.Counter({
+    name: 'replication_replay_objects_completed_total',
+    help: 'Number of objects completed from replay queues',
+    labelNames: ['origin', 'containerName'],
+});
+
+const replayCompletedBytes = new promClient.Counter({
+    name: 'replication_replay_bytes_completed_total',
+    help: 'Number of bytes completed from replay queues',
+    labelNames: ['origin', 'containerName'],
+});
+
 /**
  * Contains methods to incrememt different metrics
  * @typedef {Object} ReplicationStatusMetricsHandler
@@ -82,6 +106,10 @@ const metricsHandler = {
     lag: wrapGaugeSet(kafkaLagMetric),
     replayAttempts: wrapCounterInc(replayAttempts),
     replaySuccess: wrapCounterInc(replaySuccess),
+    replayQueuedObjects: wrapCounterInc(replayQueuedObjects),
+    replayQueuedBytes: wrapCounterInc(replayQueuedBytes),
+    replayCompletedObjects: wrapCounterInc(replayCompletedObjects),
+    replayCompletedBytes: wrapCounterInc(replayCompletedBytes),
 };
 
 /**

--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -613,6 +613,15 @@ class ReplicationStatusProcessor {
         });
         res.end(promClient.register.metrics());
     }
+
+    /**
+     * Static trampoline, for use from tests.
+     * @param {Object} repConfig - Replication configuration
+     * @returns {ReplicationStatusMetricsHandler} Metric handlers
+     */
+    static loadMetricHandlers(repConfig) {
+        return loadMetricHandlers(repConfig);
+    }
 }
 
 module.exports = ReplicationStatusProcessor;

--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -218,7 +218,7 @@ class ReplicationStatusProcessor {
         }
 
         this._setupVaultclientCache();
-        this.metricsHandlers = loadMetricHandlers(repConfig);
+        this.metricHandlers = loadMetricHandlers(repConfig);
 
         const { monitorReplicationFailureExpiryTimeS } = this.repConfig;
         this._statsClient = new StatsModel(undefined, INTERVAL,
@@ -526,7 +526,7 @@ class ReplicationStatusProcessor {
         }
         let task;
         if (sourceEntry instanceof ObjectQueueEntry) {
-            task = new UpdateReplicationStatus(this, this.metricsHandlers);
+            task = new UpdateReplicationStatus(this, this.metricHandlers);
         }
         if (task) {
             return this.taskScheduler.push({ task, entry: sourceEntry },

--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -29,7 +29,6 @@ const promClient = require('prom-client');
 const constants = require('../../../lib/constants');
 const {
     wrapCounterInc,
-    wrapGaugeSet,
     wrapHistogramObserve,
 } = require('../../../lib/util/metrics');
 
@@ -49,7 +48,6 @@ promClient.register.setDefaultLabels({
  * Contains methods to incrememt different metrics
  * @typedef {Object} ReplicationStatusMetricsHandler
  * @property {CounterInc} status - Increments the replication status metric
- * @property {GaugeSet} lag - Set the kafka lag metric
  * @property {CounterInc} replayAttempts - Increments the replay attempts metric
  * @property {CounterInc} replaySuccess - Increments the replay success metric
  * @property {CounterInc} replayQueuedObjects - Increments the replay queued objects metric
@@ -69,12 +67,6 @@ function loadMetricHandlers(repConfig) {
         name: 'replication_status_changed_total',
         help: 'Number of objects updated',
         labelNames: ['origin', 'replicationStatus'],
-    });
-
-    const kafkaLagMetric = new promClient.Gauge({
-        name: 'kafka_lag',
-        help: 'Number of update entries waiting to be consumed from the Kafka topic',
-        labelNames: ['origin', 'partition'],
     });
 
     const replayAttempts = new promClient.Counter({
@@ -129,7 +121,6 @@ function loadMetricHandlers(repConfig) {
 
     return {
         status: wrapCounterInc(replicationStatusMetric),
-        lag: wrapGaugeSet(kafkaLagMetric),
         replayAttempts: wrapCounterInc(replayAttempts),
         replaySuccess: wrapCounterInc(replaySuccess),
         replayQueuedObjects: wrapCounterInc(replayQueuedObjects),

--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -34,14 +34,12 @@ const {
 
 promClient.register.setDefaultLabels({
     origin: 'replication',
-    containerName: process.env.CONTAINER_NAME || '',
 });
 
 /**
  * Labels used for Prometheus metrics
  * @typedef {Object} MetricLabels
  * @property {string} origin - Method that began the replication
- * @property {string} containerName - Name of the container running our process
  * @property {string} [replicationStatus] - Result of the replications status
  * @property {string} [partition] - What kafka partition relates to the metric
  */
@@ -49,26 +47,26 @@ promClient.register.setDefaultLabels({
 const replicationStatusMetric = new promClient.Counter({
     name: 'replication_status_changed_total',
     help: 'Number of objects updated',
-    labelNames: ['origin', 'containerName', 'replicationStatus'],
+    labelNames: ['origin', 'replicationStatus'],
 });
 
 // TODO: Kafka lag is not set in 8.x branches see BB-1
 const kafkaLagMetric = new promClient.Gauge({
     name: 'kafka_lag',
     help: 'Number of update entries waiting to be consumed from the Kafka topic',
-    labelNames: ['origin', 'containerName', 'partition'],
+    labelNames: ['origin', 'partition'],
 });
 
 const replayAttempts = new promClient.Counter({
     name: 'replication_replay_attempts_total',
     help: 'Number of total attempts made to replay replication',
-    labelNames: ['origin', 'containerName'],
+    labelNames: ['origin'],
 });
 
 const replaySuccess = new promClient.Counter({
     name: 'replication_replay_success_total',
     help: 'Number of times an object was replicated during a replay',
-    labelNames: ['origin', 'containerName'],
+    labelNames: ['origin'],
 });
 
 /**

--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -72,50 +72,50 @@ function loadMetricHandlers(repConfig) {
     const replayAttempts = new promClient.Counter({
         name: 'replication_replay_attempts_total',
         help: 'Number of total attempts made to replay replication',
-        labelNames: ['origin'],
+        labelNames: ['origin', 'location', 'replayCount'],
     });
 
     const replaySuccess = new promClient.Counter({
         name: 'replication_replay_success_total',
         help: 'Number of times an object was replicated during a replay',
-        labelNames: ['origin'],
+        labelNames: ['origin', 'location', 'replayCount'],
     });
 
     const replayQueuedObjects = new promClient.Counter({
         name: 'replication_replay_objects_queued_total',
         help: 'Number of objects added to replay queues',
-        labelNames: ['origin'],
+        labelNames: ['origin', 'location', 'replayCount'],
     });
 
     const replayQueuedBytes = new promClient.Counter({
         name: 'replication_replay_bytes_queued_total',
         help: 'Number of bytes added to replay queues',
-        labelNames: ['origin'],
+        labelNames: ['origin', 'location', 'replayCount'],
     });
 
     const replayQueuedFileSizes = new promClient.Histogram({
         name: 'replication_replay_file_sizes_queued',
         help: 'Number of objects queued for replay by file size',
-        labelNames: ['origin'],
+        labelNames: ['origin', 'location', 'replayCount'],
         buckets: repConfig.objectSizeMetrics,
     });
 
     const replayCompletedObjects = new promClient.Counter({
         name: 'replication_replay_objects_completed_total',
         help: 'Number of objects completed from replay queues',
-        labelNames: ['origin'],
+        labelNames: ['origin', 'location', 'replayCount', 'replicationStatus'],
     });
 
     const replayCompletedBytes = new promClient.Counter({
         name: 'replication_replay_bytes_completed_total',
         help: 'Number of bytes completed from replay queues',
-        labelNames: ['origin'],
+        labelNames: ['origin', 'location', 'replayCount', 'replicationStatus'],
     });
 
     const replayCompletedFileSizes = new promClient.Histogram({
         name: 'replication_replay_file_sizes_completed',
         help: 'Number of objects completed from replay by file size',
-        labelNames: ['origin', 'replicationStatus'],
+        labelNames: ['origin', 'location', 'replayCount', 'replicationStatus'],
         buckets: repConfig.objectSizeMetrics,
     });
 

--- a/extensions/replication/replicationStatusProcessor/task.js
+++ b/extensions/replication/replicationStatusProcessor/task.js
@@ -51,14 +51,9 @@ function initAndStart() {
                     probeServer.addHandler([DEFAULT_LIVE_ROUTE, DEFAULT_READY_ROUTE],
                         (res, log) => replicationStatusProcessor.handleLiveness(res, log)
                     );
-                    // TODO: set this variable during deployment
-                    // enable metrics route only when it is enabled
-                    if (process.env.ENABLE_METRICS_PROBE === 'true') {
-                        probeServer.addHandler(
-                            DEFAULT_METRICS_ROUTE,
-                            (res, log) => replicationStatusProcessor.handleMetrics(res, log)
-                        );
-                    }
+                    probeServer.addHandler(DEFAULT_METRICS_ROUTE,
+                        (res, log) => replicationStatusProcessor.handleMetrics(res, log)
+                    );
                 }
                 logger.info('management init done');
             }

--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -181,9 +181,9 @@ class ReplicateObject extends BackbeatTask {
                     replicationStatus,
                     reason,
                 });
-                this.metricsHandler.metadataReplicationStatus({ replicationStatus });
+                this.metricsHandler.metadataReplicationStatus({ replicationStatus, location: this.site });
                 if (updateData) {
-                    this.metricsHandler.dataReplicationStatus({ replicationStatus });
+                    this.metricsHandler.dataReplicationStatus({ replicationStatus, location: this.site });
                 }
             }
             // Commit whether there was an error or not to allow
@@ -367,21 +367,24 @@ class ReplicateObject extends BackbeatTask {
         const serviceName = this.serviceName;
         this.metricsHandler.timeElapsed({
             serviceName,
+            location: this.site,
             replicationStage: replicationStages.sourceDataRead,
-        }, Date.now() - readStartTime);
-        this.metricsHandler.sourceDataBytes({ serviceName }, size);
-        this.metricsHandler.reads({ serviceName });
+        }, (Date.now() - readStartTime) / 1000);
+        this.metricsHandler.sourceDataBytes({ serviceName, location: this.site }, size);
+        this.metricsHandler.reads({ serviceName, location: this.site });
     }
 
     _publishDataWriteMetrics(size, sourceEntry, writeStartTime) {
         const serviceName = this.serviceName;
         this.metricsHandler.timeElapsed({
             serviceName,
+            location: this.site,
             replicationStage: replicationStages.destinationDataWrite,
-        }, Date.now() - writeStartTime);
-        this.metricsHandler.dataReplicationBytes({ serviceName }, size);
+        }, (Date.now() - writeStartTime) / 1000);
+        this.metricsHandler.dataReplicationBytes({ serviceName, location: this.site }, size);
         this.metricsHandler.writes({
             serviceName,
+            location: this.site,
             replicationContent: 'data',
         });
         const extMetrics = getExtMetrics(this.site, size, sourceEntry);
@@ -393,13 +396,16 @@ class ReplicateObject extends BackbeatTask {
         const serviceName = this.serviceName;
         this.metricsHandler.timeElapsed({
             serviceName,
+            location: this.site,
             replicationStage: replicationStages.destinationMetadataWrite,
-        }, Date.now() - writeStartTime);
+        }, (Date.now() - writeStartTime) / 1000);
         this.metricsHandler.metadataReplicationBytes({
             serviceName,
+            location: this.site,
         }, Buffer.byteLength(buffer));
         this.metricsHandler.writes({
             serviceName,
+            location: this.site,
             replicationContent: 'metadata',
         });
     }

--- a/extensions/replication/tasks/UpdateReplicationStatus.js
+++ b/extensions/replication/tasks/UpdateReplicationStatus.js
@@ -216,6 +216,8 @@ class UpdateReplicationStatus extends BackbeatTask {
             entry = refreshedEntry.toCompletedEntry(site);
             if (sourceEntry.getReplayCount() >= 0) {
                 this.metricsHandler.replaySuccess();
+                this.metricsHandler.replayCompletedObjects();
+                this.metricsHandler.replayCompletedBytes(sourceEntry.getContentLength());
             }
         } else if (newStatus === 'FAILED') {
             entry = this._handleFailedReplicationEntry(refreshedEntry, sourceEntry, site, log);
@@ -347,6 +349,8 @@ class UpdateReplicationStatus extends BackbeatTask {
             if (this.bucketNotificationConfig) {
                 this._publishFailedReplicationStatusNotification(queueEntry, log);
             }
+            this.metricsHandler.replayCompletedObjects();
+            this.metricsHandler.replayCompletedBytes(queueEntry.getContentLength());
             return refreshedEntry.toFailedEntry(site);
         }
         const totalAttempts = this.replayTopics.length;
@@ -361,6 +365,8 @@ class UpdateReplicationStatus extends BackbeatTask {
             // If no replay count has been defined yet:
             queueEntry.setReplayCount(totalAttempts);
             this._pushReplayEntry(queueEntry, site, log);
+            this.metricsHandler.replayQueuedObjects();
+            this.metricsHandler.replayQueuedBytes(queueEntry.getContentLength());
             return null;
         }
         log.error('count value is invalid',

--- a/extensions/replication/tasks/UpdateReplicationStatus.js
+++ b/extensions/replication/tasks/UpdateReplicationStatus.js
@@ -218,6 +218,10 @@ class UpdateReplicationStatus extends BackbeatTask {
                 this.metricsHandler.replaySuccess();
                 this.metricsHandler.replayCompletedObjects();
                 this.metricsHandler.replayCompletedBytes(sourceEntry.getContentLength());
+                this.metricsHandler.replayCompletedFileSizes(
+                    { replicationStatus: 'COMPLETED' },
+                    sourceEntry.getContentLength(),
+                );
             }
         } else if (newStatus === 'FAILED') {
             entry = this._handleFailedReplicationEntry(refreshedEntry, sourceEntry, site, log);
@@ -351,6 +355,10 @@ class UpdateReplicationStatus extends BackbeatTask {
             }
             this.metricsHandler.replayCompletedObjects();
             this.metricsHandler.replayCompletedBytes(queueEntry.getContentLength());
+            this.metricsHandler.replayCompletedFileSizes(
+                { replicationStatus: 'FAILED' },
+                queueEntry.getContentLength(),
+            );
             return refreshedEntry.toFailedEntry(site);
         }
         const totalAttempts = this.replayTopics.length;
@@ -367,6 +375,7 @@ class UpdateReplicationStatus extends BackbeatTask {
             this._pushReplayEntry(queueEntry, site, log);
             this.metricsHandler.replayQueuedObjects();
             this.metricsHandler.replayQueuedBytes(queueEntry.getContentLength());
+            this.metricsHandler.replayQueuedFileSizes(queueEntry.getContentLength());
             return null;
         }
         log.error('count value is invalid',

--- a/extensions/replication/tasks/UpdateReplicationStatus.js
+++ b/extensions/replication/tasks/UpdateReplicationStatus.js
@@ -263,20 +263,21 @@ class UpdateReplicationStatus extends BackbeatTask {
             versionId: updatedSourceEntry.getEncodedVersionId(),
             mdBlob: updatedSourceEntry.getSerialized(),
         }, log, err => {
+            const replicationStatus = updatedSourceEntry.getReplicationStatus();
             if (err) {
                 log.error('an error occurred when updating metadata', {
                     entry: updatedSourceEntry.getLogInfo(),
                     origin: 'source',
                     peer: this.sourceConfig.s3,
-                    replicationStatus:
-                        updatedSourceEntry.getReplicationStatus(),
+                    replicationStatus,
                     error: err.message,
                 });
                 return cb(err);
             }
+            this.metricsHandler.status({ replicationStatus });
             log.end().info('metadata updated', {
                 entry: updatedSourceEntry.getLogInfo(),
-                replicationStatus: updatedSourceEntry.getReplicationStatus(),
+                replicationStatus,
             });
             return cb();
         });

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -14,15 +14,12 @@ const KafkaLogReader = require('./KafkaLogReader');
 const { metricsExtension } = require('../../extensions/replication/constants');
 const NotificationConfigManager
     = require('../../extensions/notification/NotificationConfigManager');
-const promClient = require('prom-client');
+const { ZenkoMetrics } = require('arsenal').metrics;
 const constants = require('../constants');
 const { wrapCounterInc, wrapGaugeSet } = require('../util/metrics');
 const { sendSuccess } = require('arsenal').network.probe.Utils;
 
 const metricLabels = ['origin', 'logName', 'logId'];
-promClient.register.setDefaultLabels({
-    origin: 'replication',
-});
 
 /**
  * Labels used for Prometheus metrics
@@ -34,35 +31,39 @@ promClient.register.setDefaultLabels({
  * @property {string} [publishStatus] - Result of the publishing to kafka to the topic
  */
 
-const logReadOffsetMetric = new promClient.Gauge({
+const logReadOffsetMetric = ZenkoMetrics.createGauge({
     name: 'replication_read_offset',
     help: 'Current read offset of metadata journal',
     labelNames: metricLabels,
 });
 
-const logSizeMetric = new promClient.Gauge({
+const logSizeMetric = ZenkoMetrics.createGauge({
     name: 'replication_log_size',
     help: 'Current size of metadata journal',
     labelNames: metricLabels,
 });
 
-const messageMetrics = new promClient.Counter({
+const messageMetrics = ZenkoMetrics.createCounter({
     name: 'replication_populator_messages',
     help: 'Total number of Kafka messages produced by the queue populator',
-    labelNames: ['origin', 'logName', 'logId', 'publishStatus'],
+    labelNames: [...metricLabels, 'publishStatus'],
 });
 
-const objectMetrics = new promClient.Counter({
+const objectMetrics = ZenkoMetrics.createCounter({
     name: 'replication_populator_objects',
     help: 'Total objects queued for replication',
     labelNames: metricLabels,
 });
 
-const byteMetrics = new promClient.Counter({
+const byteMetrics = ZenkoMetrics.createCounter({
     name: 'replication_populator_bytes',
     help: 'Total number of bytes queued for replication not including metadata',
     labelNames: metricLabels,
 });
+
+const defaultLabels = {
+    origin: 'replication',
+};
 
 /**
  * Contains methods to incrememt different metrics
@@ -74,11 +75,11 @@ const byteMetrics = new promClient.Counter({
  * @property {GaugeSet} logSize - Set the log size metric
  */
 const metricsHandler = {
-    messages: wrapCounterInc(messageMetrics),
-    objects: wrapCounterInc(objectMetrics),
-    bytes: wrapCounterInc(byteMetrics),
-    logReadOffset: wrapGaugeSet(logReadOffsetMetric),
-    logSize: wrapGaugeSet(logSizeMetric),
+    messages: wrapCounterInc(messageMetrics, defaultLabels),
+    objects: wrapCounterInc(objectMetrics, defaultLabels),
+    bytes: wrapCounterInc(byteMetrics, defaultLabels),
+    logReadOffset: wrapGaugeSet(logReadOffsetMetric, defaultLabels),
+    logSize: wrapGaugeSet(logSizeMetric, defaultLabels),
 };
 
 class QueuePopulator {
@@ -564,9 +565,9 @@ class QueuePopulator {
     handleMetrics(res, log) {
         log.debug('metrics requested');
         res.writeHead(200, {
-            'Content-Type': promClient.register.contentType,
+            'Content-Type': ZenkoMetrics.asPrometheusContentType(),
         });
-        res.end(promClient.register.metrics());
+        res.end(ZenkoMetrics.asPrometheus());
     }
 }
 

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -19,10 +19,9 @@ const constants = require('../constants');
 const { wrapCounterInc, wrapGaugeSet } = require('../util/metrics');
 const { sendSuccess } = require('arsenal').network.probe.Utils;
 
-const metricLabels = ['origin', 'logName', 'logId', 'containerName'];
+const metricLabels = ['origin', 'logName', 'logId'];
 promClient.register.setDefaultLabels({
     origin: 'replication',
-    containerName: process.env.CONTAINER_NAME || '',
 });
 
 /**
@@ -50,7 +49,7 @@ const logSizeMetric = new promClient.Gauge({
 const messageMetrics = new promClient.Counter({
     name: 'replication_populator_messages',
     help: 'Total number of Kafka messages produced by the queue populator',
-    labelNames: ['origin', 'logName', 'logId', 'containerName', 'publishStatus'],
+    labelNames: ['origin', 'logName', 'logId', 'publishStatus'],
 });
 
 const objectMetrics = new promClient.Counter({

--- a/lib/util/metrics.js
+++ b/lib/util/metrics.js
@@ -14,14 +14,24 @@
  */
 
 /**
+ * @param {LabelValues<string>} defaultLabels - Default labels to apply
+ * @param {LabelValues<string>} labels - Labels to apply
+ * @return {LabelValues<string>} Final list of labels to apply
+ */
+function mergeLabels(defaultLabels, labels) {
+    return { ...(defaultLabels || {}), ...labels };
+}
+
+/**
  * WrapCounterInc wraps the Counters Inc method adding the metric labels used.
  *
  * @param {promClient.Counter} metric - Prom counter metric
+ * @param {LabelValues<string>} defaultLabels - Default labels to apply
  * @returns {CounterInc} - Function used to increment counter
  */
-function wrapCounterInc(metric) {
+function wrapCounterInc(metric, defaultLabels = {}) {
     return (labels, value) => {
-        metric.inc(labels, value);
+        metric.inc(mergeLabels(defaultLabels, labels), value);
     };
 }
 
@@ -29,11 +39,12 @@ function wrapCounterInc(metric) {
  * WrapGaugeSet wraps a Prometheus Guage's set method
  *
  * @param {promClient.Gauge} metric - Prom gauge metric
+ * @param {LabelValues<string>} defaultLabels - Default labels to apply
  * @returns {GaugeSet} - Function used to set gauge
  */
-function wrapGaugeSet(metric) {
+function wrapGaugeSet(metric, defaultLabels = {}) {
     return (labels, value) => {
-        metric.set(labels, value);
+        metric.set(mergeLabels(defaultLabels, labels), value);
     };
 }
 
@@ -41,11 +52,12 @@ function wrapGaugeSet(metric) {
  * WrapHistogramObserve wraps a Prometheus Histogram's observe method
  *
  * @param {promClient.Histogram} metric - Prom histogram metric
+ * @param {LabelValues<string>} defaultLabels - Default labels to apply
  * @returns {HistogramObserve} - Function used to observe histogram
  */
-function wrapHistogramObserve(metric) {
+function wrapHistogramObserve(metric, defaultLabels = {}) {
     return (labels, value) => {
-        metric.observe(labels, value);
+        metric.observe(mergeLabels(defaultLabels, labels), value);
     };
 }
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "node-rdkafka": "^2.12.0",
     "node-schedule": "^1.2.0",
     "node-zookeeper-client": "^1.1.3",
-    "prom-client": "^12.0.0",
     "uuid": "^3.1.0",
     "vaultclient": "scality/vaultclient#8.3.6",
     "werelogs": "scality/werelogs#8.1.0",

--- a/tests/config.json
+++ b/tests/config.json
@@ -149,7 +149,8 @@
                     "bindAddress": "localhost",
                     "port": 4045
                 }
-            }
+            },
+            "objectSizeMetrics": [100, 1000]
         },
         "lifecycle": {
             "zookeeperPath": "/lifecycletest",

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -4,7 +4,6 @@ const crypto = require('crypto');
 const http = require('http');
 const URL = require('url');
 const querystring = require('querystring');
-const promClient = require('prom-client');
 
 const VersionIDUtils = require('arsenal').versioning.VersionID;
 const routesUtils = require('arsenal').s3routes.routesUtils;
@@ -761,7 +760,6 @@ describe('queue processor functional tests with mocking', () => {
     let copyLocationResultsConsumer;
 
     const QueueProcessor = require('../../../extensions/replication/queueProcessor/QueueProcessor');
-    promClient.register.clear();
     const ReplicationStatusProcessor = require('../../../extensions/replication' +
                   '/replicationStatusProcessor/ReplicationStatusProcessor');
 

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -842,6 +842,7 @@ describe('queue processor functional tests with mocking', () => {
                               groupId: 'backbeat-func-test-group-id',
                           },
                           monitorReplicationFailures: true,
+                          objectSizeMetrics: [100, 1000],
                         },
                         {},
                         { topic: 'metrics-test-topic' });

--- a/tests/unit/lib/util/metrics.spec.js
+++ b/tests/unit/lib/util/metrics.spec.js
@@ -1,5 +1,5 @@
 const sinon = require('sinon');
-const { wrapCounterInc, wrapGaugeSet } =
+const { wrapCounterInc, wrapGaugeSet, wrapHistogramObserve } =
     require('../../../../lib/util/metrics');
 
 describe('Metrics', () => {
@@ -7,15 +7,75 @@ describe('Metrics', () => {
         const mockCounter = sinon.spy();
         mockCounter.inc = sinon.spy();
         const incFn = wrapCounterInc(mockCounter);
-        incFn('label', 1);
-        sinon.assert.calledOnceWithExactly(mockCounter.inc, 'label', 1);
+        incFn({ label: 'value' }, 1);
+        sinon.assert.calledOnceWithExactly(mockCounter.inc, { label: 'value' }, 1);
+    });
+
+    it('can add default labels to wrapped counter', () => {
+        const mockCounter = sinon.spy();
+        mockCounter.inc = sinon.spy();
+        const incFn = wrapCounterInc(mockCounter, { defaultLabel: 'default' });
+        incFn({ label: 'value' }, 1);
+        sinon.assert.calledOnceWithExactly(mockCounter.inc,
+            { defaultLabel: 'default', label: 'value' }, 1);
+    });
+
+    it('can override default labels on wrapped counter', () => {
+        const mockCounter = sinon.spy();
+        mockCounter.inc = sinon.spy();
+        const incFn = wrapCounterInc(mockCounter, { label: 'default' });
+        incFn({ label: 'value' }, 1);
+        sinon.assert.calledOnceWithExactly(mockCounter.inc, { label: 'value' }, 1);
     });
 
     it('can wrap gauge set', () => {
         const mockGauge = sinon.spy();
         mockGauge.set = sinon.spy();
         const setFn = wrapGaugeSet(mockGauge);
-        setFn('label', 15);
-        sinon.assert.calledOnceWithExactly(mockGauge.set, 'label', 15);
+        setFn({ label: 'value' }, 15);
+        sinon.assert.calledOnceWithExactly(mockGauge.set, { label: 'value' }, 15);
+    });
+
+    it('can add default labels to wrapped gauge', () => {
+        const mockGauge = sinon.spy();
+        mockGauge.set = sinon.spy();
+        const setFn = wrapGaugeSet(mockGauge, { defaultLabel: 'default' });
+        setFn({ label: 'value' }, 15);
+        sinon.assert.calledOnceWithExactly(mockGauge.set,
+            { defaultLabel: 'default', label: 'value' }, 15);
+    });
+
+    it('can override default labels to wrapped gauge', () => {
+        const mockGauge = sinon.spy();
+        mockGauge.set = sinon.spy();
+        const setFn = wrapGaugeSet(mockGauge, { label: 'default' });
+        setFn({ label: 'value' }, 15);
+        sinon.assert.calledOnceWithExactly(mockGauge.set, { label: 'value' }, 15);
+    });
+
+    it('can wrap histogram observe', () => {
+        const mockHistogram = sinon.spy();
+        mockHistogram.observe = sinon.spy();
+        const observeFn = wrapHistogramObserve(mockHistogram);
+        observeFn({ label: 'value' }, 15);
+        sinon.assert.calledOnceWithExactly(mockHistogram.observe, { label: 'value' }, 15);
+    });
+
+    it('can add default labels to wrapped histogram', () => {
+        const mockHistogram = sinon.spy();
+        mockHistogram.observe = sinon.spy();
+        const observeFn = wrapHistogramObserve(mockHistogram,
+            { defaultLabel: 'default' });
+        observeFn({ label: 'value' }, 15);
+        sinon.assert.calledOnceWithExactly(mockHistogram.observe,
+            { defaultLabel: 'default', label: 'value' }, 15);
+    });
+
+    it('can add default labels to wrapped histogram', () => {
+        const mockHistogram = sinon.spy();
+        mockHistogram.observe = sinon.spy();
+        const observeFn = wrapHistogramObserve(mockHistogram, { label: 'default' });
+        observeFn({ label: 'value' }, 15);
+        sinon.assert.calledOnceWithExactly(mockHistogram.observe, { label: 'value' }, 15);
     });
 });

--- a/tests/unit/replication/ReplicationStatusProcessor.js
+++ b/tests/unit/replication/ReplicationStatusProcessor.js
@@ -1,5 +1,4 @@
 const assert = require('assert');
-const promClient = require('prom-client');
 
 const ReplicationStatusProcessor =
     require('../../../extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor');
@@ -17,12 +16,6 @@ function makeReplicationStatusProcessor(replayTopics) {
 }
 
 describe('ReplicationStatusProcessor', () => {
-    beforeEach(() => {
-        // Clear register to avoid:
-        // Error: A metric with the name kafka_lag has already been registered.
-        promClient.register.clear();
-    });
-
     describe('::_reshapeReplayTopics', () => {
         it('should return undefined if the config replay topics is undefined', () => {
             const replayTopics = undefined;

--- a/tests/unit/replication/ReplicationStatusProcessor.js
+++ b/tests/unit/replication/ReplicationStatusProcessor.js
@@ -1,10 +1,6 @@
 const assert = require('assert');
 const promClient = require('prom-client');
 
-// Clear register to avoid:
-// Error: A metric with the name kafka_lag has already been registered.
-promClient.register.clear();
-
 const ReplicationStatusProcessor =
     require('../../../extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor');
 
@@ -16,11 +12,17 @@ function makeReplicationStatusProcessor(replayTopics) {
             s3: {},
             transport: 'http',
         },
-        { replayTopics },
+        { replayTopics, objectSizeMetrics: [100, 1000] },
         {});
 }
 
 describe('ReplicationStatusProcessor', () => {
+    beforeEach(() => {
+        // Clear register to avoid:
+        // Error: A metric with the name kafka_lag has already been registered.
+        promClient.register.clear();
+    });
+
     describe('::_reshapeReplayTopics', () => {
         it('should return undefined if the config replay topics is undefined', () => {
             const replayTopics = undefined;

--- a/tests/utils/mockEntries.js
+++ b/tests/utils/mockEntries.js
@@ -7,6 +7,7 @@ const sourceEntry = {
     getLocation: () => ([]),
     getUserMetadata: () => {},
     getContentType: () => {},
+    getContentLength: () => 0,
     getCacheControl: () => {},
     getContentDisposition: () => {},
     getContentEncoding: () => {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -4452,13 +4452,6 @@ prom-client@10.2.3:
   dependencies:
     tdigest "^0.1.1"
 
-prom-client@^12.0.0:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-12.0.0.tgz#9689379b19bd3f6ab88a9866124db9da3d76c6ed"
-  integrity sha512-JbzzHnw0VDwCvoqf8y1WDtq4wSBAbthMB1pcVI/0lzdqHGJI3KBJDXle70XK+c7Iv93Gihqo0a5LlOn+g8+DrQ==
-  dependencies:
-    tdigest "^0.1.1"
-
 prom-client@^13.1.0:
   version "13.2.0"
   resolved "https://registry.yarnpkg.com/prom-client/-/prom-client-13.2.0.tgz#99d13357912dd400f8911b77df19f7b328a93e92"


### PR DESCRIPTION
- Add metrics computation to MultipleBackendTask
- Implement metrics route in QueueProcessor
- Enable replication metrics
- Remove containerName label from metrics
- Collect replicationStatusMetric
- feature: BB-133 add replay specific backlog metrics
- feature: BB-132 upload size metrics for replays
- Add target location to QueueProcessor metrics
- Remove unused kafka lag metrics
- Add location and replayCount to replay metrics

Issue: BB-62
