### PR TITLE
Expose the last timestamp read from mongo oplog

### DIFF
--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -418,8 +418,14 @@ class LogReader {
         const dataEventHandler = record => {
             logger.debug('received log data', {
                 nbEntries: record.entries.length,
+                timestamp: record.timestamp,
             });
             logStats.nbLogRecordsRead += 1;
+
+            if (record.timestamp) {
+                const timestamp = new Date(record.timestamp).getTime() / 1000;
+                this._metricsHandler.logTimestamp(this.getMetricLabels(), timestamp);
+            }
 
             this._setEntryBatch(entriesToPublish);
             /**

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -43,6 +43,12 @@ const logSizeMetric = ZenkoMetrics.createGauge({
     labelNames: metricLabels,
 });
 
+const logTimestamp = ZenkoMetrics.createGauge({
+    name: 'replication_log_timestamp',
+    help: 'Last timestamp read from the metadata journal',
+    labelNames: metricLabels,
+});
+
 const messageMetrics = ZenkoMetrics.createCounter({
     name: 'replication_populator_messages',
     help: 'Total number of Kafka messages produced by the queue populator',
@@ -80,6 +86,7 @@ const metricsHandler = {
     bytes: wrapCounterInc(byteMetrics, defaultLabels),
     logReadOffset: wrapGaugeSet(logReadOffsetMetric, defaultLabels),
     logSize: wrapGaugeSet(logSizeMetric, defaultLabels),
+    logTimestamp: wrapGaugeSet(logTimestamp, defaultLabels),
 };
 
 class QueuePopulator {


### PR DESCRIPTION
It can be compared to `mongodb_mongod_replset_oplog_head_timestamp`
from mongo to see how far we lag.

Issue: BB-279
