### PR TITLE
bugfix: BB-288 remove versionId from object key in the notification

### DIFF
--- a/extensions/notification/NotificationQueuePopulator.js
+++ b/extensions/notification/NotificationQueuePopulator.js
@@ -63,7 +63,7 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
             }
             const ent = {
                 bucket,
-                key,
+                key: value.key,
                 eventType,
                 versionId,
             };
@@ -96,13 +96,18 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
                         method: 'NotificationQueuePopulator._processObjectEntry',
                         bucket,
                         key: message.key,
+                        versionId,
                         eventType,
                         eventTime: message.dateTime,
                     });
                     const internalTopic = destination.internalTopic ||
                         this.notificationConfig.topic;
                     this.publish(internalTopic,
-                        `${bucket}/${key}`,
+                        // keeping all messages for same object
+                        // in the same partition to keep the order.
+                        // here we use the object name and not the
+                        // "_id" which also includes the versionId
+                        `${bucket}/${message.key}`,
                         JSON.stringify(message));
                 }
                 return undefined;

--- a/extensions/notification/queueProcessor/QueueProcessor.js
+++ b/extensions/notification/queueProcessor/QueueProcessor.js
@@ -219,6 +219,7 @@ class QueueProcessor extends EventEmitter {
                         method: 'QueueProcessor.processKafkaEntry',
                         bucket,
                         key,
+                        versionId: sourceEntry.versionId,
                         eventType,
                         destination: this.destinationId,
                     });
@@ -239,6 +240,8 @@ class QueueProcessor extends EventEmitter {
                             method: 'QueueProcessor.processKafkaEntry',
                             bucket,
                             key,
+                            versionId: sourceEntry.versionId,
+                            encodedVersionId: eventRecord.versionId,
                             eventType: eventRecord.eventName,
                             eventTime: eventRecord.eventTime,
                             destination: this.destinationId,


### PR DESCRIPTION
Issue: [BB-288](https://scality.atlassian.net/browse/BB-288)

Current notifications display the object "_id" as the key, which contains both the object name and the unencoded versionId. changed that to showing only the object name.