### PR TITLE
bugfix: BB-289 set notification versionId to null if object is a null…

### DIFF
--- a/extensions/notification/NotificationQueuePopulator.js
+++ b/extensions/notification/NotificationQueuePopulator.js
@@ -39,6 +39,26 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
     }
 
     /**
+     * Returns the correct versionId
+     * to display according to the
+     * versioning state of the object
+     * @param {Object} value log entry object
+     * @return {String} versionId
+     */
+    _getVersionId(value) {
+        const isNullVersion = value.isNull;
+        const isVersioned = !!value.versionId;
+        // Versioning suspended objects have
+        // a versionId, however it is internal
+        // and should not be used to get the object
+        if (isNullVersion || !isVersioned) {
+            return null;
+        } else {
+            return value.versionId;
+        }
+    }
+
+    /**
      * Process object entry from the log
      *
      * @param {String} bucket - bucket
@@ -48,7 +68,7 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
      * @return {undefined}
      */
     async _processObjectEntry(bucket, key, value, type) {
-        const versionId = value.versionId || null;
+        const versionId = this._getVersionId(value);
         if (!isMasterKey(key)) {
             return undefined;
         }

--- a/tests/unit/notification/NotificationQueuePopulator.js
+++ b/tests/unit/notification/NotificationQueuePopulator.js
@@ -172,4 +172,30 @@ describe('NotificationQueuePopulator ::', () => {
             return done();
         });
     });
+
+    describe('_getVersionId', () => {
+        [
+            {
+                desc: 'non versioned',
+                input: {},
+                out: null
+            },
+            {
+                desc: 'versioned',
+                input: { versionId: '1234' },
+                out: '1234'
+            },
+            {
+                desc: 'a null version',
+                input: { isNull: true, versionId: '1234' },
+                out: null
+            },
+        ].forEach(tests => {
+            const { desc, input, out } = tests;
+            it(`Should return ${out} when object is ${desc}`, () => {
+                const versionId = notificationQueuePopulator._getVersionId(input);
+                assert.strictEqual(versionId, out);
+            });
+        });
+    });
 });


### PR DESCRIPTION
… version

Issue [BB-289](https://scality.atlassian.net/browse/BB-289)

"null" versions have an internal versionId that should not be used externally, as it's not possible to access the object using that versionId