### PR TITLE
bugfix: BB-290 update all the connector configuration instead of only…

### DIFF
--- a/extensions/oplogPopulator/modules/Connector.js
+++ b/extensions/oplogPopulator/modules/Connector.js
@@ -212,6 +212,12 @@ class Connector {
     /**
      * Updates connector pipeline with
      * buckets assigned to this connector
+     *
+     * The first time this function is called,
+     * on an old connector, it updates it's configuration
+     * as it can be outdated; having the wrong topic for example.
+     * That is why we use updateConnectorConfig() instead of
+     * updateConnectorPipeline()
      * @param {boolean} [doUpdate=false] updates connector if true
      * @returns {Promise|boolean} connector did update
      * @throws {InternalError}
@@ -226,7 +232,7 @@ class Connector {
             if (doUpdate) {
                 const timeBeforeUpdate = Date.now();
                 this._state.isUpdating = true;
-                await this._kafkaConnect.updateConnectorPipeline(this._name, this._config.pipeline);
+                await this._kafkaConnect.updateConnectorConfig(this._name, this._config);
                 this._updateConnectorState(false, timeBeforeUpdate);
                 this._state.isUpdating = false;
                 return true;

--- a/extensions/oplogPopulator/modules/ConnectorsManager.js
+++ b/extensions/oplogPopulator/modules/ConnectorsManager.js
@@ -156,10 +156,11 @@ class ConnectorsManager {
         try {
             const connectors = await Promise.all(connectorNames.map(async connectorName => {
                 // get old connector config
-                const config = await this._kafkaConnect.getConnectorConfig(connectorName);
-                // extract buckets from old connector config and filter them
-                // only leaving currently valid buckets
-                const buckets = this._extractBucketsFromConfig(config);
+                const oldConfig = await this._kafkaConnect.getConnectorConfig(connectorName);
+                // extract buckets from old connector config
+                const buckets = this._extractBucketsFromConfig(oldConfig);
+                // generating a new config as the old config can be outdated (wrong topic for example)
+                const config = this._getDefaultConnectorConfiguration(connectorName);
                 // initializing connector
                 const connector = new Connector({
                     name: connectorName,

--- a/tests/unit/oplogPopulator/Connector.js
+++ b/tests/unit/oplogPopulator/Connector.js
@@ -150,7 +150,7 @@ describe('Connector', () => {
             connector._state.isUpdating = false;
             const pipelineStub = sinon.stub(connector, '_generateConnectorPipeline')
                 .returns('example-pipeline');
-            const updateStub = sinon.stub(connector._kafkaConnect, 'updateConnectorPipeline')
+            const updateStub = sinon.stub(connector._kafkaConnect, 'updateConnectorConfig')
                 .resolves();
             const didUpdate = await connector.updatePipeline();
             assert.strictEqual(didUpdate, false);
@@ -163,12 +163,12 @@ describe('Connector', () => {
             connector._state.isUpdating = false;
             const pipelineStub = sinon.stub(connector, '_generateConnectorPipeline')
                 .returns('example-pipeline');
-            const updateStub = sinon.stub(connector._kafkaConnect, 'updateConnectorPipeline')
+            const updateStub = sinon.stub(connector._kafkaConnect, 'updateConnectorConfig')
                 .resolves();
             const didUpdate = await connector.updatePipeline(true);
             assert.strictEqual(didUpdate, true);
             assert(pipelineStub.calledOnceWith([]));
-            assert(updateStub.calledOnceWith('example-connector', 'example-pipeline'));
+            assert(updateStub.calledOnceWith('example-connector', connector._config));
         });
 
         it('Should not update when buckets assigned to connector haven\'t changed', async () => {
@@ -176,7 +176,7 @@ describe('Connector', () => {
             connector._state.isUpdating = false;
             const pipelineStub = sinon.stub(connector, '_generateConnectorPipeline')
                 .returns('example-pipeline');
-            const updateStub = sinon.stub(connector._kafkaConnect, 'updateConnectorPipeline')
+            const updateStub = sinon.stub(connector._kafkaConnect, 'updateConnectorConfig')
                 .resolves();
             const didUpdate = await connector.updatePipeline(true);
             assert.strictEqual(didUpdate, false);
@@ -189,7 +189,7 @@ describe('Connector', () => {
             connector._state.isUpdating = true;
             const pipelineStub = sinon.stub(connector, '_generateConnectorPipeline')
                 .returns('example-pipeline');
-            const updateStub = sinon.stub(connector._kafkaConnect, 'updateConnectorPipeline')
+            const updateStub = sinon.stub(connector._kafkaConnect, 'updateConnectorConfig')
                 .resolves();
             const didUpdate = await connector.updatePipeline(true);
             assert.strictEqual(didUpdate, false);


### PR DESCRIPTION
… the pipeline

Issue: [BB-290](https://scality.atlassian.net/browse/BB-290)

OplogPopulator does not update the configuration of old connectors, it only updates the buckets assigned to the connector which might cause an issue when having a connector with an outdated config that has the wrong output topic for example