### PR TITLE
Bugfix/bb 286 fix kafka log consumer not letting log reader push to topics

### DIFF
--- a/extensions/notification/NotificationQueuePopulator.js
+++ b/extensions/notification/NotificationQueuePopulator.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const util = require('util');
 
 const { isMasterKey } = require('arsenal').versioning;
 const { usersBucket, mpuBucketPrefix } = require('arsenal').constants;
@@ -24,6 +25,8 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
         this.bnConfigManager = params.bnConfigManager;
         assert(this.bnConfigManager, 'bucket notification configuration manager'
             + ' is not set');
+        // callbackify functions
+        this._processObjectEntryCb = util.callbackify(this._processObjectEntry).bind(this);
     }
 
     /**
@@ -136,29 +139,30 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
      * filter
      *
      * @param {Object} entry - log entry
-     * @return {Promise|undefined} Promise|undefined
+     * @param {Function} cb - callback
+     * @return {undefined} Promise|undefined
      */
-    async filter(entry) {
+    filterAsync(entry, cb) {
         const { bucket, key, type } = entry;
         const value = entry.value || '{}';
         const { error, result } = safeJsonParse(value);
         // ignore if entry's value is not valid
         if (error) {
             this.log.error('could not parse log entry', { value, error });
-            return undefined;
+            return cb();
         }
         // ignore bucket operations, mpu's or if the entry has no bucket
         const isUserBucketOp = !bucket || bucket === usersBucket;
         const isMpuOp = key && key.startsWith(mpuBucketPrefix);
         const isBucketOp = bucket && result && this._isBucketEntry(bucket, key);
         if ([isUserBucketOp, isMpuOp, isBucketOp].some(cond => cond)) {
-            return undefined;
+            return cb();
         }
         // object entry processing - filter and publish
         if (key && result) {
-            return this._processObjectEntry(bucket, key, result, type);
+            return this._processObjectEntryCb(bucket, key, result, type, cb);
         }
-        return undefined;
+        return cb();
     }
 }
 

--- a/lib/queuePopulator/KafkaLogConsumer/ListRecordStream.js
+++ b/lib/queuePopulator/KafkaLogConsumer/ListRecordStream.js
@@ -57,7 +57,8 @@ class ListRecordStream extends stream.Transform {
                 method: 'ListRecordStream._transform',
                 data,
             });
-            changeStreamDocument = {};
+            // skipping the event
+            return callback(null, null);
         }
         const streamObject = {
             timestamp: new Date(data.timestamp),
@@ -68,7 +69,7 @@ class ListRecordStream extends stream.Transform {
                 value: changeStreamDocument.fullDocument && JSON.stringify(changeStreamDocument.fullDocument.value),
             }],
         };
-        callback(null, streamObject);
+        return callback(null, streamObject);
     }
 }
 

--- a/lib/queuePopulator/KafkaLogConsumer/ListRecordStream.js
+++ b/lib/queuePopulator/KafkaLogConsumer/ListRecordStream.js
@@ -65,7 +65,7 @@ class ListRecordStream extends stream.Transform {
             entries: [{
                 key: changeStreamDocument.documentKey && changeStreamDocument.documentKey._id,
                 type: this._getType(changeStreamDocument.operationType),
-                value: changeStreamDocument.fullDocument && changeStreamDocument.fullDocument.value,
+                value: changeStreamDocument.fullDocument && JSON.stringify(changeStreamDocument.fullDocument.value),
             }],
         };
         callback(null, streamObject);

--- a/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
+++ b/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
@@ -77,7 +77,7 @@ class LogConsumer {
                         topic: this._topic,
                         consumerGroupId: this._consumerGroupId,
                     });
-                    return cb(true);
+                    return cb();
                 }
                 return this._waitForAssignment(wait + 2000, cb);
             }
@@ -97,9 +97,10 @@ class LogConsumer {
                 this._log.error('Error while getting offsets', {
                     method: 'LogConsumer._storeCurrentOffsets',
                     topic: this._topic,
+                    error: err.message,
                     consumerGroupId: this._consumerGroupId,
                 });
-                return cb(err);
+                return cb();
             }
             // saving offsets
             this._offsets = topicPartitions;
@@ -130,9 +131,10 @@ class LogConsumer {
                 this._log.error('An error occured while consuming messages', {
                     method: 'LogConsumer.readRecords',
                     topic: this._topic,
+                    error: err.message,
                     consumerGroupId: this._consumerGroupId,
                 });
-                return cb(err);
+                return cb();
             }
             // writing consumed messages to the stream
             messages.forEach(message => this._listRecordStream.write(message));

--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -285,6 +285,7 @@ class LogReader {
             },
             entriesToPublish: {},
             publishedEntries: {},
+            currentRecords: [],
             maxRead: params.maxRead,
             startTime: Date.now(),
             timeoutMs: params.timeoutMs,
@@ -294,6 +295,7 @@ class LogReader {
         async.waterfall([
             next => this._processReadRecords(params, batchState, next),
             next => this._processPrepareEntries(batchState, next),
+            next => this._processFilterEntries(batchState, next),
             next => this._processPublishEntries(batchState, next),
             next => this._processSaveLogOffset(batchState, next),
         ],
@@ -377,37 +379,8 @@ class LogReader {
         });
     }
 
-    async _processLogEntry(batchState, record, entry) {
-        return Promise.all(this._extensions.map(ext => {
-            /**
-             * Delete entries don't have a value field.
-             * Value field normally contains the timestamp
-             * of the event, which is needed for the notification
-             * extension.
-             * That gets added here, we use the oplog event timestamp
-             */
-            if (entry.type === 'delete' &&
-                ext.constructor.name === 'NotificationQueuePopulator') {
-                entry.value = JSON.stringify({
-                    'last-modified': record.timestamp
-                });
-            // skipping entry for other extensions
-            } else if (entry.value === undefined) {
-                return null;
-            }
-            return ext.filter({
-                type: entry.type,
-                bucket: record.db,
-                // removing the v1 metadata prefix if it exists
-                key: transformKey(entry.key),
-                value: entry.value,
-                logReader: this,
-            });
-        }));
-    }
-
     _processPrepareEntries(batchState, done) {
-        const { entriesToPublish, logRes, logStats, logger } = batchState;
+        const { logRes, logStats, logger } = batchState;
 
         // for raft log only
         if (logRes.info && logRes.info.start === null) {
@@ -426,31 +399,20 @@ class LogReader {
                 const timestamp = new Date(record.timestamp).getTime() / 1000;
                 this._metricsHandler.logTimestamp(this.getMetricLabels(), timestamp);
             }
-
-            this._setEntryBatch(entriesToPublish);
-            /**
-             * waiting for all sync and async extentions
-             * to finish processing before emptying the batch
-             */
-            async.eachSeries(record.entries, async entry => {
-                logStats.nbLogEntriesRead += 1;
-                return this._processLogEntry(batchState, record, entry);
-            }, () => {
-                this._unsetEntryBatch();
-
-                // Pause tailable streams when reaching the record batch
-                // limit, as those streams do not emit 'end' events but
-                // continuously send 'data' events as they come.
-                if (logRes.tailable &&
-                    logStats.nbLogRecordsRead >= batchState.maxRead) {
-                    logger.debug('ending batch', {
-                        method: 'LogReader._processPrepareEntries',
-                        reason: 'limit on number of read records reached',
-                        readRecords: logStats.nbLogRecordsRead,
-                    });
-                    shipBatchCb();
-                }
-            });
+            batchState.currentRecords.push(record);
+            // Pause tailable streams when reaching the record batch
+            // limit, as those streams do not emit 'end' events but
+            // continuously send 'data' events as they come.
+            if (logRes.tailable &&
+                logStats.nbLogRecordsRead >= batchState.maxRead) {
+                logger.debug('ending batch', {
+                    method: 'LogReader._processPrepareEntries',
+                    reason: 'limit on number of read records reached',
+                    readRecords: logStats.nbLogRecordsRead,
+                });
+                return shipBatchCb();
+            }
+            return undefined;
         };
         const errorEventHandler = err => {
             logger.error('error fetching entries from log', {
@@ -520,6 +482,94 @@ class LogReader {
             logStats.initialSkipCount = logRes.log.getSkipCount();
         }
         return undefined;
+    }
+
+    _processLogEntry(batchState, record, entry, cb) {
+        function _executeFilter(ext, entry, cb) {
+            if (typeof ext.filterAsync === 'function') {
+                ext.filterAsync(entry, cb);
+            } else {
+                ext.filter(entry);
+                process.nextTick(cb);
+            }
+        }
+        async.eachSeries(this._extensions, (ext, next) => {
+            /**
+             * Delete entries don't have a value field.
+             * Value field normally contains the timestamp
+             * of the event, which is needed for the notification
+             * extension.
+             * That gets added here, we use the oplog event timestamp
+             */
+            if (
+                entry.type === 'delete' &&
+                ext.constructor.name === 'NotificationQueuePopulator'
+            ) {
+                entry.value = JSON.stringify({
+                    'last-modified': record.timestamp
+                });
+            // skipping entry for other extensions
+            } else if (entry.value === undefined) {
+                return next();
+            }
+            const entryToFilter = {
+                type: entry.type,
+                bucket: record.db,
+                // removing the v1 metadata prefix if it exists
+                key: transformKey(entry.key),
+                value: entry.value,
+                logReader: this,
+            };
+            return _executeFilter(ext, entryToFilter, next);
+        }, cb);
+    }
+
+    _filterEntries(batchState, record, cb) {
+        const { logStats } = batchState;
+
+        return async.eachSeries(record.entries, (entry, next) => {
+            logStats.nbLogEntriesRead += 1;
+            return this._processLogEntry(batchState, record, entry, next);
+        }, cb);
+    }
+
+    _processFilterEntry(batchState, record, done) {
+        if (!record || !record.entries) {
+            return done();
+        }
+        const { entriesToPublish } = batchState;
+        this._setEntryBatch(entriesToPublish);
+        return this._filterEntries(batchState, record, err => {
+            this._unsetEntryBatch();
+            if (err) {
+                this.log.error('error filtering entries from log', {
+                    method: 'LogReader._processFilterEntries',
+                    error: err,
+                });
+                return done(err);
+            }
+            return done();
+        });
+    }
+
+    _processFilterEntries(batchState, done) {
+        const { currentRecords } = batchState;
+        if (!currentRecords || !currentRecords.length) {
+            return done();
+        }
+        return async.eachSeries(currentRecords,
+            (rec, next) => this._processFilterEntry(batchState, rec, next),
+            err => {
+                if (err) {
+                    this.log.error('error filtering entries from log', {
+                        method: 'LogReader._processFilterEntries',
+                        error: err,
+                    });
+                    return done(err);
+                }
+                return done();
+            }
+        );
     }
 
     _setupProducer(topic, done) {

--- a/tests/unit/lib/queuePopulator/LogReader.spec.js
+++ b/tests/unit/lib/queuePopulator/LogReader.spec.js
@@ -250,4 +250,86 @@ describe('LogReader', () => {
         assert(mockExtension.filter.notCalled);
         done();
     });
+
+    describe('_processFilterEntries', () => {
+        it('Should do nothing if no records where pushed', done => {
+            const batchState = {
+                currentRecords: [],
+            };
+            const processFilterEntryStb = sinon.stub(logReader, '_processFilterEntry');
+            logReader._processFilterEntries(batchState, err => {
+                assert.ifError(err);
+                assert(processFilterEntryStb.notCalled);
+                return done();
+            });
+        });
+
+        it('Should process all records', done => {
+            const batchState = {
+                currentRecords: [1, 2],
+            };
+            const processFilterEntryStb = sinon.stub(logReader, '_processFilterEntry')
+                .callsArg(2);
+            logReader._processFilterEntries(batchState, err => {
+                assert.ifError(err);
+                assert(processFilterEntryStb.calledTwice);
+                return done();
+            });
+        });
+    });
+
+    describe('_processFilterEntry', () => {
+        it('Should do nothing if record is empty', done => {
+            const batchState = {
+                entriesToPublish: {},
+            };
+            const filterEntriesStb = sinon.stub(logReader, '_filterEntries');
+            logReader._processFilterEntry(batchState, {}, err => {
+                assert.ifError(err);
+                assert(filterEntriesStb.notCalled);
+                return done();
+            });
+        });
+
+        it('Should process record', done => {
+            const batchState = {
+                entriesToPublish: {},
+            };
+            const record = {
+                entries: [1]
+            };
+            const setEntryBatchStb = sinon.stub(logReader, '_setEntryBatch');
+            const unsetEntryBatchStb = sinon.stub(logReader, '_unsetEntryBatch');
+            const filterEntriesStb = sinon.stub(logReader, '_filterEntries')
+                .callsArg(2);
+            logReader._processFilterEntry(batchState, record,  err => {
+                assert.ifError(err);
+                assert(filterEntriesStb.calledOnce);
+                assert(setEntryBatchStb.calledOnce);
+                assert(unsetEntryBatchStb.calledOnce);
+                return done();
+            });
+        });
+    });
+
+    describe('_filterEntries', () => {
+        it('Should process all record entries', done => {
+            const batchState = {
+                logStats: {
+                    nbLogEntriesRead: 0,
+                },
+            };
+            const record = {
+                entries: [1, 2]
+            };
+            const processLogEntryStb = sinon.stub(logReader, '_processLogEntry')
+                .callsArg(3);
+            logReader._filterEntries(batchState, record,  err => {
+                assert.ifError(err);
+                assert(processLogEntryStb.calledTwice);
+                assert.strictEqual(batchState.logStats.nbLogEntriesRead, 2);
+                return done();
+            });
+        });
+    });
 });

--- a/tests/unit/lib/queuePopulator/kafkaLogConsumer/ListRecordStream.js
+++ b/tests/unit/lib/queuePopulator/kafkaLogConsumer/ListRecordStream.js
@@ -94,16 +94,25 @@ describe('ListRecordStream', () => {
                 return done();
             });
         });
-        it('Should not fail if format is invalid', done => {
+        it('Should skip record if format is invalid', done => {
             listRecordStream.write(InvalidKafkaMessage);
+            listRecordStream.write(kafkaMessage);
             listRecordStream.once('data', data => {
+                // Streams guarantee that data is kept in the
+                // same order when writing and reading it.
+                // This means that if the function doesn't work
+                // as intended and processed the invalid
+                // event it should be read in first by this event
+                // handler which'll fail the test
                 assert.deepEqual(data, {
-                    timestamp: new Date(InvalidKafkaMessage.timestamp),
-                    db: undefined,
+                    timestamp: new Date(kafkaMessage.timestamp),
+                    db: 'example-bucket',
                     entries: [{
-                        key: undefined,
-                        type: undefined,
-                        value: undefined,
+                        key: 'example-key',
+                        type: 'put',
+                        value: JSON.stringify({
+                            field: 'value'
+                        }),
                     }],
                 });
                 return done();

--- a/tests/unit/lib/queuePopulator/kafkaLogConsumer/ListRecordStream.js
+++ b/tests/unit/lib/queuePopulator/kafkaLogConsumer/ListRecordStream.js
@@ -86,9 +86,9 @@ describe('ListRecordStream', () => {
                     entries: [{
                         key: 'example-key',
                         type: 'put',
-                        value: {
+                        value: JSON.stringify({
                             field: 'value'
-                        },
+                        }),
                     }],
                 });
                 return done();

--- a/tests/unit/lib/queuePopulator/kafkaLogConsumer/LogConsumer.js
+++ b/tests/unit/lib/queuePopulator/kafkaLogConsumer/LogConsumer.js
@@ -62,18 +62,6 @@ describe('LogConsumer', () => {
                 return done();
             });
         }).timeout(5000);
-
-        it('Should timeout', done => {
-            const getAssignemntsStub = sinon.stub();
-            getAssignemntsStub.returns([]);
-            logConsumer._consumer = {
-                assignments: getAssignemntsStub,
-            };
-            logConsumer._waitForAssignment(120001, err => {
-                assert.strict(err, true);
-                return done();
-            });
-        }).timeout(5000);
     });
 
     describe('_storeCurrentOffsets', () => {

--- a/tests/unit/lib/queuePopulator/kafkaLogConsumer/LogConsumer.js
+++ b/tests/unit/lib/queuePopulator/kafkaLogConsumer/LogConsumer.js
@@ -124,9 +124,9 @@ describe('LogConsumer', () => {
                         entries: [{
                             key: 'example-key',
                             type: 'put',
-                            value: {
+                            value: JSON.stringify({
                                 field: 'value'
-                            },
+                            }),
                         }],
                     });
                     return done();

--- a/tests/unit/notification/NotificationQueuePopulator.js
+++ b/tests/unit/notification/NotificationQueuePopulator.js
@@ -132,7 +132,7 @@ describe('NotificationQueuePopulator ::', () => {
         });
     });
 
-    describe('filter ::', () => {
+    describe('filterAsync ::', () => {
         it('Should fail if entry value parse fails', done => {
             const processEntryStub = sinon.stub(notificationQueuePopulator, '_processObjectEntry');
             const entry = {
@@ -141,9 +141,11 @@ describe('NotificationQueuePopulator ::', () => {
                 type: 'put',
                 value: '}{',
             };
-            notificationQueuePopulator.filter(entry);
-            assert(processEntryStub.notCalled);
-            return done();
+            notificationQueuePopulator.filterAsync(entry, err => {
+                assert.ifError(err);
+                assert(processEntryStub.notCalled);
+                return done();
+            });
         });
 
         it('Should fail if entry is a bucket entry', done => {
@@ -154,22 +156,27 @@ describe('NotificationQueuePopulator ::', () => {
                 type: 'put',
                 value: '{}',
             };
-            notificationQueuePopulator.filter(entry);
-            assert(processEntryStub.notCalled);
-            return done();
+            notificationQueuePopulator.filterAsync(entry, err => {
+                assert.ifError(err);
+                assert(processEntryStub.notCalled);
+                return done();
+            });
         });
 
         it('Should process the entry', done => {
-            const processEntryStub = sinon.stub(notificationQueuePopulator, '_processObjectEntry');
+            const processEntryCbStub = sinon.stub(notificationQueuePopulator, '_processObjectEntryCb')
+                .callsArg(4);
             const entry = {
                 bucket: 'example-bucket',
                 key: 'examlpe-key',
                 type: 'put',
                 value: '{}',
             };
-            notificationQueuePopulator.filter(entry);
-            assert(processEntryStub.calledOnceWith(entry.bucket, entry.key, {}, entry.type));
-            return done();
+            notificationQueuePopulator.filterAsync(entry, err => {
+                assert.ifError(err);
+                assert(processEntryCbStub.calledOnceWith(entry.bucket, entry.key, {}, entry.type));
+                return done();
+            });
         });
     });
 


### PR DESCRIPTION
Issue: [BB-286](https://scality.atlassian.net/browse/BB-286)

**Original Issue:**
Previous implementation of async in the logReader produces flakiness where some oplog entries can get processed by the filter function but not pushed into their respective topic.
The issue is only present for backbeat extensions that use an async filter function (only Bucket Notification for now).

**Changes:**
- Implement proper support for async `filter` functions (same as in 7.x branch)
- Stringified the oplog event value (bug)
- Implement filterAsync in the NotificationQueuePopulator
- Avoid crashing when having an issue consuming messages from kafka. This was done to avoid getting crashes at startup before the oplog topic get created.

Zenko Build: https://github.com/scality/Zenko/actions/runs/3376337223