### PR TITLE
BB-276: process messages to requeue objects

### DIFF
--- a/extensions/gc/tasks/GarbageCollectorTask.js
+++ b/extensions/gc/tasks/GarbageCollectorTask.js
@@ -206,7 +206,10 @@ class GarbageCollectorTask extends BackbeatTask {
                 objMD.setLocation()
                     .setDataStoreName(newLocation)
                     .setAmzStorageClass(newLocation)
-                    .setTransitionInProgress(false);
+                    .setTransitionInProgress(false)
+                    .setUserMetadata({
+                        'x-amz-meta-scal-s3-transition-attempt': undefined,
+                    });
                 return this._putMetadata(entry, objMD, log, err => {
                     if (!err) {
                         log.end().info('completed expiration of archived data',

--- a/extensions/lifecycle/objectProcessor/LifecycleObjectTransitionProcessor.js
+++ b/extensions/lifecycle/objectProcessor/LifecycleObjectTransitionProcessor.js
@@ -7,6 +7,8 @@ const LifecycleUpdateTransitionTask =
       require('../tasks/LifecycleUpdateTransitionTask');
 const LifecycleColdStatusArchiveTask =
       require('../tasks/LifecycleColdStatusArchiveTask');
+const { LifecycleResetTransitionInProgressTask } =
+      require('../tasks/LifecycleResetTransitionInProgressTask');
 
 class LifecycleObjectTransitionProcessor extends LifecycleObjectProcessor {
 
@@ -91,6 +93,10 @@ class LifecycleObjectTransitionProcessor extends LifecycleObjectProcessor {
 
     getTask(actionEntry) {
         const actionType = actionEntry.getActionType();
+
+        if (actionType === 'requeueTransition') {
+            return new LifecycleResetTransitionInProgressTask(this);
+        }
 
         if (actionType !== 'copyLocation' ||
             actionEntry.getContextAttribute('ruleType') !== 'transition') {

--- a/extensions/lifecycle/tasks/LifecycleColdStatusArchiveTask.js
+++ b/extensions/lifecycle/tasks/LifecycleColdStatusArchiveTask.js
@@ -64,8 +64,11 @@ class LifecycleColdStatusArchiveTask extends LifecycleUpdateTransitionTask {
                 if (skipLocationDeletion) {
                     objectMD.setDataStoreName(coldLocation)
                         .setAmzStorageClass(coldLocation)
-                        .setTransitionInProgress(false);
-                }
+                        .setTransitionInProgress(false)
+                        .setUserMetadata({
+                            'x-amz-meta-scal-s3-transition-attempt': undefined,
+                        });
+                    }
 
                 this._putMetadata(entry, objectMD, log, next);
             },

--- a/extensions/lifecycle/tasks/LifecycleResetTransitionInProgressTask.js
+++ b/extensions/lifecycle/tasks/LifecycleResetTransitionInProgressTask.js
@@ -1,0 +1,195 @@
+'use strict'; // eslint-disable-line
+
+const async = require('async');
+
+const errors = require('arsenal');
+const ObjectMD = require('arsenal').models.ObjectMD;
+
+const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
+const { LifecycleMetrics } = require('../LifecycleMetrics');
+
+class LifecycleResetTransitionInProgressTask extends BackbeatTask {
+    /**
+     * Process a lifecycle object entry
+     *
+     * @constructor
+     * @param {LifecycleObjectProcessor} proc - object processor instance
+     */
+     constructor(proc) {
+        const procState = proc.getStateVars();
+        super();
+        Object.assign(this, procState);
+    }
+
+    /**
+     * Execute the action specified in action entry to clear transition-in-progress flag on an object
+     *
+     * @param {ActionQueueEntry} entry - action entry to execute
+     * @param {Function} done - callback funtion
+     * @return {undefined}
+     */
+    processActionEntry(entry, done) {
+        const log = this.logger.newRequestLogger(entry.actionId);
+        const { byAccount } = entry.getAttribute('target') || {};
+
+        async.reduce(
+            Object.keys(byAccount),
+            0,
+            (objsPerBatch, accountId, done) => {
+                const buckets = byAccount[accountId] || {};
+                const bucketNames = Object.keys(buckets);
+                this.handleBatch(
+                    accountId,
+                    buckets,
+                    bucketNames,
+                    log,
+                    (err, res) => {
+                        if (err) {
+                            return done(err);
+                        }
+
+                        const sum = res.reduce((acc, v) => acc + v, 0);
+                        return done(null, sum + objsPerBatch);
+                    }
+                );
+            },
+            (err, objectCount) => {
+                if (err) {
+                    log.error('could not process message', { error: err, objectCount });
+                } else {
+                    log.info('processed requeue message', { objectCount });
+                }
+
+                done(err);
+            }
+        );
+    }
+
+    handleBatch(accountId, buckets, bucketNames, log, cb) {
+        async.map(
+            bucketNames,
+            (bucketName, next) =>
+                async.reduce(
+                    buckets[bucketName] || [],
+                    0,
+                    (objsPerBucket, { objectKey, objectVersion, eTag, ...rest }, nextObject) =>
+                        this.requeueObjectVersion(
+                            accountId,
+                            bucketName,
+                            objectKey,
+                            objectVersion,
+                            eTag,
+                            rest.try,
+                            log,
+                            (err, res) => {
+                                if (err) {
+                                    return nextObject(err);
+                                }
+
+                                return nextObject(null, res + objsPerBucket);
+                            }
+                        ),
+                    (err, res) => {
+                        if (err) {
+                            return next(err);
+                        }
+
+                        return next(null, res);
+                    }
+                ),
+            (err, res) => {
+                if (err) {
+                    return cb(err);
+                }
+
+                return cb(null, res);
+            }
+        );
+    }
+
+    requeueObjectVersion(accountId, bucketName, objectKey, objectVersion, etag, try_, bucketLogger, cb) {
+        const client = this.getBackbeatMetadataProxy(accountId);
+        if (!client) {
+            return cb(errors.InternalError.customizeDescription(
+                `Unable to obtain client for account ${accountId}`,
+            ));
+        }
+
+        const params = {
+            bucket: bucketName,
+            objectKey,
+        };
+        if (objectVersion) {
+            params.versionId = objectVersion;
+        }
+
+        const log = this.logger.newRequestLogger(bucketLogger.getUids());
+        log.addDefaultFields({
+            accountId,
+            bucketName,
+            objectKey,
+            objectVersion,
+            etag,
+            try: try_,
+        });
+
+        return client.getMetadata(params, log, (err, blob) => {
+            LifecycleMetrics.onS3Request(log, 'getMetadata', 'transition', err);
+            if (err) {
+                return cb(err);
+            }
+
+            const { result: md, error } = ObjectMD.createFromBlob(blob.Body);
+            if (error) {
+                return cb(error);
+            }
+
+            if (this.shouldSkipObject(md, etag, log)) {
+                return cb(null, 0);
+            }
+
+            md.setTransitionInProgress(false);
+            md.setUserMetadata({
+                'x-amz-meta-scal-s3-transition-attempt': try_,
+            });
+
+            return client.putMetadata({ ...params, mdBlob: md.getSerialized() }, log,
+                err => {
+                    LifecycleMetrics.onS3Request(log, 'putMetadata', 'transition', err);
+                    if (err) {
+                        return cb(err);
+                    }
+
+                    return cb(null, 1);
+                }
+            );
+        });
+    }
+
+    shouldSkipObject(md, expectedEtag, log) {
+        try {
+            const etag = JSON.parse(expectedEtag);
+            if (etag !== md.getContentMd5()) {
+                log.debug('different etag, skipping object', {
+                    currentETag: md.getContentMd5(),
+                    requeueEtag: etag,
+                });
+                return true;
+            }
+        } catch (error) {
+            log.error('unparseable etag, skipping object', { errorMessage: error.message });
+            return true;
+        }
+
+        if (!md.getTransitionInProgress()) {
+            log.debug('not transitioning, skipping object');
+            return true;
+        }
+
+        return false;
+    }
+}
+
+module.exports = {
+    LifecycleResetTransitionInProgressTask
+};

--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -841,6 +841,16 @@ class LifecycleTask extends BackbeatTask {
     }
 
     _getTransitionActionEntry(params, objectMD, log, cb) {
+        let attempt;
+        const umd = objectMD.getUserMetadata();
+        if (umd) {
+            const parsed = JSON.parse(umd);
+            const rawAttempt = parsed['x-amz-meta-scal-s3-transition-attempt'];
+            if (rawAttempt) {
+                attempt = Number.parseInt(rawAttempt, 10);
+            }
+        }
+
         const entry = ReplicationAPI.createCopyLocationAction({
             bucketName: params.bucket,
             owner: params.owner,
@@ -854,6 +864,7 @@ class LifecycleTask extends BackbeatTask {
             contentLength: objectMD.getContentLength(),
             resultsTopic: this.objectTasksTopic,
             accountId: params.accountId,
+            attempt,
         });
         entry.addContext({
             origin: 'lifecycle',

--- a/extensions/replication/ReplicationAPI.js
+++ b/extensions/replication/ReplicationAPI.js
@@ -43,6 +43,7 @@ class ReplicationAPI {
                 key: params.objectKey,
                 version: params.versionId,
                 eTag: params.eTag,
+                attempt: params.attempt,
                 lastModified: params.lastModified,
             })
             .setAttribute('toLocation', params.toLocation)
@@ -68,7 +69,7 @@ class ReplicationAPI {
      * @return {undefined}
      */
     static sendDataMoverAction(producer, action, log, cb) {
-        const { accountId, bucket, key, version, eTag } = action.getAttribute('target');
+        const { accountId, bucket, key, version, eTag, attempt } = action.getAttribute('target');
         const { origin, fromLocation, contentLength } = action.getAttribute('metrics');
         const kafkaEntry = {
             key: `${bucket}/${key}`,
@@ -94,6 +95,7 @@ class ReplicationAPI {
                 // TODO: BB-217 do not use contentLength from metrics
                 size: contentLength,
                 eTag,
+                try: attempt,
             };
             kafkaEntry.message = JSON.stringify(message);
         }

--- a/tests/unit/lifecycle/LifecycleResetTransitionInProgressTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleResetTransitionInProgressTask.spec.js
@@ -1,0 +1,90 @@
+const assert = require('assert');
+const werelogs = require('werelogs');
+
+const { ObjectMD } = require('arsenal').models;
+const ActionQueueEntry = require('../../../lib/models/ActionQueueEntry');
+const { LifecycleResetTransitionInProgressTask } = require(
+    '../../../extensions/lifecycle/tasks/LifecycleResetTransitionInProgressTask');
+
+const {
+    BackbeatMetadataProxyMock,
+    ProcessorMock,
+} = require('../mocks');
+
+describe('LifecycleResetTransitionInProgressTask', () => {
+    let backbeatMetadataProxyClient;
+    let objectProcessor;
+    let task;
+
+    const actionEntry = ActionQueueEntry.create('requeueTransition')
+        .setAttribute('target', {
+            byAccount: {
+                123: {
+                    bucket1: [{
+                        objectKey: 'obj1',
+                        objectVersion: 'v1',
+                        eTag: '"etag1"',
+                        try: 12,
+                    }]
+                },
+            },
+        });
+
+    const objectNotTransitioning = new ObjectMD()
+        .setContentMd5('etag1');
+    const objectTransitioning = new ObjectMD()
+        .setContentMd5('etag1')
+        .setTransitionInProgress(true)
+        .setUserMetadata({
+            'x-amz-meta-scal-s3-transition-attempt': 11,
+        });
+
+    beforeEach(() => {
+        backbeatMetadataProxyClient = new BackbeatMetadataProxyMock();
+
+        objectProcessor = new ProcessorMock(
+            null,
+            null,
+            backbeatMetadataProxyClient,
+            null,
+            new werelogs.Logger('test:LifecycleResetTransitionInProgressTask'));
+
+        task = new LifecycleResetTransitionInProgressTask(objectProcessor);
+    });
+
+    it('should skip object not transitioning', done => {
+        backbeatMetadataProxyClient.setMdObj(objectNotTransitioning);
+        task.processActionEntry(actionEntry, err => {
+            assert.ifError(err);
+            assert.ok(backbeatMetadataProxyClient.receivedMd === null);
+
+            done();
+        });
+    });
+
+    it('should store current attempt in user metadata', done => {
+        backbeatMetadataProxyClient.setMdObj(objectTransitioning);
+        task.processActionEntry(actionEntry, err => {
+            assert.ifError(err);
+
+            const md = backbeatMetadataProxyClient.mdObj;
+            const umd =  JSON.parse(md.getUserMetadata());
+            const attempts = umd['x-amz-meta-scal-s3-transition-attempt'];
+            assert.deepStrictEqual(12, attempts);
+
+            done();
+        });
+    });
+
+    it('should reset transition in progress flag', done => {
+        backbeatMetadataProxyClient.setMdObj(objectTransitioning);
+        task.processActionEntry(actionEntry, err => {
+            assert.ifError(err);
+
+            const md = backbeatMetadataProxyClient.mdObj;
+            assert.ok(!md.getTransitionInProgress());
+
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Adds action to clear transition-in-progress-flag from objects, with sorbet and sorbet cli as primary users.

This code was a lot more elegant with async/await but I changed back to old async after spending way too much time debugging why one of the nested promises was never `await`-ed.