### PR TITLE
bugfix: BB-323 pass `VersionId` in BackbeatMetadataProxy.putMetadata call

### DIFF
--- a/lib/BackbeatMetadataProxy.js
+++ b/lib/BackbeatMetadataProxy.js
@@ -76,6 +76,7 @@ class BackbeatMetadataProxy extends BackbeatTask {
         const req = this.backbeatSource.putMetadata({
             Bucket: bucket,
             Key: objectKey,
+            VersionId: versionId,
             ContentLength: Buffer.byteLength(mdBlob),
             Body: mdBlob,
         });


### PR DESCRIPTION
Add the missing `VersionId` field to the BackbeatAPI call, which is now mandatory when putting a specific version