### PR TITLE
feature: BB-336 support s3:ObjectRestore:Delete event notification

### DIFF
--- a/extensions/lifecycle/tasks/LifecycleUpdateExpirationTask.js
+++ b/extensions/lifecycle/tasks/LifecycleUpdateExpirationTask.js
@@ -146,9 +146,12 @@ class LifecycleUpdateExpirationTask extends BackbeatTask {
             next => this._getMetadata(entry, log, next),
             (objMD, next) => {
                 const archive = objMD.getArchive();
+                // Reset archive flags to no longer
+                // show it as restored
                 objMD.setArchive({
                     archiveInfo: archive.archiveInfo,
                 });
+                objMD.setOriginOp('s3:ObjectRestore:Delete');
                 this._putMetadata(entry, objMD, log, err => next(err, objMD));
             },
             (objMD, next) => this._garbageCollectLocation(


### PR DESCRIPTION
Issue: [BB-336](https://scality.atlassian.net/browse/BB-336)

Updating the originOp in the metadata as it is what's used to determine the notification type.