### PR TITLE
BB-269 avoid clearing dataStoreVersionId when retrying a replication

### DIFF
--- a/lib/models/ObjectQueueEntry.js
+++ b/lib/models/ObjectQueueEntry.js
@@ -198,11 +198,8 @@ class ObjectQueueEntry extends ObjectMD {
 
     toRetryEntry(site) {
         return this.clone()
-            .setReplicationBackends([{
-                site,
-                status: 'PENDING',
-                dataStoreVersionId: '',
-            }])
+            .setReplicationBackends(this.getReplicationBackends().filter(o => o.site === site))
+            .setReplicationSiteStatus(site, 'PENDING')
             .setReplicationStorageClass(site)
             .setReplicationStatus('PENDING');
     }

--- a/tests/unit/lib/models/ObjectQueueEntry.spec.js
+++ b/tests/unit/lib/models/ObjectQueueEntry.spec.js
@@ -1,0 +1,22 @@
+const assert = require('assert');
+
+const QueueEntry = require('../../../../lib/models/QueueEntry');
+const { replicationEntry } = require('../../../utils/kafkaEntries');
+
+describe('ObjectQueueEntry', () => {
+    describe('toRetryEntry', () => {
+        it('Should not clear dataStoreVersionId when retrying', () => {
+            const entry = QueueEntry.createFromKafkaEntry(replicationEntry);
+            const dataStoreVersionId = entry.getReplicationSiteDataStoreVersionId('sf');
+            const retryEntry = entry.toRetryEntry('sf');
+            assert.strictEqual(retryEntry.getReplicationSiteDataStoreVersionId('sf'),
+                dataStoreVersionId);
+        });
+        it('Should only include failed site details', () => {
+            const entry = QueueEntry.createFromKafkaEntry(replicationEntry);
+            const retryEntry = entry.toRetryEntry('sf');
+            assert.strictEqual(retryEntry.getReplicationBackends().length, 1);
+            assert.strictEqual(retryEntry.getReplicationBackends()[0].site, 'sf');
+        });
+    });
+});


### PR DESCRIPTION
Issue: [BB-269](https://scality.atlassian.net/browse/BB-269)

Replication has special code to handle replication of tags: in that case, it will not replicate the object again, but simply update the tags on the target object.

However, in the (unlikely) case where that tag update fails, the datastore version id will be reset when the entry is put in the replay queue:

```
    toRetryEntry(site) {
        return this.clone()
            .setReplicationBackends([{
                site,
                status: 'PENDING',
                dataStoreVersionId: '',
            }])
            .setReplicationStorageClass(site)
            .setReplicationStatus('PENDING');
    }
```
Consequently, the replay-processor would trigger a full replication of the object, and the data will be copied again.

[BB-269]: https://scality.atlassian.net/browse/BB-269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ