### PR TITLE
Improvement: BB-335 ignore objects with pending replication in lifecycle

### DIFF
--- a/extensions/lifecycle/tasks/LifecycleDeleteObjectTask.js
+++ b/extensions/lifecycle/tasks/LifecycleDeleteObjectTask.js
@@ -7,6 +7,7 @@ const { attachReqUids } = require('../../../lib/clients/utils');
 const { LifecycleMetrics } = require('../LifecycleMetrics');
 
 class ObjectLockedError extends Error {}
+class PendingReplicationError extends Error {}
 
 class LifecycleDeleteObjectTask extends BackbeatTask {
     /**
@@ -19,9 +20,14 @@ class LifecycleDeleteObjectTask extends BackbeatTask {
         const procState = proc.getStateVars();
         super();
         Object.assign(this, procState);
+        this.objectMD = null;
     }
 
     _getMetadata(entry, log, done) {
+        // only retreiving object metadata once
+        if (this.objectMD) {
+            return done(null, this.objectMD);
+        }
         const { owner: canonicalId, accountId } = entry.getAttribute('target');
         const backbeatClient = this.getBackbeatMetadataProxy(accountId);
         if (!backbeatClient) {
@@ -56,7 +62,8 @@ class LifecycleDeleteObjectTask extends BackbeatTask {
                     errors.InternalError.
                         customizeDescription('error parsing metadata blob'));
             }
-            return done(null, res.result);
+            this.objectMD = res.result;
+            return done(null, this.objectMD);
         });
     }
 
@@ -171,6 +178,33 @@ class LifecycleDeleteObjectTask extends BackbeatTask {
     }
 
     /**
+     * Throws error if object has a 'PENDING' replication status
+     * @param {ActionQueueEntry} entry entry object
+     * @param {Logger} log logger instance
+     * @param {Function} done callback
+     * @returns {undefined}
+     */
+    _checkReplicationStatus(entry, log, done) {
+        const actionType = entry.getActionType();
+        // skip check if entry is an incomplete MPU
+        // as we only replicate complete objects
+        if (actionType === 'deleteMPU') {
+            return done();
+        }
+        return this._getMetadata(entry, log, (err, objMD) => {
+            if (err) {
+                return done(err);
+            }
+            const replicationStatus = objMD.getReplicationStatus();
+            if (['PENDING', 'PROCESSING', 'FAILED'].includes(replicationStatus)) {
+                const error = new PendingReplicationError('object has a pending replication status');
+                return done(error);
+            }
+            return done();
+        });
+    }
+
+    /**
      * Execute the action specified in action entry to delete an object
      *
      * @param {ActionQueueEntry} entry - action entry to execute
@@ -189,10 +223,16 @@ class LifecycleDeleteObjectTask extends BackbeatTask {
         return async.series([
             next => this._checkDate(entry, log, next),
             next => this._checkObjectLockState(entry, log, next),
+            next => this._checkReplicationStatus(entry, log, next),
             next => this._executeDelete(entry, log, next),
         ], err => {
             if (err && err instanceof ObjectLockedError) {
                 log.debug('Object is locked, skipping',
+                    entry.getLogInfo());
+                return done();
+            }
+            if (err && err instanceof PendingReplicationError) {
+                log.debug('Object has pending replication status, skipping',
                     entry.getLogInfo());
                 return done();
             }

--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -23,6 +23,8 @@ const errorTransitionColdObject = errors.InternalError.
     customizeDescription('transitioning a cold object is forbidden');
 const errorObjectTemporarilyRestored = errors.InternalError.
     customizeDescription('object temporarily restored');
+const errorReplicationInProgress = errors.InternalError.
+    customizeDescription('replication of the object is currently in progress');
 
 
 // Default max AWS limit is 1000 for both list objects and list object versions
@@ -911,6 +913,10 @@ class LifecycleTask extends BackbeatTask {
             next =>
                 this._getObjectMD(params, log, next),
             (objectMD, next) => {
+                const replicationStatus = objectMD.getReplicationStatus();
+                if (['PENDING', 'PROCESSING', 'FAILED'].includes(replicationStatus)) {
+                    return next(errorReplicationInProgress);
+                }
                 const dataStoreName = objectMD.getDataStoreName();
                 const isObjectCold = dataStoreName && locationsConfig[dataStoreName]
                     && locationsConfig[dataStoreName].isCold;

--- a/tests/unit/lifecycle/LifecycleDeleteObjectTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleDeleteObjectTask.spec.js
@@ -99,6 +99,29 @@ describe('LifecycleDeleteObjectTask', () => {
         });
     });
 
+    [
+      'PENDING',
+      'PROCESSING',
+      'FAILED',
+    ].forEach(status => {
+        it(`should skip replicating object : ${status}`, done => {
+            objMd.setReplicationStatus('PENDING');
+            const entry = ActionQueueEntry.create('deleteObject')
+                .setAttribute('target.owner', 'testowner')
+                .setAttribute('target.bucket', 'testbucket')
+                .setAttribute('target.accountId', 'testid')
+                .setAttribute('target.key', 'testkey')
+                .setAttribute('target.version', 'testversion')
+                .setAttribute('details.lastModified', '2022-05-13T17:51:31.261Z');
+            s3Client.setResponse(null, {});
+            task.processActionEntry(entry, err => {
+                assert.strictEqual(s3Client.calls.deleteObject, 0);
+                assert.ifError(err);
+                done();
+            });
+        });
+    });
+
     it('should expire current version of locked object with legal hold',
         done => {
             objMd.setLegalHold(true);


### PR DESCRIPTION
Issue: [BB-335](https://scality.atlassian.net/browse/BB-335)

Skipping objects with a pending replication from getting expired or transitioned

[BB-335]: https://scality.atlassian.net/browse/BB-335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ