### PR TITLE
BB-354 support unsetting mongo replicaSet value for the OplogPopulator

### DIFF
--- a/extensions/oplogPopulator/OplogPopulator.js
+++ b/extensions/oplogPopulator/OplogPopulator.js
@@ -51,6 +51,10 @@ class OplogPopulator {
         this._mongoClient = null;
         this._metastore = null;
         // setup mongo connection data
+        const isMongoSharded = process.env.MONGODB_SHARDED === 'true';
+        if (isMongoSharded) {
+            delete this._mongoConfig.replicaSet;
+        }
         this._mongoUrl = constructConnectionString(this._mongoConfig);
         this._replicaSet = this._mongoConfig.replicaSet;
         this._database = this._mongoConfig.database;

--- a/tests/unit/oplogPopulator/oplogPopulator.js
+++ b/tests/unit/oplogPopulator/oplogPopulator.js
@@ -104,6 +104,20 @@ describe('OplogPopulator', () => {
             assert.strictEqual(oplogPopulator._replicaSet, 'rs0');
             assert.strictEqual(oplogPopulator._database, 'metadata');
         });
+
+        it('should unset replicaSet field in mongo config when in sharding mode', () => {
+            const localMongoConfig = { ...mongoConfig };
+            process.env.MONGODB_SHARDED = 'true';
+            const op = new OplogPopulator({
+                config: localMongoConfig,
+                mongoConfig: localMongoConfig,
+                activeExtensions,
+                logger,
+            });
+            delete process.env.MONGODB_SHARDED;
+            assert.strictEqual(op._replicaSet, undefined);
+            assert.strictEqual(op._mongoConfig.replicaSet, undefined);
+        });
     });
 
     describe('_setupMongoClient', () => {

--- a/tests/unit/oplogPopulator/oplogPopulator.js
+++ b/tests/unit/oplogPopulator/oplogPopulator.js
@@ -121,14 +121,14 @@ describe('OplogPopulator', () => {
     });
 
     describe('_setupMongoClient', () => {
-        it('should connect to mongo and setup client', async () => {
+        it('should connect to mongo and setup client', () => {
             const collectionStub = sinon.stub();
             const dbStub = sinon.stub().returns({
                 collection: collectionStub,
             });
             const mongoConnectStub = sinon.stub(MongoClient, 'connect')
                 .resolves({ db: dbStub });
-            await oplogPopulator._setupMongoClient()
+            return oplogPopulator._setupMongoClient()
             .then(() => {
                 const mongoUrl = 'mongodb://user:password@localhost:27017,localhost:27018,' +
                     'localhost:27019/?w=majority&readPreference=primary&replicaSet=rs0';
@@ -144,10 +144,10 @@ describe('OplogPopulator', () => {
             }).catch(err => assert.ifError(err));
         });
 
-        it('should fail when mongo connection fails', async () => {
+        it('should fail when mongo connection fails', () => {
             const mongoConnectStub = sinon.stub(MongoClient, 'connect')
                 .rejects(errors.InternalError);
-            await oplogPopulator._setupMongoClient()
+            return oplogPopulator._setupMongoClient()
             .then(() => {
                 const mongoUrl = 'mongodb://user:password@localhost:27017,' +
                     'localhost:27018,localhost:27019/?w=majority&readPreference=primary';
@@ -161,13 +161,13 @@ describe('OplogPopulator', () => {
             }).catch(err => assert.deepEqual(err, errors.InternalError));
         });
 
-        it('should fail if it can\'t get metadata db', async () => {
+        it('should fail if it can\'t get metadata db', () => {
             const dbStub = sinon.stub().returns({
                 collection: sinon.stub().throws(errors.InternalError),
             });
             const mongoConnectStub = sinon.stub(MongoClient, 'connect')
                 .resolves({ db: dbStub });
-            await oplogPopulator._setupMongoClient()
+            return oplogPopulator._setupMongoClient()
             .then(() => {
                 const mongoUrl = 'mongodb://user:password@localhost:27017,' +
                     'localhost:27018,localhost:27019/?w=majority&readPreference=primary';
@@ -182,14 +182,14 @@ describe('OplogPopulator', () => {
             }).catch(err => assert.deepEqual(err, errors.InternalError));
         });
 
-        it('should fail if it can\'t get metastore collection', async () => {
+        it('should fail if it can\'t get metastore collection', () => {
             const collectionStub = sinon.stub().throws(errors.InternalError);
             const dbStub = sinon.stub().returns({
                 collection: collectionStub,
             });
             const mongoConnectStub = sinon.stub(MongoClient, 'connect')
                 .resolves({ db: dbStub });
-            await oplogPopulator._setupMongoClient()
+            return oplogPopulator._setupMongoClient()
             .then(() => {
                 const mongoUrl = 'mongodb://user:password@localhost:27017,' +
                     'localhost:27018,localhost:27019/?w=majority&readPreference=primary';
@@ -260,7 +260,7 @@ describe('OplogPopulator', () => {
             }
         ].forEach(scenario => {
             const { extensions, filter } = scenario;
-            it(`should correctly set filter (${extensions})`, async () => {
+            it(`should correctly set filter (${extensions})`, () => {
                 const findStub = sinon.stub().returns({
                     project: () => ({
                         map: () => ({
@@ -276,7 +276,7 @@ describe('OplogPopulator', () => {
                 });
                 tmpOplogPopulator._metastore = { find: findStub };
                 tmpOplogPopulator._loadOplogHelperClasses();
-                await tmpOplogPopulator._getBackbeatEnabledBuckets()
+                return tmpOplogPopulator._getBackbeatEnabledBuckets()
                 .then(buckets => {
                     assert(findStub.calledOnceWith({
                         $or: filter,
@@ -296,43 +296,43 @@ describe('OplogPopulator', () => {
                 })
             });
             oplogPopulator._metastore = { find: findStub };
-            await oplogPopulator._getBackbeatEnabledBuckets()
+            oplogPopulator._getBackbeatEnabledBuckets()
             .then(buckets => {
                 assert.strict(buckets, undefined);
             })
             .catch(err => assert.deepEqual(err, errors.InternalError));
         });
 
-        it('should return fail when map operation fails', async () => {
+        it('should return fail when map operation fails', () => {
             const findStub = sinon.stub().returns({
                 project: () => ({
                     map: () => sinon.stub().throws(errors.InternalError),
                 })
             });
             oplogPopulator._metastore = { find: findStub };
-            await oplogPopulator._getBackbeatEnabledBuckets()
+            return oplogPopulator._getBackbeatEnabledBuckets()
             .then(buckets => {
                 assert.strict(buckets, undefined);
             })
             .catch(err => assert.deepEqual(err, errors.InternalError));
         });
 
-        it('should return fail when project operation fails', async () => {
+        it('should return fail when project operation fails', () => {
             const findStub = sinon.stub().returns({
                 project: () => sinon.stub().throws(errors.InternalError),
             });
             oplogPopulator._metastore = { find: findStub };
-            await oplogPopulator._getBackbeatEnabledBuckets()
+            return oplogPopulator._getBackbeatEnabledBuckets()
             .then(buckets => {
                 assert.strict(buckets, undefined);
             })
             .catch(err => assert.deepEqual(err, errors.InternalError));
         });
 
-        it('should return fail when find operation fails', async () => {
+        it('should return fail when find operation fails', () => {
             const findStub = sinon.stub().throws(errors.InternalError);
             oplogPopulator._metastore = { find: findStub };
-            await oplogPopulator._getBackbeatEnabledBuckets()
+            return oplogPopulator._getBackbeatEnabledBuckets()
             .then(buckets => {
                 assert.strict(buckets, undefined);
             })


### PR DESCRIPTION
Issue: [BB-354](https://scality.atlassian.net/browse/BB-354)

When mongo is configured for sharding, the replicaset needs to be unset for the OplogPopulator as it needs to correctly configure kafka-connect to connect to the mongoS instance not the mongoD.

Linked PR: https://github.com/scality/zenko-operator/pull/350