### PR TITLE
BB-355 use updateDescription field to get object metadata in kafka lo…

### DIFF
--- a/extensions/oplogPopulator/constants.js
+++ b/extensions/oplogPopulator/constants.js
@@ -3,7 +3,6 @@ const constants = {
     defaultConnectorName: 'source-connector',
     defaultConnectorConfig: {
         'connector.class': 'com.mongodb.kafka.connect.MongoSourceConnector',
-        'change.stream.full.document': 'updateLookup',
         'pipeline': '[]',
         'collection': '',
         // JSON output converter config

--- a/lib/queuePopulator/KafkaLogConsumer/ListRecordStream.js
+++ b/lib/queuePopulator/KafkaLogConsumer/ListRecordStream.js
@@ -51,6 +51,29 @@ class ListRecordStream extends stream.Transform {
     }
 
     /**
+     * Get object metadata from oplog event
+     * @param {ChangeStreamDocument} changeStreamDocument changeStreamDocument
+     * @returns {string|undefined} stringified objectMd
+     */
+    _getObjectMd(changeStreamDocument) {
+        // Metadata values from updateDescription are used instead of
+        // fullDocument as they represent the exact changes that occured
+        // to the object. We only need this for the update operation.
+
+        // The fullDocument value contains a copy of the entire updated
+        // document at a point in time after the update, this can cause issues
+        // when the object gets deleted just after the update (only for updates).
+        const updateDescriptionMd = changeStreamDocument.updateDescription
+            && changeStreamDocument.updateDescription.updatedFields
+            && changeStreamDocument.updateDescription.updatedFields.value;
+        if (changeStreamDocument.operationType === 'update') {
+            return JSON.stringify(updateDescriptionMd);
+        }
+        const fullDocumentMd = changeStreamDocument.fullDocument && changeStreamDocument.fullDocument.value;
+        return JSON.stringify(fullDocumentMd);
+    }
+
+    /**
      * Formats change stream entries
      * @param {Object} data chunk of data
      * @param {Buffer} data.value message contents as a Buffer
@@ -77,13 +100,15 @@ class ListRecordStream extends stream.Transform {
             // skipping the event
             return callback(null, null);
         }
+        const objectMd = this._getObjectMd(changeStreamDocument);
+        const opType = this._getType(changeStreamDocument.operationType, objectMd);
         const streamObject = {
             timestamp: new Date(data.timestamp),
             db: changeStreamDocument.ns && changeStreamDocument.ns.coll,
             entries: [{
                 key: changeStreamDocument.documentKey && changeStreamDocument.documentKey._id,
-                type: this._getType(changeStreamDocument.operationType, changeStreamDocument.fullDocument),
-                value: changeStreamDocument.fullDocument && JSON.stringify(changeStreamDocument.fullDocument.value),
+                type: opType,
+                value: objectMd,
             }],
         };
         return callback(null, streamObject);

--- a/tests/unit/oplogPopulator/Connector.js
+++ b/tests/unit/oplogPopulator/Connector.js
@@ -14,7 +14,6 @@ const connectorConfig = {
         'localhost:27019/?w=majority&readPreference=primary&replicaSet=rs0',
     'topic.namespace.map': '{*:"oplogTopic"}',
     'connector.class': 'com.mongodb.kafka.connect.MongoSourceConnector',
-    'change.stream.full.document': 'updateLookup',
     'pipeline': '[]',
     'collection': '',
 };

--- a/tests/unit/oplogPopulator/ConnectorsManager.js
+++ b/tests/unit/oplogPopulator/ConnectorsManager.js
@@ -15,7 +15,6 @@ const connectorConfig = {
     'connection.uri': 'mongodb://localhost:27017/?w=majority&readPreference=primary',
     'topic.namespace.map': '{\"*\":\"oplog\"}',
     'connector.class': 'com.mongodb.kafka.connect.MongoSourceConnector',
-    'change.stream.full.document': 'updateLookup',
     'pipeline': '[]',
     'collection': '',
     'output.format.value': 'json',


### PR DESCRIPTION
…g consumer

Issue: [BB-355](https://scality.atlassian.net/browse/BB-355)

**Problem:**
Some times oplog update events we get when using the Kafka log consumer don't have any metadata. This mostly happens when deleting the object right after the update.

The issue happens because we use the `fullDocument` field to retrieve the metadata, when reading the mongodb docs we see that the field represents a copy of the entire updated document at a point in time after the update, which means that in some cases this value can be unavailable like when deleting right after the update.

**Fix:**
Use the `updateDescription` field to get object metadata instead of fullDocument.
Values from `updateDescription` represent the exact changes that occurred to the object.
It is possible to have non complete metadata in this field but this shouldn't be an issue as we update the full object each time in the mongoClient.
One key updates like we do in the update we perform before each deletion will be ignored as we don't even have the `value` field that's supposed to contain the metadata.


[BB-355]: https://scality.atlassian.net/browse/BB-355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BB-355]: https://scality.atlassian.net/browse/BB-355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ