### PR TITLE
BB-338 Suspend Lifecycle transition to paused location

### DIFF
--- a/extensions/lifecycle/bucketProcessor/task.js
+++ b/extensions/lifecycle/bucketProcessor/task.js
@@ -17,9 +17,10 @@ const { applyBucketLifecycleWorkflows } = require('../management');
 const { startProbeServer } = require('../../../lib/util/probe');
 const config = require('../../../lib/Config');
 
-const { zookeeper, kafka, extensions, s3, log } = config;
+const { zookeeper, kafka, extensions, s3, log, queuePopulator } = config;
 const lcConfig = extensions.lifecycle;
 const repConfig = extensions.replication;
+const mongoConfig = queuePopulator.mongo;
 
 werelogs.configure({
     level: log.logLevel,
@@ -30,7 +31,7 @@ werelogs.configure({
 const logger = new werelogs.Logger('Backbeat:Lifecycle:Producer');
 
 const bucketProcessor = new LifecycleBucketProcessor(
-    zookeeper, kafka, lcConfig, repConfig, s3, lcConfig.transport
+    zookeeper, kafka, lcConfig, repConfig, s3, mongoConfig, lcConfig.transport,
 );
 
 function livenessCheck(res, log) {

--- a/extensions/utils/LocationStatusStream.js
+++ b/extensions/utils/LocationStatusStream.js
@@ -1,0 +1,167 @@
+const { MongoClient } = require('mongodb');
+const async = require('async');
+
+const { locationStatusCollection } = require('../../lib/constants');
+const { constructConnectionString } = require('./MongoUtils');
+const ChangeStream = require('../../lib/wrappers/ChangeStream');
+
+/**
+ * Pause a location
+ * @typedef { (locationName: string,) => void } PauseLocationFn
+ */
+/**
+ * Resume a location
+ * @typedef { (locationName: string) => void } ResumeLocationFn
+ */
+
+/**
+ * @class LocationStatusStream
+ *
+ * @classdesc uses change streams to listen to a location statuss
+ * for a service (crr, ingestion, lifecycle)
+ */
+class LocationStatusStream {
+
+    /**
+     * @constructor
+     * @param {string} serviceName service name (i.e crr, ingestion, lifecycle)
+     * @param {Object} mongoConfig mongodb configuration object
+     * @param {PauseLocationFn} pauseFn pause location function
+     * @param {ResumeLocationFn} resumeFn resume location function
+     * @param {Logger} logger logger instance
+     */
+    constructor(serviceName, mongoConfig, pauseFn, resumeFn, logger) {
+        this._serviceName = serviceName;
+        this._mongoConfig = mongoConfig;
+        this._mongoClient = null;
+        this._locationStatusColl = null;
+        this._pauseServiceForLocation = pauseFn;
+        this._resumeServiceForLocation = resumeFn;
+        this._log = logger;
+    }
+
+    /**
+     * Set up the mongo client and initiate the change stream
+     * @param {function} done - callback
+     * @return {undefined}
+     */
+    start(done) {
+        async.series([
+            done => this._setupMongoClient(done),
+            done => this._setChangeStream(done),
+            done => this._initializeLocationStatuses(done),
+        ], done);
+    }
+
+    /**
+     * Connects to MongoDB using and retreives
+     * the location status collection
+     * @param {function} cb callback
+     * @returns {undefined} undefined
+     */
+    _setupMongoClient(cb) {
+        const mongoUrl = constructConnectionString(this._mongoConfig);
+        MongoClient.connect(mongoUrl, {
+                replicaSet: this._mongoConfig.replicaSet,
+                useNewUrlParser: true,
+                useUnifiedTopology: true,
+        }, (err, client) => {
+            if (err) {
+                this._log.error('Could not connect to MongoDB', {
+                    method: 'ServiceStatusManager._setupMongoClient',
+                    error: err.message,
+                });
+                return cb(err);
+            }
+            // connect to metadata DB
+            this._mongoClient = client.db(this._mongoConfig.database, {
+                ignoreUndefined: true,
+            });
+            this._locationStatusColl = this._mongoClient.collection(locationStatusCollection);
+            this._log.info('Connected to MongoDB', {
+                method: 'ServiceStatusManager._setupMongoClient',
+            });
+            return cb();
+        });
+    }
+
+    /**
+     * Initialized the list of paused locations
+     * @param {Function} cb callback
+     * @returns {undefined}
+     */
+    _initializeLocationStatuses(cb) {
+        this._locationStatusColl.find({})
+            .toArray((err, locations) => {
+                if (err) {
+                    this._log.error('Could not fetch location statuses from mongo', {
+                        method: 'ServiceStatusManager._initializeLocationStatuses',
+                        error: err.message,
+                    });
+                    return cb(err);
+                }
+                locations.forEach(location => {
+                    const isPaused = location.value[this._serviceName].paused;
+                    if (isPaused) {
+                        this._pauseServiceForLocation(location._id);
+                    }
+                });
+                return cb();
+            });
+    }
+
+    /**
+     * Initializes a change stream on the location status collection
+     * @param {function} cb callback
+     * @returns {undefined}
+     */
+    _setChangeStream(cb) {
+        const changeStreamPipeline = [
+            {
+                $match: {
+                    operationType: {
+                        $in: ['update', 'insert', 'replace', 'delete'],
+                    },
+                },
+            },
+        ];
+        this._changeStreamWrapper = new ChangeStream({
+            logger: this._log,
+            collection: this._locationStatusColl,
+            pipeline: changeStreamPipeline,
+            handler: this._handleChangeStreamChangeEvent.bind(this),
+            throwOnError: false,
+        });
+        // start watching metastore
+        this._changeStreamWrapper.start();
+        return cb();
+    }
+
+    /**
+     * Handler for change stream events
+     * Pauses or resumes a location based on the changes that occured
+     * in mongo
+     * @param {ChangeStreamDocument} changeEvent change stream document
+     * @returns {undefined}
+     */
+    _handleChangeStreamChangeEvent(changeEvent) {
+            const location = changeEvent.documentKey._id;
+            if (changeEvent.operationType === 'delete') {
+                this._resumeServiceForLocation(location);
+            } else {
+                const status = changeEvent.fullDocument.value[this._serviceName];
+                if (status.paused) {
+                    this._pauseServiceForLocation(location);
+                } else {
+                    this._resumeServiceForLocation(location);
+                }
+            }
+            this._log.info('Change stream event processed', {
+                method: 'ServiceStatusManager._handleChangeStreamChangeEvent',
+                opType: changeEvent.operationType,
+                location,
+            });
+    }
+}
+
+module.exports = LocationStatusStream;

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -2,6 +2,7 @@
 
 const async = require('async');
 const Redis = require('ioredis');
+const { MongoClient } = require('mongodb');
 
 const { errors } = require('arsenal');
 const { RedisClient, StatsModel, ZenkoMetrics } = require('arsenal').metrics;
@@ -18,6 +19,9 @@ const { getSortedSetKey, getSortedSetMember } =
     require('../util/sortedSetHelper');
 const Metrics = require('./Metrics');
 const getRoutesFn = require('./routes');
+const locations = require('../../conf/locationConfig.json') || {};
+const { constructConnectionString } = require('../../extensions/utils/MongoUtils');
+const LocationStatusManager = require('../util/LocationStatusManager');
 
 const {
     redisKeys: crrRedisKeys,
@@ -76,6 +80,11 @@ class BackbeatAPI {
         this._metricProducer = null;
         this._healthcheck = null;
         this._zkClient = null;
+
+        this._lifecycleSites = [];
+
+        this._mongoClient = null;
+        this._locationStatusManager = null;
 
         // TODO: this should rely on the data stored in Redis and not an
         //  internal timer
@@ -155,8 +164,10 @@ class BackbeatAPI {
         const bootstrapList = this._repConfig.destination.bootstrapList;
         const sites = bootstrapList.map(item => item.site);
         const ingestionBuckets = this._config.getIngestionBuckets();
+        const allSites = Object.keys(locations);
 
         this._crrSites = sites;
+        this._lifecycleSites = allSites;
         this._ingestionSites =
             [...new Set(ingestionBuckets.map(b => b.locationConstraint))];
     }
@@ -194,6 +205,7 @@ class BackbeatAPI {
         const routes = getRoutesFn({
             crr: this._crrSites,
             ingestion: this._ingestionSites,
+            lifecycle: this._lifecycleSites,
         });
 
         // first validate healthcheck routes or prom routes since they do not
@@ -250,7 +262,7 @@ class BackbeatAPI {
             return isMatchingMethod && isMatchingExtension && isMatchingLevel;
         });
 
-        // if rDetails has an extension property, i.e. 'crr', 'ingestion'
+        // if rDetails has an extension property, i.e. 'crr', 'ingestion', 'lifecycle'
         if (rDetails.extension) {
             addKeys.service = rDetails.extension;
         }
@@ -1080,6 +1092,22 @@ class BackbeatAPI {
     }
 
     /**
+     * Get list of requested locations
+     * @param {Object} details request details
+     * @param {Object} details.extensions object containing locations per service
+     * @param {string[]} details.extensions.crr replication locations
+     * @param {string[]} details.extensions.ingetsion ingestion locations
+     * @param {string[]} details.extensions.lifecycle lifecycle locations
+     * @returns {string[]} list of site names
+     */
+    getRequestedSites(details) {
+        if (details.site === 'all') {
+            return details.extensions[details.service].filter(s => s !== 'all');
+        }
+        return [details.site];
+    }
+
+    /**
      * Pause operations for given site(s)
      * @param {Object} details - The route details
      * @param {String} body - The POST request body string
@@ -1088,55 +1116,8 @@ class BackbeatAPI {
      */
     pauseService(details, body, cb) {
         const service = details.service;
-        let sites;
-        if (details.site === 'all') {
-            sites = details.extensions[service].filter(s => s !== 'all');
-        } else {
-            sites = [details.site];
-        }
-        sites.forEach(site => {
-            // TODO: assumption that site is available on processor side
-            const topic = service === 'crr' ?
-                this._crrTopic : this._ingestionTopic;
-            const channel = `${topic}-${site}`;
-            const message = JSON.stringify({ action: 'pauseService' });
-            this._redisPublisher.publish(channel, message);
-        });
-        this._logger.info(`${service} service paused for locations: ${sites}`);
-        return cb(null, {});
-    }
-
-    /**
-     * Validate that the POST request body has the necessary content
-     * @param {String} body - the POST request body string
-     * @return {Object} object containing an error and the request body
-     */
-    _parseScheduleResumeBody(body) {
-        const msg = 'The body of your POST request is not well-formed';
-        let reqBody;
-        const defaultRes = { hours: 6 };
-        if (!body) {
-            return defaultRes;
-        }
-        try {
-            reqBody = JSON.parse(body);
-            // default 6 hours if no body value sent by user
-            if (!reqBody.hours) {
-                return defaultRes;
-            }
-            if (reqBody.hours === '' || isNaN(reqBody.hours) ||
-                parseInt(reqBody.hours, 10) <= 0) {
-                return {
-                    error: errors.MalformedPOSTrequest.customizeDescription(
-                        `${msg}: hours must be an integer greater than 0`),
-                };
-            }
-            return { hours: parseInt(reqBody.hours, 10) };
-        } catch (e) {
-            return {
-                error: errors.MalformedPOSTRequest.customizeDescription(msg),
-            };
-        }
+        const locations = this.getRequestedSites(details);
+        return this._locationStatusManager.pauseService(service, locations, cb);
     }
 
     /**
@@ -1148,46 +1129,8 @@ class BackbeatAPI {
      */
     resumeService(details, body, cb) {
         const service = details.service;
-        let schedule;
-        let sites;
-        if (details.site === 'all') {
-            sites = details.extensions[service].filter(s => s !== 'all');
-        } else {
-            sites = [details.site];
-        }
-
-        if (typeof details.schedule === 'boolean') {
-            if (!details.schedule) {
-                // escalate error
-                this._logger.error('error scheduling resume, wrong route path');
-                return cb(errors.RouteNotFound);
-            }
-            // parse body and handle scheduling
-            const { error, hours } = this._parseScheduleResumeBody(body);
-            if (error) {
-                return cb(error);
-            }
-            schedule = new Date();
-            schedule.setHours(schedule.getHours() + hours);
-        }
-
-        sites.forEach(site => {
-            const topic = service === 'crr' ?
-                this._crrTopic : this._ingestionTopic;
-            const channel = `${topic}-${site}`;
-            const message = JSON.stringify({
-                action: 'resumeService',
-                date: schedule,
-            });
-            this._redisPublisher.publish(channel, message);
-        });
-        if (schedule) {
-            this._logger.info(`${service} for locations ${sites} scheduled ` +
-                `to resume at a later time: ${schedule}`);
-        } else {
-            this._logger.info(`${service} resumed for locations ${sites}`);
-        }
-        return cb(null, {});
+        const sites = this.getRequestedSites(details);
+        return this._locationStatusManager.resumeService(service, sites, details.schedule, body, cb);
     }
 
     /**
@@ -1198,70 +1141,8 @@ class BackbeatAPI {
      */
     deleteScheduledResumeService(details, cb) {
         const service = details.service;
-        let sites;
-        if (details.site === 'all') {
-            sites = details.extensions[service].filter(s => s !== 'all');
-        } else {
-            sites = [details.site];
-        }
-        sites.forEach(site => {
-            const topic = service === 'crr' ?
-                this._crrTopic : this._ingestionTopic;
-            const channel = `${topic}-${site}`;
-            const message = JSON.stringify({
-                action: 'deleteScheduledResumeService',
-            });
-            this._redisPublisher.publish(channel, message);
-        });
-        this._logger.info(`deleted scheduled resume for locations: ${sites}`);
-        return cb(null, {});
-    }
-
-    /**
-     * Helper method to get zookeeper state details for given site(s)
-     * @param {Object} details - The route details
-     * @param {Function} cb - callback(error, stateBySite)
-     * @return {undefined}
-     */
-    _getZkStateNodeDetails(details, cb) {
-        const service = details.service;
-        let sites;
-        if (details.site === 'all') {
-            sites = details.extensions[service].filter(s => s !== 'all');
-        } else {
-            sites = [details.site];
-        }
-        const stateBySite = {};
-        async.each(sites, (site, next) => {
-            const zkNamespace = service === 'crr' ?
-                zookeeperReplicationNamespace : zookeeperIngestionNamespace;
-            const zkStatePath = service === 'crr' ?
-                zkReplicationStatePath : zkIngestionStatePath;
-            const path = `${zkNamespace}${zkStatePath}/${site}`;
-            this._zkClient.getData(path, (err, data) => {
-                if (err) {
-                    return next(err);
-                }
-                try {
-                    const d = JSON.parse(data.toString());
-                    stateBySite[site] = d;
-                } catch (e) {
-                    return next(e);
-                }
-                return next();
-            });
-        }, error => {
-            if (error) {
-                let errMessage = 'error getting state node details';
-                if (error.name === 'NO_NODE') {
-                    errMessage = 'zookeeper path was not created on queue ' +
-                        'processor start up';
-                }
-                this._logger.error(errMessage, { error });
-                return cb(errors.InternalError);
-            }
-            return cb(null, stateBySite);
-        });
+        const sites = this.getRequestedSites(details);
+        return this._locationStatusManager.deleteScheduledResumeService(service, sites, cb);
     }
 
     /**
@@ -1271,16 +1152,9 @@ class BackbeatAPI {
      * @return {undefined}
      */
     getResumeSchedule(details, cb) {
-        this._getZkStateNodeDetails(details, (err, data) => {
-            if (err) {
-                return cb(err);
-            }
-            const schedules = {};
-            Object.keys(data).forEach(site => {
-                schedules[site] = data[site].scheduledResume || 'none';
-            });
-            return cb(null, schedules);
-        });
+        const service = details.service;
+        const sites = this.getRequestedSites(details);
+        return this._locationStatusManager.getResumeSchedule(service, sites, cb);
     }
 
     /**
@@ -1290,16 +1164,9 @@ class BackbeatAPI {
      * @return {undefined}
      */
     getServiceStatus(details, cb) {
-        this._getZkStateNodeDetails(details, (err, data) => {
-            if (err) {
-                return cb(err);
-            }
-            const statuses = {};
-            Object.keys(data).forEach(site => {
-                statuses[site] = data[site].paused ? 'disabled' : 'enabled';
-            });
-            return cb(null, statuses);
-        });
+        const service = details.service;
+        const sites = this.getRequestedSites(details);
+        return this._locationStatusManager.getServiceStatus(service, sites, cb);
     }
 
     /**
@@ -1360,6 +1227,7 @@ class BackbeatAPI {
     setupInternals(cb) {
         async.parallel([
             done => this._setZookeeper(done),
+            done => this._setupMongoClient(done),
             done => this._setProducer(this._metricsTopic, (err, producer) => {
                 if (err) {
                     return done(err);
@@ -1383,14 +1251,49 @@ class BackbeatAPI {
             }),
         ], err => {
             if (err) {
-                this._logger.error('error setting up internal clients');
+                this._logger.error('error setting up internal clients', {
+                    method: 'BackbeatAPI.setupInternals',
+                    error: err.message,
+                });
                 return cb(err);
             }
             this._healthcheck = new Healthcheck(this._repConfig, this._zkClient,
                 this._crrProducer, this._crrStatusProducer,
                 this._metricProducer);
-            this._logger.info('BackbeatAPI setup ready');
-            return cb();
+            this._locationStatusManager = new LocationStatusManager(
+                this._mongoClient,
+                this._zkClient,
+                this._redisPublisher,
+                {
+                    crr: {
+                        namespace: zookeeperReplicationNamespace,
+                        statePath: zkReplicationStatePath,
+                        topic: this._crrTopic,
+                        isMongo: false,
+                    },
+                    ingestion: {
+                        namespace: zookeeperIngestionNamespace,
+                        statePath: zkIngestionStatePath,
+                        topic: this._ingestionTopic,
+                        isMongo: false,
+                    },
+                    lifecycle: {
+                        isMongo: true,
+                    }
+                },
+                this._logger,
+            );
+            return this._locationStatusManager._setupLocationStatusStore(err => {
+                if (err) {
+                    this._logger.error('error setting up location status manager', {
+                        method: 'BackbeatAPI.setupInternals',
+                        error: err.message,
+                    });
+                    return cb(err);
+                }
+                this._logger.info('BackbeatAPI setup ready');
+                return cb();
+            });
         });
     }
 
@@ -1421,6 +1324,38 @@ class BackbeatAPI {
         zkClient.once('connected', () => {
             zkClient.removeAllListeners('error');
             this._zkClient = zkClient;
+            return cb();
+        });
+    }
+
+    /**
+     * Connects to MongoDB using and retreives
+     * the location status collection
+     * @param {function} cb callback
+     * @returns {undefined} undefined
+     */
+    _setupMongoClient(cb) {
+        const mongoConfig = this._config.queuePopulator.mongo;
+        const mongoUrl = constructConnectionString(mongoConfig);
+        MongoClient.connect(mongoUrl, {
+                replicaSet: mongoConfig.replicaSet,
+                useNewUrlParser: true,
+                useUnifiedTopology: true,
+        }, (err, client) => {
+            if (err) {
+                this._logger.error('Could not connect to MongoDB', {
+                    method: 'BackbeatAPI._setupMongoClient',
+                    error: err.message,
+                });
+                return cb(err);
+            }
+            // connect to metadata DB
+            this._mongoClient = client.db(mongoConfig.database, {
+                ignoreUndefined: true,
+            });
+            this._logger.info('Connected to MongoDB', {
+                method: 'BackbeatAPI._setupMongoClient',
+            });
             return cb();
         });
     }

--- a/lib/api/BackbeatRequest.js
+++ b/lib/api/BackbeatRequest.js
@@ -51,13 +51,7 @@ class BackbeatRequest {
             this._routeDetails.marker = marker;
             this._routeDetails.sitename = sitename;
         } else {
-            // for now: pause/resume/status
-            this._routeDetails.extension = parts[0];
-            this._routeDetails.status = parts[1];
-            this._routeDetails.site = parts[2] || 'all';
-            if (parts[3]) {
-                this._routeDetails.schedule = parts[3] === 'schedule';
-            }
+            this._parsePauseResumeStatusRoutes(parts);
         }
     }
 
@@ -66,7 +60,7 @@ class BackbeatRequest {
      * @param {Array} parts - The route schema split by '/'
      * @return {undefined}
      */
-    _parseIngestionRoutes(parts) {
+    _parsePauseResumeStatusRoutes(parts) {
         this._routeDetails.extension = parts[0];
         this._routeDetails.status = parts[1];
         this._routeDetails.site = parts[2] || 'all';
@@ -121,7 +115,9 @@ class BackbeatRequest {
         } else if (parts[0] === 'monitoring') {
             this._parseMonitoringRoutes(parts);
         } else if (parts[0] === 'ingestion') {
-            this._parseIngestionRoutes(parts);
+            this._parsePauseResumeStatusRoutes(parts);
+        } else if (parts[0] === 'lifecycle') {
+            this._parsePauseResumeStatusRoutes(parts);
         }
         return;
     }

--- a/lib/api/routes.js
+++ b/lib/api/routes.js
@@ -7,12 +7,14 @@
  * @param {Object} locations - Locations by service
  * @param {Array} locations.crr - The list of replication location names
  * @param {Array} locations.ingestion - The list of ingestion location names
+ * @param {Array} locations.lifecycle - The list of lifecycle location names
  * @return {Array} The array of route objects
  */
 function routes(locations) {
     /* eslint-disable no-param-reassign */
     locations.crr = locations.crr || [];
     locations.ingestion = locations.ingestion || [];
+    locations.lifecycle = locations.lifecycle || [];
     /* eslint-enable no-param-reassign */
 
     return [
@@ -146,6 +148,7 @@ function routes(locations) {
         },
         // Route: /_/crr/pause/<location>
         // Route: /_/ingestion/pause/<location>
+        // Route: /_/lifecycle/pause/<location>
         // Where <location> is an optional field
         {
             httpMethod: 'POST',
@@ -153,13 +156,16 @@ function routes(locations) {
             extensions: {
                 crr: [...locations.crr, 'all'],
                 ingestion: [...locations.ingestion, 'all'],
+                lifecycle: [...locations.lifecycle, 'all'],
             },
             method: 'pauseService',
         },
         // Route: /_/crr/resume/<location>
         // Route: /_/ingestion/resume/<location>
+        // Route: /_/lifecycle/resume/<location>
         // Route: /_/crr/resume/<location>/schedule
         // Route: /_/ingestion/resume/<location>/schedule
+        // Route: /_/lifecycle/resume/<location>/schedule
         // Where <location> is an optional field unless "schedule" route
         {
             httpMethod: 'POST',
@@ -167,6 +173,7 @@ function routes(locations) {
             extensions: {
                 crr: [...locations.crr, 'all'],
                 ingestion: [...locations.ingestion, 'all'],
+                lifecycle: [...locations.lifecycle, 'all'],
             },
             method: 'resumeService',
         },
@@ -176,22 +183,26 @@ function routes(locations) {
             extensions: {
                 crr: [...locations.crr, 'all'],
                 ingestion: [...locations.ingestion, 'all'],
+                lifecycle: [...locations.lifecycle, 'all'],
             },
             method: 'deleteScheduledResumeService',
         },
         // Route: /_/crr/resume/<location>
         // Route: /_/ingestion/resume/<location>
+        // Route: /_/lifecycle/resume/<location>
         {
             httpMethod: 'GET',
             type: 'resume',
             extensions: {
                 crr: [...locations.crr, 'all'],
                 ingestion: [...locations.ingestion, 'all'],
+                lifecycle: [...locations.lifecycle, 'all'],
             },
             method: 'getResumeSchedule',
         },
         // Route: /_/crr/status/<location>
         // Route: /_/ingestion/status/<location>
+        // Route: /_/lifecycle/status/<location>
         // Where <location> is an optional field
         {
             httpMethod: 'GET',
@@ -199,6 +210,7 @@ function routes(locations) {
             extensions: {
                 crr: [...locations.crr, 'all'],
                 ingestion: [...locations.ingestion, 'all'],
+                lifecycle: [...locations.lifecycle, 'all'],
             },
             method: 'getServiceStatus',
         },

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -21,6 +21,7 @@ const constants = {
         replicationStatusProcessor: 'ReplicationStatusProcessor',
     },
     compressionType: 'Zstd',
+    locationStatusCollection: '__locationStatusStore',
 };
 
 module.exports = constants;

--- a/lib/models/LocationStatus.js
+++ b/lib/models/LocationStatus.js
@@ -1,0 +1,167 @@
+/**
+ * Class to manage a location's pause/resume state on its
+ * different services.
+ * Current supported services are : crr, ingestion, lifecycle
+ */
+class LocationStatus {
+
+    /**
+     * @constructor
+     * @param {string[]} services services to init
+     * @param {Object} locationStatus initial location status values
+     */
+    constructor(services, locationStatus) {
+        this._data = this._initStatus(services);
+        if (locationStatus) {
+            const data = locationStatus instanceof LocationStatus ?
+                locationStatus._data : locationStatus;
+            Object.keys(this._data).forEach(svc => {
+                this._data[svc] = {
+                    paused: (data[svc] && data[svc].paused) || false,
+                    scheduledResume: (data[svc] && data[svc].scheduledResume) || null,
+                };
+            });
+        }
+    }
+
+    /**
+     * Initializes the status of all services
+     * The default status of a service is unpaused
+     * @param {string[]} servicesToInit services to be initialized
+     * @return {Object} initial services status
+     */
+    _initStatus(servicesToInit) {
+        const initStatus = {
+            paused: false,
+            scheduledResume: null,
+        };
+        return {
+            crr: servicesToInit.includes('crr') ? initStatus : null,
+            ingestion: servicesToInit.includes('ingestion') ? initStatus : null,
+            lifecycle: servicesToInit.includes('lifecycle') ? initStatus : null,
+        };
+    }
+
+    /**
+     * initializes a service status
+     * @param {string} service service name
+     * @return {undefined}
+     */
+    _initService(service) {
+        this._data[service] = {
+            paused: false,
+            scheduledResume: null,
+        };
+    }
+
+    /**
+     * @param {string} service service name
+     * @param {boolean} paused true if paused
+     * @return {undefined}
+     */
+    setServicePauseStatus(service, paused) {
+        if (Object.keys(this._data).includes(service)) {
+            if (!this._data[service]) {
+                this._initService(service);
+            }
+            this._data[service].paused = paused;
+        }
+    }
+
+    /**
+     * @param {string} service service name
+     * @return { boolean | null} true if paused
+     */
+    getServicePauseStatus(service) {
+        if (!this._data[service]) {
+            return null;
+        }
+        return this._data[service].paused;
+    }
+
+    /**
+     * @param {string} service service name
+     * @param {Date | null} [date] scheduled resume date
+     * @return {undefined}
+     */
+    setServiceResumeSchedule(service, date) {
+        if (this._data[service]) {
+            if (date) {
+                this._data[service].scheduledResume = date.toString();
+            } else {
+                this._data[service].scheduledResume = null;
+            }
+        }
+    }
+
+    /**
+     * @param {string} service service name
+     * @return { Date | null} scheduled resume date
+     */
+    getServiceResumeSchedule(service) {
+        const schedule = this._data[service] && this._data[service].scheduledResume;
+        if (!schedule) {
+            return null;
+        }
+        return new Date(schedule);
+    }
+
+    /**
+     * @param {string | string[]} service service(s) name
+     * @return {undefined}
+     */
+    pauseLocation(service) {
+        const servicesList = Array.isArray(service) ?
+            service : [service];
+        servicesList.forEach(svc => {
+            if (!this.getServicePauseStatus(svc)) {
+                this.setServicePauseStatus(svc, true);
+            }
+        });
+    }
+
+    /**
+     * @param {string | string[]} service service(s) name
+     * @param {Date} [schedule] date to resume service(s)
+     * @return {undefined}
+     */
+    resumeLocation(service, schedule) {
+        const servicesList = Array.isArray(service) ?
+            service : [service];
+        servicesList.forEach(svc => {
+            if (!this.getServicePauseStatus(svc)) {
+                return;
+            }
+            let shouldPause = false;
+            if (schedule) {
+                shouldPause = true;
+            }
+            this.setServicePauseStatus(svc, shouldPause);
+            this.setServiceResumeSchedule(svc, schedule || null);
+        });
+    }
+
+    /**
+     * @param {string} service service name
+     * @return {Object|null} service status object
+     */
+    getService(service) {
+        return this._data[service] || null;
+    }
+
+    /**
+     * @return {Object} location status object
+     */
+    getValue() {
+        return this._data;
+    }
+
+    /**
+     * @return {string} serialized location status data
+     */
+    getSerialized() {
+        return JSON.stringify(this.getValue());
+    }
+}
+
+module.exports = LocationStatus;

--- a/lib/util/LocationStatusManager.js
+++ b/lib/util/LocationStatusManager.js
@@ -1,0 +1,590 @@
+const async = require('async');
+const schedule = require('node-schedule');
+const { errors } = require('arsenal');
+const LocationStatus = require('../models/LocationStatus');
+
+const validLocations = require('../../conf/locationConfig.json') || {};
+const { locationStatusCollection } = require('../constants');
+
+const actions = {
+    deleteSchedule: 'deleteScheduledResumeService',
+    pause: 'pauseService',
+    resume: 'resumeService',
+};
+
+/**
+ * Contains methods to incrememt different metrics
+ * @typedef {Object} ServiceConfig
+ * @property {string} namespace - crr config
+ * @property {string} statePath - zookeeper state path
+ * @property {string} topic - redis channel name
+ * @property {string} isMongo - true if service uses mongo to store status
+ */
+
+/**
+ * @class LocationStatusManager
+ *
+ * @classdesc manages the pause/resume status of the locations
+ * on different services.
+ */
+class LocationStatusManager {
+
+    /**
+     * @constructor
+     * @param {MongoClient} mongoClient mongo client instance
+     * @param {zookeeper-client.Client} zkClient zookeeper client instance
+     * @param {Redis} redis redis publisher
+     * @param {Object} serviceConfig config of each service
+     * @param {ServiceConfig} serviceConfig.crr config of crr
+     * @param {ServiceConfig} serviceConfig.ingestion config of ingestion
+     * @param {ServiceConfig} serviceConfig.lifecycle config of lifecycle
+     * @param {Logger} logger logger instance
+     */
+    constructor(mongoClient, zkClient, redis, serviceConfig, logger) {
+        this._mongoClient = mongoClient;
+        this._zkClient = zkClient;
+        this._redis = redis;
+        this._serviceConfig = serviceConfig;
+        this._logger = logger;
+
+        // services to initialize in mongo for each location
+        this._supportedServices = Object.keys(serviceConfig)
+            .filter(svc => serviceConfig[svc].isMongo);
+
+        this._locationStatusColl = null;
+
+        this._locationStatusStore = {};
+        this._scheduledResumeJobs = {
+            crr: {},
+            ingestion: {},
+            lifecycle: {},
+        };
+    }
+
+    /**
+     * Creates mongo collection for
+     * storing the location status
+     * @param {function} cb callback
+     * @return {undefined}
+     */
+    _initCollection(cb) {
+        this._mongoClient.createCollection(locationStatusCollection, err => {
+            // in case the collection already exists, we ignore the error
+            if (err && err.codeName !== 'NamespaceExists') {
+                this._logger.error('Could not create mongo collection', {
+                    method: 'LocationStatusManager._initCollection',
+                    collection: locationStatusCollection,
+                    error: err.message,
+                });
+                return cb(err);
+            }
+            this._locationStatusColl = this._mongoClient.collection(locationStatusCollection);
+            return cb();
+        });
+    }
+
+    /**
+     * list all location status documents from mongodb
+     * @param {function} cb callback
+     * @returns {undefined}}
+     */
+    _listCollectionDocuments(cb) {
+        this._locationStatusColl.find({}, (err, cursor) => {
+            if (err) {
+                this._logger.error('Could not list documents', {
+                    method: 'LocationStatusManager._listCollectionDocuments',
+                    collection: locationStatusCollection,
+                    error: err.message,
+                });
+            }
+            return cursor.toArray(cb);
+        });
+    }
+
+    /**
+     * Add valid mongo locations to local store
+     * @param {Object[]} locations list of locations data from mongo
+     * @param {function} cb callback
+     * @returns {undefined}
+     */
+    _getPreviousLocationStates(locations, cb) {
+        const validLocationNames = Object.keys(validLocations);
+        locations
+            .filter(loc => validLocationNames.includes(loc._id))
+            .forEach(loc => {
+                this._locationStatusStore[loc._id] = new LocationStatus(this._supportedServices, loc.value);
+                // schedule jobs if any
+                Object.keys(loc.value).forEach(service => {
+                    const date = loc.value[service] && loc.value[service].scheduledResume;
+                    if (date) {
+                        this._scheduleResumeJob(loc._id, service, new Date(date));
+                    }
+                });
+            });
+        return cb(null, locations);
+    }
+
+    /**
+     * remove invalid locations from mongo
+     * @param {Object[]} locations list of locations data from mongo
+     * @param {function} cb callback
+     * @returns {undefined}
+     */
+    _deleteInvalidLocations(locations, cb) {
+        const validLocationNames = Object.keys(validLocations);
+        const invalidLocations = locations
+            .filter(loc => !validLocationNames.includes(loc._id))
+            .map(loc => loc._id);
+        return this._locationStatusColl.deleteMany({
+            _id: {
+                $in: invalidLocations
+            }
+        }, err => {
+            if (err) {
+                this._logger.error('Could not delete invalid locations', {
+                    method: 'LocationStatusManager._deleteInvalidLocations',
+                    error: err.message,
+                });
+                return cb(err);
+            }
+            return cb(null, locations);
+        });
+    }
+
+    /**
+     * Adds newly added locations to
+     * mongo and the local store
+     * @param {Object[]} locations list of locations data from mongo
+     * @param {function} cb callback
+     * @returns {undefined}
+     */
+    _addNewLocations(locations, cb) {
+        const validLocationNames = Object.keys(validLocations);
+        const mongoLocations = locations.map(loc => loc._id);
+        const newLocations = validLocationNames
+            .filter(loc => !mongoLocations.includes(loc));
+        async.eachLimit(newLocations, 10, (location, next) => {
+            const locationConfig = new LocationStatus(this._supportedServices);
+            this._locationStatusStore[location] = locationConfig;
+            this._locationStatusColl.insert({
+                _id: location,
+                value: locationConfig.getValue(),
+            }, next);
+        }, err => {
+            if (err) {
+                this._logger.error('Could not add new locations', {
+                    method: 'LocationStatusManager._addNewLocations',
+                    error: err.message,
+                });
+                return cb(err);
+            }
+            return cb(null, locations);
+        });
+    }
+
+    /**
+     * Initialize the status of locations stored in mongo
+     * @param {function} cb callback
+     * @return {undefined}
+     */
+    _setupLocationStatusStore(cb) {
+        async.waterfall([
+            done => this._initCollection(done),
+            done => this._listCollectionDocuments(done),
+            (locations, done) => this._getPreviousLocationStates(locations, done),
+            (locations, done) => this._deleteInvalidLocations(locations, done),
+            (locations, done) => this._addNewLocations(locations, done),
+        ], err => {
+            if (err) {
+                this._logger.error('Could not setup location statuses in mongo', {
+                    method: 'LocationStatusManager._setupLocationStatusStore',
+                    error: err.message,
+                });
+                return cb(err);
+            }
+            this._logger.info('Locations status setup complete', {
+                method: 'LocationStatusManager._setupLocationStatusStore',
+            });
+            return cb();
+        });
+    }
+
+    /**
+     * publish an action to redis channel
+     * @param {string} service service name
+     * @param {string} location location name
+     * @param {string} action action name
+     * @param {Date} [schedule] scheduled resume date
+     * @returns {undefined}
+     */
+    _pushActionToRedis(service, location, action, schedule = null) {
+        const topic = this._serviceConfig[service].topic;
+        const channel = `${topic}-${location}`;
+        const message = {
+            action,
+        };
+        if (schedule) {
+            message.date = schedule;
+        }
+        this._redis.publish(channel, JSON.stringify(message));
+    }
+
+    /**
+     * Updates a location's pause/resume status
+     * in mongo based on local values
+     * @param {string} location location name
+     * @param {callback} cb callack
+     * @returns {undefined}
+     */
+    _updateServiceStatusForLocation(location, cb) {
+        this._locationStatusColl.updateOne(
+            { _id: location },
+            {
+                $set: {
+                    _id: location,
+                    value: this._locationStatusStore[location].getValue(),
+                }
+            },
+            { upsert: false }, err => {
+                if (err) {
+                    this._logger.error('Could not update location service status in MongoDB', {
+                        method: 'LocationStatusManager._updateServiceStatusForLocation',
+                        error: err.message,
+                    });
+                    return cb(err);
+                }
+                return cb();
+            });
+    }
+
+    /**
+     * Helper method to get zookeeper state details for given location(s)
+     * @param {string} service service name, can be one of "lifecycle", "crr", "ingestion"
+     * @param {string[]} locations location names to get
+     * @param {Function} cb callback(error, stateBySite)
+     * @return {undefined}
+     */
+    _getZkStateDetails(service, locations, cb) {
+        const stateBySite = {};
+        async.each(locations, (location, next) => {
+            const zkNamespace = this._serviceConfig[service].namespace;
+            const zkStatePath = this._serviceConfig[service].statePath;
+            const path = `${zkNamespace}${zkStatePath}/${location}`;
+            this._zkClient.getData(path, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                try {
+                    const d = JSON.parse(data.toString());
+                    stateBySite[location] = d;
+                } catch (e) {
+                    return next(e);
+                }
+                return next();
+            });
+        }, error => {
+            if (error) {
+                let errMessage = 'error getting state node details';
+                if (error.name === 'NO_NODE') {
+                    errMessage = 'zookeeper path was not created on queue ' +
+                        'processor start up';
+                }
+                this._logger.error(errMessage, {
+                    method: 'LocationStatusManager._getZkStateDetails',
+                    error,
+                });
+                return cb(errors.InternalError);
+            }
+            return cb(null, stateBySite);
+        });
+    }
+
+    /**
+     * Calls the correct location state getter based
+     * on where the service state is stored
+     * @param {string} service service to pause for locations
+     * @param {string[]} locations location names to pause
+     * @param {Function} cb callback
+     * @returns {undefined}
+     */
+    _getStateDetails(service, locations, cb) {
+        if (!this._serviceConfig[service] || this._serviceConfig[service].isMongo) {
+            const selectedLocations = {};
+            locations.forEach(loc => {
+                selectedLocations[loc] = this._locationStatusStore[loc].getService(service);
+            });
+            return cb(null, selectedLocations);
+        }
+        return this._getZkStateDetails(service, locations, cb);
+    }
+
+    /**
+     * Get status of service for one or multiple locations
+     * @param {string} service service to pause for locations
+     * @param {string[]} locations location names to pause
+     * @param {Function} cb callback
+     * @returns {undefined}
+     */
+    getServiceStatus(service, locations, cb) {
+        this._getStateDetails(service, locations, (err, data) => {
+            if (err) {
+                return cb(err);
+            }
+            const statuses = {};
+            Object.keys(data).forEach(location => {
+                statuses[location] = data[location].paused ? 'disabled' : 'enabled';
+            });
+            return cb(null, statuses);
+        });
+    }
+
+    /**
+     * Get scheduled resume of service for one or multiple locations
+     * @param {string} service service to pause for locations
+     * @param {string[]} locations location names to pause
+     * @param {Function} cb callback
+     * @returns {undefined}
+     */
+    getResumeSchedule(service, locations, cb) {
+        this._getStateDetails(service, locations, (err, data) => {
+            if (err) {
+                return cb(err);
+            }
+            const schedules = {};
+            Object.keys(data).forEach(location => {
+                schedules[location] = data[location].scheduledResume || 'none';
+            });
+            return cb(null, schedules);
+        });
+    }
+
+    /**
+     * Removes previously scheduled resume job
+     * @param {string} location location name
+     * @param {string} service service name
+     * @returns {undefined}
+     */
+    _deleteResumeJob(location, service) {
+        const prvSchedule = this._scheduledResumeJobs[service][location];
+        if (prvSchedule) {
+            prvSchedule.cancel();
+            delete this._scheduledResumeJobs[service][location];
+        }
+    }
+
+    /**
+     * Validate that the POST request body has the necessary content
+     * @param {String} body the POST request body string
+     * @return {Object} object containing an error and the request body
+     */
+    _parseScheduleResumeBody(body) {
+        const msg = 'The body of your POST request is not well-formed';
+        let reqBody;
+        const defaultRes = { hours: 6 };
+        if (!body) {
+            return defaultRes;
+        }
+        try {
+            reqBody = JSON.parse(body);
+            // default 6 hours if no body value sent by user
+            if (!reqBody.hours) {
+                return defaultRes;
+            }
+            if (reqBody.hours === '' || isNaN(reqBody.hours) ||
+                parseInt(reqBody.hours, 10) <= 0) {
+                return {
+                    error: errors.MalformedPOSTrequest.customizeDescription(
+                        `${msg}: hours must be an integer greater than 0`),
+                };
+            }
+            return { hours: parseInt(reqBody.hours, 10) };
+        } catch (e) {
+            this._logger.error('Error parsing request body', {
+                method: 'LocationStatusManager._parseScheduleResumeBody',
+                error: e.message,
+            });
+            return {
+                error: errors.MalformedPOSTRequest.customizeDescription(msg),
+            };
+        }
+    }
+
+    /**
+     * Schedules resume of a location status for a service
+     * @param {string} location location name
+     * @param {string} service service name
+     * @param {Date} date resume date
+     * @returns {undefined}
+     */
+    _scheduleResumeJob(location, service, date) {
+        function triggerResume() {
+            this._locationStatusStore[location].resumeLocation(service);
+            this._updateServiceStatusForLocation(location, err => {
+                if (err) {
+                    this._logger.error('error resuming scheduled job, retrying in 1min', {
+                        method: 'LocationStatusManager._scheduleResumeJob',
+                        error: err,
+                        location,
+                    });
+                    // if an error occurs, need to retry
+                    // for now, schedule minute from now
+                    const date = new Date();
+                    date.setMinutes(date.getMinutes() + 1);
+                    this._scheduledResumeJobs[service][location] = schedule.scheduleJob(date,
+                        triggerResume.bind(this));
+                }
+                this._logger.info('location resumed', {
+                    method: 'LocationStatusManager._scheduleResumeJob',
+                    location,
+                    service,
+                });
+            });
+        }
+        this._deleteResumeJob(location, service);
+        if (new Date() > date) {
+            triggerResume.bind(this)();
+        } else {
+            this._scheduledResumeJobs[service][location] = schedule.scheduleJob(date,
+                triggerResume.bind(this));
+            }
+    }
+
+    /**
+     * Deletes the scheduled resume of service for one or more locations
+     * @param {string} service service to pause for locations
+     * @param {string[]} locations location names
+     * @param {Function} cb callback
+     * @returns {undefined}
+     */
+    deleteScheduledResumeService(service, locations, cb) {
+        return async.eachLimit(locations, 10, (location, next) => {
+            if (this._serviceConfig[service] && !this._serviceConfig[service].isMongo) {
+                this._pushActionToRedis(service, location, actions.deleteSchedule);
+                return next();
+            }
+            const paused = this._locationStatusStore[location].getServicePauseStatus(service);
+            if (paused) {
+                this._deleteResumeJob(location, service);
+                this._locationStatusStore[location].setServiceResumeSchedule(service, null);
+                return this._updateServiceStatusForLocation(location, next);
+            }
+            return next();
+        }, err => {
+            if (err) {
+                const errMsg = `failed to delete scheduled resume for locations: ${locations}`;
+                this._logger.error(errMsg, {
+                    method: 'LocationStatusManager.deleteScheduledResumeService',
+                    error: err.message,
+                    service,
+                });
+                return cb(null, errors.InternalError.customizeDescription(errMsg));
+            }
+            this._logger.info(`deleted scheduled resume for locations: ${locations}`, {
+                method: 'LocationStatusManager.deleteScheduledResumeService',
+                service,
+            });
+            return cb(null, {});
+        });
+    }
+
+    /**
+     * Pauses a service for one or multiple locations
+     * @param {string} service service to pause for locations
+     * @param {string[]} locations location names to pause
+     * @param {Function} cb callback
+     * @returns {undefined}
+     */
+    pauseService(service, locations, cb) {
+        async.eachLimit(locations, 10, (location, next) => {
+            if (this._serviceConfig[service] && !this._serviceConfig[service].isMongo) {
+                this._pushActionToRedis(service, location, actions.pause);
+                return next();
+            }
+            const paused = this._locationStatusStore[location].getServicePauseStatus(service);
+                if (!paused) {
+                    this._locationStatusStore[location].pauseLocation(service);
+                    return this._updateServiceStatusForLocation(location, next);
+                }
+            return next();
+        }, err => {
+            if (err) {
+                const errMsg = `failed to pause ${service} service for locations: ${locations}`;
+                this._logger.error(errMsg, {
+                    method: 'LocationStatusManager.pauseService',
+                    error: err.message,
+                    service,
+                });
+                return cb(null, errors.InternalError.customizeDescription(errMsg));
+            }
+            this._logger.info(`${service} service paused for locations: ${locations}`, {
+                method: 'LocationStatusManager.pauseService',
+                service,
+            });
+            return cb(null, {});
+        });
+    }
+
+    /**
+     * Resumes a service for one or multiple locations
+     * @param {string} service service to resume for locations
+     * @param {string[]} locations location names to resume
+     * @param {boolean|undefined} isScheduled true if the
+     * resume should be scheduled
+     * @param {string} body the POST request body string
+     * @param {Function} cb callback
+     * @returns {undefined}
+     */
+    resumeService(service, locations, isScheduled, body, cb) {
+        let schedule;
+
+        if (typeof isScheduled === 'boolean') {
+            if (!isScheduled) {
+                // escalate error
+                this._logger.error('error scheduling resume, wrong route path');
+                return cb(errors.RouteNotFound);
+            }
+            // parse body and handle scheduling
+            const { error, hours } = this._parseScheduleResumeBody(body);
+            if (error) {
+                return cb(error);
+            }
+            schedule = new Date();
+            schedule.setHours(schedule.getHours() + hours);
+        }
+
+        return async.eachLimit(locations, 10, (location, next) => {
+            if (this._serviceConfig[service] && !this._serviceConfig[service].isMongo) {
+                this._pushActionToRedis(service, location, actions.resume, schedule);
+                return next();
+            }
+            const paused = this._locationStatusStore[location].getServicePauseStatus(service);
+            if (paused) {
+                this._locationStatusStore[location].resumeLocation(service, schedule);
+                if (schedule) {
+                    this._scheduleResumeJob(location, service, schedule);
+                }
+                return this._updateServiceStatusForLocation(location, next);
+            }
+            return next();
+        }, err => {
+            if (err) {
+                const errMsg = `failed to resume ${service} service for locations: ${locations}`;
+                this._logger.error(errMsg, {
+                    method: 'LocationStatusManager.resumeService',
+                    error: err.message,
+                    service,
+                });
+                return cb(null, errors.InternalError.customizeDescription(errMsg));
+            }
+            const logMsg = schedule ? `${service} for locations ${locations} scheduled ` +
+                `to resume at a later time: ${schedule}` : `${service} resumed for locations ${locations}`;
+            this._logger.info(logMsg, {
+                method: 'LocationStatusManager.resumeService',
+                service,
+            });
+            return cb(null, {});
+        });
+    }
+}
+
+module.exports = LocationStatusManager;

--- a/tests/functional/lifecycle/LifecycleBucketProcessor.spec.js
+++ b/tests/functional/lifecycle/LifecycleBucketProcessor.spec.js
@@ -18,6 +18,7 @@ const {
     bucketTasksTopic,
     objectTasksTopic,
     testTimeout,
+    mongoConfig,
 } = require('./configObjects');
 
 const bucketEntryMessage = {
@@ -45,7 +46,7 @@ describe('Lifecycle Bucket Processor', function lifecycleBucketProcessor() {
 
     function generateRetryTest(s3Client, shouldRetry = true) {
         const lbp = new LifecycleBucketProcessor(
-            zkConfig, kafkaConfig, lcConfig, repConfig, s3Config);
+            zkConfig, kafkaConfig, lcConfig, repConfig, s3Config, mongoConfig);
 
         lbp.clientManager.getS3Client = () => s3Client;
         lbp.clientManager.getBackbeatClient = () => ({});

--- a/tests/functional/lifecycle/LifecycleTask.js
+++ b/tests/functional/lifecycle/LifecycleTask.js
@@ -423,6 +423,7 @@ class LifecycleBucketProcessorMock {
             bucketTasksTopic: 'bucket-tasks',
             objectTasksTopic: 'object-tasks',
             kafkaBacklogMetrics: this._kafkaBacklogMetrics,
+            pausedLocations: new Set(),
             log: this._log,
             ncvHeap: this.ncvHeap,
         };

--- a/tests/functional/lifecycle/configObjects.js
+++ b/tests/functional/lifecycle/configObjects.js
@@ -44,6 +44,14 @@ const repConfig = {
 
 const s3Config = {};
 
+const mongoConfig = {
+    replicaSetHosts: 'localhost:27017,localhost:27018,localhost:27019',
+    writeConcern: 'majority',
+    replicaSet: 'rs0',
+    readPreference: 'primary',
+    database: 'metadata'
+};
+
 const testTimeout = 30000;
 
 module.exports = {
@@ -55,4 +63,5 @@ module.exports = {
     repConfig,
     s3Config,
     testTimeout,
+    mongoConfig,
 };

--- a/tests/unit/api/BackbeatRequest.spec.js
+++ b/tests/unit/api/BackbeatRequest.spec.js
@@ -93,66 +93,41 @@ describe('BackbeatRequest helper class', () => {
             assert.strictEqual(contentType, 'application/json');
         });
 
-        it('should parse crr pause/resume routes and store internally as ' +
-        'route details', () => {
-            const req = new BackbeatRequest({
-                url: '/_/crr/pause/mysite',
-                method: 'POST',
+        [
+            'crr',
+            'ingestion',
+            'lifecycle'
+        ].forEach(service => {
+            it(`should parse ${service} pause/resume routes and store internally` +
+            'as route details', () => {
+                const req = new BackbeatRequest({
+                    url: `/_/${service}/resume/mysite`,
+                    method: 'POST',
+                });
+                const details = req.getRouteDetails();
+
+                assert.strictEqual(details.extension, service);
+                assert.strictEqual(details.status, 'resume');
+                assert.strictEqual(details.site, 'mysite');
+
+                const req2 = new BackbeatRequest({
+                    url: `/_/${service}/resume`,
+                    method: 'POST',
+                });
+                const details2 = req2.getRouteDetails();
+                // should default to 'all' if none specified
+                assert.strictEqual(details2.site, 'all');
+
+                const req3 = new BackbeatRequest({
+                    url: `/_/${service}/status`,
+                    method: 'GET',
+                });
+                const details3 = req3.getRouteDetails();
+
+                assert.strictEqual(details3.extension, service);
+                assert.strictEqual(details3.status, 'status');
+                assert.strictEqual(details3.site, 'all');
             });
-            const details = req.getRouteDetails();
-
-            assert.strictEqual(details.extension, 'crr');
-            assert.strictEqual(details.status, 'pause');
-            assert.strictEqual(details.site, 'mysite');
-
-            const req2 = new BackbeatRequest({
-                url: '/_/crr/pause',
-                method: 'POST',
-            });
-            const details2 = req2.getRouteDetails();
-            // should default to 'all' if none specified
-            assert.strictEqual(details2.site, 'all');
-
-            const req3 = new BackbeatRequest({
-                url: '/_/crr/status',
-                method: 'GET',
-            });
-            const details3 = req3.getRouteDetails();
-
-            assert.strictEqual(details3.extension, 'crr');
-            assert.strictEqual(details3.status, 'status');
-            assert.strictEqual(details3.site, 'all');
-        });
-
-        it('should parse ingestion pause/resume routes and store internally ' +
-        'as route details', () => {
-            const req = new BackbeatRequest({
-                url: '/_/ingestion/resume/mysite',
-                method: 'POST',
-            });
-            const details = req.getRouteDetails();
-
-            assert.strictEqual(details.extension, 'ingestion');
-            assert.strictEqual(details.status, 'resume');
-            assert.strictEqual(details.site, 'mysite');
-
-            const req2 = new BackbeatRequest({
-                url: '/_/ingestion/resume',
-                method: 'POST',
-            });
-            const details2 = req2.getRouteDetails();
-            // should default to 'all' if none specified
-            assert.strictEqual(details2.site, 'all');
-
-            const req3 = new BackbeatRequest({
-                url: '/_/ingestion/status',
-                method: 'GET',
-            });
-            const details3 = req3.getRouteDetails();
-
-            assert.strictEqual(details3.extension, 'ingestion');
-            assert.strictEqual(details3.status, 'status');
-            assert.strictEqual(details3.site, 'all');
         });
     });
 

--- a/tests/unit/lib/models/LocationStatus.spec.js
+++ b/tests/unit/lib/models/LocationStatus.spec.js
@@ -1,0 +1,108 @@
+const assert = require('assert');
+
+const LocationStatus = require('../../../../lib/models/LocationStatus');
+
+const locationStatusObj = {
+    crr: {
+        paused: true,
+        scheduledResume: null,
+    },
+    ingestion: {
+        paused: false,
+        scheduledResume: null,
+    },
+    lifecycle: {
+        paused: true,
+        scheduledResume: 'Fri Jan 27 2023 13:56:12 GMT+0100',
+    },
+};
+
+describe('LocationStatus', () => {
+    let locationStatus = null;
+
+    beforeEach(() => {
+        locationStatus = new LocationStatus(['crr', 'ingestion', 'lifecycle'], locationStatusObj);
+    });
+
+    it('should init location service status as unpaused', () => {
+        const ls = new LocationStatus(['crr', 'ingestion', 'lifecycle']);
+        Object.keys(ls._data).forEach(service => {
+            assert.strictEqual(ls._data[service].paused, false);
+            assert.strictEqual(ls._data[service].scheduledResume, null);
+        });
+    });
+
+    it('should copy data from LocationStatus', () => {
+        const lsToCopy = new LocationStatus(['crr', 'ingestion', 'lifecycle'], locationStatusObj);
+        const ls = new LocationStatus(['crr', 'ingestion', 'lifecycle'], lsToCopy);
+        Object.keys(locationStatusObj).forEach(service => {
+            assert.strictEqual(ls._data[service].paused, lsToCopy._data[service].paused);
+            assert.strictEqual(ls._data[service].scheduledResume, lsToCopy._data[service].scheduledResume);
+        });
+    });
+
+    it('should copy data from object', () => {
+        const ls = new LocationStatus(['crr', 'ingestion', 'lifecycle'], locationStatusObj);
+        Object.keys(locationStatusObj).forEach(service => {
+            assert.strictEqual(ls._data[service].paused, locationStatusObj[service].paused);
+            assert.strictEqual(ls._data[service].scheduledResume, locationStatusObj[service].scheduledResume);
+        });
+    });
+
+    it('should initialize non specified services', () => {
+        const tmpLocStatus = Object.assign({}, locationStatusObj);
+        delete tmpLocStatus.ingestion;
+        const ls = new LocationStatus(['crr', 'ingestion', 'lifecycle'], tmpLocStatus);
+        assert.strictEqual(ls._data.ingestion.paused, false);
+        assert.strictEqual(ls._data.ingestion.scheduledResume, null);
+    });
+
+    it('should set service status', () => {
+        locationStatus.setServicePauseStatus('ingestion', true);
+        assert.strictEqual(locationStatus._data.ingestion.paused, true);
+    });
+
+    it('should get service status', () => {
+        const isPaused = locationStatus.getServicePauseStatus('lifecycle');
+        assert.strictEqual(isPaused, locationStatusObj.lifecycle.paused);
+    });
+
+    it('should set service resume schedule', () => {
+        const date = new Date();
+        locationStatus.setServiceResumeSchedule('crr', date);
+        assert.strictEqual(locationStatus._data.crr.scheduledResume, date.toString());
+    });
+
+    it('should get service resume schedule', () => {
+        const schedule = locationStatus.getServiceResumeSchedule('lifecycle');
+        assert.deepEqual(schedule, new Date(locationStatusObj.lifecycle.scheduledResume));
+    });
+
+    it('should get null service resume schedule', () => {
+        const schedule = locationStatus.getServiceResumeSchedule('crr');
+        assert.strictEqual(schedule, null);
+    });
+
+    it('should pause services', () => {
+        locationStatus.pauseLocation('ingestion');
+        assert.strictEqual(locationStatus._data.ingestion.paused, true);
+    });
+
+    it('should resume services', () => {
+        locationStatus.resumeLocation('lifecycle');
+        assert.strictEqual(locationStatus._data.lifecycle.paused, false);
+        assert.strictEqual(locationStatus._data.lifecycle.scheduledResume, null);
+    });
+
+    it('should set resume shedule', () => {
+        const date = new Date();
+        locationStatus.resumeLocation('crr', date);
+        assert.strictEqual(locationStatus._data.crr.paused, true);
+        assert.strictEqual(locationStatus._data.crr.scheduledResume, date.toString());
+    });
+
+    it('should return serialized location status data', () => {
+        const data = locationStatus.getValue();
+        assert.deepEqual(data, locationStatusObj);
+    });
+});

--- a/tests/unit/lib/util/LocationStatusManager.spec.js
+++ b/tests/unit/lib/util/LocationStatusManager.spec.js
@@ -1,0 +1,404 @@
+'use strict'; // eslint-disable-line
+
+const sinon = require('sinon');
+const async = require('async');
+const assert = require('assert');
+
+const fakeLogger = require('../../../utils/fakeLogger');
+const locationConfig = require('../../../../conf/locationConfig.json') || {};
+const LocationStatus = require('../../../../lib/models/LocationStatus');
+const LocationStatusManager = require('../../../../lib/util/LocationStatusManager');
+
+const zkNodes = {
+    '/backbeat/crr/state/us-east-1': {
+        paused: false,
+    },
+    '/backbeat/crr/state/us-east-2': {
+        paused: false,
+    },
+};
+
+const fakeMongoClient = {};
+const fakeZkClient = {
+    getData: (path, cb) => cb(null, Buffer.from(JSON.stringify(zkNodes[path]))),
+};
+const fakeRedisClient = {};
+
+describe('LocationStatusManager', () => {
+    let lsm;
+
+    beforeEach(() => {
+        lsm = new LocationStatusManager(
+            fakeMongoClient,
+            fakeZkClient,
+            fakeRedisClient,
+            {
+                crr: {
+                    namespace: '/backbeat/crr',
+                    statePath: '/state',
+                    topic: 'crr-topic',
+                    isMongo: false,
+                },
+                ingestion: {
+                    namespace: '/backbeat/ingestion',
+                    statePath: '/state',
+                    topic: 'ingestion-topic',
+                    isMongo: false,
+                },
+                lifecycle: {
+                    isMongo: true,
+                },
+            },
+            fakeLogger,
+        );
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    describe('pauseService', () => {
+        it('should pause selected service', done => {
+            sinon.stub(lsm, '_updateServiceStatusForLocation').yields();
+            lsm._locationStatusStore['us-east-1'] = new LocationStatus(['lifecycle']);
+            lsm._locationStatusStore['us-east-2'] = new LocationStatus(['lifecycle']);
+            lsm.pauseService('lifecycle', ['us-east-1', 'us-east-2'], err => {
+                assert.ifError(err);
+                assert.strictEqual(lsm._locationStatusStore['us-east-1']
+                    .getServicePauseStatus('lifecycle'), true);
+                assert.strictEqual(lsm._locationStatusStore['us-east-2']
+                    .getServicePauseStatus('lifecycle'), true);
+                return done();
+            });
+        });
+    });
+
+    describe('_deleteResumeJob', () => {
+        it('should clear previously scheduled resume job', () => {
+            const cancelFn = sinon.stub();
+            lsm._scheduledResumeJobs.lifecycle['us-east-1'] = {
+                cancel: cancelFn,
+            };
+            lsm._deleteResumeJob('us-east-1', 'lifecycle');
+            assert(cancelFn.calledOnce);
+            assert.strictEqual(lsm._scheduledResumeJobs.lifecycle['us-east-1'], undefined);
+        });
+    });
+
+    describe('_scheduleResumeJob', () => {
+        it('should schedule and execute resume job', () => {
+            const clock = sinon.useFakeTimers();
+            sinon.stub(lsm, '_updateServiceStatusForLocation').yields();
+            lsm._locationStatusStore['us-east-1'] = new LocationStatus(['lifecycle']);
+            lsm._locationStatusStore['us-east-1'].pauseLocation('lifecycle');
+            const date = new Date();
+            date.setMinutes(date.getMinutes() + 1);
+            lsm._scheduleResumeJob('us-east-1', 'lifecycle', date);
+            assert.strictEqual(lsm._locationStatusStore['us-east-1']
+                .getServicePauseStatus('lifecycle'), true);
+            clock.tick(90000); // 1.5min in ms
+            assert.strictEqual(lsm._locationStatusStore['us-east-1']
+                .getServicePauseStatus('lifecycle'), false);
+            clock.restore();
+        });
+    });
+
+    describe('resumeService', () => {
+        it('should resume paused locations', done => {
+            sinon.stub(lsm, '_updateServiceStatusForLocation').yields();
+            lsm._locationStatusStore['us-east-1'] = new LocationStatus(['lifecycle']);
+            lsm._locationStatusStore['us-east-1'].pauseLocation('lifecycle');
+            lsm._locationStatusStore['us-east-2'] = new LocationStatus(['lifecycle']);
+            lsm._locationStatusStore['us-east-2'].pauseLocation('lifecycle');
+            lsm.resumeService('lifecycle', ['us-east-1', 'us-east-2'], null, null, err => {
+                assert.ifError(err);
+                assert.strictEqual(lsm._locationStatusStore['us-east-1']
+                    .getServicePauseStatus('lifecycle'), false);
+                assert.strictEqual(lsm._locationStatusStore['us-east-2']
+                    .getServicePauseStatus('lifecycle'), false);
+                return done();
+            });
+        });
+
+        it('should schedule a resume of paused locations', done => {
+            const clock = sinon.useFakeTimers();
+            sinon.stub(lsm, '_updateServiceStatusForLocation').yields();
+            lsm._locationStatusStore['us-east-1'] = new LocationStatus(['lifecycle']);
+            lsm._locationStatusStore['us-east-1'].pauseLocation('lifecycle');
+            lsm._locationStatusStore['us-east-2'] = new LocationStatus(['lifecycle']);
+            lsm._locationStatusStore['us-east-2'].pauseLocation('lifecycle');
+            lsm.resumeService('lifecycle', ['us-east-1', 'us-east-2'], true, null, err => {
+                assert.ifError(err);
+                assert.strictEqual(lsm._locationStatusStore['us-east-1']
+                    .getServicePauseStatus('lifecycle'), true);
+                assert.strictEqual(lsm._locationStatusStore['us-east-2']
+                    .getServicePauseStatus('lifecycle'), true);
+                // default schedule is 6hrs
+                clock.tick(2.34e+7); // 6.5hrs in ms
+                assert.strictEqual(lsm._locationStatusStore['us-east-1']
+                    .getServicePauseStatus('lifecycle'), false);
+                assert.strictEqual(lsm._locationStatusStore['us-east-2']
+                    .getServicePauseStatus('lifecycle'), false);
+                clock.restore();
+                return done();
+            });
+        });
+    });
+
+    describe('deleteScheduledResumeService', () => {
+        it('should delete scheduled resume job', done => {
+            const clock = sinon.useFakeTimers();
+            sinon.stub(lsm, '_updateServiceStatusForLocation').yields();
+            lsm._locationStatusStore['us-east-1'] = new LocationStatus(['lifecycle']);
+            lsm._locationStatusStore['us-east-1'].pauseLocation('lifecycle');
+            lsm._locationStatusStore['us-east-2'] = new LocationStatus(['lifecycle']);
+            lsm._locationStatusStore['us-east-2'].pauseLocation('lifecycle');
+            async.series([
+                next => lsm.resumeService('lifecycle', ['us-east-1', 'us-east-2'], true, null, next),
+                next => lsm.deleteScheduledResumeService('lifecycle', ['us-east-1', 'us-east-2'], next),
+                next => {
+                    // default schedule is 6hrs
+                    clock.tick(2.52e+7); // 7hrs in ms
+                    assert.strictEqual(lsm._locationStatusStore['us-east-1']
+                        .getServicePauseStatus('lifecycle'), true);
+                    assert.strictEqual(lsm._locationStatusStore['us-east-2']
+                        .getServicePauseStatus('lifecycle'), true);
+                    clock.restore();
+                    return next();
+                },
+            ], done);
+        });
+    });
+
+
+    describe('getResumeSchedule', () => {
+        it('should return the scheduled time for a resume job', done => {
+            const date = new Date();
+            const expectedSchedules = {
+                'us-east-1': date.toString(),
+                'us-east-2': 'none',
+            };
+            lsm._locationStatusStore['us-east-1'] = new LocationStatus(['lifecycle']);
+            lsm._locationStatusStore['us-east-1'].pauseLocation('lifecycle');
+            lsm._locationStatusStore['us-east-1'].resumeLocation('lifecycle', date);
+            lsm._locationStatusStore['us-east-2'] = new LocationStatus(['lifecycle']);
+            lsm.getResumeSchedule('lifecycle', ['us-east-1', 'us-east-2'], (err, schedules) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(schedules, expectedSchedules);
+                return done();
+            });
+        });
+    });
+
+    describe('getServiceStatus', () => {
+        it('should return the pause/resume status of a service', done => {
+            const expectedStatuses = {
+                'us-east-1': 'disabled',
+                'us-east-2': 'enabled',
+            };
+            lsm._locationStatusStore['us-east-1'] = new LocationStatus(['lifecycle']);
+            lsm._locationStatusStore['us-east-1'].pauseLocation('lifecycle');
+            lsm._locationStatusStore['us-east-2'] = new LocationStatus(['lifecycle']);
+            lsm.getServiceStatus('lifecycle', ['us-east-1', 'us-east-2'], (err, statuses) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(statuses, expectedStatuses);
+                return done();
+            });
+        });
+    });
+
+    describe('_setupLocationStatusStore', () => {
+        [
+            {
+                case: 'should add missing locations',
+                mongoLocations: [
+                    {
+                        _id: 'us-east-1',
+                        value: {
+                            lifecycle: {
+                                paused: true,
+                                scheduledResume: null,
+                            }
+                        }
+                    },
+                    {
+                        _id: 'us-east-2',
+                        value: {
+                            lifecycle: {
+                                paused: true,
+                                scheduledResume: null,
+                            }
+                        }
+                    },
+                ],
+            },
+            {
+                case: 'should remove invalid locations',
+                mongoLocations: [
+                    {
+                        _id: 'us-east-3',
+                        value: {
+                            lifecycle: {
+                                paused: true,
+                                scheduledResume: null,
+                            }
+                        }
+                    },
+                ],
+            }
+        ].forEach(params => {
+            it(params.case, done => {
+                lsm._mongoClient = {
+                    createCollection: sinon.stub().yields(),
+                    collection: () => ({
+                        find: sinon.stub().yields(null, {
+                            toArray: sinon.stub().yields(null, params.mongoLocations),
+                        }),
+                        insert: sinon.stub().yields(),
+                        deleteMany: sinon.stub().yields(),
+                    }),
+                };
+                lsm._setupLocationStatusStore(err => {
+                    assert.ifError(err);
+                    const finalLocations = Object.keys(lsm._locationStatusStore);
+                    const validLocations = Object.keys(locationConfig);
+                    assert.deepStrictEqual(finalLocations, validLocations);
+                    return done();
+                });
+            });
+        });
+    });
+
+    describe('_getStateDetails', () => {
+        it('should return the correct state (mongo)', done => {
+            const zkStateStub = sinon.stub(lsm, '_getZkStateDetails').yields();
+            lsm._locationStatusStore = {
+                'us-east-1': new LocationStatus(['lifecycle']),
+                'us-east-2': new LocationStatus(['lifecycle']),
+            };
+            lsm._getStateDetails('lifecycle', ['us-east-1', 'us-east-2'], err => {
+                assert.ifError(err);
+                assert(zkStateStub.notCalled);
+                return done();
+            });
+        });
+
+        it('should return the correct state (zookeeper)', done => {
+            const zkStateStub = sinon.stub(lsm, '_getZkStateDetails').yields();
+            lsm._getStateDetails('ingestion', ['us-east-1', 'us-east-2'], err => {
+                assert.ifError(err);
+                assert(zkStateStub.calledOnce);
+                return done();
+            });
+        });
+    });
+
+    describe('_getZkStateDetails', () => {
+        it('should correctly read zookeeper state', done => {
+            lsm._getZkStateDetails('crr', ['us-east-1', 'us-east-2'], (err, data) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(data, {
+                    'us-east-1': zkNodes['/backbeat/crr/state/us-east-1'],
+                    'us-east-2': zkNodes['/backbeat/crr/state/us-east-2'],
+                });
+                return done();
+            });
+        });
+    });
+
+
+    describe('_parseScheduleResumeBody', () => {
+        it('should correctly extract scheduled time from body', () => {
+            const body = JSON.stringify({ hours: 1 });
+            const hours = lsm._parseScheduleResumeBody(body);
+            assert.deepStrictEqual(hours, { hours: 1 });
+        });
+
+        it('should set default value', () => {
+            const body = JSON.stringify({});
+            const hours = lsm._parseScheduleResumeBody(body);
+            assert.deepStrictEqual(hours, { hours: 6 });
+        });
+    });
+
+    describe('_pushActionToRedis', () => {
+        it('should pick correct channel', () => {
+            lsm._redis.publish = sinon.stub();
+            const date = new Date();
+            lsm._pushActionToRedis('crr', 'us-east-1', 'resumeService', date);
+            assert(lsm._redis.publish.firstCall
+                .calledWith('crr-topic-us-east-1', JSON.stringify({ action: 'resumeService', date })));
+            lsm._pushActionToRedis('ingestion', 'us-east-2', 'pauseService');
+            assert(lsm._redis.publish.lastCall
+                .calledWith('ingestion-topic-us-east-2', JSON.stringify({ action: 'pauseService' })));
+        });
+    });
+
+    describe('_addNewLocations', () => {
+        it('should add new locations', done => {
+            lsm._locationStatusColl = {
+                insert: sinon.stub().yields(),
+            };
+            lsm._addNewLocations([], err => {
+                assert.ifError(err);
+                const validLocations = Object.keys(locationConfig);
+                assert(Object.keys(lsm._locationStatusStore).every(loc => validLocations.includes(loc)));
+                return done();
+            });
+        });
+    });
+
+    describe('_deleteInvalidLocations', () => {
+        it('should remove invalid locations', done => {
+            const mongoLocations = [
+                {
+                    _id: 'us-east-4',
+                    value: {
+                        lifecycle: {
+                            paused: true,
+                            scheduledResume: null,
+                        }
+                    }
+                },
+            ];
+            const deleteManyStub = sinon.stub().yields();
+            lsm._locationStatusColl = {
+                deleteMany: deleteManyStub,
+            };
+            lsm._deleteInvalidLocations(mongoLocations, err => {
+                assert.ifError(err);
+                assert.deepStrictEqual(deleteManyStub.args[0][0], {
+                    _id: {
+                        $in: ['us-east-4'],
+                    }
+                });
+                return done();
+            });
+        });
+    });
+
+    describe('_getPreviousLocationStates', () => {
+        it('should retreive location state', done => {
+            sinon.stub(lsm, '_scheduleResumeJob');
+            const date = new Date();
+            const mongoLocations = [
+                {
+                    _id: 'us-east-1',
+                    value: {
+                        lifecycle: {
+                            paused: true,
+                            scheduledResume: date.toString(),
+                        }
+                    }
+                },
+            ];
+            lsm._getPreviousLocationStates(mongoLocations, err => {
+                assert.ifError(err);
+                assert.strictEqual(lsm._locationStatusStore['us-east-1'].getServicePauseStatus('lifecycle'), true);
+                assert.strictEqual(lsm._locationStatusStore['us-east-1']
+                    .getServiceResumeSchedule('lifecycle').toString(), date.toString());
+                return done();
+            });
+        });
+    });
+});

--- a/tests/unit/lifecycle/LifecycleBucketProcessor.spec.js
+++ b/tests/unit/lifecycle/LifecycleBucketProcessor.spec.js
@@ -1,0 +1,40 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+const sinon = require('sinon');
+
+const LifecycleBucketProcessor = require(
+    '../../../extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor');
+
+const {
+    zkConfig,
+    kafkaConfig,
+    lcConfig,
+    repConfig,
+    s3Config,
+    mongoConfig,
+} = require('../../functional/lifecycle/configObjects');
+
+
+describe('Lifecycle Bucket Processor', () => {
+    let lbp;
+    beforeEach(() => {
+        lbp = new LifecycleBucketProcessor(
+            zkConfig, kafkaConfig, lcConfig, repConfig, s3Config, mongoConfig);
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('_pauseServiceForLocation:: should add location to paused location list', () => {
+        lbp._pauseServiceForLocation('new-location');
+        assert(lbp._pausedLocations.has('new-location'));
+    });
+
+    it('_resumeService:: should add location to paused location list', () => {
+        lbp._pauseServiceForLocation('new-location');
+        lbp._resumeServiceForLocation('new-location');
+        assert(!lbp._pausedLocations.has('new-location'));
+    });
+});

--- a/tests/unit/utils/LocationStatusStream.spec.js
+++ b/tests/unit/utils/LocationStatusStream.spec.js
@@ -1,0 +1,124 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+const sinon = require('sinon');
+
+const LocationStatusStream = require('../../../extensions/utils/LocationStatusStream');
+const FakeLogger = require('../../utils/fakeLogger');
+
+const {
+    mongoConfig,
+} = require('../../functional/lifecycle/configObjects');
+
+
+describe('LocationStatusStream', () => {
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('_initializeLocationStatuses:: should initialize paused locations', done => {
+        const locations = [
+            {
+                _id: 'us-east-1',
+                value: {
+                    lifecycle: {
+                        paused: true,
+                    },
+                },
+            },
+            {
+                _id: 'us-east-2',
+                value: {
+                    lifecycle: {
+                        paused: true,
+                    },
+                },
+            },
+            {
+                _id: 'us-east-3',
+                value: {
+                    lifecycle: {
+                        paused: true,
+                    },
+                },
+            },
+        ];
+        const pauseStub = sinon.stub();
+        const lss = new LocationStatusStream('lifecycle', mongoConfig, pauseStub, null, FakeLogger);
+        lss._locationStatusColl = {
+            find: () => ({
+                toArray: sinon.stub().yields(null, locations),
+            }),
+        };
+        lss._initializeLocationStatuses(err => {
+            assert.ifError(err);
+            assert(pauseStub.getCall(0).calledWith('us-east-1'));
+            assert(pauseStub.getCall(1).calledWith('us-east-2'));
+            assert(pauseStub.getCall(2).calledWith('us-east-3'));
+            return done();
+        });
+    });
+
+    [
+        {
+            case: 'should correctly pause location',
+            event: {
+                operationType: 'update',
+                documentKey: {
+                    _id: 'us-east-1',
+
+                },
+                fullDocument: {
+                    _id: 'us-east-1',
+                    value: {
+                        lifecycle: {
+                            paused: true,
+                        },
+                    },
+                },
+            },
+            expectedFunctionCall: 'pause',
+        },
+        {
+            case: 'should correctly resume location',
+            event: {
+                operationType: 'update',
+                documentKey: {
+                    _id: 'us-east-1',
+
+                },
+                fullDocument: {
+                    _id: 'us-east-1',
+                    value: {
+                        lifecycle: {
+                            paused: false,
+                        },
+                    },
+                },
+            },
+            expectedFunctionCall: 'resume',
+        },
+        {
+            case: 'should remove deleted location',
+            event: {
+                operationType: 'delete',
+                documentKey: {
+                    _id: 'us-east-1',
+
+                },
+                fullDocument: null,
+            },
+            expectedFunctionCall: 'resume',
+        }
+    ].forEach(params => {
+        it(`_handleChangeStreamChangeEvent:: ${params.case}`, () => {
+            const pauseStub = sinon.stub();
+            const resumeStub = sinon.stub();
+            const lss = new LocationStatusStream('lifecycle', mongoConfig, pauseStub, resumeStub, FakeLogger);
+            lss._handleChangeStreamChangeEvent(params.event);
+            const fn = params.expectedFunctionCall === 'pause' ? pauseStub : resumeStub;
+            assert(fn.calledOnceWith(params.event.documentKey._id));
+        });
+    });
+});


### PR DESCRIPTION
Issue: [BB-338](https://scality.atlassian.net/browse/BB-338)

*Changes :*

- Adapt the same Pause/Resume API routes used for replication and ingestion to also support lifecycle routes
- Lifecycle routes will use mongo to store the location status
- Backbeat API will be the only process modifying the state of locations in MongoDB, hence scheduling a resume job will be handled in Backbeat API contrary to how it works in other extensions.
- The lifecycle bucket processor will be listening to mongo events using change streams and will be pausing and resuming locations based on the modifications to the state applied to MongoDB

**Note for reviewers:** 
Please review per commit as it will make understanding the changes easier.

[BB-338]: https://scality.atlassian.net/browse/BB-338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ