### PR TITLE
BB-362 remove kafka connect connector config from logs

### DIFF
--- a/extensions/oplogPopulator/modules/Connector.js
+++ b/extensions/oplogPopulator/modules/Connector.js
@@ -94,7 +94,6 @@ class Connector {
             this._logger.error('Error while calculating config size', {
                 method: 'Connector.getConfigSizeInBytes',
                 connector: this._name,
-                config: this._config,
                 error: err.description || err.message,
             });
             throw errors.InternalError.customizeDescription(err.description);
@@ -107,7 +106,6 @@ class Connector {
      * @throws {InternalError}
      */
     async spawn() {
-        const connectorConfig = { ...this._config };
         try {
             await this._kafkaConnect.createConnector({
                 name: this._name,
@@ -117,7 +115,6 @@ class Connector {
             this._logger.error('Error while spawning connector', {
                 method: 'Connector.spawn',
                 connector: this._name,
-                config: connectorConfig,
                 error: err.description || err.message,
             });
             throw errors.InternalError.customizeDescription(err.description);

--- a/lib/wrappers/KafkaConnectWrapper.js
+++ b/lib/wrappers/KafkaConnectWrapper.js
@@ -141,7 +141,6 @@ class KafkaConnectWrapper {
         } catch (err) {
             this._logger.error('Error when creating connector', {
                 method: 'KafkaConnectManager.createConnector',
-                config,
                 error: err.description,
             });
             throw err;
@@ -242,13 +241,11 @@ class KafkaConnectWrapper {
                 this._logger.error('Error when putting configuration', {
                     method: 'KafkaConnectManager.updateConnectorConfig',
                     connector: connectorName,
-                    config,
                     error: err.description,
                 });
                 throw err;
             }
         }
-        // do nothing if connector not found
         this._logger.error('Can\'t update connector config, connector not found', {
             method: 'KafkaConnectManager.updateConnectorConfig',
             connector: connectorName,

--- a/lib/wrappers/KafkaConnectWrapper.js
+++ b/lib/wrappers/KafkaConnectWrapper.js
@@ -250,7 +250,7 @@ class KafkaConnectWrapper {
             method: 'KafkaConnectManager.updateConnectorConfig',
             connector: connectorName,
         });
-        return undefined;
+        throw errors.InternalError.customizeDescription('Could not find connector to update');
     }
 
     /**

--- a/tests/unit/lib/wrappers/kafkaConnectWrapper.js
+++ b/tests/unit/lib/wrappers/kafkaConnectWrapper.js
@@ -131,7 +131,7 @@ describe('KafkaConnectWrapper', () => {
                 assert(makeRequestStub.notCalled);
                 assert(getConnectorStub.calledOnce);
             })
-            .catch(err => assert.ifError(err));
+            .catch(err => assert.strictEqual(err.name, errors.InternalError.name));
         });
 
         it('should throw error when getConnectors fails', async () => {


### PR DESCRIPTION
kafka connect connector config contains the mongodb connection string which should not be logged

also fixing a bug with the oplog populator where if a connector update fails cause the connector can't be found, it is not considered an error