### PR TITLE
feature/BB-363-implicit-circuitbreaker-target

### DIFF
--- a/extensions/lifecycle/conductor/LifecycleConductor.js
+++ b/extensions/lifecycle/conductor/LifecycleConductor.js
@@ -20,6 +20,9 @@ const VaultClientWrapper = require('../../../extensions/utils/VaultClientWrapper
 
 const { LifecycleMetrics } = require('../LifecycleMetrics');
 const { BreakerState, CircuitBreaker } = require('breakbeat').CircuitBreaker;
+const {
+    updateCircuitBreakerConfigForImplicitOutputQueue
+} = require('../../../lib/CircuitBreaker');
 
 const DEFAULT_CRON_RULE = '* * * * *';
 const DEFAULT_CONCURRENCY = 10;
@@ -112,7 +115,13 @@ class LifecycleConductor {
             this.logger,
         );
 
-        this._circuitBreaker = this.buildCircuitBreaker(this.lcConfig.conductor.circuitBreaker);
+        const circuitBreakerConfig = updateCircuitBreakerConfigForImplicitOutputQueue(
+            lcConfig.conductor.circuitBreaker,
+            lcConfig.bucketProcessor.groupId,
+            lcConfig.bucketTasksTopic,
+        );
+
+        this._circuitBreaker = this.buildCircuitBreaker(circuitBreakerConfig);
     }
 
     buildCircuitBreaker(conf) {

--- a/lib/CircuitBreaker.js
+++ b/lib/CircuitBreaker.js
@@ -1,0 +1,36 @@
+'use strict'; // eslint-disable-line
+/* eslint no-param-reassign: 0 */
+
+function updateCircuitBreakerConfigForImplicitOutputQueue(cbConf, groupId, topic) {
+    if (!cbConf || !cbConf.probes) {
+        return cbConf;
+    }
+
+    cbConf.probes.forEach(p => {
+        if (p.type !== 'kafkaConsumerLag') {
+            return cbConf;
+        }
+
+        if (!p.implicitSingleOutputTopic) {
+            return cbConf;
+        }
+
+        delete p.implicitSingleOutputTopic;
+
+        if (groupId) {
+            p.consumerGroupName = groupId;
+        }
+
+        if (topic) {
+            p.topicName = topic;
+        }
+
+        return undefined;
+    });
+
+    return cbConf;
+}
+
+module.exports = {
+    updateCircuitBreakerConfigForImplicitOutputQueue
+};

--- a/tests/functional/lifecycle/LifecycleConductor.spec.js
+++ b/tests/functional/lifecycle/LifecycleConductor.spec.js
@@ -96,6 +96,12 @@ const baseLCConfig = {
         type: 'account',
         account: 'lifecycle',
     },
+    bucketProcessor: {
+        groupId: 'a',
+        probeServer: {
+            port: 8553,
+        }
+    },
     coldStorageArchiveTopicPrefix: 'cold-archive-req-',
 };
 

--- a/tests/unit/lib/util/circuitBreaker.spec.js
+++ b/tests/unit/lib/util/circuitBreaker.spec.js
@@ -1,0 +1,162 @@
+const assert = require('assert');
+const { updateCircuitBreakerConfigForImplicitOutputQueue } =
+    require('../../../../lib/CircuitBreaker');
+
+describe('updateCircuitBreakerConfigForImplicitOutputQueue', () => {
+    it('should inject kafka conf if implicit flag', () => {
+        const cbConf = {
+            probes: [
+                {
+                    type: 'kafkaConsumerLag',
+                    implicitSingleOutputTopic: true,
+                }
+            ],
+        };
+
+        const res = updateCircuitBreakerConfigForImplicitOutputQueue(
+            cbConf, 'group', 'topic'
+        );
+
+        assert.deepStrictEqual(res, {
+            probes: [
+                {
+                    type: 'kafkaConsumerLag',
+                    consumerGroupName: 'group',
+                    topicName: 'topic',
+                }
+            ],
+        });
+    });
+
+    it('should inject topic conf if implicit flag and group not provided', () => {
+        const cbConf = {
+            probes: [
+                {
+                    type: 'kafkaConsumerLag',
+                    implicitSingleOutputTopic: true,
+                    consumerGroupName: 'group',
+                }
+            ],
+        };
+
+        const res = updateCircuitBreakerConfigForImplicitOutputQueue(
+            cbConf, null, 'topic'
+        );
+
+        assert.deepStrictEqual(res, {
+            probes: [
+                {
+                    type: 'kafkaConsumerLag',
+                    consumerGroupName: 'group',
+                    topicName: 'topic',
+                }
+            ],
+        });
+    });
+
+    it('should inject consumer conf if implicit flag and topic not provided', () => {
+        const cbConf = {
+            probes: [
+                {
+                    type: 'kafkaConsumerLag',
+                    implicitSingleOutputTopic: true,
+                    topicName: 'topic',
+                }
+            ],
+        };
+
+        const res = updateCircuitBreakerConfigForImplicitOutputQueue(
+            cbConf, 'group', null
+        );
+
+        assert.deepStrictEqual(res, {
+            probes: [
+                {
+                    type: 'kafkaConsumerLag',
+                    consumerGroupName: 'group',
+                    topicName: 'topic',
+                }
+            ],
+        });
+    });
+
+    it('should not inject kafka conf if no implicit flag', () => {
+        const cbConf = {
+            probes: [
+                {
+                    type: 'kafkaConsumerLag',
+                }
+            ],
+        };
+
+        const res = updateCircuitBreakerConfigForImplicitOutputQueue(
+            cbConf, 'group', 'topic'
+        );
+
+        assert.deepStrictEqual(res, {
+            probes: [
+                {
+                    type: 'kafkaConsumerLag',
+                }
+            ],
+        });
+    });
+
+    it('should not inject kafka conf if implicit flag false', () => {
+        const cbConf = {
+            probes: [
+                {
+                    type: 'kafkaConsumerLag',
+                    implicitSingleOutputTopic: false,
+                }
+            ],
+        };
+
+        const res = updateCircuitBreakerConfigForImplicitOutputQueue(
+            cbConf, 'group', 'topic'
+        );
+
+        assert.deepStrictEqual(res, {
+            probes: [
+                {
+                    type: 'kafkaConsumerLag',
+                    implicitSingleOutputTopic: false,
+                }
+            ],
+        });
+    });
+
+    it('should not inject kafka conf if wrong probe type', () => {
+        const cbConf = {
+            probes: [
+                {
+                    type: 'noop',
+                    implicitSingleOutputTopic: true,
+                }
+            ],
+        };
+
+        const res = updateCircuitBreakerConfigForImplicitOutputQueue(
+            cbConf, 'group', 'topic'
+        );
+
+        assert.deepStrictEqual(res, {
+            probes: [
+                {
+                    type: 'noop',
+                    implicitSingleOutputTopic: true,
+                }
+            ],
+        });
+    });
+
+    it('should not inject kafka conf if no probes', () => {
+        const cbConf = {};
+
+        const res = updateCircuitBreakerConfigForImplicitOutputQueue(
+            cbConf, 'group', 'topic'
+        );
+
+        assert.deepStrictEqual(res, {});
+    });
+});


### PR DESCRIPTION
Support specifying lifecycle circuit breaker probes for kafka lag by not naming consumer group names and topics explicitly, but just setting the `implicitSingleOutputTopic` flag on the probe, so that the `BackbeatConsumer`'s circuit breaker automatically monitors the process' output queue.