### PR TITLE
BB-352 Implement lifecycle rule aggregator

### DIFF
--- a/extensions/lifecycle/util/RulesReducer.js
+++ b/extensions/lifecycle/util/RulesReducer.js
@@ -1,0 +1,282 @@
+const lowest = (acc, cur) => (acc < cur ? acc : cur);
+
+class RulesReducer {
+    /**
+     * Constructor of RulesReducer
+     *
+     * @constructor
+     * @param {string} versioningStatus - bucket's version status: 'Enabled', 'Disabled' or 'Suspended'
+     * @param {Date} currentDate - current date
+     * @param {Object} bucketLCRules - lifecycle rules
+     * @param {Object} options - rule lifecycle options
+     * @param {boolean} options.expireOneDayEarlier - moves lifecycle expiration deadlines 1 day earlier
+     * @param {boolean} options.transitionOneDayEarlier - moves lifecycle transition deadlines 1 day earlier
+    */
+    constructor(versioningStatus, currentDate, bucketLCRules, options) {
+        this._isVersioning = versioningStatus === 'Enabled' || versioningStatus === 'Suspended';
+        this._currentDate = currentDate;
+        this._bucketLCRules = this._sortByPrefix(bucketLCRules);
+        this._expireOneDayEarlier = options.expireOneDayEarlier;
+        this._transitionOneDayEarlier = options.transitionOneDayEarlier;
+    }
+
+    /**
+     * _getRulePrefix: retrieve prefix from a rule
+     * @param {object} r - lifecycle rule
+     * @return {string} prefix
+     */
+    _getRulePrefix(r) {
+        return r.Prefix || (r.Filter && (r.Filter.And ? r.Filter.And.Prefix : r.Filter.Prefix)) || '';
+    }
+
+    /**
+     * _sortByPrefix: sorts the lifecycle rules in ascending order based on the value of the Prefix property
+     * @param {array} rules - lifecycle rules
+     * @return {array} returns the sorted rules
+     */
+    _sortByPrefix(rules) {
+        return rules.sort((a, b) => this._getRulePrefix(a).localeCompare(this._getRulePrefix(b)));
+    }
+
+    /**
+     * toListings: determines the list of API calls needed to list all eligible objects based on
+     * the bucket lifecycle rules.
+     * @return {object} aggregatedRules - aggregated rules for each type
+     * @return {array} aggregatedRules.currents - array of rules
+     * @return {array} aggregatedRules.nonCurrents - array of rules
+     * @return {array} aggregatedRules.orphans - array of rules
+     */
+    toListings() {
+        if (this._isVersioning) {
+            return this._getListingsForVersionedBucket();
+        }
+        return this._getListingsForNonVersionedBucket();
+    }
+
+    /**
+     * _decrementExpirationDay: moves lifecycle expiration deadlines 1 day earlier.
+     * @param {number} days - Indicates the lifetime, in days, of the objects that are subject to the rule.
+     * @return {number} days
+     */
+    _decrementExpirationDay(days) {
+        if (days > 0 && this._expireOneDayEarlier) {
+            return days - 1;
+        }
+        return days;
+    }
+
+    /**
+     * _decrementTransitionDay: moves lifecycle transition deadlines 1 day earlier.
+     * @param {number} days - Indicates the lifetime, in days, of the objects that are subject to the rule.
+     * @return {number} days
+     */
+    _decrementTransitionDay(days) {
+        if (days > 0 && this._transitionOneDayEarlier) {
+            return days - 1;
+        }
+        return days;
+    }
+
+    /**
+     * _getListingsForNonVersionedBucket: gets listings infos from lifecycle rules of a non-versioned bucket
+     * NOTE: On a non-versioned bucket, only one type of listing can be performed:
+     * - "current" targeting current objects (Expiration and Transitions).
+     * @return {object} aggregatedRules - aggregated rules for each type
+     * @return {array} aggregatedRules.currents - array of rules
+     */
+    _getListingsForNonVersionedBucket() {
+        const reducedRules = this._bucketLCRules.reduce((accumulator, r) => {
+            const currents = accumulator.currents;
+            const reducedCurrents = this._reduceCurrentRules(r, currents);
+            return { currents: reducedCurrents };
+        }, { currents: [] });
+
+        return reducedRules;
+    }
+
+    /**
+     * _getListingsForVersionedBucket: gets listings infos from lifecycle rules of a versioned bucket
+     * NOTE: On a versioned bucket, three types of listing can be performed:
+     * - "current" targeting current objects (Expiration and Transitions).
+     * - "noncurrent" targeting non-current obejcts (NonCurrentExpiration and NonCurrentTransitions).
+     * - "orphan" targeting orphan delete markers (Expiration and Expiration.ExpiredObjectDeleteMarker).
+     * @return {object} aggregatedRules - aggregated rules for each type
+     * @return {array} aggregatedRules.currents - array of rules
+     * @return {array} aggregatedRules.nonCurrents - array of rules
+     * @return {array} aggregatedRules.orphans - array of rules
+     */
+    _getListingsForVersionedBucket() {
+        const reducedRules = this._bucketLCRules.reduce((accumulator, r) => {
+            const nonCurrents = accumulator.nonCurrents;
+            const currents = accumulator.currents;
+            const orphans = accumulator.orphans;
+
+            const reducedCurrents = this._reduceCurrentRules(r, currents);
+            const reducedNonCurrents = this._reduceNonCurrentRules(r, nonCurrents);
+            const reducedOrphans = this._reduceOrphanDeleteMarkerRule(r, orphans);
+
+            return { currents: reducedCurrents, nonCurrents: reducedNonCurrents, orphans: reducedOrphans };
+        }, { currents: [], nonCurrents: [], orphans: [] });
+
+        return reducedRules;
+    }
+
+    /**
+     * _reduceCurrentRules: checks if the rule targets current versions and, if so,
+     * adds its result to the listings array.
+     * The listings will be used to defined the parameters of "list current versions".
+     * @param {object} r - lifecycle rule to be evaluated
+     * @param {array} currents - array of current listings information
+     * @return {array} aggregatedListings - array of current listings information after evaluation
+     */
+    _reduceCurrentRules(r, currents) {
+        // handle the case when rule is disabled.
+        if (r.Status !== 'Enabled') {
+            return currents;
+        }
+        const prefix = this._getRulePrefix(r);
+        const isTransitions = r.Transitions && r.Transitions[0];
+        let days;
+
+        // IMPROVEMENT: ZENKO-4541 If only one transition (no expiration) rule is set for a given prefix,
+        // we can add the filter "value.dataStoreName != destinationLocationName" to our listing query
+        // to only return keys that have not been transitioned yet.
+
+        if (r.Expiration) {
+            // NOTE: Expiration Days cannot be 0.
+            if (r.Expiration.Days) {
+                days = this._decrementExpirationDay(r.Expiration.Days);
+            } else if (r.Expiration.Date) {
+                if (r.Expiration.Date <= this._currentDate) {
+                    days = 0;
+                }
+            }
+        }
+
+        if (isTransitions) {
+            // NOTE: Transitions Days can be 0.
+            // NOTE: Cannot mixed 'Date' and 'Days' based Transition actions.
+            if (r.Transitions[0].Days !== undefined) {
+                let lowestTransitionDays = r.Transitions.map(t => t.Days).reduce(lowest);
+                lowestTransitionDays = this._decrementTransitionDay(lowestTransitionDays);
+                days = days === undefined ? lowestTransitionDays : Math.min(days, lowestTransitionDays);
+
+            } else if (r.Transitions[0].Date) {
+                const lowestDate = r.Transitions.map(t => t.Date).reduce(lowest);
+
+                if (lowestDate <= this._currentDate) {
+                    days = 0;
+                }
+            }
+        }
+
+        return this._aggregateByPrefix(currents, prefix, days);
+    }
+
+    /**
+     * _reduceNonCurrentRules: checks if the rule targets non-current versions and, if so,
+     * add its result to the listings array.
+     * The listings will be used to defined the parameters of "list non-current versions".
+     * @param {object} r - lifecycle rule to be evaluated
+     * @param {array} nonCurrents - array of non-current listings information
+     * @return {array} aggregatedListings - array of non-current listings information after evaluation
+     */
+    _reduceNonCurrentRules(r, nonCurrents) {
+        if (r.Status !== 'Enabled') {
+            return nonCurrents;
+        }
+
+        const prefix = this._getRulePrefix(r);
+        const isTransitions = r.NoncurrentVersionTransitions && r.NoncurrentVersionTransitions.length > 0;
+        let days;
+
+        if (r.NoncurrentVersionExpiration) {
+            // 'NoncurrentDays' for NoncurrentVersionExpiration action is a positive integer
+            if (r.NoncurrentVersionExpiration.NoncurrentDays) {
+                days = this._decrementExpirationDay(r.NoncurrentVersionExpiration.NoncurrentDays);
+            }
+        }
+
+        if (isTransitions) {
+            // NoncurrentDays for NoncurrentVersionTransitions action can be 0
+            if (r.NoncurrentVersionTransitions[0].NoncurrentDays !== undefined) {
+                let lowestTransitionDays = r.NoncurrentVersionTransitions
+                    .map(t => t.NoncurrentDays).reduce(lowest);
+                lowestTransitionDays = this._decrementTransitionDay(lowestTransitionDays);
+                days = days === undefined ? lowestTransitionDays : Math.min(days, lowestTransitionDays);
+            }
+        }
+
+        return this._aggregateByPrefix(nonCurrents, prefix, days);
+    }
+
+    /**
+     * _reduceOrphanDeleteMarkerRule: checks if the rule targets orphan delete markers and, if so,
+     * adds its result to the listings array.
+     * The listings will be used to defined the parameters of "list orphan delete markers".
+     * @param {object} r - lifecycle rule to be evaluated
+     * @param {array} orphans - array of "orphan delete markers" listings information
+     * @return {array} aggregatedListings - array of "orphan delete markers" listings information after evaluation
+     */
+    _reduceOrphanDeleteMarkerRule(r, orphans) {
+        if (r.Status !== 'Enabled') {
+            return orphans;
+        }
+
+        const prefix = this._getRulePrefix(r);
+        let days;
+
+        // NOTE: When you specify the Days tag, Amazon S3 automatically performs ExpiredObjectDeleteMarker
+        // cleanup when the delete markers are old enough to satisfy the age criteria.
+        if (r.Expiration) {
+            if (r.Expiration.Days) {
+                days = this._decrementExpirationDay(r.Expiration.Days);
+            } else if (r.Expiration.Date) {
+                if (r.Expiration.Date <= this._currentDate) {
+                    days = 0;
+                }
+            } else if (r.Expiration.ExpiredObjectDeleteMarker) {
+                days = 0;
+            }
+        }
+
+        return this._aggregateByPrefix(orphans, prefix, days);
+    }
+
+    /**
+     * _aggregateByPrefix: adds a new listing or aggregate by prefix
+     * e.g [{ prefix: 's', days: 10 }, { prefix: 's/c', days: 5 }, { prefix: 's/c/a', days: 1 }]
+     * should return [{ prefix: 's', days: 1 }] after aggregating by prefix
+     * @param {array} listings - [listings] listings
+     * @param {string} listings.prefix - rules' prefix
+     * @param {string} listings.days - number of days after which action should apply
+     * @param {string} prefix - prefix of the currently evaluated rule
+     * @param {string} days - days of the currently evaluated rule
+     * @return {array} aggregatedListings
+     */
+    _aggregateByPrefix(listings, prefix, days) {
+        // NOTE: if days is undefined, no listing created.
+        if (days === undefined) {
+            return listings;
+        }
+
+        const previousListing = listings[listings.length - 1];
+        const shareListing = previousListing && prefix.startsWith(previousListing.prefix);
+        if (shareListing) {
+            if (days < previousListing.days) {
+                previousListing.days = days;
+            }
+        } else {
+            listings.push({
+                prefix,
+                days,
+            });
+        }
+
+        return listings;
+    }
+}
+
+module.exports = {
+    RulesReducer,
+};

--- a/extensions/lifecycle/util/rules.js
+++ b/extensions/lifecycle/util/rules.js
@@ -1,0 +1,165 @@
+const { RulesReducer } = require('./RulesReducer');
+const { lifecycleListing: { NON_CURRENT_TYPE, CURRENT_TYPE, ORPHAN_DM_TYPE } } = require('../../../lib/constants');
+
+// Default max AWS limit is 1000 for both list objects and list object versions
+const MAX_KEYS = process.env.CI === 'true' ? 3 : 1000;
+
+function _getBeforeDate(currentDate, days) {
+    const beforeDate = new Date(currentDate);
+    beforeDate.setDate(beforeDate.getDate() - days);
+    return beforeDate.toISOString();
+}
+
+function _makeListParams(listType, currentDate, listing) {
+    const p = {
+        prefix: listing.prefix,
+        listType,
+    };
+    if (listing.days > 0) {
+        p.beforeDate = _getBeforeDate(currentDate, listing.days);
+    }
+
+    return p;
+}
+
+/**
+ * _mergeParams: flattens the listings array
+ * @param {Date} currentDate           - current date
+ * @param {Object} listings            - rules grouped by list type (current, noncurrent, orphan)
+ * @param {array} listings.currents    - array of listing: { prefix, days }
+ * @param {array} listings.nonCurrents - array of listing: { prefix, days }
+ * @param {array} listings.orphans     - array of listing: { prefix, days }
+ * @return {array} mergedListings      - listing informations, array of { prefix, listType, [beforeDate] }
+ */
+function _mergeParams(currentDate, { currents = [], nonCurrents = [], orphans = [] }) {
+    return [
+      ...currents.map(listing => _makeListParams(CURRENT_TYPE, currentDate, listing)),
+      ...nonCurrents.map(listing => _makeListParams(NON_CURRENT_TYPE, currentDate, listing)),
+      ...orphans.map(listing => _makeListParams(ORPHAN_DM_TYPE, currentDate, listing)),
+    ];
+  }
+
+/**
+ * _getParamsFromListings: retrieves the lifecycle listing informations from listings gathered
+ * from the lifecycle rules
+ * @param {string} bucketName          - name of the bucket
+ * @param {Date} currentDate           - current date
+ * @param {Object} listings            - listings gathered from the lifecycle rules
+ * @param {array} listings.currents    - array of listing { prefix, days }
+ * @param {array} listings.nonCurrents - array of listing { prefix, days }
+ * @param {array} listings.orphans     - array of listing { prefix, days }
+ * @return {Object} info               - listing informations { params, listType, remainings }
+ */
+function _getParamsFromListings(bucketName, currentDate, listings) {
+    const listingsParams = _mergeParams(currentDate, listings);
+    let params;
+    let listType;
+
+    if (listingsParams.length > 0) {
+        const firstParams = listingsParams[0];
+        const { prefix, beforeDate } = firstParams;
+        listType = firstParams.listType;
+        params = {
+            Bucket: bucketName,
+            Prefix: prefix,
+            MaxKeys: MAX_KEYS,
+        };
+
+        if (beforeDate) {
+            params.BeforeDate = beforeDate;
+        }
+
+        listingsParams.shift(); // remove the first element
+    }
+
+    return { params, listType, remainings: listingsParams };
+}
+
+/**
+ * _getParamsFromDetails: retrieves the lifecycle listing parameters from details
+ * @param {string} bucketName - name of the bucket
+ * @param {Object} details - listing details from "bucketTasks" topic entry
+ * @param {string} details.listType - type of lifecycle listing (current, noncurrent, orphan)
+ * @param {string} details.prefix - prefix
+ * @param {string} details.beforeDate - before date
+ * @param {string} details.keyMarker - next key marker for versioned buckets
+ * @param {string} details.versionIdMarker - next version id marker for versioned buckets
+ * @param {string} details.marker - next marker for non-versioned buckets
+ * @return {Object} info - listing informations { params, listType, remainings }
+ */
+function _getParamsFromDetails(bucketName, details) {
+    const { prefix, beforeDate, listType } = details;
+    // if listType is invalid, do not list.
+    if (![CURRENT_TYPE, NON_CURRENT_TYPE, ORPHAN_DM_TYPE].includes(listType)) {
+        return {};
+    }
+
+    const params = {
+        Bucket: bucketName,
+        Prefix: prefix,
+        MaxKeys: MAX_KEYS,
+    };
+
+    if (listType === CURRENT_TYPE || listType === ORPHAN_DM_TYPE) {
+        params.Marker = details.marker;
+    }
+
+    if (listType === NON_CURRENT_TYPE) {
+        params.KeyMarker = details.keyMarker;
+        params.VersionIdMarker = details.versionIdMarker;
+    }
+
+    if (beforeDate) {
+        params.BeforeDate = beforeDate;
+    }
+
+    return { params, listType, remainings: [] };
+}
+
+/**
+ * rulesToParams: retrieves the lifecycle listing parameters from the lifecycle rules
+ * @param {string} versioningStatus - bucket's version status
+ * @param {Date} currentDate - current date
+ * @param {Object} bucketLCRules - lifecycle rules
+ * @param {object} bucketData - bucket data from Kafka bucketTasks topic
+ * @param {object} bucketData.target - target bucket info
+ * @param {string} bucketData.target.bucket - bucket name
+ * @param {string} bucketData.target.owner - owner id
+ * @param {object} bucketData.details - listing details from "bucketTasks" topic entry
+ * @param {string} bucketData.details.listType - type of lifecycle listing (current, noncurrent, orphan)
+ * @param {string} [bucketData.details.prefix] - prefix
+ * @param {string} [bucketData.details.beforeDate] - before date
+ * @param {string} [bucketData.details.keyMarker] - next key marker for versioned buckets
+ * @param {string} [bucketData.details.versionIdMarker] - next version id marker for versioned buckets
+ * @param {string} [bucketData.details.marker] - next marker for non-versioned buckets
+ * @param {Object} options - lifecycle options
+ * @param {boolean} options.expireOneDayEarlier - moves lifecycle expiration deadlines 1 day earlier
+ * @param {boolean} options.transitionOneDayEarlier - moves lifecycle transition deadlines 1 day earlier
+ *
+ * @return {Object} info - listings informations { params, listingDetails, remainings }
+ * @return {Object} info.params - params of the first lifecycle listing
+ * @return {string} info.params.Bucket - bucket name
+ * @return {string} info.params.Prefix - limits the response to keys that begin with the specified prefix
+ * @return {string} info.params.MaxKeys - maximum number of keys returned in the response
+ * @return {string} info.params.Marker - for non-versioned buckets, where to start listing from
+ * @return {string} info.params.KeyMarker - for versioned buckets, where to start listing from
+ * @return {string} info.params.Marker - for versioned buckets, where to start listing from
+ * @return {string} [info.params.BeforeDate] - limit keys with last-modified older than beforeDate
+ * @return {string} info.listType -  type of listing (current, noncurrent or orphan)
+ * @return {Array} info.remainings - array of remaining listings
+ */
+function rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options) {
+    const bucketName = bucketData.target.bucket;
+    if (bucketData.details && bucketData.details.listType) {
+        return _getParamsFromDetails(bucketName, bucketData.details);
+    }
+
+    const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+    const listings = rulesReducer.toListings();
+
+    return _getParamsFromListings(bucketName, currentDate, listings);
+}
+
+module.exports = {
+    rulesToParams,
+};

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -22,6 +22,11 @@ const constants = {
     },
     compressionType: 'Zstd',
     locationStatusCollection: '__locationStatusStore',
+    lifecycleListing: {
+        CURRENT_TYPE: 'current',
+        NON_CURRENT_TYPE: 'noncurrent',
+        ORPHAN_DM_TYPE: 'orphan',
+    },
 };
 
 module.exports = constants;

--- a/tests/unit/lifecycle/RulesReducer.spec.js
+++ b/tests/unit/lifecycle/RulesReducer.spec.js
@@ -1,0 +1,676 @@
+const assert = require('assert');
+
+const { RulesReducer } = require('../../../extensions/lifecycle/util/RulesReducer');
+
+const locationName = 'aws-loc';
+const locationName2 = 'aws-loc2';
+
+const expectedEmptyResult = {
+    currents: []
+};
+
+const options = {
+    expireOneDayEarlier: false,
+    transitionOneDayEarlier: false,
+};
+
+describe('RulesReducer with versioning Disabled', () => {
+    const versioningStatus = 'Disabled';
+
+    it('with no rule', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [];
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expectedEmptyResult);
+    });
+
+    it('with date that has not passed', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Date: currentDate + 1000 },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            }
+        ];
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expectedEmptyResult);
+    });
+
+    it('with rule targeting non current versions', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                NoncurrentVersionExpiration: { NoncurrentDays: 1 },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 1, StorageClass: locationName }],
+                ID: '456',
+                Prefix: '',
+                Status: 'Enabled',
+            }
+        ];
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expectedEmptyResult);
+    });
+
+    it('with rule targeting orphan delete markers', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: {
+                    ExpiredObjectDeleteMarker: true,
+                },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            },
+        ];
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expectedEmptyResult);
+    });
+
+    it('with disabled rule', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Date: currentDate },
+                ID: '123',
+                Prefix: '',
+                Status: 'Disabled',
+            }
+        ];
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expectedEmptyResult);
+    });
+
+    it('with Expiration rule using Date', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Date: currentDate },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{
+                prefix: '',
+                days: 0,
+            }]
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration rule using Days', () => {
+        const currentDate = Date.now();
+        const prefix = '';
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{
+                prefix: '',
+                days: 1,
+            }]
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration rule using Days and prefix', () => {
+        const currentDate = Date.now();
+        const prefix = 'pre';
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{
+                prefix,
+                days: 1,
+            }]
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration rule using Filter.Prefix', () => {
+        const currentDate = Date.now();
+        const prefix = 'pre';
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Status: 'Enabled',
+                Filter: {
+                    Prefix: prefix,
+                }
+            }
+        ];
+        const expected = {
+            currents: [{
+                prefix,
+                days: 1,
+            }]
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration rule using Filter.And.Prefix', () => {
+        const currentDate = Date.now();
+        const prefix = 'pre';
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Status: 'Enabled',
+                Filter: {
+                    And: {
+                        Prefix: prefix,
+                    }
+                }
+            }
+        ];
+        const expected = {
+            currents: [{
+                prefix,
+                days: 1,
+            }]
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Transitions rule using Date', () => {
+        const currentDate = Date.now();
+        const prefix = '';
+        const bucketLCRules = [
+            {
+                Transitions: [{ Date: currentDate, StorageClass: locationName }],
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{
+                prefix: '',
+                days: 0,
+            }]
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration and Transitions rule using Days', () => {
+        const currentDate = Date.now();
+        const prefix = '';
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                Transitions: [{ Days: 2, StorageClass: locationName }],
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{
+                prefix: '',
+                days: 1,
+            }]
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration and Transitions rule using Days and Date', () => {
+        const currentDate = Date.now();
+        const prefix = '';
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                Transitions: [{ Date: currentDate, StorageClass: locationName }],
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{
+                prefix: '',
+                days: 0,
+            }]
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with one Transition rule but multiple transitions', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Transitions: [
+                    { Days: 1, StorageClass: locationName },
+                    { Days: 2, StorageClass: locationName2 }
+                ],
+                ID: '123',
+                Prefix: 'toto/titi',
+                Status: 'Enabled',
+            },
+        ];
+        const expected = {
+            currents: [{
+                prefix: 'toto/titi',
+                days: 1,
+            }]
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with multiple Expiration rules that share prefix', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: 'toto/titi',
+                Status: 'Enabled',
+            },
+            {
+                Expiration: { Days: 2 },
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{
+                prefix: 'toto',
+                days: 1,
+            }]
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with multiple Transition rules that share prefix', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName }],
+                ID: '123',
+                Prefix: 'toto/titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Days: 2, StorageClass: locationName }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{
+                prefix: 'toto',
+                days: 1,
+            }]
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with multiple Expiration rules that do not share prefix', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: 'titi',
+                Status: 'Enabled',
+            },
+            {
+                Expiration: { Days: 2 },
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{
+                prefix: 'titi',
+                days: 1,
+            }, {
+                prefix: 'toto',
+                days: 2,
+            }]
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with multiple Transitions rules that do not share prefix', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName }],
+                ID: '123',
+                Prefix: 'titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Date: currentDate, StorageClass: locationName2 }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{
+                prefix: 'titi',
+                days: 1,
+            }, {
+                prefix: 'toto',
+                days: 0,
+            }]
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with multiple Expiration and Transitions rules that do share prefix', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: 'toto/titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Date: currentDate, StorageClass: locationName2 }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{
+                prefix: 'toto',
+                days: 0,
+            }]
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with multiple Expiration and Transitions rules that do not share prefix', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: 'titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Date: currentDate, StorageClass: locationName2 }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{
+                prefix: 'titi',
+                days: 1,
+            }, {
+                prefix: 'toto',
+                days: 0,
+            }]
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with multiple Expiration and Transitions rules with different prefixes', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 10 },
+                ID: '0',
+                Prefix: 'a',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Date: currentDate, StorageClass: locationName2 }],
+                ID: '1',
+                Prefix: 'b',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Date: currentDate, StorageClass: locationName2 }],
+                ID: '2',
+                Prefix: 'caa',
+                Status: 'Enabled',
+            },
+            {
+                Expiration: { Days: 4 },
+                ID: '3',
+                Prefix: 'ca',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Days: 8, StorageClass: locationName2 }],
+                ID: '4',
+                Prefix: 'cb',
+                Status: 'Enabled',
+            },
+            {
+                Expiration: { Days: 10 },
+                ID: '5',
+                Prefix: 'c',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Days: 2, StorageClass: locationName2 }],
+                ID: '6',
+                Prefix: 'daa',
+                Status: 'Enabled',
+            },
+            {
+                Expiration: { Days: 4 },
+                ID: '7',
+                Prefix: 'da',
+                Status: 'Enabled',
+            },
+            {
+                Expiration: { Days: 6 },
+                ID: '8',
+                Prefix: 'db',
+                Status: 'Enabled',
+            },
+            {
+                Expiration: { Days: 8 },
+                ID: '9',
+                Prefix: 'd',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [
+                { prefix: 'a', days: 10 },
+                { prefix: 'b', days: 0 },
+                { prefix: 'c', days: 0 },
+                { prefix: 'd', days: 2 },
+            ]
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with expireOneDayEarlier', () => {
+        const currentDate = Date.now();
+        const customOptions = {
+            expireOneDayEarlier: true,
+            transitionOneDayEarlier: false,
+        };
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: 'titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName2 }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{
+                prefix: 'titi',
+                days: 0,
+            }, {
+                prefix: 'toto',
+                days: 1,
+            }]
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, customOptions);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with transitionOneDayEarlier', () => {
+        const currentDate = Date.now();
+        const customOptions = {
+            expireOneDayEarlier: false,
+            transitionOneDayEarlier: true,
+        };
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: 'titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName2 }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{
+                prefix: 'titi',
+                days: 1,
+            }, {
+                prefix: 'toto',
+                days: 0,
+            }]
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, customOptions);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with expireOneDayEarlier and transitionOneDayEarlier', () => {
+        const currentDate = Date.now();
+        const customOptions = {
+            expireOneDayEarlier: true,
+            transitionOneDayEarlier: true,
+        };
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: 'titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName2 }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{
+                prefix: 'titi',
+                days: 0,
+            }, {
+                prefix: 'toto',
+                days: 0,
+            }]
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, customOptions);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+});

--- a/tests/unit/lifecycle/RulesReducerWithVersion.spec.js
+++ b/tests/unit/lifecycle/RulesReducerWithVersion.spec.js
@@ -1,0 +1,829 @@
+const assert = require('assert');
+
+const { RulesReducer } = require('../../../extensions/lifecycle/util/RulesReducer');
+
+const locationName = 'aws-loc';
+const locationName2 = 'aws-loc2';
+
+const expectedEmptyResult = {
+    currents: [],
+    nonCurrents: [],
+    orphans: [],
+};
+
+const options = {
+    expireOneDayEarlier: false,
+    transitionOneDayEarlier: false,
+};
+
+describe('RulesReducer with versioning Enabled', () => {
+    const versioningStatus = 'Enabled';
+
+    it('with no rule', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [];
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expectedEmptyResult);
+    });
+
+    it('with date that has not passed', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Date: currentDate + 1000 },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            }
+        ];
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expectedEmptyResult);
+    });
+
+    it('with disabled rule', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '0',
+                Prefix: '',
+                Status: 'Disabled',
+            },
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName }],
+                ID: '1',
+                Prefix: '',
+                Status: 'Disabled',
+            },
+            {
+                NoncurrentVersionExpiration: { NoncurrentDays: 1 },
+                ID: '2',
+                Prefix: '',
+                Status: 'Disabled',
+            },
+            {
+                NoncurrentVersionTransitions: [{ NonCurrentDays: 1, StorageClass: locationName }],
+                ID: '3',
+                Prefix: '',
+                Status: 'Disabled',
+            },
+        ];
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expectedEmptyResult);
+    });
+
+    it('with Expiration rule using Date', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Date: currentDate },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{ prefix: '', days: 0 }],
+            nonCurrents: [],
+            orphans: [{ prefix: '', days: 0 }],
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration rule using Days', () => {
+        const currentDate = Date.now();
+        const prefix = '';
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{ prefix: '', days: 1 }],
+            nonCurrents: [],
+            orphans: [{ prefix: '', days: 1 }],
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration rule using Days and prefix', () => {
+        const currentDate = Date.now();
+        const prefix = 'pre';
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{ prefix, days: 1 }],
+            nonCurrents: [],
+            orphans: [{ prefix: 'pre', days: 1 }],
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Transitions rule using Date', () => {
+        const currentDate = Date.now();
+        const prefix = '';
+        const bucketLCRules = [
+            {
+                Transitions: [{ Date: currentDate, StorageClass: locationName }],
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{ prefix: '', days: 0 }],
+            nonCurrents: [],
+            orphans: [],
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration and Transitions rule using Days', () => {
+        const currentDate = Date.now();
+        const prefix = '';
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                Transitions: [{ Days: 2, StorageClass: locationName }],
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{ prefix: '', days: 1 }],
+            nonCurrents: [],
+            orphans: [{ prefix: '', days: 1 }],
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration and Transitions rule using Days and Date', () => {
+        const currentDate = Date.now();
+        const prefix = '';
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                Transitions: [{ Date: currentDate, StorageClass: locationName }],
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{ prefix: '', days: 0 }],
+            nonCurrents: [],
+            orphans: [{ prefix: '', days: 1 }],
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with one Transition rule but multiple transitions', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Transitions: [
+                    { Days: 1, StorageClass: locationName },
+                    { Days: 2, StorageClass: locationName2 }
+                ],
+                ID: '123',
+                Prefix: 'toto/titi',
+                Status: 'Enabled',
+            },
+        ];
+        const expected = {
+            currents: [{ prefix: 'toto/titi', days: 1 }],
+            nonCurrents: [],
+            orphans: [],
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with multiple Expiration rules that share prefix', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: 'toto/titi',
+                Status: 'Enabled',
+            },
+            {
+                Expiration: { Days: 2 },
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{ prefix: 'toto', days: 1 }],
+            nonCurrents: [],
+            orphans: [{ prefix: 'toto', days: 1 }],
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with multiple Transition rules that share prefix', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName }],
+                ID: '123',
+                Prefix: 'toto/titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Days: 2, StorageClass: locationName }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{ prefix: 'toto', days: 1 }],
+            nonCurrents: [],
+            orphans: [],
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with multiple Expiration rules that do not share prefix', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: 'titi',
+                Status: 'Enabled',
+            },
+            {
+                Expiration: { Days: 2 },
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [
+                { prefix: 'titi', days: 1 },
+                { prefix: 'toto', days: 2 }
+            ],
+            nonCurrents: [],
+            orphans: [
+                { prefix: 'titi', days: 1 },
+                { prefix: 'toto', days: 2 }
+            ],
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with multiple Transitions rules that do not share prefix', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName }],
+                ID: '123',
+                Prefix: 'titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Date: currentDate, StorageClass: locationName2 }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [
+                { prefix: 'titi', days: 1 },
+                { prefix: 'toto', days: 0 }
+            ],
+            nonCurrents: [],
+            orphans: [],
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with multiple Expiration and Transitions rules that do share prefix', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: 'toto/titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Date: currentDate, StorageClass: locationName2 }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{ prefix: 'toto', days: 0 }],
+            nonCurrents: [],
+            orphans: [{ prefix: 'toto/titi', days: 1 }],
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with multiple Expiration and Transitions rules that do not share prefix', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: 'titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Date: currentDate, StorageClass: locationName2 }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [
+                { prefix: 'titi', days: 1 },
+                { prefix: 'toto', days: 0, },
+            ],
+            nonCurrents: [],
+            orphans: [{ prefix: 'titi', days: 1 }],
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with NoncurrentVersionExpiration rule', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                NoncurrentVersionExpiration: { NoncurrentDays: 2 },
+                ID: '0',
+                Prefix: '',
+                Status: 'Enabled',
+            },
+        ];
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        const expected = {
+            currents: [],
+            nonCurrents: [{
+                prefix: '',
+                days: 2,
+            }],
+            orphans: [],
+        };
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with NoncurrentVersionTransitions rule', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 2, StorageClass: locationName }],
+                ID: '0',
+                Prefix: '',
+                Status: 'Enabled',
+            },
+        ];
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        const expected = {
+            currents: [],
+            nonCurrents: [{
+                prefix: '',
+                days: 2,
+            }],
+            orphans: [],
+        };
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with NoncurrentVersionExpiration and NoncurrentVersionTransitions rule that do not share prefix', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                NoncurrentVersionExpiration: { NoncurrentDays: 1 },
+                ID: '0',
+                Prefix: 'toto/titi',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 2, StorageClass: locationName }],
+                ID: '1',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            },
+        ];
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        const expected = {
+            currents: [],
+            nonCurrents: [{
+                prefix: 'toto',
+                days: 1,
+            }],
+            orphans: [],
+        };
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with NoncurrentVersionExpiration and NoncurrentVersionTransitions rule that do not share prefix', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                NoncurrentVersionExpiration: { NoncurrentDays: 1 },
+                ID: '0',
+                Prefix: 'p1',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 2, StorageClass: locationName }],
+                ID: '1',
+                Prefix: 'p2',
+                Status: 'Enabled',
+            },
+        ];
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        const expected = {
+            currents: [],
+            nonCurrents: [
+                { prefix: 'p1', days: 1 },
+                { prefix: 'p2', days: 2 },
+            ],
+            orphans: [],
+        };
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration.ExpiredObjectDeleteMarker', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: {
+                    ExpiredObjectDeleteMarker: true,
+                },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            },
+        ];
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        const expected = {
+            currents: [],
+            nonCurrents: [],
+            orphans: [{ prefix: '', days: 0 }],
+        };
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration and Expiration.ExpiredObjectDeleteMarker', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: {
+                    ExpiredObjectDeleteMarker: true,
+                },
+                ID: '0',
+                Prefix: '',
+                Status: 'Enabled',
+            },
+            {
+                Expiration: {  Days: 1 },
+                ID: '1',
+                Prefix: '',
+                Status: 'Enabled',
+            },
+        ];
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        const expected = {
+            currents: [{ prefix: '', days: 1 }],
+            nonCurrents: [],
+            orphans: [{ prefix: '', days: 0 }],
+        };
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration, Transitions, NoncurrentVersionExpiration and NoncurrentVersionTransitions rules', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 10 },
+                ID: '0',
+                Prefix: 'a',
+                Status: 'Enabled',
+            },
+            {
+                Expiration: { Days: 4 },
+                ID: '3',
+                Filter: {
+                    Prefix: 'ca',
+                },
+                Status: 'Enabled',
+            },
+            {
+                Expiration: { Days: 10 },
+                ID: '5',
+                Filter: {
+                    And: {
+                        Prefix: 'c',
+                    }
+                },
+                Status: 'Enabled',
+            },
+            {
+                Expiration: { Days: 6 },
+                ID: '8',
+                Filter: {
+                    Prefix: 'db',
+                },
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Date: currentDate, StorageClass: locationName2 }],
+                ID: '2',
+                Prefix: 'caa',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Days: 2, StorageClass: locationName2 }],
+                ID: '6',
+                Prefix: 'daa',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 1, StorageClass: locationName2 }],
+                ID: '1',
+                Filter: {
+                    Prefix: 'b',
+                },
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 8, StorageClass: locationName2 }],
+                ID: '4',
+                Prefix: 'cb',
+                Filter: {
+                    And: {
+                        Prefix: 'cb',
+                    }
+                },
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionExpiration: { NoncurrentDays: 4 },
+                ID: '7',
+                Prefix: 'da',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionExpiration: { NoncurrentDays: 8 },
+                ID: '9',
+                Filter: {
+                    And: {
+                        Prefix: 'd',
+                    }
+                },
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [
+                { prefix: 'a', days: 10 },
+                { prefix: 'c', days: 0 },
+                { prefix: 'daa', days: 2 },
+                { prefix: 'db', days: 6 },
+            ],
+            nonCurrents: [
+                { prefix: 'b', days: 1 },
+                { prefix: 'cb', days: 8 },
+                { prefix: 'd', days: 4 },
+            ],
+            orphans: [
+                { prefix: 'a', days: 10 },
+                { prefix: 'c', days: 4 },
+                { prefix: 'db', days: 6 },
+            ],
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with expireOneDayEarlier', () => {
+        const currentDate = Date.now();
+        const customOptions = {
+            expireOneDayEarlier: true,
+            transitionOneDayEarlier: false,
+        };
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '1',
+                Prefix: 'p1',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName2 }],
+                ID: '2',
+                Prefix: 'p2',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionExpiration: { NoncurrentDays: 1 },
+                ID: '3',
+                Prefix: 'p3',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 1, StorageClass: locationName }],
+                ID: '4',
+                Prefix: 'p4',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [
+                { prefix: 'p1', days: 0 },
+                { prefix: 'p2', days: 1 },
+            ],
+            nonCurrents: [
+                { prefix: 'p3', days: 0 },
+                { prefix: 'p4', days: 1 }],
+            orphans: [
+                { prefix: 'p1', days: 0, },
+            ],
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, customOptions);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with transitionOneDayEarlier', () => {
+        const currentDate = Date.now();
+        const customOptions = {
+            expireOneDayEarlier: false,
+            transitionOneDayEarlier: true,
+        };
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '1',
+                Prefix: 'p1',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName2 }],
+                ID: '2',
+                Prefix: 'p2',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionExpiration: { NoncurrentDays: 1 },
+                ID: '3',
+                Prefix: 'p3',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 1, StorageClass: locationName }],
+                ID: '4',
+                Prefix: 'p4',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [
+                { prefix: 'p1', days: 1 },
+                { prefix: 'p2', days: 0 },
+            ],
+            nonCurrents: [
+                { prefix: 'p3', days: 1 },
+                { prefix: 'p4', days: 0 }],
+            orphans: [
+                { prefix: 'p1', days: 1, },
+            ],
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, customOptions);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+
+    it('with transitionOneDayEarlier', () => {
+        const currentDate = Date.now();
+        const customOptions = {
+            expireOneDayEarlier: true,
+            transitionOneDayEarlier: true,
+        };
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '1',
+                Prefix: 'p1',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName2 }],
+                ID: '2',
+                Prefix: 'p2',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionExpiration: { NoncurrentDays: 1 },
+                ID: '3',
+                Prefix: 'p3',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 1, StorageClass: locationName }],
+                ID: '4',
+                Prefix: 'p4',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [
+                { prefix: 'p1', days: 0 },
+                { prefix: 'p2', days: 0 },
+            ],
+            nonCurrents: [
+                { prefix: 'p3', days: 0 },
+                { prefix: 'p4', days: 0 }],
+            orphans: [
+                { prefix: 'p1', days: 0, },
+            ],
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, customOptions);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+});

--- a/tests/unit/lifecycle/rules.spec.js
+++ b/tests/unit/lifecycle/rules.spec.js
@@ -1,0 +1,797 @@
+const assert = require('assert');
+
+const { rulesToParams } = require('../../../extensions/lifecycle/util/rules');
+
+const ONE_DAY_IN_SEC = 60 * 60 * 24 * 1000;
+const MAX_KEYS = process.env.CI === 'true' ? 3 : 1000;
+
+const bucketName = 'bucket1';
+const ownerId = 'f2a3ae88659516fbcad23cae38acc9fbdfcbcaf2e38c05d2e5e1bd1b9f930ff3';
+const accountId = '345320934593';
+const locationName = 'aws-loc';
+const locationName2 = 'aws-loc2';
+
+const bucketData = {
+    action: 'processObjects',
+    target: {
+      bucket: bucketName,
+      owner: ownerId,
+      accountId,
+    },
+    details: {}
+};
+
+const expectedEmptyResult = {
+    listType: undefined,
+    params: undefined,
+    remainings: []
+};
+
+const options = {
+    expireOneDayEarlier: false,
+    transitionOneDayEarlier: false,
+};
+
+describe('rulesToParams with versioning Disabled', () => {
+    const versioningStatus = 'Disabled';
+
+    it('with no rule', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [];
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expectedEmptyResult);
+    });
+
+    it('with irrelevant rule with date that has not passed', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Date: currentDate + 1000 },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            }
+        ];
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expectedEmptyResult);
+    });
+
+    it('with rule targeting non current versions', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                NoncurrentVersionExpiration: { NoncurrentDays: 1 },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 1, StorageClass: locationName }],
+                ID: '456',
+                Prefix: '',
+                Status: 'Enabled',
+            }
+        ];
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expectedEmptyResult);
+    });
+
+    it('with rule targeting orphan delete markers', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: {
+                    ExpiredObjectDeleteMarker: true,
+                },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            },
+        ];
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expectedEmptyResult);
+    });
+
+    it('with disabled rule', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Date: currentDate },
+                ID: '123',
+                Prefix: '',
+                Status: 'Disabled',
+            }
+        ];
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expectedEmptyResult);
+    });
+
+    it('with details', () => {
+        const currentDate = Date.now();
+        const details = {
+            listType: 'current',
+            prefix: '',
+            marker: 'key1'
+        };
+        const bd = { ...bucketData, details };
+        const bucketLCRules = [
+            {
+                Expiration: { Date: currentDate },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            }
+        ];
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bd, options);
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: '',
+               MaxKeys: MAX_KEYS,
+               Marker: 'key1',
+            },
+            listType: 'current',
+            remainings: []
+        };
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with invalid details listType', () => {
+        const currentDate = Date.now();
+        const prefix = 'pre';
+        const details = {
+            listType: 'invalid',
+            prefix,
+            marker: 'key1'
+        };
+        const bd = { ...bucketData, details };
+        const bucketLCRules = [
+            {
+                Expiration: { Date: currentDate },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            }
+        ];
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bd, options);
+        const expected = {};
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with details and prefix', () => {
+        const currentDate = Date.now();
+        const prefix = 'pre';
+        const details = {
+            listType: 'current',
+            prefix,
+            marker: 'key1'
+        };
+        const bd = { ...bucketData, details };
+        const bucketLCRules = [
+            {
+                Expiration: { Date: currentDate },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            }
+        ];
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bd, options);
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: prefix,
+               MaxKeys: MAX_KEYS,
+               Marker: 'key1',
+            },
+            listType: 'current',
+            remainings: []
+        };
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with details and beforeDate', () => {
+        const currentDate = Date.now();
+        const prefix = 'pre';
+        const beforeDate = (new Date(currentDate)).toISOString();
+        const details = {
+            listType: 'current',
+            prefix,
+            beforeDate,
+            marker: 'key1'
+        };
+        const bd = { ...bucketData, details };
+        const bucketLCRules = [
+            {
+                Expiration: { Date: currentDate },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            }
+        ];
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bd, options);
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: prefix,
+               MaxKeys: MAX_KEYS,
+               Marker: 'key1',
+               BeforeDate: beforeDate,
+            },
+            listType: 'current',
+            remainings: []
+        };
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration rule using Date', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Date: currentDate },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: '',
+               MaxKeys: MAX_KEYS,
+            },
+            listType: 'current',
+            remainings: []
+        };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration rule using Days', () => {
+        const currentDate = Date.now();
+        const prefix = '';
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: prefix,
+               MaxKeys: MAX_KEYS,
+               BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: []
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration rule using Days and prefix', () => {
+        const currentDate = Date.now();
+        const prefix = 'pre';
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: prefix,
+               MaxKeys: MAX_KEYS,
+               BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: []
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration rule using Filter.Prefix', () => {
+        const currentDate = Date.now();
+        const prefix = 'pre';
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Filter: {
+                    Prefix: prefix,
+                },
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: prefix,
+               MaxKeys: MAX_KEYS,
+               BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: []
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration rule using Filter.And.Prefix', () => {
+        const currentDate = Date.now();
+        const prefix = 'pre';
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Filter: {
+                    And: {
+                        Prefix: prefix,
+                    }
+                },
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: prefix,
+               MaxKeys: MAX_KEYS,
+               BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: []
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Transitions rule using Date', () => {
+        const currentDate = Date.now();
+        const prefix = '';
+        const bucketLCRules = [
+            {
+                Transitions: [{ Date: currentDate, StorageClass: locationName }],
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: prefix,
+               MaxKeys: MAX_KEYS,
+            },
+            listType: 'current',
+            remainings: []
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration and Transitions rule using Days', () => {
+        const currentDate = Date.now();
+        const prefix = '';
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                Transitions: [{ Days: 2, StorageClass: locationName }],
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: prefix,
+               MaxKeys: MAX_KEYS,
+               BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: []
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration and Transitions rule using Days and Date', () => {
+        const currentDate = Date.now();
+        const prefix = '';
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                Transitions: [{ Date: currentDate, StorageClass: locationName }],
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: prefix,
+               MaxKeys: MAX_KEYS,
+            },
+            listType: 'current',
+            remainings: []
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with one Transition rule but multiple transitions', () => {
+        const currentDate = Date.now();
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Transitions: [
+                    { Days: 1, StorageClass: locationName },
+                    { Days: 2, StorageClass: locationName2 }
+                ],
+                ID: '123',
+                Prefix: 'toto/titi',
+                Status: 'Enabled',
+            },
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: 'toto/titi',
+               MaxKeys: MAX_KEYS,
+               BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: []
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with multiple Expiration rules that share prefix', () => {
+        const currentDate = Date.now();
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: 'toto/titi',
+                Status: 'Enabled',
+            },
+            {
+                Expiration: { Days: 2 },
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: 'toto',
+               MaxKeys: MAX_KEYS,
+               BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: []
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with multiple Transition rules that share prefix', () => {
+        const currentDate = Date.now();
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName }],
+                ID: '123',
+                Prefix: 'toto/titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Days: 2, StorageClass: locationName }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: 'toto',
+               MaxKeys: MAX_KEYS,
+               BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: []
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with multiple Expiration rules that do not share prefix', () => {
+        const currentDate = Date.now();
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const expectedBeforeDate2 = (new Date(currentDate - 2 * ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: 'titi',
+                Status: 'Enabled',
+            },
+            {
+                Expiration: { Days: 2 },
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: 'titi',
+               MaxKeys: MAX_KEYS,
+               BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: [{
+                listType: 'current',
+                prefix: 'toto',
+                beforeDate: expectedBeforeDate2,
+             }]
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with multiple Transitions rules that do not share prefix', () => {
+        const currentDate = Date.now();
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName }],
+                ID: '123',
+                Prefix: 'titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Date: currentDate, StorageClass: locationName2 }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: 'titi',
+               BeforeDate: expectedBeforeDate,
+               MaxKeys: MAX_KEYS,
+            },
+            listType: 'current',
+            remainings: [{
+                listType: 'current',
+                prefix: 'toto',
+             }]
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration and Transitions rules that do share prefix', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: 'toto/titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Date: currentDate, StorageClass: locationName2 }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: 'toto',
+               MaxKeys: MAX_KEYS,
+            },
+            listType: 'current',
+            remainings: []
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration and Transitions rules that do not share prefix', () => {
+        const currentDate = Date.now();
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: 'titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Date: currentDate, StorageClass: locationName2 }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: 'titi',
+               MaxKeys: MAX_KEYS,
+               BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: [{
+                listType: 'current',
+                prefix: 'toto',
+             }]
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with expireOneDayEarlier', () => {
+        const currentDate = Date.now();
+        const customOptions = {
+            expireOneDayEarlier: true,
+            transitionOneDayEarlier: false,
+        };
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: 'titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName2 }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: 'titi',
+               MaxKeys: MAX_KEYS,
+            },
+            listType: 'current',
+            remainings: [{
+                listType: 'current',
+                prefix: 'toto',
+                beforeDate: expectedBeforeDate,
+             }]
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, customOptions);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with transitionOneDayEarlier', () => {
+        const currentDate = Date.now();
+        const customOptions = {
+            expireOneDayEarlier: false,
+            transitionOneDayEarlier: true,
+        };
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: 'titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName2 }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: 'titi',
+               MaxKeys: MAX_KEYS,
+               BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: [{
+                listType: 'current',
+                prefix: 'toto',
+            }]
+        };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, customOptions);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with expireOneDayEarlier and transitionOneDayEarlier', () => {
+        const currentDate = Date.now();
+        const customOptions = {
+            expireOneDayEarlier: true,
+            transitionOneDayEarlier: true,
+        };
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: 'titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName2 }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: 'titi',
+               MaxKeys: MAX_KEYS,
+            },
+            listType: 'current',
+            remainings: [{
+                listType: 'current',
+                prefix: 'toto',
+            }]
+        };
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, customOptions);
+        assert.deepStrictEqual(result, expected);
+    });
+});

--- a/tests/unit/lifecycle/rulesWithVersion.spec.js
+++ b/tests/unit/lifecycle/rulesWithVersion.spec.js
@@ -1,0 +1,1013 @@
+const assert = require('assert');
+
+const { rulesToParams } = require(
+    '../../../extensions/lifecycle/util/rules');
+
+const ONE_DAY_IN_SEC = 60 * 60 * 24 * 1000;
+const MAX_KEYS = process.env.CI === 'true' ? 3 : 1000;
+
+const bucketName = 'bucket1';
+const ownerId = 'f2a3ae88659516fbcad23cae38acc9fbdfcbcaf2e38c05d2e5e1bd1b9f930ff3';
+const accountId = '345320934593';
+const locationName = 'aws-loc';
+const locationName2 = 'aws-loc2';
+
+const bucketData = {
+    action: 'processObjects',
+    target: {
+      bucket: bucketName,
+      owner: ownerId,
+      accountId,
+    },
+    details: {}
+};
+
+const options = {
+    expireOneDayEarlier: false,
+    transitionOneDayEarlier: false,
+};
+
+const expectedEmptyResult = {
+    listType: undefined,
+    params: undefined,
+    remainings: []
+};
+
+describe('rulesToParams with versioning Enabled', () => {
+    const versioningStatus = 'Enabled';
+
+    it('with no rule', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [];
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expectedEmptyResult);
+    });
+
+    it('with irrelevant rule with date that has not passed', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Date: currentDate + 1000 },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            }
+        ];
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expectedEmptyResult);
+    });
+
+    it('with rule targeting orphan delete markers', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: {
+                    ExpiredObjectDeleteMarker: true,
+                },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            },
+        ];
+
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: '',
+               MaxKeys: MAX_KEYS,
+            },
+            listType: 'orphan',
+            remainings: []
+        };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with disabled rule', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Date: currentDate },
+                ID: '123',
+                Prefix: '',
+                Status: 'Disabled',
+            }
+        ];
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expectedEmptyResult);
+    });
+
+    it('with details', () => {
+        const currentDate = Date.now();
+        const details = {
+            listType: 'current',
+            prefix: '',
+            marker: 'key1'
+        };
+        const bd = { ...bucketData, details };
+        const bucketLCRules = [
+            {
+                Expiration: { Date: currentDate },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            }
+        ];
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bd, options);
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: '',
+               MaxKeys: MAX_KEYS,
+               Marker: 'key1',
+            },
+            listType: 'current',
+            remainings: []
+        };
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with details and prefix', () => {
+        const currentDate = Date.now();
+        const prefix = 'pre';
+        const details = {
+            listType: 'current',
+            prefix,
+            marker: 'key1'
+        };
+        const bd = { ...bucketData, details };
+        const bucketLCRules = [
+            {
+                Expiration: { Date: currentDate },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            }
+        ];
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bd, options);
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: prefix,
+               MaxKeys: MAX_KEYS,
+               Marker: 'key1',
+            },
+            listType: 'current',
+            remainings: []
+        };
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with details and beforeDate', () => {
+        const currentDate = Date.now();
+        const prefix = 'pre';
+        const beforeDate = (new Date(currentDate)).toISOString();
+        const details = {
+            listType: 'current',
+            prefix,
+            beforeDate,
+            marker: 'key1'
+        };
+        const bd = { ...bucketData, details };
+        const bucketLCRules = [
+            {
+                Expiration: { Date: currentDate },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            }
+        ];
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bd, options);
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: prefix,
+               MaxKeys: MAX_KEYS,
+               Marker: 'key1',
+               BeforeDate: beforeDate,
+            },
+            listType: 'current',
+            remainings: []
+        };
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration rule using Date', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Date: currentDate },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: '',
+               MaxKeys: MAX_KEYS,
+            },
+            listType: 'current',
+            remainings: [{
+                listType: 'orphan',
+                prefix: '',
+            }]
+        };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration rule using Days', () => {
+        const currentDate = Date.now();
+        const prefix = '';
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: prefix,
+               MaxKeys: MAX_KEYS,
+               BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: [{
+                listType: 'orphan',
+                prefix: '',
+                beforeDate: expectedBeforeDate,
+            }]
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration rule using Days and prefix', () => {
+        const currentDate = Date.now();
+        const prefix = 'pre';
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: prefix,
+               MaxKeys: MAX_KEYS,
+               BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: [{
+                listType: 'orphan',
+                prefix,
+                beforeDate: expectedBeforeDate,
+            }]
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Transitions rule using Date', () => {
+        const currentDate = Date.now();
+        const prefix = '';
+        const bucketLCRules = [
+            {
+                Transitions: [{ Date: currentDate, StorageClass: locationName }],
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: prefix,
+               MaxKeys: MAX_KEYS,
+            },
+            listType: 'current',
+            remainings: []
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration and Transitions rule using Days', () => {
+        const currentDate = Date.now();
+        const prefix = '';
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                Transitions: [{ Days: 2, StorageClass: locationName }],
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: prefix,
+               MaxKeys: MAX_KEYS,
+               BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: [{
+                listType: 'orphan',
+                prefix,
+                beforeDate: expectedBeforeDate,
+            }]
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration and Transitions rule using Days and Date', () => {
+        const currentDate = Date.now();
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const prefix = '';
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                Transitions: [{ Date: currentDate, StorageClass: locationName }],
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: prefix,
+               MaxKeys: MAX_KEYS,
+            },
+            listType: 'current',
+            remainings: [{
+                listType: 'orphan',
+                beforeDate: expectedBeforeDate,
+                prefix,
+            }]
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with one Transition rule but multiple transitions', () => {
+        const currentDate = Date.now();
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Transitions: [
+                    { Days: 1, StorageClass: locationName },
+                    { Days: 2, StorageClass: locationName2 }
+                ],
+                ID: '123',
+                Prefix: 'toto/titi',
+                Status: 'Enabled',
+            },
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: 'toto/titi',
+               MaxKeys: MAX_KEYS,
+               BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: []
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with multiple Expiration rules that share prefix', () => {
+        const currentDate = Date.now();
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: 'toto/titi',
+                Status: 'Enabled',
+            },
+            {
+                Expiration: { Days: 2 },
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: 'toto',
+               MaxKeys: MAX_KEYS,
+               BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: [{
+                listType: 'orphan',
+                prefix: 'toto',
+                beforeDate: expectedBeforeDate,
+            }]
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with multiple Transition rules that share prefix', () => {
+        const currentDate = Date.now();
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName }],
+                ID: '123',
+                Prefix: 'toto/titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Days: 2, StorageClass: locationName }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: 'toto',
+               MaxKeys: MAX_KEYS,
+               BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: []
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with multiple Expiration rules that do not share prefix', () => {
+        const currentDate = Date.now();
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const expectedBeforeDate2 = (new Date(currentDate - 2 * ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: 'titi',
+                Status: 'Enabled',
+            },
+            {
+                Expiration: { Days: 2 },
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: 'titi',
+               MaxKeys: MAX_KEYS,
+               BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: [{
+                listType: 'current',
+                prefix: 'toto',
+                beforeDate: expectedBeforeDate2,
+            }, {
+                listType: 'orphan',
+                prefix: 'titi',
+                beforeDate: expectedBeforeDate,
+            }, {
+                listType: 'orphan',
+                prefix: 'toto',
+                beforeDate: expectedBeforeDate2,
+            }]
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with multiple Transitions rules that do not share prefix', () => {
+        const currentDate = Date.now();
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName }],
+                ID: '123',
+                Prefix: 'titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Date: currentDate, StorageClass: locationName2 }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: 'titi',
+               MaxKeys: MAX_KEYS,
+               BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: [{
+                listType: 'current',
+                prefix: 'toto',
+             }]
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration and Transitions rules that do share prefix', () => {
+        const currentDate = Date.now();
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: 'toto/titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Date: currentDate, StorageClass: locationName2 }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: 'toto',
+               MaxKeys: MAX_KEYS,
+            },
+            listType: 'current',
+            remainings: [{
+                listType: 'orphan',
+                prefix: 'toto/titi',
+                beforeDate: expectedBeforeDate,
+            }]
+         };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration and Transitions rules that do not share prefix', () => {
+        const currentDate = Date.now();
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: 'titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Date: currentDate, StorageClass: locationName2 }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: 'titi',
+               MaxKeys: MAX_KEYS,
+               BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: [{
+                listType: 'current',
+                prefix: 'toto',
+            }, {
+                listType: 'orphan',
+                prefix: 'titi',
+                beforeDate: expectedBeforeDate,
+            }]
+        };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with NoncurrentVersionExpiration and NoncurrentVersionTransitions rules', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                NoncurrentVersionExpiration: { NoncurrentDays: 1 },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 0, StorageClass: locationName }],
+                ID: '456',
+                Prefix: '',
+                Status: 'Enabled',
+            }
+        ];
+
+        const expected = {
+            params: {
+                Bucket: bucketName,
+                Prefix: '',
+                MaxKeys: MAX_KEYS,
+            },
+            listType: 'noncurrent',
+            remainings: []
+        };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with NoncurrentVersionExpiration and NoncurrentVersionTransitions rules with different prefix', () => {
+        const currentDate = Date.now();
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                NoncurrentVersionExpiration: { NoncurrentDays: 1 },
+                ID: '123',
+                Prefix: 'p1',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 0, StorageClass: locationName }],
+                ID: '456',
+                Prefix: 'p2',
+                Status: 'Enabled',
+            },
+        ];
+
+        const expected = {
+            params: {
+                Bucket: bucketName,
+                Prefix: 'p1',
+                MaxKeys: MAX_KEYS,
+                BeforeDate: expectedBeforeDate,
+            },
+            listType: 'noncurrent',
+            remainings: [{
+                listType: 'noncurrent',
+                prefix: 'p2',
+            }]
+        };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with NoncurrentVersionExpiration and NoncurrentVersionTransitions rules with shared prefix', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                NoncurrentVersionExpiration: { NoncurrentDays: 1 },
+                ID: '123',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 0, StorageClass: locationName }],
+                ID: '456',
+                Prefix: 'toto/titi',
+                Status: 'Enabled',
+            },
+        ];
+
+        const expected = {
+            params: {
+                Bucket: bucketName,
+                Prefix: 'toto',
+                MaxKeys: MAX_KEYS,
+            },
+            listType: 'noncurrent',
+            remainings: []
+        };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration, Transtions, NoncurrentVersionExpiration and NoncurrentVersionTransitions rules', () => {
+        const currentDate = Date.now();
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const expectedBeforeDate2 = (new Date(currentDate - 2 * ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 2 },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName }],
+                ID: '456',
+                Prefix: '',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionExpiration: { NoncurrentDays: 2 },
+                ID: '789',
+                Prefix: '',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 1, StorageClass: locationName }],
+                ID: '101',
+                Prefix: '',
+                Status: 'Enabled',
+            },
+        ];
+
+        const expected = {
+            params: {
+                Bucket: bucketName,
+                Prefix: '',
+                MaxKeys: MAX_KEYS,
+                BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: [{
+                listType: 'noncurrent',
+                prefix: '',
+                beforeDate: expectedBeforeDate,
+            }, {
+                listType: 'orphan',
+                prefix: '',
+                beforeDate: expectedBeforeDate2,
+            }]
+        };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with Expiration and ExpiredObjectDeleteMarker rules', () => {
+        const currentDate = Date.now();
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            },
+            {
+                Expiration: { ExpiredObjectDeleteMarker: true },
+                ID: '456',
+                Prefix: '',
+                Status: 'Enabled',
+            },
+        ];
+
+        const expected = {
+            params: {
+                Bucket: bucketName,
+                Prefix: '',
+                MaxKeys: MAX_KEYS,
+                BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: [{
+                listType: 'orphan',
+                prefix: '',
+            }]
+        };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with expireOneDayEarlier', () => {
+        const currentDate = Date.now();
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const customOptions = {
+            expireOneDayEarlier: true,
+            transitionOneDayEarlier: false,
+        };
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '1',
+                Prefix: 'p1',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName2 }],
+                ID: '2',
+                Prefix: 'p2',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionExpiration: { NoncurrentDays: 1 },
+                ID: '3',
+                Prefix: 'p3',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 1, StorageClass: locationName }],
+                ID: '4',
+                Prefix: 'p4',
+                Status: 'Enabled',
+            }
+        ];
+
+        const expected = {
+            params: {
+                Bucket: 'bucket1',
+                Prefix: 'p1',
+                MaxKeys: MAX_KEYS,
+            },
+            listType: 'current',
+            remainings: [
+                {
+                    prefix: 'p2',
+                    listType: 'current',
+                    beforeDate: expectedBeforeDate,
+                },
+                {
+                    prefix: 'p3',
+                    listType: 'noncurrent',
+                },
+                {
+                    prefix: 'p4',
+                    listType: 'noncurrent',
+                    beforeDate: expectedBeforeDate,
+                },
+                {
+                    prefix: 'p1',
+                    listType: 'orphan',
+                }
+            ]
+        };
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, customOptions);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with transitionOneDayEarlier', () => {
+        const currentDate = Date.now();
+        const expectedBeforeDate = (new Date(currentDate - ONE_DAY_IN_SEC)).toISOString();
+        const customOptions = {
+            expireOneDayEarlier: false,
+            transitionOneDayEarlier: true,
+        };
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '1',
+                Prefix: 'p1',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName2 }],
+                ID: '2',
+                Prefix: 'p2',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionExpiration: { NoncurrentDays: 1 },
+                ID: '3',
+                Prefix: 'p3',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 1, StorageClass: locationName }],
+                ID: '4',
+                Prefix: 'p4',
+                Status: 'Enabled',
+            }
+        ];
+
+        const expected = {
+            params: {
+                Bucket: 'bucket1',
+                Prefix: 'p1',
+                MaxKeys: MAX_KEYS,
+                BeforeDate: expectedBeforeDate,
+            },
+            listType: 'current',
+            remainings: [
+                {
+                    prefix: 'p2',
+                    listType: 'current',
+                },
+                {
+                    prefix: 'p3',
+                    listType: 'noncurrent',
+                    beforeDate: expectedBeforeDate,
+                },
+                {
+                    prefix: 'p4',
+                    listType: 'noncurrent',
+                },
+                {
+                    prefix: 'p1',
+                    listType: 'orphan',
+                    beforeDate: expectedBeforeDate,
+                }
+            ]
+        };
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, customOptions);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with expireOneDayEarlier and transitionOneDayEarlier', () => {
+        const currentDate = Date.now();
+        const customOptions = {
+            expireOneDayEarlier: true,
+            transitionOneDayEarlier: true,
+        };
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 1 },
+                ID: '1',
+                Prefix: 'p1',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName2 }],
+                ID: '2',
+                Prefix: 'p2',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionExpiration: { NoncurrentDays: 1 },
+                ID: '3',
+                Prefix: 'p3',
+                Status: 'Enabled',
+            },
+            {
+                NoncurrentVersionTransitions: [{ NoncurrentDays: 1, StorageClass: locationName }],
+                ID: '4',
+                Prefix: 'p4',
+                Status: 'Enabled',
+            }
+        ];
+
+        const expected = {
+            params: {
+                Bucket: 'bucket1',
+                Prefix: 'p1',
+                MaxKeys: MAX_KEYS,
+            },
+            listType: 'current',
+            remainings: [
+                {
+                    prefix: 'p2',
+                    listType: 'current',
+                },
+                {
+                    prefix: 'p3',
+                    listType: 'noncurrent',
+                },
+                {
+                    prefix: 'p4',
+                    listType: 'noncurrent',
+                },
+                {
+                    prefix: 'p1',
+                    listType: 'orphan',
+                }
+            ]
+        };
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, customOptions);
+        assert.deepStrictEqual(result, expected);
+    });
+});


### PR DESCRIPTION
**Backbeat lifecycle rule aggregator**

The Backbeat “lifecycle rule aggregator” determines the list of API calls needed to list all eligible objects based on the bucket lifecycle rules.

The lifecycle rule aggregator will group rules by "list type".

For each "list type" corresponds a listing call:
- **current**: {Expiration, Transition} → ListLifecycleObjects or ListLifecycleCurrentVersions depending on the bucket versioning state.
- **noncurrent**: {NoncurrentVersionExpiration, NoncurrentVersionTransition} → ListLifecycleNonCurrentVersions
- **orphan**: {Expiration, Expiration.ExpiredObjectDeleteMarker} → ListLifecycleDeleteMarkers

For a given "list type", the rules will be aggregated by the wildest prefix to not list the same key multiple times. _E.g. rules: [{ prefix: 's', days: 10 }, { prefix: 's/c', days: 5 }, { prefix: 's/c/a', days: 1 }]  should return [{ prefix: 's', days: 1 }] after aggregating by prefix._