### PR TITLE
add s3 lifecycle expiration event

### DIFF
--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -184,6 +184,44 @@
                 }
             }
         },
+        "DeleteObjectFromExpiration": {
+            "http": {
+                "method": "DELETE",
+                "requestUri": "/_/backbeat/expiration/{Bucket}/{Key}"
+            },
+            "input": {
+                "type": "structure",
+                "required": [
+                    "Bucket",
+                    "Key"
+                ],
+                "members": {
+                    "Bucket": {
+                        "location": "uri",
+                        "locationName": "Bucket"
+                    },
+                    "Key": {
+                        "location": "uri",
+                        "locationName": "Key"
+                    },
+                    "VersionId": {
+                        "type": "string",
+                        "documentation": "VersionId used to reference a specific version of the object.",
+                        "location": "querystring",
+                        "locationName": "versionId"
+                    }
+                },
+                "payload": "Body"
+            },
+            "output": {
+                "type": "structure",
+                "members": {
+                    "versionId": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "MultipleBackendDeleteObject": {
             "http": {
                 "method": "DELETE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "8.6.8",
+  "version": "8.6.9",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/lifecycle/LifecycleDeleteObjectTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleDeleteObjectTask.spec.js
@@ -13,26 +13,29 @@ const {
     S3ClientMock,
     BackbeatMetadataProxyMock,
     ProcessorMock,
+    BackbeatClientMock,
 } = require('../mocks');
 
 describe('LifecycleDeleteObjectTask', () => {
     let s3Client;
-    let backbeatClient;
+    let backbeatMdProxyClient;
     let objectProcessor;
     let objMd;
     let task;
+    let backbeatClient;
 
     beforeEach(() => {
         s3Client = new S3ClientMock();
-        backbeatClient = new BackbeatMetadataProxyMock();
+        backbeatMdProxyClient = new BackbeatMetadataProxyMock();
+        backbeatClient = new BackbeatClientMock();
         objectProcessor = new ProcessorMock(
             s3Client,
-            null,
             backbeatClient,
+            backbeatMdProxyClient,
             null,
             new werelogs.Logger('test:LifecycleDeleteObjectTask'));
         objMd = new ObjectMD();
-        backbeatClient.setMdObj(objMd);
+        backbeatMdProxyClient.setMdObj(objMd);
         task = new LifecycleDeleteObjectTask(objectProcessor);
     });
 
@@ -75,8 +78,9 @@ describe('LifecycleDeleteObjectTask', () => {
             .setAttribute('target.key', 'testkey')
             .setAttribute('details.lastModified', '2022-05-13T17:51:31.261Z');
         s3Client.setResponse(null, {});
+        backbeatClient.setResponse(null, {});
         task.processActionEntry(entry, err => {
-            assert.strictEqual(s3Client.calls.deleteObject, 1);
+            assert.strictEqual(backbeatClient.times.deleteObjectFromExpiration, 1);
             assert.ifError(err);
             done();
         });
@@ -132,8 +136,9 @@ describe('LifecycleDeleteObjectTask', () => {
                 .setAttribute('target.key', 'testkey')
                 .setAttribute('details.lastModified', '2022-05-13T17:51:31.261Z');
             s3Client.setResponse(null, {});
+            backbeatClient.setResponse(null, {});
             task.processActionEntry(entry, err => {
-                assert.strictEqual(s3Client.calls.deleteObject, 1);
+                assert.strictEqual(backbeatClient.times.deleteObjectFromExpiration, 1);
                 assert.ifError(err);
                 done();
             });
@@ -168,8 +173,9 @@ describe('LifecycleDeleteObjectTask', () => {
                 .setAttribute('target.key', 'testkey')
                 .setAttribute('details.lastModified', '2022-05-13T17:51:31.261Z');
             s3Client.setResponse(null, {});
+            backbeatClient.setResponse(null, {});
             task.processActionEntry(entry, err => {
-                assert.strictEqual(s3Client.calls.deleteObject, 1);
+                assert.strictEqual(backbeatClient.times.deleteObjectFromExpiration, 1);
                 assert.ifError(err);
                 done();
             });
@@ -186,8 +192,9 @@ describe('LifecycleDeleteObjectTask', () => {
             .setAttribute('target.version', 'testversion')
             .setAttribute('details.lastModified', '2022-05-13T17:51:31.261Z');
         s3Client.setResponse(null, {});
+        backbeatClient.setResponse(null, {});
         task.processActionEntry(entry, err => {
-            assert.strictEqual(s3Client.calls.deleteObject, 1);
+            assert.strictEqual(backbeatClient.times.deleteObjectFromExpiration, 1);
             assert.ifError(err);
             done();
         });

--- a/tests/unit/mocks.js
+++ b/tests/unit/mocks.js
@@ -41,10 +41,21 @@ class MockRequestAPI extends EventEmitter {
 
 class BackbeatClientMock {
     constructor() {
+        this.response = null;
         this.batchDeleteResponse = {};
         this.times = {
             batchDeleteResponse: 0,
+            deleteObjectFromExpiration: 0,
         };
+    }
+
+    deleteObjectFromExpiration() {
+        this.times.deleteObjectFromExpiration += 1;
+        return new MockRequestAPI(this.response.error, this.response.data);
+    }
+
+    setResponse(error, data) {
+        this.response = { error, data };
     }
 
     batchDelete(params, cb) {

--- a/tests/utils/BackbeatClientMock.js
+++ b/tests/utils/BackbeatClientMock.js
@@ -1,0 +1,67 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+const { errors } = require('arsenal');
+
+class BackbeatClientMock {
+    constructor(failures) {
+        this.failures = failures;
+
+        this.calls = {};
+        this.stubMethod('deleteObjectFromExpiration', {});
+    }
+
+    makeRetryableError() {
+        const err = errors.ServiceUnavailable.customizeDescription('failing on purpose');
+        err.retryable = true;
+        return err;
+    }
+
+    stubMethod(methodName, successResult, stubError) {
+        this.calls[methodName] = 0;
+
+        this[methodName] = (params, done) => {
+            this.calls[methodName]++;
+
+            if (this.failures[methodName] >= this.calls[methodName]) {
+                const error = stubError || this.makeRetryableError();
+
+                if (done) {
+                    return process.nextTick(done, error);
+                }
+
+                return {
+                    send: cb => process.nextTick(cb, error),
+                    on: () => {},
+                };
+            }
+
+            if (done) {
+                return process.nextTick(done, null, successResult);
+            }
+
+            return {
+                send: cb => process.nextTick(cb, null, successResult),
+                on: () => {},
+            };
+        };
+    }
+
+    verifyRetries() {
+        Object.keys(this.failures).forEach(f => {
+            assert.strictEqual(this.calls[f], this.failures[f] + 1,
+                `did not retry ${this.failures[f]} times`);
+        });
+    }
+
+    verifyNoRetries() {
+        Object.keys(this.failures).forEach(f => {
+            assert.strictEqual(this.calls[f], 1,
+                `called ${this.calls[f]} times, expected 1`);
+        });
+    }
+}
+
+module.exports = {
+    BackbeatClientMock,
+};


### PR DESCRIPTION
Add new aws route to internal cloudserver to delete an object from lifecycle expiration

This route is used in cloudserver to raise the correct event notification

- [x] when listing is fixed with version suspended, test that this is raising the right event and not multiple ones as it does actually

ISSUE: BB-375