### PR TITLE
BB-365: operator management: update isTransient config list

### DIFF
--- a/lib/management/operatorBackend.js
+++ b/lib/management/operatorBackend.js
@@ -78,6 +78,11 @@ function initManagement(params, done) {
         }));
     const locations = require('../../conf/locationConfig.json') || {};
 
+    Object.keys(locations).forEach(locName => {
+        config.setIsTransientLocation(
+            locName, locations[locName].isTransient);
+    });
+
     const ingestionEnabled = params.enableIngestionUpdates;
     if (ingestionEnabled) {
         return periodicallyUpdateIngestionBuckets(locations, logger, done);


### PR DESCRIPTION
addresses issue in which operator management backend does not populate the transient list, resulting in transient check failing for replication/garbage collection.