### PR TITLE
BB-380 Add excluded-data-store-name listing parameter

### DIFF
--- a/extensions/lifecycle/tasks/LifecycleTaskV2.js
+++ b/extensions/lifecycle/tasks/LifecycleTaskV2.js
@@ -52,12 +52,15 @@ class LifecycleTaskV2 extends LifecycleTask {
     _handleRemainingListings(remainings, bucketData, log) {
         if (remainings && remainings.length) {
             remainings.forEach(l => {
-                const prefix = l.prefix;
-                const listType = l.listType;
-                const beforeDate = l.beforeDate;
+                const {
+                    prefix,
+                    listType,
+                    beforeDate,
+                    storageClass,
+                } = l;
 
                 const entry = Object.assign({}, bucketData, {
-                    details: { beforeDate, prefix, listType },
+                    details: { beforeDate, prefix, listType, storageClass },
                 });
 
                 this._sendBucketEntry(entry, err => {
@@ -115,8 +118,9 @@ class LifecycleTaskV2 extends LifecycleTask {
                     details: {
                         beforeDate: params.BeforeDate,
                         prefix: params.Prefix,
+                        storageClass: params.ExcludedDataStoreName,
                         listType,
-                        ...markerInfo,
+                        ...markerInfo
                     },
                 });
 
@@ -178,6 +182,7 @@ class LifecycleTaskV2 extends LifecycleTask {
                     details: {
                         beforeDate: params.BeforeDate,
                         prefix: params.Prefix,
+                        storageClass: params.ExcludedDataStoreName,
                         listType,
                         ...markerInfo,
                     },

--- a/extensions/lifecycle/util/RulesReducer.js
+++ b/extensions/lifecycle/util/RulesReducer.js
@@ -214,7 +214,7 @@ class RulesReducer {
             }
 
             // NOTE: Our implementation (AWS compatible) requires a distinct 'StorageClass' for
-            // 'NoncurrentVersionTransition' actions within the same 'Rule'.
+            // 'NoncurrentVersionTransitions' actions within the same 'Rule'.
             // This means that if a rule contains multiple actions,
             // each action must have a different 'StorageClass'.
             if (r.NoncurrentVersionTransitions.length === 1) {

--- a/extensions/lifecycle/util/rules.js
+++ b/extensions/lifecycle/util/rules.js
@@ -15,8 +15,13 @@ function _makeListParams(listType, currentDate, listing) {
         prefix: listing.prefix,
         listType,
     };
+
     if (listing.days > 0) {
         p.beforeDate = _getBeforeDate(currentDate, listing.days);
+    }
+
+    if (listing.storageClass) {
+        p.storageClass = listing.storageClass;
     }
 
     return p;
@@ -57,7 +62,7 @@ function _getParamsFromListings(bucketName, currentDate, listings) {
 
     if (listingsParams.length > 0) {
         const firstParams = listingsParams[0];
-        const { prefix, beforeDate } = firstParams;
+        const { prefix, beforeDate, storageClass } = firstParams;
         listType = firstParams.listType;
         params = {
             Bucket: bucketName,
@@ -67,6 +72,10 @@ function _getParamsFromListings(bucketName, currentDate, listings) {
 
         if (beforeDate) {
             params.BeforeDate = beforeDate;
+        }
+
+        if (storageClass) {
+            params.ExcludedDataStoreName = storageClass;
         }
 
         listingsParams.shift(); // remove the first element
@@ -88,7 +97,7 @@ function _getParamsFromListings(bucketName, currentDate, listings) {
  * @return {Object} info - listing informations { params, listType, remainings }
  */
 function _getParamsFromDetails(bucketName, details) {
-    const { prefix, beforeDate, listType } = details;
+    const { prefix, beforeDate, listType, storageClass } = details;
     // if listType is invalid, do not list.
     if (![CURRENT_TYPE, NON_CURRENT_TYPE, ORPHAN_DM_TYPE].includes(listType)) {
         return {};
@@ -111,6 +120,10 @@ function _getParamsFromDetails(bucketName, details) {
 
     if (beforeDate) {
         params.BeforeDate = beforeDate;
+    }
+
+    if (storageClass) {
+        params.ExcludedDataStoreName = storageClass;
     }
 
     return { params, listType, remainings: [] };

--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -1255,6 +1255,9 @@
         "ETag": {
             "type": "string"
         },
+        "ExcludedDataStoreName": {
+            "type": "string"
+        },
         "Marker": {
             "type": "string"
         },
@@ -1290,6 +1293,12 @@
                 "documentation": "<p>Limit the response to keys modified prior to before date.</p>",
                 "location": "querystring",
                 "locationName": "before-date"
+              },
+              "ExcludedDataStoreName": {
+                "shape": "ExcludedDataStoreName",
+                "documentation": "<p>Limit the response to only include keys that are stored outside of the ExcludedDataStoreName. Used for lifecycle transition rule.</p>",
+                "location": "querystring",
+                "locationName": "excluded-data-store-name"
               },
               "EncodingType": {
                 "shape": "EncodingType",
@@ -1387,6 +1396,12 @@
                 "documentation": "<p>Limit the response to keys modified prior to before date.</p>",
                 "location": "querystring",
                 "locationName": "before-date"
+              },
+              "ExcludedDataStoreName": {
+                "shape": "ExcludedDataStoreName",
+                "documentation": "<p>Limit the response to only include keys that are stored outside of the ExcludedDataStoreName. Used for lifecycle transition rule.</p>",
+                "location": "querystring",
+                "locationName": "excluded-data-store-name"
               },
               "EncodingType": {
                 "shape": "EncodingType",

--- a/tests/functional/lifecycle/LifecycleTaskV2-versioned.js
+++ b/tests/functional/lifecycle/LifecycleTaskV2-versioned.js
@@ -623,7 +623,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
         });
     });
 
-    it('should publish one bucket entry if listing keys to be transitioned  is trucated', done => {
+    it('should publish one bucket entry if listing keys to be transitioned is truncated', done => {
         const transitionRule = [
             {
                 NoncurrentVersionTransitions: [{ NoncurrentDays: 2, StorageClass: destinationLocation }],

--- a/tests/functional/lifecycle/LifecycleTaskV2.js
+++ b/tests/functional/lifecycle/LifecycleTaskV2.js
@@ -233,7 +233,10 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
             // test parameters used to list lifecycle keys
             const { listLifecycleParams } = backbeatMetadataProxy;
-            expectNominalListingParams(bucketName, listLifecycleParams);
+            assert.strictEqual(listLifecycleParams.Bucket, bucketName);
+            assert.strictEqual(listLifecycleParams.Prefix, '');
+            assert.strictEqual(listLifecycleParams.ExcludedDataStoreName, destinationLocation);
+            assert(!!listLifecycleParams.BeforeDate);
             return done();
         });
     });
@@ -252,6 +255,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
             listType: 'current',
             prefix,
             beforeDate,
+            storageClass: destinationLocation,
         } };
 
         const nbRetries = 0;
@@ -267,6 +271,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
             assert.strictEqual(listLifecycleParams.Prefix, prefix);
             assert.strictEqual(listLifecycleParams.BeforeDate, beforeDate);
             assert.strictEqual(listLifecycleParams.Marker, 'key0');
+            assert.strictEqual(listLifecycleParams.ExcludedDataStoreName, destinationLocation);
 
             // test that the entry is valid and pushed to kafka topic
             assert.strictEqual(kafkaEntries.length, 1);
@@ -410,7 +415,10 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
             // test parameters used to list lifecycle keys
             const { listLifecycleParams } = backbeatMetadataProxy;
-            expectNominalListingParams(bucketName, listLifecycleParams);
+            assert.strictEqual(listLifecycleParams.Bucket, bucketName);
+            assert.strictEqual(listLifecycleParams.Prefix, '');
+            assert.strictEqual(listLifecycleParams.ExcludedDataStoreName, destinationLocation);
+            assert(!!listLifecycleParams.BeforeDate);
 
             // test that the entry is valid and pushed to kafka topic
             assert.strictEqual(kafkaEntries.length, 1);
@@ -451,7 +459,10 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
             // test parameters used to list lifecycle keys
             const { listLifecycleParams } = backbeatMetadataProxy;
-            expectNominalListingParams(bucketName, listLifecycleParams);
+            assert.strictEqual(listLifecycleParams.Bucket, bucketName);
+            assert.strictEqual(listLifecycleParams.Prefix, '');
+            assert.strictEqual(listLifecycleParams.ExcludedDataStoreName, destinationLocation);
+            assert(!!listLifecycleParams.BeforeDate);
 
             // test that the entry is valid and pushed to kafka topic
             assert.strictEqual(kafkaEntries.length, 0);
@@ -485,6 +496,49 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
                 marker: keyName,
                 prefix: '',
                 listType: 'current',
+            });
+            return done();
+        });
+    });
+
+    it('should publish one bucket entry if listing keys to be transitioned is trucated', done => {
+        const transitionRule = [
+            {
+                Transitions: [{ Days: 2, StorageClass: destinationLocation }],
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            }
+        ];
+        const keyName = 'key1';
+        const key = keyMock.current({ keyName, daysEarlier: 0 });
+        const contents = [key];
+        backbeatMetadataProxy.listLifecycleResponse =
+            { contents, isTruncated: true, markerInfo: { marker: keyName } };
+
+        const nbRetries = 0;
+        return lifecycleTask.processBucketEntry(transitionRule, bucketData, s3,
+        backbeatMetadataProxy, nbRetries, err => {
+            assert.ifError(err);
+            // test that the current listing is triggered
+            assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'current');
+
+            // test parameters used to list lifecycle keys
+            const { listLifecycleParams } = backbeatMetadataProxy;
+            assert.strictEqual(listLifecycleParams.Bucket, bucketName);
+            assert.strictEqual(listLifecycleParams.Prefix, '');
+            assert.strictEqual(listLifecycleParams.ExcludedDataStoreName, destinationLocation);
+            assert(!!listLifecycleParams.BeforeDate);
+
+            // test that the entry is valid and pushed to kafka topic
+            assert.strictEqual(kafkaEntries.length, 1);
+            const firstEntry = kafkaEntries[0];
+            testKafkaEntry.expectBucketEntry(firstEntry, {
+                hasBeforeDate: true,
+                marker: keyName,
+                prefix: '',
+                listType: 'current',
+                storageClass: destinationLocation,
             });
             return done();
         });
@@ -588,6 +642,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
                 listType: 'current',
                 hasBeforeDate: true,
                 prefix: 'pre2',
+                storageClass: destinationLocation,
             });
             return done();
         });

--- a/tests/functional/lifecycle/LifecycleTaskV2.js
+++ b/tests/functional/lifecycle/LifecycleTaskV2.js
@@ -501,7 +501,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
         });
     });
 
-    it('should publish one bucket entry if listing keys to be transitioned is trucated', done => {
+    it('should publish one bucket entry if listing keys to be transitioned is truncated', done => {
         const transitionRule = [
             {
                 Transitions: [{ Days: 2, StorageClass: destinationLocation }],

--- a/tests/functional/lifecycle/utils.js
+++ b/tests/functional/lifecycle/utils.js
@@ -99,7 +99,16 @@ class TestKafkaEntry {
         assert.strictEqual(message.resultsTopic, this.objectTopic);
     }
 
-    expectBucketEntry(e, { listType, hasBeforeDate, prefix, marker, keyMarker, versionIdMarker, uploadIdMarker }) {
+    expectBucketEntry(e, {
+        listType,
+        hasBeforeDate,
+        prefix,
+        marker,
+        keyMarker,
+        versionIdMarker,
+        uploadIdMarker,
+        storageClass,
+    }) {
         assert(e);
         assert.strictEqual(e.topicName, this.bucketTopic);
         assert.strictEqual(e.entry.length, 1);
@@ -120,6 +129,7 @@ class TestKafkaEntry {
         assert.strictEqual(details.versionIdMarker, versionIdMarker);
         assert.strictEqual(details.uploadIdMarker, uploadIdMarker);
         assert.strictEqual(details.listType, listType);
+        assert.strictEqual(details.storageClass, storageClass);
     }
 }
 
@@ -229,6 +239,7 @@ function expectNominalListingParams(bucketName, params) {
     assert.strictEqual(params.Bucket, bucketName);
     assert.strictEqual(params.Prefix, '');
     assert(!!params.BeforeDate);
+    assert(!params.ExcludedDataStoreName);
 }
 
 module.exports = {

--- a/tests/unit/lifecycle/RulesReducer.spec.js
+++ b/tests/unit/lifecycle/RulesReducer.spec.js
@@ -233,6 +233,7 @@ describe('RulesReducer with versioning Disabled', () => {
             currents: [{
                 prefix: '',
                 days: 0,
+                storageClass: locationName,
             }]
         };
         const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
@@ -362,6 +363,35 @@ describe('RulesReducer with versioning Disabled', () => {
             currents: [{
                 prefix: 'toto',
                 days: 1,
+                storageClass: locationName,
+            }]
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with multiple Transition rules that share prefix but not the same StorageClass', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Transitions: [{ Days: 1, StorageClass: locationName }],
+                ID: '123',
+                Prefix: 'toto/titi',
+                Status: 'Enabled',
+            },
+            {
+                Transitions: [{ Days: 2, StorageClass: locationName2 }],
+                ID: '456',
+                Prefix: 'toto',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{
+                prefix: 'toto',
+                days: 1,
             }]
         };
         const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
@@ -421,9 +451,11 @@ describe('RulesReducer with versioning Disabled', () => {
             currents: [{
                 prefix: 'titi',
                 days: 1,
+                storageClass: locationName,
             }, {
                 prefix: 'toto',
                 days: 0,
+                storageClass: locationName2,
             }]
         };
         const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
@@ -483,6 +515,7 @@ describe('RulesReducer with versioning Disabled', () => {
             }, {
                 prefix: 'toto',
                 days: 0,
+                storageClass: locationName2,
             }]
         };
         const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
@@ -558,7 +591,7 @@ describe('RulesReducer with versioning Disabled', () => {
         const expected = {
             currents: [
                 { prefix: 'a', days: 10 },
-                { prefix: 'b', days: 0 },
+                { prefix: 'b', days: 0, storageClass: locationName2 },
                 { prefix: 'c', days: 0 },
                 { prefix: 'd', days: 2 },
             ]
@@ -596,6 +629,7 @@ describe('RulesReducer with versioning Disabled', () => {
             }, {
                 prefix: 'toto',
                 days: 1,
+                storageClass: locationName2,
             }]
         };
         const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, customOptions);
@@ -631,6 +665,7 @@ describe('RulesReducer with versioning Disabled', () => {
             }, {
                 prefix: 'toto',
                 days: 0,
+                storageClass: locationName2,
             }]
         };
         const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, customOptions);
@@ -666,6 +701,7 @@ describe('RulesReducer with versioning Disabled', () => {
             }, {
                 prefix: 'toto',
                 days: 0,
+                storageClass: locationName2,
             }]
         };
         const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, customOptions);


### PR DESCRIPTION
If transition rules are configured with a shared storage class and prefix, Backbeat Lifecycle Bucket Processor will exclude keys that have already been transitioned (i.e stored in the (shared) storage class).

Backbeat Lifecycle Bucket Processor uses the lifecycle listing APIs with the `excluded-data-store-name` parameter to filter out keys that have already been transitioned.