### PR TITLE
Use resumeAfter to resume changestream on 4.0

### DIFF
--- a/extensions/oplogPopulator/OplogPopulator.js
+++ b/extensions/oplogPopulator/OplogPopulator.js
@@ -1,8 +1,9 @@
 const joi = require('joi');
+const semver = require('semver');
 const { errors } = require('arsenal');
 const { MongoClient } = require('mongodb');
 const constants = require('./constants');
-const { constructConnectionString } = require('../utils/MongoUtils');
+const { constructConnectionString, getMongoVersion } = require('../utils/MongoUtils');
 const ChangeStream = require('../../lib/wrappers/ChangeStream');
 const Allocator = require('./modules/Allocator');
 const ConnectorsManager = require('./modules/ConnectorsManager');
@@ -31,7 +32,7 @@ class OplogPopulator {
      * @param {Object} params.config - oplog populator config
      * @param {Object} params.mongoConfig - mongo connection config
      * @param {Object} params.mongoConfig.authCredentials - mongo auth credentials
-     * @param {Object} params.mongoConfig.replicaSetHosts - mongo creplication hosts
+     * @param {Object} params.mongoConfig.replicaSetHosts - mongo replication hosts
      * @param {Object} params.mongoConfig.writeConcern - mongo write concern
      * @param {Object} params.mongoConfig.replicaSet - mongo replica set
      * @param {Object} params.mongoConfig.readPreference - mongo read preference
@@ -54,6 +55,7 @@ class OplogPopulator {
         // MongoDB related
         this._mongoClient = null;
         this._metastore = null;
+        this._mongoVersion = null;
         // setup mongo connection data
         this._mongoUrl = constructConnectionString(this._mongoConfig);
         this._replicaSet = this._mongoConfig.replicaSet;
@@ -87,6 +89,8 @@ class OplogPopulator {
             this._logger.info('Connected to MongoDB', {
                 method: 'OplogPopulator._setupMongoClient',
             });
+            // get mongodb version
+            this._mongoVersion = await getMongoVersion(this._mongoClient);
             return undefined;
         } catch (err) {
             this._logger.error('Could not connect to MongoDB', {
@@ -231,6 +235,7 @@ class OplogPopulator {
             pipeline: changeStreamPipeline,
             handler: this._handleChangeStreamChangeEvent.bind(this),
             throwOnError: false,
+            useStartAfter: semver.gte(this._mongoVersion, '4.2.0'),
         });
         // start watching metastore
         this._changeStreamWrapper.start();

--- a/extensions/utils/MongoUtils.js
+++ b/extensions/utils/MongoUtils.js
@@ -1,3 +1,5 @@
+const util = require('util');
+
 /**
  * Constructs mongo connection config
  * @param {Object} mongoConfig mongo connection config
@@ -29,6 +31,28 @@ function constructConnectionString(mongoConfig) {
     return url;
 }
 
+
+/**
+ * returns mongo version
+ * @param {MongoClient} client mongo client
+ * @param {Function} [callback] callback function
+ * @returns {string|undefined} mongo version or
+ * undefined if using the callback function
+ */
+async function getMongoVersion(client, callback) {
+    async function getVersion() {
+        const res = await client.command({
+            buildInfo: 1,
+        });
+        return res.version;
+    }
+    if (callback) {
+        return util.callbackify(getVersion)(callback);
+    }
+    return getVersion();
+}
+
 module.exports = {
-    constructConnectionString
+    constructConnectionString,
+    getMongoVersion,
 };

--- a/lib/wrappers/ChangeStream.js
+++ b/lib/wrappers/ChangeStream.js
@@ -7,6 +7,7 @@ const paramsJoi = joi.object({
     handler: joi.function().required(),
     pipeline: joi.array().required(),
     throwOnError: joi.boolean().required(),
+    useStartAfter: joi.boolean().default(false),
 }).required();
 
 /**
@@ -24,6 +25,7 @@ class ChangeStream {
      * @param {Object[]} params.pipeline change stream pipeline
      * @param {Function} params.handler change event handler function
      * @param {Boolean} params.throwOnError throw error if got change stream error event
+     * @param {string} params.useStartAfter use `startAfter` (mongo 4.2+) or `resumeAfter` after error
      */
     constructor(params) {
         joi.attempt(params, paramsJoi);
@@ -34,6 +36,7 @@ class ChangeStream {
         this._throwOnError = params.throwOnError;
         this._resumeToken = null;
         this._changeStream = null;
+        this._resumeField = params.useStartAfter ? 'startAfter' : 'resumeAfter';
     }
 
     /**
@@ -68,7 +71,7 @@ class ChangeStream {
     start() {
         const changeStreamParams = { fullDocument: 'updateLookup' };
         if (this._resumeToken) {
-            changeStreamParams.startAfter = this._resumeToken;
+            changeStreamParams[this._resumeField] = this._resumeToken;
         }
         try {
             this._changeStream = this._collection.watch(this._pipeline, changeStreamParams);

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "node-rdkafka": "^2.12.0",
     "node-schedule": "^1.2.0",
     "node-zookeeper-client": "^1.1.3",
+    "semver": "^5.6.0",
     "typescript": "^4.9.5",
     "uuid": "^3.1.0",
     "vaultclient": "scality/vaultclient#8.3.11",

--- a/tests/unit/lib/wrappers/ChangeStream.js
+++ b/tests/unit/lib/wrappers/ChangeStream.js
@@ -21,6 +21,7 @@ describe('ChangeStream', () => {
             handler: () => {},
             pipeline: [],
             throwOnError: false,
+            useStartAfter: false,
         });
     });
 
@@ -172,15 +173,41 @@ describe('ChangeStream', () => {
             });
         });
 
-        it('Should resume change stream using resumeToken', done => {
+        it('should use startAfter to resume change stream', done => {
             const watchStub = sinon.stub().returns(new events.EventEmitter());
-            wrapper._collection = {
-                watch: watchStub,
-            };
+            const wrapper = new ChangeStream({
+                logger,
+                collection: {
+                    watch: watchStub,
+                },
+                handler: () => { },
+                pipeline: [],
+                throwOnError: false,
+                useStartAfter: true,
+            });
+            assert.equal(wrapper._resumeField, 'startAfter');
             wrapper._resumeToken = '1234';
             const changeStreamParams = {
                 fullDocument: 'updateLookup',
                 startAfter: '1234',
+            };
+            assert.doesNotThrow(() => {
+                wrapper.start();
+                assert(watchStub.calledOnceWith([], changeStreamParams));
+                return done();
+            });
+        });
+
+        it('should resume change stream using resumeToken', done => {
+            const watchStub = sinon.stub().returns(new events.EventEmitter());
+            wrapper._collection = {
+                watch: watchStub,
+            };
+            assert.equal(wrapper._resumeField, 'resumeAfter');
+            wrapper._resumeToken = '1234';
+            const changeStreamParams = {
+                fullDocument: 'updateLookup',
+                resumeAfter: '1234',
             };
             assert.doesNotThrow(() => {
                 wrapper.start();

--- a/tests/unit/utils/MongoUtils.js
+++ b/tests/unit/utils/MongoUtils.js
@@ -41,3 +41,24 @@ describe('constructConnectionString', () => {
         return done();
     });
 });
+
+describe('getMongoVersion', () => {
+    const client = {
+        command: () => ({
+            version: '4.2.0',
+        }),
+    };
+
+    it('Should return mongo version in the passed callback', done => {
+        MongoUtils.getMongoVersion(client, (err, version) => {
+            assert.ifError(err);
+            assert.strictEqual(version, '4.2.0');
+            done();
+        });
+    });
+
+    it('Should return mongo version as a return value', async () => {
+        const version = await MongoUtils.getMongoVersion(client);
+        assert.strictEqual(version, '4.2.0');
+    });
+});


### PR DESCRIPTION
On 4.2, we should use `startAfter` parameter to resume the change stream.
However, this is not available on 4.0, so we must use `resumeAfter`
instead.

Changes:
- Use `resumeAfter` or `startAfter` depending on mongo version
- Use Change Steam wrapper in notification config manager to avoid duplicate logic

Issue: BB-386
