### PR TITLE
BB-387: add lifeycle bucket checks before index checks

### DIFF
--- a/extensions/lifecycle/conductor/LifecycleConductor.js
+++ b/extensions/lifecycle/conductor/LifecycleConductor.js
@@ -192,7 +192,7 @@ class LifecycleConductor {
     }
 
     _indexesGetOrCreate(task, log, cb) {
-        if (this._bucketSource !== 'mongodb') {
+        if (this._bucketSource !== 'mongodb' || !task.isLifecycled) {
             return process.nextTick(cb, null, lifecycleTaskVersions.v1);
         }
 
@@ -552,7 +552,7 @@ class LifecycleConductor {
                     .find(
                         entry ? { _id: { $gt: entry } } : {}
                     )
-                    .project({ '_id': 1, 'value.owner': 1 });
+                    .project({ '_id': 1, 'value.owner': 1, 'value.lifecycleConfiguration': 1 });
 
                 return done(null, cursor);
             },
@@ -589,6 +589,7 @@ class LifecycleConductor {
                                     queue.push({
                                         bucketName: name,
                                         canonicalId: doc.value.owner,
+                                        isLifecycled: !!doc.value.lifecycleConfiguration,
                                     });
                                     nEnqueued += 1;
                                     lastSentId = doc._id;

--- a/tests/unit/lifecycle/LifecycleConductor.spec.js
+++ b/tests/unit/lifecycle/LifecycleConductor.spec.js
@@ -22,6 +22,7 @@ const { BackbeatMetadataProxyMock } = require('../mocks');
 const testTask = {
     bucketName: 'testbucket',
     canonicalId: 'testid',
+    isLifecycled: true,
 };
 
 describe('Lifecycle Conductor', () => {
@@ -59,6 +60,15 @@ describe('Lifecycle Conductor', () => {
             });
         });
 
+        it('should return v1 for non-lifecyled buckets', () => {
+            conductor._bucketSource = 'mongodb';
+            const task = Object.assign({}, testTask, { isLifecyled: false });
+            conductor._indexesGetOrCreate(task, log, (err, taskVersion) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(taskVersion, lifecycleTaskVersions.v1);
+            });
+        });
+
         it('should return v1 if backbeat client cannot be created', () => {
             conductor.clientManager.getBackbeatMetadataProxy = () => null;
             conductor._indexesGetOrCreate(testTask, log, (err, taskVersion) => {
@@ -76,9 +86,9 @@ describe('Lifecycle Conductor', () => {
                     null, // metadata proxy error
                 ],
                 [
-                    [], // upated job state
+                    [], // updated job state
                     null, // expected putIndex object
-                    lifecycleTaskVersions.v2, // expcted version
+                    lifecycleTaskVersions.v2, // expected version
                 ],
             ],
             [


### PR DESCRIPTION
check that bucket has lifecycle enabled before applying lifecycle optimization indexes