### PR TITLE
BB-392 : Run transition when expiration rules are also defined for the bucket

### DIFF
--- a/.github/workflows/alerts.yaml
+++ b/.github/workflows/alerts.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Render and test lifecycle 
         uses: scality/action-prom-render-test@1.0.2

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Docker Buildk
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to Registry
         uses: docker/login-action@v1
@@ -29,7 +29,7 @@ jobs:
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,5 +1,6 @@
 ---
 name: release
+run-name: release ${{ inputs.tag }}
 
 on:
   workflow_dispatch:
@@ -17,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # TODO: remove the following step once Oras CLI 0.13.0 bug https://github.com/oras-project/oras/issues/447 is fixed.
       - name: Downgrade Oras to 0.12.0
@@ -29,7 +30,7 @@ jobs:
           rm -rf oras_0.12.0_*.tar.gz oras-install/
 
       - name: Set up Docker Buildk
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to Registry
         uses: docker/login-action@v1
@@ -69,7 +70,7 @@ jobs:
             policies/queue_populator_policy.json:application/vnd.iam-policy+json
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -19,10 +19,10 @@ jobs:
       packages: write
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Docker Buildk
-      uses: docker/setup-buildx-action@v1
+      uses: docker/setup-buildx-action@v2
       with:
         buildkitd-flags: --debug
 
@@ -34,7 +34,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push kafka
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v4
       with:
         push: true
         context: .github/dockerfiles/kafka
@@ -43,7 +43,7 @@ jobs:
         cache-to: type=gha,mode=max
 
     - name: Build and push syntheticbucketd
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v4
       with:
         push: true
         context: .
@@ -92,12 +92,12 @@ jobs:
         - 27019:27019
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Install build dependencies
       run: |
         sudo apt-get update
         sudo apt-get install -y build-essential libzstd-dev
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v4
       with:
         go-version: '1.16.2'
     - uses: actions/setup-node@v2

--- a/extensions/lifecycle/tasks/LifecycleTaskV2.js
+++ b/extensions/lifecycle/tasks/LifecycleTaskV2.js
@@ -288,10 +288,8 @@ class LifecycleTaskV2 extends LifecycleTask {
      * @return {undefined}
      */
     _compareCurrent(bucketData, obj, rules, log, cb) {
-        if (rules.Expiration) {
-            this._checkAndApplyExpirationRule(bucketData, obj, rules,
-                log);
-
+        if (rules.Expiration &&
+            this._checkAndApplyExpirationRule(bucketData, obj, rules, log)) {
             return process.nextTick(cb);
         }
         if (rules.Transition) {
@@ -333,8 +331,8 @@ class LifecycleTaskV2 extends LifecycleTask {
             return process.nextTick(() => cb(errors.InternalError.customizeDescription(errMsg)));
         }
 
-        if (rules.NoncurrentVersionExpiration) {
-            this._checkAndApplyNCVExpirationRule(bucketData, obj, rules, log);
+        if (rules.NoncurrentVersionExpiration &&
+            this._checkAndApplyNCVExpirationRule(bucketData, obj, rules, log)) {
             return process.nextTick(cb);
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "8.6.15",
+  "version": "8.6.17",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixed transition getting skipped when an expiration rule was defined for the same bucket even when not applied.

Issue: BB-392