### PR TITLE
BB-399: make initial ingestion scan take into consideration the location status

### DIFF
--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -749,29 +749,47 @@ class IngestionPopulator {
         return false;
     }
 
+    _processLogReaderEntries(logReader, params, cb) {
+        // skipping if previous batch still in progress
+        if (logReader.isBatchInProgress()) {
+            this.log.debug('ingestion batch still in progress, skipping', {
+                zenkoBucket: logReader.getTargetZenkoBucketName(),
+                location: logReader.getLocationConstraint(),
+            });
+            return cb();
+        }
+        // skipping if location is paused
+        if (this._pausedLocations[logReader.getLocationConstraint()] !== undefined) {
+            this.log.debug('location paused, skipping', {
+                zenkoBucket: logReader.getTargetZenkoBucketName(),
+                location: logReader.getLocationConstraint(),
+            });
+            return cb();
+        }
+        return logReader.processLogEntries(params, (error, hasMoreLog) => {
+            if (error) {
+                this.log.warn('error processing log entries', {
+                    error,
+                    zenkoBucket: logReader.getTargetZenkoBucketName(),
+                    location: logReader.getLocationConstraint(),
+                });
+            }
+            if (hasMoreLog) {
+                // keep ingesting new logs without waiting to converge faster
+                // in the initial bucket scan
+                return this._processLogReaderEntries(logReader, params, cb);
+            }
+            // do not escalate error to avoid crashing pod
+            // instead retry on next cron
+            return cb();
+        });
+    }
+
     _processLogEntries(params, done) {
         const { maxParallelReaders } = this.ingestionConfig;
         return async.eachLimit(this.logReaders, maxParallelReaders,
             (logReader, cb) => {
-                if (logReader.isBatchInProgress()) {
-                    this.log.debug('ingestion batch still in progress', {
-                        zenkoBucket: logReader.getTargetZenkoBucketName(),
-                        location: logReader.getLocationConstraint(),
-                    });
-                    return cb();
-                }
-                return logReader.processLogEntries(params, error => {
-                    if (error) {
-                        this.log.warn('error processing log entries', {
-                            error,
-                            zenkoBucket: logReader.getTargetZenkoBucketName(),
-                            location: logReader.getLocationConstraint(),
-                        });
-                    }
-                    // do not escalate error to avoid crashing pod
-                    // instead retry on next cron
-                    return cb();
-                });
+                this._processLogReaderEntries(logReader, params, cb);
             }, done);
     }
 

--- a/lib/queuePopulator/IngestionReader.js
+++ b/lib/queuePopulator/IngestionReader.js
@@ -190,11 +190,7 @@ class IngestionReader extends LogReader {
             if (err) {
                 return done(err);
             }
-            if (hasMoreLog) {
-                // keep ingesting new log without waiting
-                return this.processLogEntries(params, done);
-            }
-            return done();
+            return done(null, hasMoreLog);
         });
     }
 


### PR DESCRIPTION
The initial bucket scan doesn't respect the cron rule as we continuously list the objects to converge faster, the listing is done in a single `_processLogEntries` call which makes it ignore the location status (paused, resumed).

Issue: BB-399