### PR TITLE
Set 'null' as version id when replicating non versioned objects

### DIFF
--- a/extensions/replication/tasks/MultipleBackendTask.js
+++ b/extensions/replication/tasks/MultipleBackendTask.js
@@ -200,7 +200,7 @@ class MultipleBackendTask extends ReplicateObject {
             }
         }
 
-        this.retry({
+        return this.retry({
             actionDesc: 'stream part data',
             logFields: { entry: sourceEntry.getLogInfo(), range },
             actionFunc: done => this._getRangeAndPutMPUPartOnce(sourceEntry,
@@ -949,7 +949,7 @@ class MultipleBackendTask extends ReplicateObject {
             }
         }
 
-        this.retry({
+        return this.retry({
             actionDesc: 'send object tagging XML data',
             entry: sourceEntry,
             logFields: { entry: sourceEntry.getLogInfo() },
@@ -1004,7 +1004,7 @@ class MultipleBackendTask extends ReplicateObject {
             }
         }
 
-        this.retry({
+        return this.retry({
             actionDesc: 'delete object tagging',
             logFields: { entry: sourceEntry.getLogInfo() },
             actionFunc: done => this._deleteObjectTaggingOnce(sourceEntry,
@@ -1057,7 +1057,7 @@ class MultipleBackendTask extends ReplicateObject {
             }
         }
 
-        this.retry({
+        return this.retry({
             actionDesc: 'put delete marker',
             logFields: { entry: sourceEntry.getLogInfo() },
             actionFunc: done => this._putDeleteMarkerOnce(

--- a/extensions/replication/tasks/MultipleBackendTask.js
+++ b/extensions/replication/tasks/MultipleBackendTask.js
@@ -126,7 +126,7 @@ class MultipleBackendTask extends ReplicateObject {
         const params = {
             bucket: sourceEntry.getBucket(),
             objectKey: sourceEntry.getObjectKey(),
-            versionId: sourceEntry.getEncodedVersionId(),
+            versionId: sourceEntry.getEncodedVersionId() || 'null',
         };
         return this.backbeatSourceProxy.getMetadata(
         params, log, (err, blob) => {
@@ -236,7 +236,7 @@ class MultipleBackendTask extends ReplicateObject {
             sourceReq = this.backbeatSource.getObject({
                 Bucket: sourceEntry.getBucket(),
                 Key: sourceEntry.getObjectKey(),
-                VersionId: sourceEntry.getEncodedVersionId(),
+                VersionId: sourceEntry.getEncodedVersionId() || 'null',
                 // A 0-byte part has no range.
                 Range: range && `bytes=${range.start}-${range.end}`,
                 LocationConstraint: sourceEntry.getDataStoreName(),
@@ -319,7 +319,7 @@ class MultipleBackendTask extends ReplicateObject {
             Key: sourceEntry.getObjectKey(),
             StorageType: sourceEntry.getReplicationStorageType(),
             StorageClass: this.site,
-            VersionId: sourceEntry.getEncodedVersionId(),
+            VersionId: sourceEntry.getEncodedVersionId() || 'null',
             UserMetaData: sourceEntry.getUserMetadata(),
             ContentType: sourceEntry.getContentType(),
             CacheControl: sourceEntry.getCacheControl() || undefined,
@@ -479,7 +479,7 @@ class MultipleBackendTask extends ReplicateObject {
             Key: sourceEntry.getObjectKey(),
             StorageType: sourceEntry.getReplicationStorageType(),
             StorageClass: this.site,
-            VersionId: sourceEntry.getEncodedVersionId(),
+            VersionId: sourceEntry.getEncodedVersionId() || 'null',
             UserMetaData: sourceEntry.getUserMetadata(),
             ContentType: sourceEntry.getContentType(),
             CacheControl: sourceEntry.getCacheControl() || undefined,
@@ -745,7 +745,7 @@ class MultipleBackendTask extends ReplicateObject {
             sourceReq = this.backbeatSource.getObject({
                 Bucket: sourceEntry.getBucket(),
                 Key: sourceEntry.getObjectKey(),
-                VersionId: sourceEntry.getEncodedVersionId(),
+                VersionId: sourceEntry.getEncodedVersionId() || 'null',
                 LocationConstraint: sourceEntry.getDataStoreName(),
             });
             attachReqUids(sourceReq, log);
@@ -877,7 +877,7 @@ class MultipleBackendTask extends ReplicateObject {
         this.backbeatSourceProxy.getMetadata({
             bucket: sourceEntry.getBucket(),
             objectKey: sourceEntry.getObjectKey(),
-            versionId: sourceEntry.getEncodedVersionId(),
+            versionId: sourceEntry.getEncodedVersionId() || 'null',
         }, log, cb);
     }
 
@@ -900,7 +900,7 @@ class MultipleBackendTask extends ReplicateObject {
             ContentMD5: sourceEntry.getContentMd5(),
             StorageType: sourceEntry.getReplicationStorageType(),
             StorageClass: this.site,
-            VersionId: sourceEntry.getEncodedVersionId(),
+            VersionId: sourceEntry.getEncodedVersionId() || 'null',
             UserMetaData: sourceEntry.getUserMetadata(),
             ContentType: sourceEntry.getContentType() || undefined,
             CacheControl: sourceEntry.getCacheControl() || undefined,


### PR DESCRIPTION
Non versioned object are also considered a null version when in a versioned bucket, we should specify 'null' as query version id for Cloudserver to properly replicate these objects

Issue: BB-403