### PR TITLE
Configure heartbeat in the kafka connect connectors

### DIFF
--- a/extensions/oplogPopulator/OplogPopulator.js
+++ b/extensions/oplogPopulator/OplogPopulator.js
@@ -256,6 +256,7 @@ class OplogPopulator {
                oplogTopic: this._config.topic,
                cronRule: this._config.connectorsUpdateCronRule,
                prefix: this._config.prefix,
+               heartbeatIntervalMs: this._config.heartbeatIntervalMs,
                kafkaConnectHost: this._config.kafkaConnectHost,
                kafkaConnectPort: this._config.kafkaConnectPort,
                metricsHandler: this._metricsHandler,

--- a/extensions/oplogPopulator/OplogPopulatorConfigValidator.js
+++ b/extensions/oplogPopulator/OplogPopulatorConfigValidator.js
@@ -9,6 +9,7 @@ const joiSchema = joi.object({
     prefix: joi.string().optional(),
     probeServer: probeServerJoi.default(),
     connectorsUpdateCronRule: joi.string().default('*/1 * * * * *'),
+    heartbeatIntervalMs: joi.number().default(10000),
 });
 
 function configValidator(backbeatConfig, extConfig) {

--- a/tests/unit/oplogPopulator/ConnectorsManager.js
+++ b/tests/unit/oplogPopulator/ConnectorsManager.js
@@ -55,6 +55,7 @@ const connectorConfig = {
             }, 'null'],
         }],
     }),
+    'heartbeat.interval.ms': 10000,
 };
 
 const connector1 = new Connector({
@@ -75,6 +76,7 @@ describe('ConnectorsManager', () => {
             mongoUrl: 'mongodb://localhost:27017/?w=majority&readPreference=primary',
             oplogTopic: 'oplog',
             cronRule: '*/5 * * * * *',
+            heartbeatIntervalMs: 10000,
             kafkaConnectHost: '127.0.0.1',
             kafkaConnectPort: 8083,
             metricsHandler: new OplogPopulatorMetrics(logger),


### PR DESCRIPTION
Hearbeat prevents having an outdated resume token in the connectors by constantly updating the offset to the last object in the oplog

Outdated offsets can happen in two cases:
- Not enough updates in MongoDB, so the offset stays the same until the oplog event holding the offset gets expired from the oplog.
- Too many updates in the DB, which causes the event holding the offset to be overwritten as the oplog is a capped collection that overwrites the earliest events when it fills up.

Issue: BB-407