### PR TITLE
Oplog populator keep extra fields in the connector config

### DIFF
--- a/extensions/oplogPopulator/modules/ConnectorsManager.js
+++ b/extensions/oplogPopulator/modules/ConnectorsManager.js
@@ -168,7 +168,9 @@ class ConnectorsManager {
                 // initializing connector
                 const connector = new Connector({
                     name: connectorName,
-                    config,
+                    // update existing connector config while leaving in fields that were
+                    // added manually like 'offset.topic.name'
+                    config: { ...oldConfig, ...config },
                     buckets,
                     logger: this._logger,
                     kafkaConnectHost: this._kafkaConnectHost,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "8.6.21",
+  "version": "8.6.22",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/oplogPopulator/ConnectorsManager.js
+++ b/tests/unit/oplogPopulator/ConnectorsManager.js
@@ -136,13 +136,17 @@ describe('ConnectorsManager', () => {
     });
 
     describe('_getOldConnectors', () => {
-        it('Should return old connector', async () => {
+        it('Should update connector config while keeping the extra fields', async () => {
+            const config = { ...connectorConfig };
+            config['topic.namespace.map'] = 'outdated-topic';
+            config['offset.partitiom.name'] = 'partition-name';
             sinon.stub(connectorsManager._kafkaConnect, 'getConnectorConfig')
-                .resolves(connectorConfig);
-            sinon.stub(connectorsManager, '_extractBucketsFromConfig').returns([]);
+                .resolves(config);
             const connectors = await connectorsManager._getOldConnectors(['source-connector']);
             assert.strictEqual(connectors.length, 1);
             assert.strictEqual(connectors[0].name, 'source-connector');
+            assert.strictEqual(connectors[0].config['offset.partitiom.name'], 'partition-name');
+            assert.strictEqual(connectors[0].config['topic.namespace.map'], '{"*":"oplog"}');
         });
     });
 


### PR DESCRIPTION
When connectors stop consuming the oplog because of the outdated
resume token issue, we can only unblock them by renaming the partition
used to store the offsets. This is done by adding an extra parameter in
the connectors' config.

This parameter is not included in the config by default, and we want to
keep it from changing when the oplog populator restarts.

Issue: [BB-416](https://scality.atlassian.net/browse/BB-416)

[BB-416]: https://scality.atlassian.net/browse/BB-416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ