### PR TITLE
bf: BB-419 increase notification default concurrency

### DIFF
--- a/extensions/notification/NotificationConfigManager.js
+++ b/extensions/notification/NotificationConfigManager.js
@@ -364,7 +364,7 @@ class NotificationConfigManager {
                 = 'error setting bucket notification configuration';
             this.log.error(errMsg, {
                 method: 'BucketNotificationConfigManager.setConfig',
-                error: err,
+                error: err.message,
                 bucket,
                 config,
             });

--- a/extensions/notification/NotificationConfigValidator.js
+++ b/extensions/notification/NotificationConfigValidator.js
@@ -8,7 +8,7 @@ const joiSchema = {
     queueProcessor: {
         groupId: joi.string().required(),
         retryTimeoutS: joi.number().default(300),
-        concurrency: joi.number().greater(0).default(10),
+        concurrency: joi.number().greater(0).default(1000),
         logConsumerMetricsIntervalS: joi.number().greater(0).default(60),
     },
 };

--- a/extensions/notification/destination/KafkaNotificationDestination.js
+++ b/extensions/notification/destination/KafkaNotificationDestination.js
@@ -56,15 +56,18 @@ class KafkaNotificationDestination extends NotificationDestination {
      * Process entry in the sub-class and send it
      *
      * @param {Object[]} messages - message to be sent
-     * @param {function} done - callback
+     * @param {function} done - callback when delivery report has been received
      * @return {undefined}
      */
     send(messages, done) {
         this._notificationProducer.send(messages, error => {
             if (error) {
-                this._log.error('error publishing message', {
+                const { host, topic } = this._destinationConfig;
+                this._log.error('error in message delivery to external Kafka destination', {
                     method: 'KafkaNotificationDestination.send',
-                    error,
+                    host,
+                    topic,
+                    error: error.message,
                 });
             }
             done();

--- a/extensions/notification/destination/KafkaNotificationDestination.js
+++ b/extensions/notification/destination/KafkaNotificationDestination.js
@@ -15,10 +15,11 @@ class KafkaNotificationDestination extends NotificationDestination {
     }
 
     _setupProducer(done) {
-        const { host, topic, auth } = this._destinationConfig;
+        const { host, topic, pollIntervalMs, auth } = this._destinationConfig;
         const producer = new KafkaProducer({
             kafka: { hosts: host },
             topic,
+            pollIntervalMs,
             auth,
         });
         producer.once('error', done);

--- a/extensions/notification/destination/KafkaProducer.js
+++ b/extensions/notification/destination/KafkaProducer.js
@@ -16,6 +16,7 @@ const ACK_TIMEOUT = 5000;
 const FLUSH_TIMEOUT = 5000;
 
 const PRODUCER_MESSAGE_MAX_BYTES = 5000020;
+const PRODUCER_POLL_INTERVAL_MS = 2000;
 
 const CLIENT_ID = 'KafkaNotificationProducer';
 
@@ -28,6 +29,10 @@ class KafkaProducer extends EventEmitter {
     * @param {string} config.auth - kafka auth configuration
     * @param {Object} config.kafka - kafka connection config
     * @param {string} config.kafka.hosts - kafka hosts list
+    * @param {number} [config.messageMaxBytes] - maximum size of a single message
+    * @param {number} [config.pollIntervalMs] - producer poll interval
+    * between delivery report fetches, in milliseconds
+    * @param {object} [config.auth] - authentication info to access Kafka
     */
     constructor(config) {
         super();
@@ -37,7 +42,7 @@ class KafkaProducer extends EventEmitter {
                 hosts: joi.string().required(),
             }).required(),
             topic: joi.string().required(),
-            pollIntervalMs: joi.number().default(2000),
+            pollIntervalMs: joi.number().default(PRODUCER_POLL_INTERVAL_MS),
             messageMaxBytes: joi.number().default(PRODUCER_MESSAGE_MAX_BYTES),
             auth: joi.object().optional(),
         };

--- a/extensions/notification/queueProcessor/QueueProcessor.js
+++ b/extensions/notification/queueProcessor/QueueProcessor.js
@@ -28,12 +28,26 @@ class QueueProcessor extends EventEmitter {
      *   specific to queue processor
      * @param {String} notifConfig.queueProcessor.groupId - kafka
      *   consumer group ID
+     * @param {String} [notifConfig.queueProcessor.concurrency=1000] -
+     * how many notifications can be processed concurrently, between
+     * the time they are consumed from the internal Kafka queue and
+     * the time a delivery report is received from the external Kafka
+     * broker (see also {@link destinationConfig.pollIntervalMs})
      * @param {String} notifConfig.queueProcessor.retryTimeoutS -
      *   number of seconds before giving up retries of an entry
      * @param {Object} destinationConfig - destination configuration object
      * @param {String} destinationConfig.type - destination type
      * @param {String} destinationConfig.host - destination host
      * @param {String} destinationConfig.auth - destination auth configuration
+     * @param {number} [destinationConfig.pollIntervalMs=2000] - for
+     * Kafka destinations: producer poll interval between delivery
+     * report fetches, in milliseconds. Reducing the delay could
+     * reduce latency in message delivery under high load and/or slow
+     * external Kafka cluster, at the expense of more polling overhead
+     * IMPORTANT: make sure {@link notifConfig.queueProcessor.concurrency}
+     * is set to a value high enough so that "concurrency / poll_interval_seconds"
+     * which is the maximum notifications per second per notification
+     * processor, is not below the required throughput
      * @param {String} destinationId - resource name/id of destination
      */
     constructor(zkConfig, kafkaConfig, notifConfig, destinationConfig,

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -22,6 +22,7 @@ const FLUSH_TIMEOUT = 5000;
 * little extra bytes of padding for approximation.
 */
 const PRODUCER_MESSAGE_MAX_BYTES = 5000020;
+const PRODUCER_POLL_INTERVAL_MS = 2000;
 
 const CLIENT_ID = 'BackbeatProducer';
 
@@ -34,6 +35,9 @@ class BackbeatProducer extends EventEmitter {
     * @param {Object} config.kafka - kafka connection config
     * @param {string} config.kafka.hosts - kafka hosts list
     * as "host:port[,host:port...]"
+    * @param {number} [config.messageMaxBytes] - maximum size of a single message
+    * @param {number} [config.pollIntervalMs] - producer poll interval
+    * between delivery report fetches, in milliseconds
     */
     constructor(config) {
         super();
@@ -43,7 +47,7 @@ class BackbeatProducer extends EventEmitter {
                 hosts: joi.string().required(),
             }).required(),
             topic: joi.string(),
-            pollIntervalMs: joi.number().default(2000),
+            pollIntervalMs: joi.number().default(PRODUCER_POLL_INTERVAL_MS),
             messageMaxBytes: joi.number().default(PRODUCER_MESSAGE_MAX_BYTES),
         };
         const validConfig = joi.attempt(config, configJoi,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "7.10.11",
+  "version": "7.10.12",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/notification/QueueProcessor.spec.js
+++ b/tests/unit/notification/QueueProcessor.spec.js
@@ -1,0 +1,166 @@
+const assert = require('assert');
+const async = require('async');
+const sinon = require('sinon');
+
+const QueueProcessor = require(
+    '../../../extensions/notification/queueProcessor/QueueProcessor');
+
+describe('notification QueueProcessor', () => {
+    let qp;
+
+    before(done => {
+        qp = new QueueProcessor(null, null, null, {
+            host: 'external-kafka-host',
+        }, 'destId');
+        qp.bnConfigManager = {
+            getConfig: () => ({
+                notificationConfiguration: {
+                    queueConfig: [
+                        {
+                            queueArn: 'arn:scality:bucketnotif:::destId',
+                            events: [
+                                's3:ObjectCreated:*',
+                            ],
+                        },
+                    ],
+                },
+            }),
+            setConfig: () => {},
+        };
+        qp.bnConfigManager.setConfig('mybucket', {
+            host: 'foo',
+        });
+        qp._setupDestination('kafka', done);
+    });
+
+    it('should send notification to external destination and invoke callback on delivery report', done => {
+        const sendCb = sinon.stub().callsFake(cb => cb());
+        const send = sinon.stub().callsFake((messages, cb) => setTimeout(() => sendCb(cb), 100));
+        qp._destination._notificationProducer = {
+            send,
+        };
+        qp.processKafkaEntry({
+            value: JSON.stringify({
+                bucket: 'mybucket',
+                key: 'key',
+                eventType: 's3:ObjectCreated:Put',
+                value: '{}',
+            }),
+        }, err => {
+            assert.ifError(err);
+
+            assert(send.calledOnce);
+            assert(sendCb.calledOnce);
+            assert(Array.isArray(send.args[0][0]));
+            assert(send.args[0][0][0].key === 'mybucket/key');
+            assert(typeof send.args[0][0][0].message === 'object');
+            assert(Array.isArray(send.args[0][0][0].message.Records));
+            assert.strictEqual(send.args[0][0][0].message.Records.length, 1);
+            assert.strictEqual(
+                send.args[0][0][0].message.Records[0].eventName,
+                's3:ObjectCreated:Put'
+            );
+            done();
+        });
+    });
+
+    // FIXME: this test could fit better in Integration as it would
+    // also test the resilience of the producer, but at the time this
+    // test was written Bucket Notification tests are not yet running
+    // in Integration (refs: BB-419, INTGR-895)
+    it('should process 10K notifications with 1K concurrency to send to external destination',
+    function test10KNotif(done) {
+        this.timeout(5000);
+
+        const origLogger = qp.logger;
+        qp.logger = {
+            debug: () => {},
+            info: () => {},
+        };
+        // fake how Kafka Producer delivers pending delivery reports at a regular interval
+        let pendingDeliveryReports = [];
+        const flushDeliveryReportsInterval = setInterval(() => {
+            const _pendingDeliveryReports = pendingDeliveryReports;
+            pendingDeliveryReports = [];
+            for (const deliveryReportCb of _pendingDeliveryReports) {
+                deliveryReportCb();
+            }
+        }, 200);
+        const send = sinon.stub().callsFake((messages, cb) => {
+            // push the delivery report to be delivered asynchronously later
+            pendingDeliveryReports.push(cb);
+        });
+        qp._destination._notificationProducer = {
+            send,
+        };
+        async.timesLimit(10000, 1000, (i, iDone) => qp.processKafkaEntry({
+            value: JSON.stringify({
+                bucket: 'mybucket',
+                key: `key-${i}`,
+                eventType: 's3:ObjectCreated:Put',
+                value: '{}',
+            }),
+        }, iDone), err => {
+            assert.ifError(err);
+            assert.strictEqual(pendingDeliveryReports.length, 0);
+            qp.logger = origLogger;
+            clearInterval(flushDeliveryReportsInterval);
+            done();
+        });
+    });
+
+    it('should send notification to external destination with delivery error', done => {
+        const send = sinon.stub().callsFake((messages, cb) => cb(new Error('delivery error')));
+        qp._destination._notificationProducer = {
+            send,
+        };
+        qp.processKafkaEntry({
+            value: JSON.stringify({
+                bucket: 'mybucket',
+                key: 'key',
+                eventType: 's3:ObjectCreated:Put',
+                value: '{}',
+            }),
+        }, err => {
+            assert.ifError(err);
+
+            assert(send.calledOnce);
+            setTimeout(done, 100);
+        });
+    });
+
+    it('should not send an entry without "eventType" attribute', done => {
+        const send = sinon.spy();
+        qp._destination._notificationProducer = {
+            send,
+        };
+        qp.processKafkaEntry({
+            value: JSON.stringify({
+                bucket: 'mybucket',
+                key: 'key',
+                // no "eventType"
+                value: '{}',
+            }),
+        }, err => {
+            assert.ifError(err);
+            // should not have been sent
+            assert(send.notCalled);
+            done();
+        });
+    });
+
+    it('should not send an entry if the message is invalid JSON', done => {
+        const send = sinon.spy();
+        qp._destination._notificationProducer = {
+            send,
+        };
+        qp.processKafkaEntry({
+            value: 'notjson',
+        }, err => {
+            assert(err);
+            // should not have been sent
+            assert(send.notCalled);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
**Replaces https://github.com/scality/backbeat/pull/2421**

- increase default notification BackbeatConsumer concurrency

  Notification QueueProcessor was limited by a concurrency of 10, which meant it could only wait for 10 delivery reports from the producer before consuming more entries.

  Increased the default concurrency to 1000 to improve throughput and add a test to show that it behaves well with this number of pending reports (the processing does not involve anything else asynchronous than waiting for delivery reports), as well as a few other extra tests.

  Also fix and improve logging related to processing errors and error reporting from delivery reports.

- [cleanup] BackbeatProducer.pollIntervalMs default as constant

  Use a code constant for `pollIntervalMs`, and add a JSDoc about it (and `messageMaxBytes`)

- [impr] configurable notif Kafka poll interval

  Make the external Kafka producer poll interval configurable: while the default is 2000ms, it could be helpful to reduce its value, e.g. to reduce latency of delivery in case the external Kafka cluster cannot receive all notifications in time.

  It's not clear at this point what would be a better value due to lack of testing to the limits, and 2000ms doesn't look unreasonable as a trade-off between latency and polling overhead, so leaving the default value as it is. It is however important to have a concurrency value high enough to not limit the possible throughput per notification processor, which is limited by "concurrency / poll_interval_seconds" messages per second. The concurrency has been raised to 1000 by default which therefore allows 500 messages per second to go through per processor with a 2000ms poll interval.