### PR TITLE
BB-420: fix conductor race condition

### DIFF
--- a/extensions/lifecycle/conductor/LifecycleConductor.js
+++ b/extensions/lifecycle/conductor/LifecycleConductor.js
@@ -332,8 +332,6 @@ class LifecycleConductor {
                 return done();
             }
 
-            nBucketsQueued += tasks.length;
-
             const unknownCanonicalIds = new Set(
                 tasks
                     .map(t => t.canonicalId)
@@ -356,6 +354,8 @@ class LifecycleConductor {
                 (tasksWithAccountId, next) => this._createBucketTaskMessages(tasksWithAccountId, log, next),
             ],
             (err, messages) => {
+                nBucketsQueued += tasks.length;
+
                 log.info('bucket push progress', {
                     nBucketsQueued,
                     bucketsInCargo: tasks.length,


### PR DESCRIPTION
issue: race condition occurs when queued bucket completion checks
resolving to true while async operations are still in progress, resulting
in the improper reset of state variables and preventing the creation of
indexes for queued buckets; this issue is caused by the combination of
the mBucketsQueued state variable being incremented before the
completion of the async operations and the completion interval check

fix: moved the incrementation of nBucketsQueued to after the completion
of the async operations
