### PR TITLE
BB-415: fix implicitSingleOutputTopic param leaking into breaker conf

### DIFF
--- a/lib/CircuitBreaker.js
+++ b/lib/CircuitBreaker.js
@@ -12,14 +12,19 @@ function updateCircuitBreakerConfigForImplicitOutputQueue(cbConf, groupId, topic
 
     cbConf.probes.forEach(p => {
         if (p.type !== 'kafkaConsumerLag') {
-            return cbConf;
+            return;
         }
 
-        if (!p.implicitSingleOutputTopic) {
-            return cbConf;
+        if (!Object.prototype.hasOwnProperty.call(p, 'implicitSingleOutputTopic')) {
+            return;
         }
 
+        const implicitSingleOutputTopic = p.implicitSingleOutputTopic;
         delete p.implicitSingleOutputTopic;
+
+        if (!implicitSingleOutputTopic) {
+            return;
+        }
 
         if (groupId) {
             p.consumerGroupName = groupId;
@@ -29,7 +34,7 @@ function updateCircuitBreakerConfigForImplicitOutputQueue(cbConf, groupId, topic
             p.topicName = topic;
         }
 
-        return undefined;
+        return;
     });
 
     return cbConf;

--- a/tests/unit/lib/util/circuitBreaker.spec.js
+++ b/tests/unit/lib/util/circuitBreaker.spec.js
@@ -123,7 +123,6 @@ describe('updateCircuitBreakerConfigForImplicitOutputQueue', () => {
             probes: [
                 {
                     type: 'kafkaConsumerLag',
-                    implicitSingleOutputTopic: false,
                 }
             ],
         });


### PR DESCRIPTION
Defining a kafka lag probe with `implicitSingleOutputTopic: false` would leave the `implicitSingleOutputTopic` attribute which doesn't pass breakbeat's conf validation.