### PR TITLE
Ensure _getBackbeatClient Always Returns BackbeatMetadataProxy

### DIFF
--- a/tests/unit/lifecycle/LifecycleBucketProcessor.spec.js
+++ b/tests/unit/lifecycle/LifecycleBucketProcessor.spec.js
@@ -1,0 +1,46 @@
+'use strict'; // eslint-disable-line
+
+const assert = require('assert');
+const LifecycleBucketProcessor = require('../../../extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor');
+const BackbeatMetadataProxy = require('../../../lib/BackbeatMetadataProxy');
+
+const zkConfig = {};
+const kafkaConfig = {};
+const lcConfig = { auth: {}, bucketProcessor: {} };
+const repConfig = {};
+const s3Config = { host: 'init.test.host', port: 8000 };
+
+describe('LifecycleBucketProcessor', () => {
+    describe('_getBackbeatClient', () => {
+        let lbp;
+
+        beforeEach(() => {
+            lbp = new LifecycleBucketProcessor(zkConfig, kafkaConfig, lcConfig, repConfig, s3Config, 'http');
+            lbp.credentialsManager = {
+                getCredentials() {
+                    return {
+                        accessKeyId: 'ak0',
+                        secretAccessKey: 'sk0',
+                    };
+                },
+            };
+        });
+
+        it('should return an instance of BackbeatMetadataProxy', () => {
+            const canonicalId = 'cid0';
+            const accountId = 'id0';
+            const client = lbp._getBackbeatClient(canonicalId, accountId);
+
+            assert.ok(client instanceof BackbeatMetadataProxy, 'client is not an instance of BackbeatMetadataProxy');
+        });
+
+        it('should return an instance of BackbeatMetadataProxy after caching', () => {
+            const canonicalId = 'cid0';
+            const accountId = 'id0';
+            lbp._getBackbeatClient(canonicalId, accountId);
+            const client = lbp._getBackbeatClient(canonicalId, accountId);
+
+            assert.ok(client instanceof BackbeatMetadataProxy, 'client is not an instance of BackbeatMetadataProxy');
+        });
+    });
+});


### PR DESCRIPTION
The `_getBackbeatClient` function from the `BucketProcessor` should consistently return an instance of `BackbeatMetadataProxy`. However, there is an issue in the code where the function returns an instance of `BackbeatClient` when caching. 

**Impact:**

- **Ring S3C**: no direct impact today, since `backbeatClient` is only used for "lifecycle Transition workflow" that has been backported but is not supported yet. However, the inconstant result of `_getBackbeatClient` blocks additional development such as “lifecycle listing optimization “.

- **Artesca**: no impact since the logic has been fixed already with the ClientManager: https://github.com/scality/backbeat/blob/development/8.7/lib/clients/ClientManager.js 

_Note:_ the getBackbeatClient from the ObjectProcessor is correctly implemented.