### PR TITLE
BB-432: remove useless kafka connectors

### DIFF
--- a/extensions/oplogPopulator/OplogPopulatorMetrics.js
+++ b/extensions/oplogPopulator/OplogPopulatorMetrics.js
@@ -133,6 +133,22 @@ class OplogPopulatorMetrics {
     }
 
     /**
+     * updates s3_oplog_populator_connectors metric
+     * when a connector is destroyed
+     * @returns {undefined}
+     */
+    onConnectorDestroyed() {
+        try {
+            this.connectors.dec({ isOld: false }, 1);
+        } catch (error) {
+            this._logger.error('An error occured while pushing metrics', {
+                method: 'OplogPopulatorMetrics.onConnectorDestroyed',
+                error: error.message,
+            });
+        }
+    }
+
+    /**
      * updates s3_oplog_populator_reconfiguration_lag_seconds metric
      * @param {Connector} connector connector instance
      * @param {Boolean} success true if reconfiguration was successful

--- a/extensions/oplogPopulator/OplogPopulatorMetrics.js
+++ b/extensions/oplogPopulator/OplogPopulatorMetrics.js
@@ -46,7 +46,6 @@ class OplogPopulatorMetrics {
         this.connectors = ZenkoMetrics.createGauge({
             name: 's3_oplog_populator_connectors',
             help: 'Total number of configured connectors',
-            labelNames: ['isOld'],
         });
         this.reconfigurationLag = ZenkoMetrics.createHistogram({
             name: 's3_oplog_populator_reconfiguration_lag_seconds',
@@ -121,9 +120,7 @@ class OplogPopulatorMetrics {
      */
     onConnectorsInstantiated(isOld, count = 1) {
         try {
-            this.connectors.inc({
-                isOld,
-            }, count);
+            this.connectors.inc(count);
         } catch (error) {
             this._logger.error('An error occured while pushing metrics', {
                 method: 'OplogPopulatorMetrics.onConnectorsInstantiated',
@@ -139,9 +136,9 @@ class OplogPopulatorMetrics {
      */
     onConnectorDestroyed() {
         try {
-            this.connectors.dec({ isOld: false }, 1);
+            this.connectors.dec(1);
         } catch (error) {
-            this._logger.error('An error occured while pushing metrics', {
+            this._logger.error('An error occurred while pushing metrics', {
                 method: 'OplogPopulatorMetrics.onConnectorDestroyed',
                 error: error.message,
             });

--- a/extensions/oplogPopulator/modules/ConnectorsManager.js
+++ b/extensions/oplogPopulator/modules/ConnectorsManager.js
@@ -177,6 +177,7 @@ class ConnectorsManager {
                     // added manually like 'offset.topic.name'
                     config: { ...oldConfig, ...config },
                     buckets,
+                    isRunning: true,
                     logger: this._logger,
                     kafkaConnectHost: this._kafkaConnectHost,
                     kafkaConnectPort: this._kafkaConnectPort,
@@ -239,46 +240,97 @@ class ConnectorsManager {
     }
 
     /**
+     * Spawns a connector when buckets are configured for it and is not running,
+     * or destroys connector with no buckets configured
+     * @param {Connector} connector connector instance
+     * @returns {Promise<Boolean>} true if connector state changed
+     * @throws {InternalError}
+     */
+    async _spawnOrDestroyConnector(connector) {
+        try {
+            if (connector.isRunning && connector.bucketCount === 0) {
+                await connector.destroy();
+                this._metricsHandler.onConnectorDestroyed(false);
+                this._logger.info('Successfully spawned a connector', {
+                    method: 'ConnectorsManager._spawnOrDestroyConnector',
+                    connector: connector.name
+                });
+                return true;
+            } else if (!connector.isRunning && connector.bucketCount > 0) {
+                await connector.spawn();
+                this._metricsHandler.onConnectorsInstantiated(false);
+                this._logger.info('Successfully destroyed a connector', {
+                    method: 'ConnectorsManager._spawnOrDestroyConnector',
+                    connector: connector.name
+                });
+                return true;
+            } else if (connector.isRunning) {
+                return connector.updatePipeline(true);
+            }
+            return false;
+        } catch (err) {
+            this._logger.error('Error while spawning or destorying connector', {
+                method: 'ConnectorsManager._spawnOrDestroyConnector',
+                connector: this._name,
+                error: err.description || err.message,
+            });
+            throw errors.InternalError.customizeDescription(err.description);
+        }
+    }
+
+    /**
+     * Updates the connectors if their configuration changed
+     * @returns {undefined}
+     */
+    async _updateConnectors() {
+        const connectorsStatus = {};
+        let connectorUpdateFailed = false;
+        await eachLimit(this._connectors, 10, async connector => {
+            const startTime = Date.now();
+            connectorsStatus[connector.name] = {
+                numberOfBuckets: connector.bucketCount,
+                updated: null,
+            };
+            try {
+                // check if we need to spawn/despawn the connector
+                // - connector is destroyed if no buckets are configured
+                // - connector is spawned when buckets are configured on it
+                // or update the connector when buckets configuration changed
+                const updated = await this._spawnOrDestroyConnector(connector);
+                connectorsStatus[connector.name].updated = updated;
+                if (updated) {
+                    const delta = (Date.now() - startTime) / 1000;
+                    this._metricsHandler.onConnectorReconfiguration(connector, true, delta);
+                }
+            } catch (err) {
+                connectorUpdateFailed = true;
+                connectorsStatus[connector.name].updated = false;
+                this._metricsHandler.onConnectorReconfiguration(connector, false);
+                this._logger.error('Failed to updated connector', {
+                    method: 'ConnectorsManager._updateConnectors',
+                    connector: connector.name,
+                    bucketCount: connector.bucketCount,
+                    error: err.description || err.message,
+                });
+            }
+        });
+        const logMessage = connectorUpdateFailed ? 'Failed to update some or all the connectors' :
+            'Successfully updated all the connectors';
+        const logFunction = connectorUpdateFailed ? this._logger.error.bind(this._logger) :
+            this._logger.info.bind(this._logger);
+        logFunction(logMessage, {
+            method: 'ConnectorsManager._updateConnectors',
+            connectorsStatus,
+        });
+    }
+
+    /**
      * Schedules connector updates
      * @returns {undefined}
      */
     scheduleConnectorUpdates() {
         schedule.scheduleJob(this._cronRule, async () => {
-            const connectorsStatus = {};
-            let connectorUpdateFailed = false;
-            await eachLimit(this._connectors, 10, async connector => {
-                const startTime = Date.now();
-                connectorsStatus[connector.name] = {
-                    numberOfBuckets: connector.bucketCount,
-                    updated: null,
-                };
-                try {
-                    const updated = await connector.updatePipeline(true);
-                    connectorsStatus[connector.name].updated = updated;
-                    if (updated) {
-                        const delta = (Date.now() - startTime) / 1000;
-                        this._metricsHandler.onConnectorReconfiguration(connector, true, delta);
-                    }
-                } catch (err) {
-                    connectorUpdateFailed = true;
-                    connectorsStatus[connector.name].updated = false;
-                    this._metricsHandler.onConnectorReconfiguration(connector, false);
-                    this._logger.error('Failed to updated connector', {
-                        method: 'ConnectorsManager.scheduleConnectorUpdates',
-                        connector: connector.name,
-                        bucketCount: connector.bucketCount,
-                        error: err.description || err.message,
-                    });
-                }
-            });
-            const logMessage = connectorUpdateFailed ? 'Failed to update some or all the connectors' :
-                'Successfully updated all the connectors';
-            const logFunction = connectorUpdateFailed ? this._logger.error.bind(this._logger) :
-                this._logger.info.bind(this._logger);
-            logFunction(logMessage, {
-                method: 'ConnectorsManager.scheduleConnectorUpdates',
-                connectorsStatus,
-            });
+            await this._updateConnectors();
         });
     }
 

--- a/extensions/oplogPopulator/modules/ConnectorsManager.js
+++ b/extensions/oplogPopulator/modules/ConnectorsManager.js
@@ -232,8 +232,8 @@ class ConnectorsManager {
         try {
             if (connector.isRunning && connector.bucketCount === 0) {
                 await connector.destroy();
-                this._metricsHandler.onConnectorDestroyed(false);
-                this._logger.info('Successfully spawned a connector', {
+                this._metricsHandler.onConnectorDestroyed();
+                this._logger.info('Successfully destroyed a connector', {
                     method: 'ConnectorsManager._spawnOrDestroyConnector',
                     connector: connector.name
                 });

--- a/monitoring/oplog-populator/dashboard.py
+++ b/monitoring/oplog-populator/dashboard.py
@@ -51,7 +51,7 @@ class Metrics:
     ]
 
     CONNECTORS = metrics.CounterMetric(
-        's3_oplog_populator_connectors', 'isOld',
+        's3_oplog_populator_connectors',
         job="${oplog_populator_job}", namespace="${namespace}"
     )
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "8.6.26",
+  "version": "8.6.27",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/oplogPopulator/Allocator.js
+++ b/tests/unit/oplogPopulator/Allocator.js
@@ -13,6 +13,7 @@ const logger = new werelogs.Logger('Allocator');
 
 const defaultConnectorParams = {
     config: {},
+    isRunning: false,
     logger,
     kafkaConnectHost: '127.0.0.1',
     kafkaConnectPort: 8083,

--- a/tests/unit/oplogPopulator/Connector.js
+++ b/tests/unit/oplogPopulator/Connector.js
@@ -26,6 +26,7 @@ describe('Connector', () => {
             name: 'example-connector',
             config: connectorConfig,
             buckets: [],
+            isRunning: false,
             kafkaConnectHost: '127.0.0.1',
             kafkaConnectPort: 8083,
             logger,
@@ -40,11 +41,13 @@ describe('Connector', () => {
         it('Should spawn connector with correct pipeline', async () => {
             const createStub = sinon.stub(connector._kafkaConnect, 'createConnector')
                 .resolves();
+            assert.strictEqual(connector.isRunning, false);
             await connector.spawn();
             assert(createStub.calledOnceWith({
                 name: 'example-connector',
                 config: connectorConfig
             }));
+            assert.strictEqual(connector.isRunning, true);
         });
     });
 
@@ -52,8 +55,11 @@ describe('Connector', () => {
         it('Should destroy connector', async () => {
             const deleteStub = sinon.stub(connector._kafkaConnect, 'deleteConnector')
                 .resolves();
+            connector._isRunning = true;
+            assert.strictEqual(connector.isRunning, true);
             await connector.destroy();
             assert(deleteStub.calledOnceWith('example-connector'));
+            assert.strictEqual(connector.isRunning, false);
         });
     });
 

--- a/tests/unit/oplogPopulator/ConnectorsManager.js
+++ b/tests/unit/oplogPopulator/ConnectorsManager.js
@@ -115,9 +115,10 @@ describe('ConnectorsManager', () => {
                 .returns('source-connector');
             sinon.stub(connectorsManager, '_getDefaultConnectorConfiguration')
                 .returns(connectorConfig);
-            const connector = await connectorsManager.addConnector(false);
+            const connector = await connectorsManager.addConnector();
             assert(connector instanceof Connector);
             assert.strictEqual(connector.name, 'source-connector');
+            assert.strictEqual(connector.isRunning, false);
         });
     });
 

--- a/tests/unit/oplogPopulator/ConnectorsManager.js
+++ b/tests/unit/oplogPopulator/ConnectorsManager.js
@@ -58,18 +58,30 @@ const connectorConfig = {
     'heartbeat.interval.ms': 10000,
 };
 
-const connector1 = new Connector({
-    name: 'source-connector',
-    buckets: [],
-    config: connectorConfig,
-    logger,
-    kafkaConnectHost: '127.0.0.1',
-    kafkaConnectPort: 8083,
-});
-
 describe('ConnectorsManager', () => {
     let connectorsManager;
+    let connector1;
+
+    let connectorCreateStub;
+    let connectorDeleteStub;
+    let connectorUpdateStub;
+
     beforeEach(() => {
+        connector1 = new Connector({
+            name: 'source-connector',
+            buckets: [],
+            config: connectorConfig,
+            isRunning: true,
+            logger,
+            kafkaConnectHost: '127.0.0.1',
+            kafkaConnectPort: 8083,
+        });
+        connectorCreateStub = sinon.stub(connector1._kafkaConnect, 'createConnector')
+            .resolves();
+        connectorDeleteStub = sinon.stub(connector1._kafkaConnect, 'deleteConnector')
+            .resolves();
+        connectorUpdateStub = sinon.stub(connector1._kafkaConnect, 'updateConnectorConfig')
+            .resolves();
         connectorsManager = new ConnectorsManager({
             nbConnectors: 1,
             database: 'metadata',
@@ -85,7 +97,7 @@ describe('ConnectorsManager', () => {
     });
 
     afterEach(() => {
-        sinon.restore();
+        sinon.reset();
     });
 
     describe('_getDefaultConnectorConfiguration', () => {
@@ -115,7 +127,7 @@ describe('ConnectorsManager', () => {
                 .returns('source-connector');
             sinon.stub(connectorsManager, '_getDefaultConnectorConfiguration')
                 .returns(connectorConfig);
-            const connector = await connectorsManager.addConnector();
+            const connector = connectorsManager.addConnector();
             assert(connector instanceof Connector);
             assert.strictEqual(connector.name, 'source-connector');
             assert.strictEqual(connector.isRunning, false);
@@ -150,6 +162,7 @@ describe('ConnectorsManager', () => {
             assert.strictEqual(connectors[0].name, 'source-connector');
             assert.strictEqual(connectors[0].config['offset.partitiom.name'], 'partition-name');
             assert.strictEqual(connectors[0].config['topic.namespace.map'], '{"*":"oplog"}');
+            assert.strictEqual(connectors[0].isRunning, true);
         });
     });
 
@@ -171,11 +184,118 @@ describe('ConnectorsManager', () => {
             sinon.stub(connectorsManager._kafkaConnect, 'getConnectors')
                 .resolves([]);
             sinon.stub(connectorsManager, 'addConnector')
-                .resolves(connector1);
+                .returns(connector1);
             const connectors = await connectorsManager.initializeConnectors();
             assert.deepEqual(connectors, [connector1]);
             assert.deepEqual(connectorsManager._connectors, [connector1]);
             assert.deepEqual(connectorsManager._oldConnectors, []);
+        });
+    });
+
+    describe('_spawnOrDestroyConnector', () => {
+        it('should destroy running connector when no buckets are configured', async () => {
+            connector1._isRunning = true;
+            connector1._state.bucketsGotModified = false;
+            connector1._buckets = new Set();
+            const updated = await connectorsManager._spawnOrDestroyConnector(connector1);
+            assert.strictEqual(updated, true);
+            assert(connectorCreateStub.notCalled);
+            assert(connectorDeleteStub.calledOnceWith(connector1.name));
+        });
+
+        it('should spawn a non running connector when buckets are configured', async () => {
+            connector1._isRunning = false;
+            connector1._state.bucketsGotModified = false;
+            connector1._buckets = new Set(['bucket1']);
+            const updated = await connectorsManager._spawnOrDestroyConnector(connector1);
+            assert.strictEqual(updated, true);
+            assert(connectorCreateStub.calledOnceWith({
+                name: connector1.name,
+                config: connector1.config
+            }));
+            assert(connectorDeleteStub.notCalled);
+        });
+
+        it('should do nothing when a running connector has buckets', async () => {
+            connector1._isRunning = true;
+            connector1._state.bucketsGotModified = false;
+            connector1._buckets = new Set(['bucket1']);
+            const updated = await connectorsManager._spawnOrDestroyConnector(connector1);
+            assert.strictEqual(updated, false);
+            assert(connectorCreateStub.notCalled);
+            assert(connectorDeleteStub.notCalled);
+        });
+
+        it('should do nothing when a non running connector still has no buckets', async () => {
+            connector1._isRunning = false;
+            connector1._state.bucketsGotModified = false;
+            connector1._buckets = new Set();
+            const updated = await connectorsManager._spawnOrDestroyConnector(connector1);
+            assert.strictEqual(updated, false);
+            assert(connectorCreateStub.notCalled);
+            assert(connectorDeleteStub.notCalled);
+        });
+    });
+
+    describe('_updateConnectors', () => {
+        it('should update a running connector when its buckets changed', async () => {
+            connector1._isRunning = true;
+            connector1._state.bucketsGotModified = false;
+            connector1._buckets = new Set(['bucket1']);
+            connectorsManager._connectors = [connector1];
+            connector1._buckets = new Set(['bucket1']);
+            connector1.addBucket('bucket2', false);
+            await connectorsManager._updateConnectors();
+            assert(connectorCreateStub.notCalled);
+            assert(connectorDeleteStub.notCalled);
+            assert(connectorUpdateStub.calledOnceWith(
+                connector1.name,
+                connector1.config
+            ));
+        });
+        it('should not update a running connector when its buckets didn\'t change', async () => {
+            connector1._isRunning = true;
+            connector1._state.bucketsGotModified = false;
+            connector1._buckets = new Set(['bucket1']);
+            connectorsManager._connectors = [connector1];
+            await connectorsManager._updateConnectors();
+            assert(connectorCreateStub.notCalled);
+            assert(connectorDeleteStub.notCalled);
+            assert(connectorUpdateStub.notCalled);
+        });
+        it('should destroy a running connector if no buckets are assigned to it', async () => {
+            connector1._isRunning = true;
+            connector1._state.bucketsGotModified = false;
+            connector1._buckets = new Set([]);
+            connectorsManager._connectors = [connector1];
+            await connectorsManager._updateConnectors();
+            assert(connectorCreateStub.notCalled);
+            assert(connectorDeleteStub.calledOnceWith(connector1.name));
+            assert(connectorUpdateStub.notCalled);
+        });
+        it('should spawn a non running connector when buckets are assigned to it', async () => {
+            connector1._isRunning = false;
+            connector1._state.bucketsGotModified = false;
+            connector1._buckets = new Set([]);
+            connectorsManager._connectors = [connector1];
+            connector1._buckets = new Set(['bucket1']);
+            await connectorsManager._updateConnectors();
+            assert(connectorCreateStub.calledOnceWith({
+                name: connector1.name,
+                config: connector1.config
+            }));
+            assert(connectorDeleteStub.notCalled);
+            assert(connectorUpdateStub.notCalled);
+        });
+        it('should do nothing when a non running connector has not buckets', async () => {
+            connector1._isRunning = false;
+            connector1._state.bucketsGotModified = false;
+            connector1._buckets = new Set([]);
+            connectorsManager._connectors = [connector1];
+            await connectorsManager._updateConnectors();
+            assert(connectorCreateStub.notCalled);
+            assert(connectorDeleteStub.notCalled);
+            assert(connectorUpdateStub.notCalled);
         });
     });
 });

--- a/tests/unit/oplogPopulator/allocationStrategy/LeastFullConnector.js
+++ b/tests/unit/oplogPopulator/allocationStrategy/LeastFullConnector.js
@@ -10,6 +10,7 @@ const logger = new werelogs.Logger('LeastFullConnector');
 
 const defaultConnectorParams = {
     config: {},
+    isRunning: true,
     logger,
     kafkaConnectHost: '127.0.0.1',
     kafkaConnectPort: 8083,


### PR DESCRIPTION
Issue: BB-432

- Avoid spawning the connectors at startup
- Delete connectors when no bucket is assigned to them