### PR TITLE
Bucket-processor : do not retry the whole listing range when their is an error on individual objects

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -100,7 +100,7 @@ jobs:
     - uses: actions/setup-go@v4
       with:
         go-version: '1.16.2'
-    - uses: actions/setup-node@v2
+    - uses: actions/setup-node@v3
       with:
         node-version: '16'
         cache: yarn

--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -1284,7 +1284,7 @@ class LifecycleTask extends BackbeatTask {
                     (err, data) => {
                         if (err) {
                             // error already logged at source
-                            return done(err);
+                            return next(err);
                         }
                         const allVersions = [...data.Versions,
                             ...data.DeleteMarkers];
@@ -1469,7 +1469,7 @@ class LifecycleTask extends BackbeatTask {
                 return done();
             }
             if (rules.Transition) {
-                this._applyTransitionRule({
+                return this._applyTransitionRule({
                     owner: bucketData.target.owner,
                     accountId: bucketData.target.accountId,
                     bucket: bucketData.target.bucket,
@@ -1477,8 +1477,7 @@ class LifecycleTask extends BackbeatTask {
                     eTag: obj.ETag,
                     lastModified: obj.LastModified,
                     site: rules.Transition.StorageClass,
-                }, log);
-                return done();
+                }, log, done);
             }
 
             return done();
@@ -1522,8 +1521,7 @@ class LifecycleTask extends BackbeatTask {
         }
 
         if (rules.NoncurrentVersionTransition) {
-            this._checkAndApplyNCVTransitionRule(bucketData, version, rules, log);
-            return done();
+            return this._checkAndApplyNCVTransitionRule(bucketData, version, rules, log, done);
         }
 
         log.debug('no action taken on versioned object', {
@@ -1561,7 +1559,7 @@ class LifecycleTask extends BackbeatTask {
             return done();
         }
         if (rules.Transition) {
-            this._applyTransitionRule({
+            return this._applyTransitionRule({
                 owner: bucketData.target.owner,
                 accountId: bucketData.target.accountId,
                 bucket: bucketData.target.bucket,
@@ -1571,8 +1569,7 @@ class LifecycleTask extends BackbeatTask {
                 lastModified: version.LastModified,
                 site: rules.Transition.StorageClass,
                 encodedVersionId: undefined,
-            }, log);
-            return done();
+            }, log, done);
         }
 
         log.debug('no action taken on IsLatest version', {

--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -35,6 +35,20 @@ const MAX_KEYS = process.env.CI === 'true' ? 3 : 1000;
 // concurrency mainly used in async calls
 const CONCURRENCY_DEFAULT = 10;
 
+// Max number of retries (with exp. backoff) that can be be performed for a single
+// entry. We don't use the default, to avoid retrying for a long time (5 minutes)
+// which could make Kafka timeout. 4 retries (e.g. 5 attempts) should be around 8
+// seconds.
+const MAX_RETRIES = 4;
+
+// Maximum number of retries when processing entries in the range.
+// We will retry a few times, but limit the total number of retries to ensure the
+// range is processed timely. Not retrying is not too bad, as the next run will.
+// We are processing 10 entries at a time, so a range should take around 1 second.
+// Since entries get processed in parallel, they will get distributed accross the
+// parallel tasks, so the total delay of retries should about 1m30s.
+const MAX_RETRIES_TOTAL = CONCURRENCY_DEFAULT * MAX_RETRIES * 10;
+
 /**
  * compare 2 version by their stale dates returning:
  * - LT (-1) if v1 is less than v2
@@ -84,6 +98,7 @@ class LifecycleTask extends BackbeatTask {
             this._lifecycleDateTime
         );
         this._supportedRules = supportedLifecycleRules;
+        this._totalRetries = 0;
     }
 
     setSupportedRules(supportedRules) {
@@ -898,14 +913,14 @@ class LifecycleTask extends BackbeatTask {
             // so we possibly retry each individual entry here, and ignore errors.
             // Ignoring error is not too bad, the entry will be picked up again on
             // next lifecycle run
-            return this.retry({
-                actionDesc: 'compare rules lifecycle entry',
+            return this._retryEntry({
                 logFields: {
                     key: obj.Key,
                     versionId: obj.VersionId,
                     staleDate: obj.staleDate,
                     versioningStatus,
                 },
+                log,
                 actionFunc: done => async.waterfall([
                     next => this._getRules(bucketData, lcRules, obj, log, next),
                     (applicableRules, next) => {
@@ -917,10 +932,39 @@ class LifecycleTask extends BackbeatTask {
                             next);
                     },
                 ], done),
-                shouldRetryFunc: err => err.retryable,
-                log,
-            }, () => cb());
+            }, cb);
         }, done);
+    }
+
+    /**
+     * Retries processing an entry, respecting both individual and global retry
+     * limits to avoid stalling the whole process.
+     *
+     * @param {Object} params - The parameters object.
+     * @param {Function} params.actionFunc - The action function to retry.
+     * @param {Object} params.log - The logger object.
+     * @param {Object} params.logFields - The logger fields object.
+     * @param {Function} cb - The callback function to execute after the retries.
+     * @returns {void}
+     */
+    _retryEntry(params, cb) {
+        const { actionFunc, log, logFields } = params;
+        this.retry({
+            actionDesc: 'compare rules lifecycle entry',
+            logFields,
+            log,
+            actionFunc,
+            maxRetries: MAX_RETRIES, // override maximum number of retries
+            shouldRetryFunc: err => err.retryable && this._totalRetries < MAX_RETRIES_TOTAL,
+            onRetryFunc: () => this._totalRetries++,
+        }, () => {
+            // To maintain consistency with the flow logic of LifecycleTask, no
+            // errors will be returned from the callback.
+            // This ensures that any failures during the looping process through
+            // the keys (as seen in _compareRulesToList()) will not cause a
+            // break in the loop.
+            cb();
+        });
     }
 
     /**
@@ -1216,11 +1260,7 @@ class LifecycleTask extends BackbeatTask {
             if (cb) {
                 // NOTE: The purpose of introducing asynchronous logic here is to improve
                 // the flow control of LifecycleTaskV2.
-                // Additionally, to maintain consistency with the flow logic of LifecycleTask,
-                // no errors will be returned from the callback.
-                // This ensures that any failures during the looping process through the keys
-                // (as seen in _compareRulesToList()) will not cause a break in the loop.
-                cb();
+                cb(err);
             }
             return;
         });

--- a/extensions/lifecycle/tasks/LifecycleTaskV2.js
+++ b/extensions/lifecycle/tasks/LifecycleTaskV2.js
@@ -260,8 +260,15 @@ class LifecycleTaskV2 extends LifecycleTask {
         }
         return async.eachLimit(contents, CONCURRENCY_DEFAULT, (obj, cb) => {
             const applicableRules = this._getRules(bucketData, lcRules, obj);
-            return this._compare(bucketData, obj,
-                    applicableRules, log, cb);
+            return this._retryEntry({
+                logFields: {
+                    key: obj.Key,
+                    versionId: obj.VersionId,
+                    staleDate: obj.staleDate,
+                },
+                log,
+                actionFunc: done => this._compare(bucketData, obj, applicableRules, log, done),
+            }, cb);
         }, done);
     }
 

--- a/lib/tasks/BackbeatTask.js
+++ b/lib/tasks/BackbeatTask.js
@@ -23,6 +23,7 @@ class BackbeatTask {
         const backoffCtx = new BackOff(this.retryParams.backoff);
         let nbRetries = 0;
         const startTime = noTimeout ? undefined : Date.now();
+        const maxRetries = args.maxRetries || this.retryParams.maxRetries;
 
         // FIXME workaround for S3C-4457:
         //
@@ -60,13 +61,9 @@ class BackbeatTask {
                 if (!shouldRetryFunc(err)) {
                     return doneOnce(err);
                 }
-                if (onRetryFunc) {
-                    onRetryFunc(err);
-                }
 
                 const now = Date.now();
-                const retriesMaxedOut = nbRetries >=
-                    this.retryParams.maxRetries;
+                const retriesMaxedOut = nbRetries >= maxRetries;
                 const timeoutReached = startTime !== undefined &&
                     now >= (startTime + this.retryParams.timeoutS * 1000);
                 // Give up if max retries reached or if timeout reached and
@@ -83,6 +80,11 @@ class BackbeatTask {
                         }, logFields || {}), log);
                     return doneOnce(err);
                 }
+
+                if (onRetryFunc) {
+                    onRetryFunc(err);
+                }
+
                 const retryDelayMs = backoffCtx.duration();
                 log.info('scheduling retry due to temporary failure',
                     Object.assign({ nbRetries, actionDesc,


### PR DESCRIPTION
Misc tweaks to lifecycle, which should avoid duplicated processing.

- Properly handle async calls to `_applyTransitionRule`
- Do not retry whole batch when a single entry fails

Issue: BB-437
