### PR TITLE
Improve bucket processor logs

### DIFF
--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -213,6 +213,7 @@ class LifecycleTask extends BackbeatTask {
                     }
 
                     const entry = Object.assign({}, bucketData, {
+                        contextInfo: { reqId: log.getSerializedUids() },
                         details: { marker },
                     });
                     this._sendBucketEntry(entry, err => {
@@ -385,6 +386,9 @@ class LifecycleTask extends BackbeatTask {
                 // Uses last version whether Version or DeleteMarker
                 const last = allVersions[allVersions.length - 1];
                 const entry = Object.assign({}, bucketData, {
+                    contextInfo: {
+                        reqId: log.getSerializedUids(),
+                    },
                     details: {
                         keyMarker: data.NextKeyMarker,
                         versionIdMarker: data.NextVersionIdMarker,
@@ -468,6 +472,9 @@ class LifecycleTask extends BackbeatTask {
                     // re-queue to kafka with `NextUploadIdMarker` &
                     // `NextKeyMarker` only once.
                     const entry = Object.assign({}, bucketData, {
+                        contextInfo: {
+                            reqId: log.getSerializedUids(),
+                        },
                         details: {
                             keyMarker: data.NextKeyMarker,
                             uploadIdMarker: data.NextUploadIdMarker,
@@ -1759,6 +1766,8 @@ class LifecycleTask extends BackbeatTask {
         log.debug('processing bucket entry', {
             bucket: bucketData.target.bucket,
             owner: bucketData.target.owner,
+            contextInfo: bucketData.contextInfo,
+            details: bucketData.details,
         });
 
         // Initially, processing a Bucket entry should check mpu AND
@@ -1826,10 +1835,12 @@ class LifecycleTask extends BackbeatTask {
                 ], cb);
             },
         ], err => {
-            this.log.info('finished processing task for bucket lifecycle', {
+            log.info('finished processing task for bucket lifecycle', {
                 method: 'LifecycleTask.processBucketEntry',
                 bucket: bucketData.target.bucket,
                 owner: bucketData.target.owner,
+                contextInfo: bucketData.contextInfo,
+                details: bucketData.details,
             });
             // An optimization is possible by only publishing when
             // finishing a complete bucket listing, let it aside for

--- a/extensions/lifecycle/tasks/LifecycleTaskV2.js
+++ b/extensions/lifecycle/tasks/LifecycleTaskV2.js
@@ -52,6 +52,7 @@ class LifecycleTaskV2 extends LifecycleTask {
                 } = l;
 
                 const entry = Object.assign({}, bucketData, {
+                    contextInfo: { requestId: log.getSerializedUids() },
                     details: { beforeDate, prefix, listType, storageClass },
                 });
 
@@ -114,6 +115,7 @@ class LifecycleTaskV2 extends LifecycleTask {
             // re-queue truncated listing only once.
             if (isTruncated && nbRetries === 0) {
                 const entry = Object.assign({}, bucketData, {
+                    contextInfo: { requestId: log.getSerializedUids() },
                     details: {
                         beforeDate: params.BeforeDate,
                         prefix: params.Prefix,
@@ -197,6 +199,7 @@ class LifecycleTaskV2 extends LifecycleTask {
             // re-queue truncated listing only once.
             if (isTruncated && nbRetries === 0) {
                 const entry = Object.assign({}, bucketData, {
+                    contextInfo: { requestId: log.getSerializedUids() },
                     details: {
                         beforeDate: params.BeforeDate,
                         prefix: params.Prefix,

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -179,6 +179,7 @@ class BackbeatConsumer extends EventEmitter {
             'offset_commit_cb': this._onOffsetCommit.bind(this),
             // automatically create topic
             'allow.auto.create.topics': true,
+            'rebalance_cb': true,
         };
         const topicParams = {};
         if (this._fromOffset !== undefined) {
@@ -186,6 +187,9 @@ class BackbeatConsumer extends EventEmitter {
         }
         if (this._fetchMaxBytes !== undefined) {
             consumerParams['fetch.message.max.bytes'] = this._fetchMaxBytes;
+        }
+        if (process.env.RDKAFKA_DEBUG_LOGS) {
+            consumerParams.debug = process.env.RDKAFKA_DEBUG_LOGS;
         }
         if (this._site) {
             this._log.info('follower fetching enabled for topic/consumer group', {
@@ -196,6 +200,22 @@ class BackbeatConsumer extends EventEmitter {
             consumerParams['client.rack'] = this._site;
         }
         this._consumer = new kafka.KafkaConsumer(consumerParams, topicParams);
+
+        this._consumer.on('event', event => this._log.info('rdkafka.event', { event }));
+        this._consumer.on('event.log', log => this._log.info('rdkafka.log', { log }));
+        this._consumer.on('warning', warning => this._log.warn('rdkafka.warning', { warning }));
+        this._consumer.on('event.error', err => this._log.error('rdkafka.error', { err }));
+        this._consumer.on('event.throttle', throttle => this._log.info('rdkafka.throttle', { throttle }));
+        this._consumer.on('rebalance', (err, assignment) => {
+            if (err.code === kafka.CODES.ERRORS.ERR__ASSIGN_PARTITIONS) {
+                this._log.debug('rdkafka.assign', { err, assignment });
+            } else if (err.code === kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
+                this._log.debug('rdkafka.revoke', { err });
+            } else {
+                this._log.error('rdkafka.rebalance', { err, assignment });
+            }
+        });
+
         this._consumer.connect({ timeout: 10000 }, () => {
             const opts = {
                 topic: withTopicPrefix('backbeat-sanitycheck'),

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -32,6 +32,12 @@ class BackbeatProducer extends EventEmitter {
 
         this._producer = new Producer(this.producerConfig, this.topicConfig);
 
+        this._producer.on('event', event => this._log.info('rdkafka.event', { event }));
+        this._producer.on('event.log', log => this._log.info('rdkafka.log', { log }));
+        this._producer.on('warning', warning => this._log.warn('rdkafka.warning', { warning }));
+        this._producer.on('event.error', err => this._log.error('rdkafka.error', { err }));
+        this._producer.on('event.throttle', throttle => this._log.info('rdkafka.throttle', { throttle }));
+
         this.connect();
         this.setListeners();
         return this;
@@ -63,12 +69,18 @@ class BackbeatProducer extends EventEmitter {
     }
 
     get producerConfig() {
-        return {
+        const producerParams = {
             'metadata.broker.list': this._kafkaHosts,
             'message.max.bytes': this._maxRequestSize,
             'dr_cb': true,
             'compression.type': Constants.compressionType,
         };
+
+        if (process.env.RDKAFKA_DEBUG_LOGS) {
+            producerParams.debug = process.env.RDKAFKA_DEBUG_LOGS;
+        }
+
+        return producerParams;
     }
 
     get topicConfig() {

--- a/tests/functional/lifecycle/LifecycleConductor.spec.js
+++ b/tests/functional/lifecycle/LifecycleConductor.spec.js
@@ -41,6 +41,7 @@ const expected2Messages = [
     {
         value: {
             action: 'processObjects',
+            contextInfo: { reqId: 'test-request-id' },
             target: { bucket: 'bucket1', owner: 'owner1', taskVersion: 'v1' },
             details: {},
         },
@@ -48,6 +49,7 @@ const expected2Messages = [
     {
         value: {
             action: 'processObjects',
+            contextInfo: { reqId: 'test-request-id' },
             target: { bucket: 'bucket1-2', owner: 'owner1', taskVersion: 'v1' },
             details: {},
         },
@@ -58,6 +60,7 @@ const expected4Messages = [
     {
         value: {
             action: 'processObjects',
+            contextInfo: { reqId: 'test-request-id' },
             target: { bucket: 'bucket1', owner: 'owner1', taskVersion: 'v1' },
             details: {},
         },
@@ -65,6 +68,7 @@ const expected4Messages = [
     {
         value: {
             action: 'processObjects',
+            contextInfo: { reqId: 'test-request-id' },
             target: { bucket: 'bucket1-2', owner: 'owner1', taskVersion: 'v1' },
             details: {},
         },
@@ -72,6 +76,7 @@ const expected4Messages = [
     {
         value: {
             action: 'processObjects',
+            contextInfo: { reqId: 'test-request-id' },
             target: { bucket: 'bucket3', owner: 'owner3', taskVersion: 'v1' },
             details: {},
         },
@@ -79,6 +84,7 @@ const expected4Messages = [
     {
         value: {
             action: 'processObjects',
+            contextInfo: { reqId: 'test-request-id' },
             target: { bucket: 'bucket4', owner: 'owner4', taskVersion: 'v1' },
             details: {},
         },

--- a/tests/unit/lifecycle/LifecycleConductor.spec.js
+++ b/tests/unit/lifecycle/LifecycleConductor.spec.js
@@ -50,7 +50,7 @@ describe('Lifecycle Conductor', () => {
         this.timeout(4000);
         // tests that `activeIndexingJobRetrieved` is not reset until the e
         it('should not reset `activeIndexingJobsRetrieved` while async operations are in progress', done => {
-            let order = [];
+            const order = [];
 
             conductor._mongodbClient = { getIndexingJobs: () => {} };
             conductor._producer = { send: (msg, cb) => cb() };

--- a/tests/utils/BackbeatTestConsumer.js
+++ b/tests/utils/BackbeatTestConsumer.js
@@ -26,6 +26,13 @@ class BackbeatTestConsumer extends BackbeatConsumer {
                 const parsedMsg = typeof expectedMsg.value === 'object' ?
                           JSON.parse(message.value) :
                           message.value.toString();
+                if (typeof expectedMsg.value === 'object' &&
+                    expectedMsg.value.contextInfo?.reqId === 'test-request-id') {
+                    // RequestId is generated randomly, we can't compare it: just check that it is
+                    // present
+                    assert(parsedMsg.contextInfo?.reqId, 'expected contextInfo.reqId field');
+                    parsedMsg.contextInfo.reqId = expectedMsg.value.contextInfo?.reqId;
+                }
                 assert.deepStrictEqual(
                     parsedMsg, expectedMsg.value,
                     `unexpected message value ${parsedMsg}, ` +


### PR DESCRIPTION
Log rdkafka events, with a env-var flag allowing to enable all debug logs from the lib, for troubelshooting.

Also log bucket processor task `RequestId`, and pass the conductor's `RequestId` through kafka: so that it is possible to follow the chain of messages.

Issue: BB-439
