### PR TITLE
BB-451: Add fallback timestamp to delete notifications

### DIFF
--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -385,6 +385,7 @@ class LogReader {
                 key: _transformKey(entry.key),
                 value: entry.value,
                 logReader: this,
+                timestamp: record.timestamp,
             };
             return _executeFilter(ext, entryToFilter, next);
         }, cb);

--- a/tests/unit/lib/queuePopulator/LogReader.spec.js
+++ b/tests/unit/lib/queuePopulator/LogReader.spec.js
@@ -76,6 +76,7 @@ describe('LogReader', () => {
                 key: testCase.processedKey,
                 value: '{}',
                 logReader,
+                timestamp: undefined,
             });
         });
     });

--- a/tests/unit/notification/NotificationQueuePopulator.js
+++ b/tests/unit/notification/NotificationQueuePopulator.js
@@ -1,0 +1,104 @@
+const assert = require('assert');
+const werelogs = require('werelogs');
+
+const NotificationQueuePopulator = require('../../../extensions/notification/NotificationQueuePopulator');
+
+const log = new werelogs.Logger('NotificationQueuePopulator:test');
+werelogs.configure({
+    level: 'warn',
+    dump: 'error',
+});
+
+const bucket = 'bucket1';
+const objectKey = 'object1';
+const value = {
+    bucket,
+};
+const fallbackCommitTimestamp = '2022-10-12T00:01:02.003Z';
+const mdTimestamp = '2023-10-12T00:01:02.003Z';
+const configTopic = 'topic1';
+
+describe('NotificationQueuePopulator', () => {
+    describe('_processObjectEntry', () => {
+        it('should use the fallback event timestamp for deletes', () => {
+            const type = 'del';
+            let published = false;
+
+            const qp = new NotificationQueuePopulator({
+                logger: log,
+                config: {
+                    topic: configTopic,
+                },
+                bnConfigManager: {
+                    getConfig: () => ({
+                        bucket,
+                        notificationConfiguration: {
+                            queueConfig: [
+                                {
+                                    events: ['*'],
+                                },
+                            ],
+                        },
+                    }),
+                },
+            });
+
+            qp.publish = (topic, key, data) => {
+                const parsed = JSON.parse(data);
+
+                assert.deepStrictEqual(topic, configTopic);
+                assert.deepStrictEqual(key, `${bucket}/${objectKey}`);
+                assert.deepStrictEqual(parsed.dateTime, fallbackCommitTimestamp);
+
+                published = true;
+            };
+
+            qp._processObjectEntry(bucket, objectKey, value, type, fallbackCommitTimestamp);
+
+            assert(published);
+        });
+
+        it('should use the event timestamp from MD if available', () => {
+            let published = false;
+
+            const qp = new NotificationQueuePopulator({
+                logger: log,
+                config: {
+                    topic: configTopic,
+                },
+                bnConfigManager: {
+                    getConfig: () => ({
+                        bucket,
+                        notificationConfiguration: {
+                            queueConfig: [
+                                {
+                                    events: ['*'],
+                                },
+                            ],
+                        },
+                    }),
+                },
+            });
+
+            qp.publish = (topic, key, data) => {
+                const parsed = JSON.parse(data);
+
+                assert.deepStrictEqual(topic, configTopic);
+                assert.deepStrictEqual(key, `${bucket}/${objectKey}`);
+                assert.deepStrictEqual(parsed.dateTime, mdTimestamp);
+
+                published = true;
+            };
+
+            const valueWithMD = {
+                'originOp': 's3:ObjectCreated:Put',
+                'last-modified': mdTimestamp,
+                ...value,
+            };
+
+            qp._processObjectEntry(bucket, objectKey, valueWithMD, null, fallbackCommitTimestamp);
+
+            assert(published);
+        });
+    });
+});


### PR DESCRIPTION
Delete notification events were missing the `eventTime` attribute because the `last-modified` MD field was not present in the raft log. This change uses the raft log entries' `timestamp` attribute in its place for delete operations.