### PR TITLE
forward system signals to the node process using tini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ FROM node:${NODE_VERSION}
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         jq \
+        tini \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /usr/src/app
@@ -49,6 +50,6 @@ COPY . /usr/src/app
 COPY --from=builder /usr/src/app/node_modules ./node_modules/
 COPY --from=builder /usr/local/bin/dockerize /usr/local/bin/
 
-ENTRYPOINT ["/usr/src/app/docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "/usr/src/app/docker-entrypoint.sh"]
 
 EXPOSE 8900


### PR DESCRIPTION
`npm run` doesn’t handle signal forwarding and crashes on the SIGTERM signal sent by Kubernetes.
This prevents backbeat from doing a cleanup before shutting down.

We'll use `Tini`, which spawns a process at PID 1 that handles forwarding system signals to all it's child processes.
This is the recommended solution found in the [NodeJS best practicing guide](https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#handling-kernel-signals).

Issur: BB-459