### PR TITLE
Wait for current tasks to finish before shutdown in BackbeatConsumer

### DIFF
--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -585,15 +585,24 @@ class BackbeatConsumer extends EventEmitter {
                     logger.bind(this._log)('rdkafka.commit failed', { e: e.toString(), assignment });
                 }
 
-                try {
-                    this._consumer.unassign();
-                } catch (e) {
-                    // Ignore exceptions if we are not connected
-                    const logger = this._consumer.isConnected() ? this._log.error : this._log.info;
-                    logger.bind(this._log)('rdkafka.unassign failed', { e: e.toString(), assignment });
-                }
+                const doUnassign = () => {
+                    try {
+                        this._consumer.unassign();
+                    } catch (e) {
+                        // Ignore exceptions if we are not connected
+                        const logger = this._consumer.isConnected() ? this._log.error : this._log.info;
+                        logger.bind(this._log)('rdkafka.unassign failed', { e: e.toString(), assignment });
+                    }
 
-                this.emit('unassign', status);
+                    this.emit('unassign', status);
+                };
+
+                // publish offsets to zookeeper
+                if (this._kafkaBacklogMetricsConfig) {
+                    this._publishOffsetsCron(doUnassign);
+                } else {
+                    doUnassign();
+                }
             });
 
             if (!this._processingQueue || this._processingQueue.idle()) {
@@ -911,37 +920,30 @@ class BackbeatConsumer extends EventEmitter {
         this._circuitBreaker.stop();
         return async.waterfall([
             next => {
-                if (this._kafkaBacklogMetricsConfig) {
-                    // publish offsets to zookeeper
-                    return this._publishOffsetsCron(() => next());
+                if (this._consumer.isConnected()) {
+                    const subscription = this._consumer.subscription() || [];
+                    if (subscription.length > 0) {
+                        this._consumer.unsubscribe();
+                        // Wait for partition unassign to complete before
+                        // disconnecting, the rebalance callback will handle
+                        // waiting for current jobs to complete as well as commit
+                        // the latest offsets
+                        this.once('unassign', () => next());
+                        return;
+                    }
                 }
-                return process.nextTick(next);
+                process.nextTick(next);
             },
             next => {
                 if (this._zookeeper) {
                     this._zookeeper.close();
+                }
+                if (this._consumer.isConnected()) {
+                    this._consumer.disconnect();
+                    this._consumer.once('disconnected', () => next());
                 } else {
                     process.nextTick(next);
                 }
-            },
-            next => {
-                const subscription = this._consumer.subscription() || [];
-                if (subscription.length > 0) {
-                    this._consumer.unsubscribe();
-                    // Wait for partition unassign to complete before
-                    // disconnecting, the rebalance callback will handle
-                    // waiting for current jobs to complete as well as commit
-                    // the latest offsets
-                    this.on('unassign', next);
-                } else {
-                    next(UNASSIGN_STATUS.IDLE);
-                }
-            },
-            (status, next) => {
-                if (status !== UNASSIGN_STATUS.TIMEOUT) {
-                    this._consumer.disconnect();
-                }
-                this._consumer.once('disconnected', () => next());
             },
         ], () => cb());
     }

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -20,6 +20,12 @@ const CONCURRENCY_DEFAULT = 1;
 const CLIENT_ID = 'BackbeatConsumer';
 const { withTopicPrefix } = require('./util/topic');
 
+const UNASSIGN_STATUS = {
+    IDLE: 'idle',
+    DRAINED: 'drained',
+    TIMEOUT: 'timeout',
+};
+
 /**
  * Stats on how we are consuming Kafka
  * @typedef {Object} ConsumerStats
@@ -447,7 +453,6 @@ class BackbeatConsumer extends EventEmitter {
         });
     }
 
-
     /**
      * Track processing of a task.
      * @param {*} entry - kafka entry being processed
@@ -587,14 +592,16 @@ class BackbeatConsumer extends EventEmitter {
                     const logger = this._consumer.isConnected() ? this._log.error : this._log.info;
                     logger.bind(this._log)('rdkafka.unassign failed', { e: e.toString(), assignment });
                 }
+
+                this.emit('unassign', status);
             });
 
             if (!this._processingQueue || this._processingQueue.idle()) {
-                unassign('idle');
+                unassign(UNASSIGN_STATUS.IDLE);
                 return;
             }
 
-            this._processingQueue.drain = () => unassign('drained');
+            this._processingQueue.drain = () => unassign(UNASSIGN_STATUS.DRAINED);
 
             // Set timeout of `max.poll.interval.ms`), to ensure we complete the rebalance
             // eventually (even if a task is really stuck), and don't get kicked out of the consumer
@@ -602,7 +609,7 @@ class BackbeatConsumer extends EventEmitter {
             // disconnect the consumer, so that the healthcheck will fail and the process will get
             // restarted.
             this._drainProcessQueueTimeout = setTimeout(() => {
-                unassign('timeout');
+                unassign(UNASSIGN_STATUS.TIMEOUT);
 
                 this._log.error('rdkafka.rebalance timeout: consumer stuck, disconnecting');
                 this._consumer.disconnect();
@@ -902,17 +909,8 @@ class BackbeatConsumer extends EventEmitter {
             return setTimeout(() => this.close(cb), 1000);
         }
         this._circuitBreaker.stop();
-        return async.series([
+        return async.waterfall([
             next => {
-                if (this._consumer) {
-                    try {
-                        this._consumer.commit();
-                    } catch (e) {
-                        // Ignore exceptions if we are not connected
-                        const logger = this._consumer.isConnected() ? this._log.error : this._log.debug;
-                        logger.bind(this._log)('commit failed', { e: e.toString() });
-                    }
-                }
                 if (this._kafkaBacklogMetricsConfig) {
                     // publish offsets to zookeeper
                     return this._publishOffsetsCron(() => next());
@@ -922,14 +920,28 @@ class BackbeatConsumer extends EventEmitter {
             next => {
                 if (this._zookeeper) {
                     this._zookeeper.close();
-                }
-                if (this._consumer) {
-                    this._consumer.unsubscribe();
-                    this._consumer.disconnect();
-                    this._consumer.on('disconnected', () => next());
                 } else {
                     process.nextTick(next);
                 }
+            },
+            next => {
+                const subscription = this._consumer.subscription() || [];
+                if (subscription.length > 0) {
+                    this._consumer.unsubscribe();
+                    // Wait for partition unassign to complete before
+                    // disconnecting, the rebalance callback will handle
+                    // waiting for current jobs to complete as well as commit
+                    // the latest offsets
+                    this.on('unassign', next);
+                } else {
+                    next(UNASSIGN_STATUS.IDLE);
+                }
+            },
+            (status, next) => {
+                if (status !== UNASSIGN_STATUS.TIMEOUT) {
+                    this._consumer.disconnect();
+                }
+                this._consumer.once('disconnected', () => next());
             },
         ], () => cb());
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "8.6.28",
+  "version": "8.6.29",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
To avoid processing Kafka messages multiple times by different consumers, the BackbeatConsumer needs to wait for the current jobs to finish before committing the updated offsets.

This has to be done twice, once when Kafka rebalances and the second on shutdown.

This PR addresses the shutdown part.

Issue: BB-455