### PR TITLE
Complete & commit current task(s) on rebalance

### DIFF
--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -601,6 +601,11 @@ class BackbeatConsumer extends EventEmitter {
                             { topic: self._topic, groupId: self._groupId });
                         clearInterval(producerTimer);
                         clearInterval(consumerTimer);
+                        self._consumer.offsetsStore([{
+                            topic: self._topic,
+                            partition: message.partition,
+                            offset: message.offset + 1,
+                        }]);
                         self._consumer.commit();
                         self._consumer.unsubscribe();
                         producer.close(() => {

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -181,7 +181,7 @@ class BackbeatConsumer extends EventEmitter {
             // automatically create topic
             'allow.auto.create.topics': true,
             'statistics.interval.ms': 1000,
-            'rebalance_cb': true,
+            'rebalance_cb': this._onRebalance.bind(this),
             // decrease max metadata age to 5s to decrease potential lag between
             // consumer and producer when a partition is added to a topic
             'metadata.max.age.ms': 5000,
@@ -212,15 +212,6 @@ class BackbeatConsumer extends EventEmitter {
         this._consumer.on('event.error', err => this._log.error('rdkafka.error', { err }));
         this._consumer.on('event.throttle', throttle => this._log.info('rdkafka.throttle', { throttle }));
         this._consumer.on('event.stats', observeKafkaStats);
-        this._consumer.on('rebalance', (err, assignment) => {
-            if (err.code === kafka.CODES.ERRORS.ERR__ASSIGN_PARTITIONS) {
-                this._log.debug('rdkafka.assign', { err, assignment });
-            } else if (err.code === kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
-                this._log.debug('rdkafka.revoke', { err });
-            } else {
-                this._log.error('rdkafka.rebalance', { err, assignment });
-            }
-        });
 
         this._consumer.connect({ timeout: 10000 }, () => {
             const opts = {
@@ -495,6 +486,59 @@ class BackbeatConsumer extends EventEmitter {
         this._log.debug('commit offsets callback',
                         { topicPartitions, groupId: this._groupId });
         return undefined;
+    }
+
+    /**
+     * @param {kafka.KafkaError} err Rebalance event
+     * @param {TopicPartition[]} assignment List of (un)assigned partitions
+     * @returns {void}
+     */
+    _onRebalance(err, assignment) {
+        if (err.code === kafka.CODES.ERRORS.ERR__ASSIGN_PARTITIONS) {
+            this._log.debug('rdkafka.assign', { err, assignment });
+
+            try {
+                this._consumer.assign(assignment);
+            } catch (e) {
+                // Ignore exceptions if we are not connected
+                const logger = this._consumer.isConnected() ? this._log.error : this._log.debug;
+                logger.bind(this._log)('rdkafka.assign failed', { err, e, assignment });
+            }
+        } else if (err.code === kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
+            this._log.debug('rdkafka.revoke', {
+                err, assignment,
+                queueLen: this._processingQueue?.length(),
+                running: this._processingQueue?.running(),
+            });
+
+            if (!this._processingQueue || this._processingQueue.idle()) {
+                try {
+                    this._consumer.unassign();
+                } catch (e) {
+                    // Ignore exceptions if we are not connected
+                    const logger = this._consumer.isConnected() ? this._log.error : this._log.info;
+                    logger.bind(this._log)('rdkafka.unassign failed', { e, assignment });
+                }
+                return;
+            }
+
+            this._processingQueue.drain = () => {
+                this._log.debug('processing queue drained, un-assigning');
+
+                // Reset the drain callback
+                this._processingQueue.drain = () => { };
+
+                try {
+                    this._consumer.unassign();
+                } catch (e) {
+                    // Ignore exceptions if we are not connected
+                    const logger = this._consumer.isConnected() ? this._log.error : this._log.info;
+                    logger.bind(this._log)('rdkafka.unassign failed', { e, assignment });
+                }
+            };
+        } else {
+            this._log.error('rdkafka.rebalance', { err, assignment });
+        }
     }
 
     /**

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -513,6 +513,15 @@ class BackbeatConsumer extends EventEmitter {
 
             if (!this._processingQueue || this._processingQueue.idle()) {
                 try {
+                    // Ensure the state is committed before un-assigning
+                    this._consumer.commit();
+                } catch (e) {
+                    // Ignore exceptions if we are not connected
+                    const logger = this._consumer.isConnected() ? this._log.error : this._log.info;
+                    logger.bind(this._log)('rdkafka.commit failed', { e, assignment });
+                }
+
+                try {
                     this._consumer.unassign();
                 } catch (e) {
                     // Ignore exceptions if we are not connected
@@ -527,6 +536,15 @@ class BackbeatConsumer extends EventEmitter {
 
                 // Reset the drain callback
                 this._processingQueue.drain = () => { };
+
+                try {
+                    // Ensure the state is committed before un-assigning
+                    this._consumer.commit();
+                } catch (e) {
+                    // Ignore exceptions if we are not connected
+                    const logger = this._consumer.isConnected() ? this._log.error : this._log.info;
+                    logger.bind(this._log)('rdkafka.commit failed', { e, assignment });
+                }
 
                 try {
                     this._consumer.unassign();

--- a/tests/functional/lib/BackbeatConsumer.js
+++ b/tests/functional/lib/BackbeatConsumer.js
@@ -37,6 +37,7 @@ describe('BackbeatConsumer main tests', () => {
         consumedMessages.push(message.value);
         process.nextTick(cb);
     }
+
     before(function before(done) {
         this.timeout(60000);
 
@@ -199,6 +200,143 @@ describe('BackbeatConsumer main tests', () => {
             done();
         });
     }).timeout(30000);
+});
+
+describe('BackbeatConsumer rebalance tests', () => {
+    const topic = 'backbeat-consumer-spec-rebalance';
+    const groupId = `replication-group-${Math.random()}`;
+    const messages = [
+        { key: 'foo', message: '{"hello":"foo"}' },
+        { key: 'bar', message: '{"world":"bar"}' },
+        { key: 'qux', message: '{"hi":"qux"}' },
+    ];
+    let producer;
+    let consumer;
+    let consumer2;
+    let processedMessages;
+    let consumedMessages;
+
+    function queueProcessor(message, cb) {
+        assert(processedMessages.length < messages.length);
+
+        consumer.emit('consumed.message', message.value.toString());
+
+        // Shorter delay for first message, to ensure there is something being processed during the
+        // rebalance
+        setTimeout(() => {
+            processedMessages.push(message.value);
+            assert(processedMessages.length <= messages.length);
+
+            process.nextTick(() => {
+                cb();
+
+                consumer.emit('processed.message', message.value.toString());
+
+                if (processedMessages.length === messages.length) {
+                    assert.deepStrictEqual(
+                        processedMessages.map(buffer => buffer.toString()),
+                        messages.map(e => e.message));
+                    consumer.emit('processed.all');
+                }
+            });
+        }, consumedMessages++ ? 4000 : 2000);
+    }
+
+    before(function before(done) {
+        this.timeout(60000);
+
+        // Bootstrap just once at the beginning of the test suite
+        consumer = new BackbeatConsumer({
+            zookeeper: zookeeperConf,
+            kafka: { hosts: consumerKafkaConf.hosts }, groupId, topic,
+            queueProcessor,
+            bootstrap: true,
+        });
+        consumer.on('ready', () => consumer.close(done));
+    });
+
+    beforeEach(function before(done) {
+        this.timeout(60000);
+
+        consumedMessages = 0;
+        processedMessages = [];
+        producer = new BackbeatProducer({
+            kafka: producerKafkaConf, topic,
+            pollIntervalMs: 100
+        });
+        consumer = new BackbeatConsumer({
+            zookeeper: zookeeperConf,
+            kafka: consumerKafkaConf, groupId, topic,
+            queueProcessor,
+            concurrency: 2,
+        });
+
+        async.parallel([
+            innerDone => producer.on('ready', innerDone),
+            innerDone => async.series([
+                cb => consumer.on('ready', cb),
+                cb => {
+                    consumer2 = new BackbeatConsumer({
+                        zookeeper: zookeeperConf,
+                        kafka: consumerKafkaConf, groupId, topic,
+                        queueProcessor,
+                    });
+                    consumer2.on('ready', cb);
+                },
+            ], innerDone),
+        ], done);
+    });
+
+    afterEach(function after(done) {
+        this.timeout(10000);
+        async.parallel([
+            innerDone => producer.close(innerDone),
+            innerDone => consumer.close(innerDone),
+            innerDone => (consumer2 ? consumer2.close(innerDone) : innerDone()),
+        ], done);
+    });
+
+    it('should handle rebalance when no task in progress', done => {
+        consumer.on('processed.all', () => {
+            // create second consumer: should rebalance...
+            consumer2._queueProcessor = message => {
+                assert.fail(`unexpected message received ${message.value}`);
+            };
+            consumer2.subscribe();
+
+            // wait a bit, ensure no message happens afterwards...
+            setTimeout(done, 5000);
+        });
+
+        consumer.subscribe();
+
+        // send data to topic : should be consumed
+        producer.send(messages, err => {
+            assert.ifError(err);
+        });
+    }).timeout(40000);
+
+    it('should commit current tasks during rebalance', done => {
+        consumer.on('processed.all', () => {
+            // wait a bit, ensure no message happens afterwards...
+            setTimeout(done, 5000);
+        });
+
+        consumer.on('consumed.message', message => {
+            consumer._log.debug('consumed', { message });
+            if (consumedMessages === 0) {
+                // trigger rebalance during processing of first message
+                consumer2.subscribe();
+            }
+        });
+
+        consumer.subscribe();
+
+        // send data to topic : should be consumed
+        producer.send(messages, err => {
+            assert.ifError(err);
+        });
+    }).timeout(40000);
 });
 
 describe('BackbeatConsumer concurrency tests', () => {

--- a/tests/functional/lib/BackbeatConsumer.js
+++ b/tests/functional/lib/BackbeatConsumer.js
@@ -345,11 +345,14 @@ describe('BackbeatConsumer concurrency tests', () => {
     let producer;
     let consumer;
     let consumedMessages = [];
+    let taskStuckCallbacks = [];
 
     function queueProcessor(message, cb) {
         if (message.value.toString() !== 'taskStuck') {
             consumedMessages.push(message.value);
             process.nextTick(cb);
+        } else {
+            taskStuckCallbacks.push(cb);
         }
     }
     before(function before(done) {
@@ -375,6 +378,9 @@ describe('BackbeatConsumer concurrency tests', () => {
     afterEach(() => {
         consumedMessages = [];
         consumer.removeAllListeners('consumed');
+
+        taskStuckCallbacks.map(cb => cb());
+        taskStuckCallbacks = [];
     });
     after(done => {
         async.parallel([
@@ -591,11 +597,14 @@ describe('BackbeatConsumer with circuit breaker', () => {
         let producer;
         let consumer;
         let consumedMessages = [];
+        let taskStuckCallbacks = [];
 
         function queueProcessor(message, cb) {
             if (message.value.toString() !== 'taskStuck') {
                 consumedMessages.push(message.value);
                 process.nextTick(cb);
+            } else {
+                taskStuckCallbacks.push(cb);
             }
         }
         before(function before(done) {
@@ -624,6 +633,9 @@ describe('BackbeatConsumer with circuit breaker', () => {
         afterEach(() => {
             consumedMessages = [];
             consumer.removeAllListeners('consumed');
+
+            taskStuckCallbacks.map(cb => cb());
+            taskStuckCallbacks = [];
         });
         after(done => {
             async.parallel([


### PR DESCRIPTION
Implement rebalance callback, so that we will now properly handle the rebalance process at
application level, and thus avoid extra rebalances or processing the same entry multiple times:
* On `unassign`, wait until current tasks are complete, by draining the queue;
* Then explicitely commit, to ensure the persisted timely (since we are usually relying on a
  auto-commit timer, which may happen at any time in the process)
* Finally call the unassign() method of consumer to let the cluster sync and proceed with the
  rebalance.

We are expected (by kafka) to do this whole process within `max.poll.interval.ms` (default 5min),
similar to how we are expected to poll periodically. This should be fine in general, except in case
of a bug where a task is really stuck. In that case, the consumer will get kicked out of the
cluster, and commit may fail. If tasks eventually unblock, the consumer will reconnect to the
cluster on next call to `consume()`, which will trigger a rebalance. There is no guard yet against
this, and we keep the same behavior as before in those cases.

- Store offset in BackbeatConsumer bootstrap
- Add kafka consumer rebalance test
- Drain the queue on rebalance
- Commit before unassigning
- Fix BackbeatConsumer breakbeat tests

Issue: BB-441
