### PR TITLE
BB-462 Expiring non-versioned objects fails

### DIFF
--- a/lib/BackbeatMetadataProxy.js
+++ b/lib/BackbeatMetadataProxy.js
@@ -114,7 +114,11 @@ class BackbeatMetadataProxy extends BackbeatTask {
             if (err) {
                 // eslint-disable-next-line no-param-reassign
                 err.origin = 'source';
-                if (err.ObjNotFound || err.code === 'ObjNotFound') {
+                // <!> Only in S3C <!> Backbeat API returns 'InvalidBucketState' error if the bucket is not versioned.
+                // In this case, instead of logging an error, it should be logged as a debug message,
+                // to avoid causing unnecessary concern to the customer.
+                // TODO: After the implementation of CLDSRV-461, we could remove this check.
+                if (err.ObjNotFound || err.code === 'ObjNotFound' || err.code === 'InvalidBucketState') {
                     return cbOnce(err);
                 }
                 log.error('an error occurred when getting metadata from S3', {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "7.10.13",
+  "version": "7.10.14",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/lifecycle/mocks.js
+++ b/tests/unit/lifecycle/mocks.js
@@ -19,6 +19,11 @@ class BackbeatClientMock {
     constructor() {
         this.mdObj = null;
         this.receivedMd = null;
+        this.error = null;
+    }
+
+    setError(error) {
+        this.error = error;
     }
 
     setMdObj(mdObj) {
@@ -26,10 +31,18 @@ class BackbeatClientMock {
     }
 
     getMetadata(params, log, cb) {
+        if (this.error) {
+            return cb(this.error);
+        }
+
         return cb(null, { Body: this.mdObj.getSerialized() });
     }
 
     putMetadata(params, log, cb) {
+        if (this.error) {
+            return cb(this.error);
+        }
+
         this.receivedMd = JSON.parse(params.mdBlob);
         return cb();
     }


### PR DESCRIPTION
**Note1: The change won't be forward-ported into Artesca branches.**
Note2: Only buckets with versioning enabled can be configured for replication.

To expire non-versioned objects correctly, we currently rely on the InvalidBucketState error returned when the S3C Backbeat API is used for a non-versioned bucket's object, until CLDSRV-461 is implemented to add support for non-versioned buckets to the Backbeat API.