### PR TITLE
Change connector partition name on restart

### DIFF
--- a/extensions/oplogPopulator/modules/Connector.js
+++ b/extensions/oplogPopulator/modules/Connector.js
@@ -115,6 +115,13 @@ class Connector {
      * @throws {InternalError}
      */
     async spawn() {
+        if (this._isRunning) {
+            this._logger.error('tried spawning an already created connector', {
+                method: 'Connector.spawn',
+                connector: this._name,
+            });
+            return;
+        }
         try {
             await this._kafkaConnect.createConnector({
                 name: this._name,
@@ -137,6 +144,13 @@ class Connector {
      * @throws {InternalError}
      */
     async destroy() {
+        if (!this._isRunning) {
+            this._logger.error('tried destroying an already destroyed connector', {
+                method: 'Connector.destroy',
+                connector: this._name,
+            });
+            return;
+        }
         try {
             await this._kafkaConnect.deleteConnector(this._name);
             this._isRunning = false;
@@ -262,7 +276,7 @@ class Connector {
         }
         this._config.pipeline = this._generateConnectorPipeline([...this._buckets]);
         try {
-            if (doUpdate) {
+            if (doUpdate && this._isRunning) {
                 const timeBeforeUpdate = Date.now();
                 this._state.isUpdating = true;
                 await this._kafkaConnect.updateConnectorConfig(this._name, this._config);

--- a/extensions/oplogPopulator/modules/Connector.js
+++ b/extensions/oplogPopulator/modules/Connector.js
@@ -1,4 +1,5 @@
 const joi = require('joi');
+const uuid = require('uuid');
 const { errors } = require('arsenal');
 const KafkaConnectWrapper = require('../../../lib/wrappers/KafkaConnectWrapper');
 
@@ -110,6 +111,14 @@ class Connector {
     }
 
     /**
+     * Updates partition name in connector config
+     * @returns {undefined}
+     */
+    updatePartitionName() {
+        this._config['offset.partition.name'] = `partition-${uuid.v4()}`;
+    }
+
+    /**
      * Creates the Kafka-connect mongo connector
      * @returns {Promise|undefined} undefined
      * @throws {InternalError}
@@ -122,6 +131,8 @@ class Connector {
             });
             return;
         }
+        // reset resume token to avoid getting outdated token
+        this.updatePartitionName();
         try {
             await this._kafkaConnect.createConnector({
                 name: this._name,

--- a/tests/unit/oplogPopulator/Connector.js
+++ b/tests/unit/oplogPopulator/Connector.js
@@ -49,6 +49,15 @@ describe('Connector', () => {
             }));
             assert.strictEqual(connector.isRunning, true);
         });
+        it('Should change partition name on creation', async () => {
+            sinon.stub(connector._kafkaConnect, 'createConnector')
+                .resolves();
+            await connector.spawn();
+            const partitionName = connector.config['offset.partition.name'];
+            connector._isRunning = false;
+            await connector.spawn();
+            assert.notStrictEqual(partitionName, connector.config['offset.partition.name']);
+        });
         it('Should not try spawning a new connector when on is already existent', async () => {
             const createStub = sinon.stub(connector._kafkaConnect, 'createConnector')
                 .resolves();
@@ -237,6 +246,14 @@ describe('Connector', () => {
             connector._config = { key: 'value' };
             const size = connector.getConfigSizeInBytes();
             assert.strictEqual(size, 15);
+        });
+    });
+
+    describe('updatePartitionName', () => {
+        it('Should update partition name in config', () => {
+            connector._config['offset.partition.name'] = 'partition-name';
+            connector.updatePartitionName();
+            assert.notStrictEqual(connector._config['offset.partition.name'], 'partition-name');
         });
     });
 });


### PR DESCRIPTION
The partition name is used as an indicator in the offsets topic to distinguish between resume tokens of the different connectors.
    
When a connector is respawned it should start processing event from the current moment and not use the previous resume token as it can be invalid if the connector stayed shut for a long time and the mongo oplog rotated.
  
Issue: BB-463