### PR TITLE
Add timeout on rebalance

### DIFF
--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -414,9 +414,13 @@ class BackbeatConsumer extends EventEmitter {
                     this._offsetLedger.onOffsetConsumed(
                         entry.topic, entry.partition, entry.offset);
                     this._messagesConsumed++;
+
+                    const finishProcessingTask = this._startProcessingTask(entry);
                     this._processingQueue.push(entry, (err, completionArgs) => {
                         this._onEntryProcessingDone(err, entry, completionArgs);
+                        finishProcessingTask(err);
                     });
+
                     // update Zenko metrics with the latest consumed
                     // message timestamp, to later allow computing
                     // backlog metrics on demand
@@ -441,6 +445,35 @@ class BackbeatConsumer extends EventEmitter {
                 this._scheduleNextTryConsume();
             }
         });
+    }
+
+
+    /**
+     * Track processing of a task.
+     * @param {*} entry - kafka entry being processed
+     * @param {string} entry.topic - topic name
+     * @param {string} entry.partition - partition number of consumed message
+     * @param {string} entry.offset - offset of consumed message
+     * @returns {function} - callback function to be called when task has been processed
+     */
+    _startProcessingTask(entry) {
+        const { topic, partition, offset } = entry;
+        const consumerGroup = this._groupId;
+        const taskStartTime = Date.now();
+
+        let slow = false;
+        const slowTimer = setTimeout(() => {
+            this._log.warn('slow task', { topic, partition, consumerGroup, offset });
+            slow = true;
+            KafkaBacklogMetrics.onSlowTask(topic, partition, consumerGroup);
+        }, this._maxPollIntervalMs);
+
+        return err => {
+            clearTimeout(slowTimer);
+
+            const duration = Date.now() - taskStartTime;
+            KafkaBacklogMetrics.onTaskProcessed(topic, partition, consumerGroup, !!err, slow, duration);
+        };
     }
 
     _scheduleNextTryConsume() {

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -73,6 +73,7 @@ class BackbeatConsumer extends EventEmitter {
         super();
 
         const configJoi = joi.object({
+            clientId: joi.string().default(CLIENT_ID),
             zookeeper: joi.object({
                 connectionString: joi.string().required(),
             }).when('kafka.backlogMetrics', { is: joi.exist(), then: joi.required() }),
@@ -101,7 +102,7 @@ class BackbeatConsumer extends EventEmitter {
         const validConfig = joi.attempt(config, configJoi,
                                         'invalid config params');
 
-        const { zookeeper, kafka, topic, groupId, queueProcessor,
+        const { clientId, zookeeper, kafka, topic, groupId, queueProcessor,
                 fromOffset, concurrency, fetchMaxBytes,
                 canary, bootstrap, circuitBreaker, circuitBreakerMetrics } = validConfig;
 
@@ -111,7 +112,7 @@ class BackbeatConsumer extends EventEmitter {
         this._maxPollIntervalMs = kafka.maxPollIntervalMs;
         this._site = kafka.site;
         this._fromOffset = fromOffset;
-        this._log = new Logger(CLIENT_ID);
+        this._log = new Logger(clientId);
         this._topic = withTopicPrefix(topic);
         this._groupId = groupId;
         this._queueProcessor = queueProcessor;
@@ -869,7 +870,13 @@ class BackbeatConsumer extends EventEmitter {
         return async.series([
             next => {
                 if (this._consumer) {
-                    this._consumer.commit();
+                    try {
+                        this._consumer.commit();
+                    } catch (e) {
+                        // Ignore exceptions if we are not connected
+                        const logger = this._consumer.isConnected() ? this._log.error : this._log.debug;
+                        logger.bind(this._log)('commit failed', { e: e.toString() });
+                    }
                 }
                 if (this._kafkaBacklogMetricsConfig) {
                     // publish offsets to zookeeper

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -3,6 +3,7 @@ const kafka = require('node-rdkafka');
 const assert = require('assert');
 const async = require('async');
 const joi = require('joi');
+const jsutil = require('arsenal').jsutil;
 const Logger = require('werelogs').Logger;
 const { BreakerState, CircuitBreaker } = require('breakbeat').CircuitBreaker;
 
@@ -82,6 +83,7 @@ class BackbeatConsumer extends EventEmitter {
                     intervalS: joi.number().default(60),
                 },
                 site: joi.string(),
+                maxPollIntervalMs: joi.number().min(45000).default(300000),
             }).required(),
             topic: joi.string().required(),
             groupId: joi.string().required(),
@@ -106,6 +108,7 @@ class BackbeatConsumer extends EventEmitter {
         this._zookeeperEndpoint = zookeeper && zookeeper.connectionString;
         this._kafkaHosts = kafka.hosts;
         this._kafkaBacklogMetricsConfig = kafka.backlogMetrics;
+        this._maxPollIntervalMs = kafka.maxPollIntervalMs;
         this._site = kafka.site;
         this._fromOffset = fromOffset;
         this._log = new Logger(CLIENT_ID);
@@ -132,6 +135,7 @@ class BackbeatConsumer extends EventEmitter {
         this._publishOffsetsCronTimer = null;
         this._publishOffsetsCronActive = false;
         this._consumedEventTimeout = null;
+        this._drainProcessQueueTimeout = null;
 
         /** @type {ConsumerStats} */
         this.consumerStats = { lag: {} };
@@ -185,6 +189,7 @@ class BackbeatConsumer extends EventEmitter {
             // decrease max metadata age to 5s to decrease potential lag between
             // consumer and producer when a partition is added to a topic
             'metadata.max.age.ms': 5000,
+            'max.poll.interval.ms': this._maxPollIntervalMs,
         };
         const topicParams = {};
         if (this._fromOffset !== undefined) {
@@ -323,12 +328,9 @@ class BackbeatConsumer extends EventEmitter {
             // error occurs when the kafka broker reaps the idle
             // connections every few minutes, and librdkafka handles
             // reconnection automatically anyway, so we ignore those
-            // harmless errors (moreover with the current
-            // implementation there's no way to access the original
-            // error code, so we match the message instead).
-            if (!['broker transport failure',
-                  'all broker connections are down']
-                .includes(error.message)) {
+            // harmless errors
+            if (error.code === kafka.CODES.ERRORS.ERR__ALL_BROKERS_DOWN ||
+                error.code === kafka.CODES.ERRORS.ERR__TRANSPORT) {
                 this._log.error('consumer error', {
                     error,
                     topic: this._topic,
@@ -495,30 +497,45 @@ class BackbeatConsumer extends EventEmitter {
      */
     _onRebalance(err, assignment) {
         if (err.code === kafka.CODES.ERRORS.ERR__ASSIGN_PARTITIONS) {
-            this._log.debug('rdkafka.assign', { err, assignment });
+            this._log.info('rdkafka.assign', { assignment });
 
             try {
                 this._consumer.assign(assignment);
             } catch (e) {
                 // Ignore exceptions if we are not connected
                 const logger = this._consumer.isConnected() ? this._log.error : this._log.debug;
-                logger.bind(this._log)('rdkafka.assign failed', { err, e, assignment });
+                logger.bind(this._log)('rdkafka.assign failed', { e: e.toString(), assignment });
             }
         } else if (err.code === kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
-            this._log.debug('rdkafka.revoke', {
-                err, assignment,
+            this._log.info('rdkafka.revoke', {
+                assignment,
                 queueLen: this._processingQueue?.length(),
                 running: this._processingQueue?.running(),
             });
 
-            if (!this._processingQueue || this._processingQueue.idle()) {
+            const unassign = jsutil.once(message => {
+                this._log.info(`processing queue ${message}, un-assigning`, {
+                    queueLen: this._processingQueue?.length(),
+                    running: this._processingQueue?.running(),
+                });
+
+                // Reset the drain callback
+                if (this._processingQueue) {
+                    this._processingQueue.drain = () => { };
+                }
+
+                // Reset the timer
+                clearTimeout(this._drainProcessQueueTimeout);
+                this._drainProcessQueueTimeout = null;
+
                 try {
                     // Ensure the state is committed before un-assigning
                     this._consumer.commit();
                 } catch (e) {
                     // Ignore exceptions if we are not connected
-                    const logger = this._consumer.isConnected() ? this._log.error : this._log.info;
-                    logger.bind(this._log)('rdkafka.commit failed', { e, assignment });
+                    const logger = this._consumer.isConnected() &&
+                        e.code !== kafka.CODES.ERRORS.ERR__STATE ? this._log.error : this._log.info;
+                    logger.bind(this._log)('rdkafka.commit failed', { e: e.toString(), assignment });
                 }
 
                 try {
@@ -526,34 +543,28 @@ class BackbeatConsumer extends EventEmitter {
                 } catch (e) {
                     // Ignore exceptions if we are not connected
                     const logger = this._consumer.isConnected() ? this._log.error : this._log.info;
-                    logger.bind(this._log)('rdkafka.unassign failed', { e, assignment });
+                    logger.bind(this._log)('rdkafka.unassign failed', { e: e.toString(), assignment });
                 }
+            });
+
+            if (!this._processingQueue || this._processingQueue.idle()) {
+                unassign('empty');
                 return;
             }
 
-            this._processingQueue.drain = () => {
-                this._log.debug('processing queue drained, un-assigning');
+            this._processingQueue.drain = () => unassign('drained');
 
-                // Reset the drain callback
-                this._processingQueue.drain = () => { };
+            // Set timeout of `max.poll.interval.ms`), to ensure we complete the rebalance
+            // eventually (even if a task is really stuck), and don't get kicked out of the consumer
+            // group. If the timeout is reached, since one task (or more) tasks are stuck, we
+            // disconnect the consumer, so that the healthcheck will fail and the process will get
+            // restarted.
+            this._drainProcessQueueTimeout = setTimeout(() => {
+                unassign('timeout');
 
-                try {
-                    // Ensure the state is committed before un-assigning
-                    this._consumer.commit();
-                } catch (e) {
-                    // Ignore exceptions if we are not connected
-                    const logger = this._consumer.isConnected() ? this._log.error : this._log.info;
-                    logger.bind(this._log)('rdkafka.commit failed', { e, assignment });
-                }
-
-                try {
-                    this._consumer.unassign();
-                } catch (e) {
-                    // Ignore exceptions if we are not connected
-                    const logger = this._consumer.isConnected() ? this._log.error : this._log.info;
-                    logger.bind(this._log)('rdkafka.unassign failed', { e, assignment });
-                }
-            };
+                this._log.error('rdkafka.rebalance timeout: consumer stuck, disconnecting');
+                this._consumer.disconnect();
+            }, this._maxPollIntervalMs - 1000); // 1 second earlier, to be within the limit
         } else {
             this._log.error('rdkafka.rebalance', { err, assignment });
         }

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -553,11 +553,13 @@ class BackbeatConsumer extends EventEmitter {
                 running: this._processingQueue?.running(),
             });
 
-            const unassign = jsutil.once(message => {
-                this._log.info(`processing queue ${message}, un-assigning`, {
+            const unassign = jsutil.once(status => {
+                this._log.info(`processing queue ${status}, un-assigning`, {
                     queueLen: this._processingQueue?.length(),
                     running: this._processingQueue?.running(),
                 });
+
+                KafkaBacklogMetrics.onRebalance(this._topic, this._groupId, status);
 
                 // Reset the drain callback
                 if (this._processingQueue) {
@@ -588,7 +590,7 @@ class BackbeatConsumer extends EventEmitter {
             });
 
             if (!this._processingQueue || this._processingQueue.idle()) {
-                unassign('empty');
+                unassign('idle');
                 return;
             }
 

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -136,6 +136,7 @@ class BackbeatConsumer extends EventEmitter {
         this._publishOffsetsCronActive = false;
         this._consumedEventTimeout = null;
         this._drainProcessQueueTimeout = null;
+        this._tryConsumedTimeout = null;
 
         /** @type {ConsumerStats} */
         this.consumerStats = { lag: {} };
@@ -363,6 +364,11 @@ class BackbeatConsumer extends EventEmitter {
     }
 
     _tryConsume() {
+        if (this._tryConsumedTimeout) {
+            clearTimeout(this._tryConsumedTimeout);
+            this._tryConsumedTimeout = null;
+        }
+
         if (this._circuitBreaker.state !== BreakerState.Nominal) {
             this._log.debug('circuitbreaker tripped, retry in 1s');
             this._scheduleNextTryConsume();
@@ -419,9 +425,9 @@ class BackbeatConsumer extends EventEmitter {
                     return undefined;
                 });
             }
-            if (err || entries.length === 0) {
+            if (err || entries.length < nNewConsumeRequests) {
                 this._log.debug(err ? `error, retry in 1s: ${err.message}` :
-                    'no message is available yet, retry in 1s',
+                    `not enough message available yet, retry in 1s: ${entries.length}`,
                     { topic: this._topic, groupId: this._groupId });
                 // if the topic does not exist (even with 'allow.auto.create.topics'),
                 // the consumer will be ready only after automatic getMetadata is called,
@@ -437,7 +443,7 @@ class BackbeatConsumer extends EventEmitter {
     }
 
     _scheduleNextTryConsume() {
-        setTimeout(this._tryConsume.bind(this), 1000);
+        this._tryConsumedTimeout = setTimeout(this._tryConsume.bind(this), 1000);
     }
 
     _onEntryProcessingDone(err, entry, completionArgs) {

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -1,5 +1,5 @@
 const { EventEmitter } = require('events');
-const { Producer } = require('node-rdkafka');
+const { Producer, CODES } = require('node-rdkafka');
 const joi = require('joi');
 
 const { errors, jsutil } = require('arsenal');
@@ -186,13 +186,10 @@ class BackbeatProducer extends EventEmitter {
         // error occurs when the kafka broker reaps the idle
         // connections every few minutes, and librdkafka handles
         // reconnection automatically anyway, so we ignore those
-        // harmless errors (moreover with the current
-        // implementation there's no way to access the original
-        // error code, so we match the message instead).
+        // harmless errors
         const config = this._config;
-        if (!['broker transport failure',
-            'all broker connections are down']
-            .includes(error.message)) {
+        if (error.code === CODES.ERRORS.ERR__ALL_BROKERS_DOWN ||
+            error.code === CODES.ERRORS.ERR__TRANSPORT) {
             this._log.error('error with producer', {
                 config,
                 error: error.message,

--- a/lib/KafkaBacklogMetrics.js
+++ b/lib/KafkaBacklogMetrics.js
@@ -37,6 +37,19 @@ const latestConsumeEventTimestampGauge = metrics.ZenkoMetrics.createGauge({
     labelNames: ['topic', 'partition', 'consumergroup'],
 });
 
+const slowTasksCountGauge = metrics.ZenkoMetrics.createGauge({
+    name: promMetricNames.slowTasksCount,
+    help: 'Current number of slow tasks',
+    labelNames: ['topic', 'partition', 'consumergroup'],
+});
+
+const taskProcessingTime = metrics.ZenkoMetrics.createHistogram({
+    name: promMetricNames.taskProcessingTime,
+    help: 'Duration of a task',
+    labelNames: ['topic', 'partition', 'consumergroup', 'error'],
+    buckets: [0.01, 0.1, 1, 10, 50, 100, 200, 300],
+});
+
 // global error instances for private use
 const CheckConditionError = new Error();
 const NoNodeError = new Error();
@@ -129,6 +142,32 @@ class KafkaBacklogMetrics extends EventEmitter {
         latestConsumeEventTimestampGauge.set({
             topic, partition, consumergroup: consumerGroup,
         }, Date.now() / 1000);
+    }
+
+    static onSlowTask(topic, partition, consumerGroup) {
+        slowTasksCountGauge.inc({
+            topic, partition, consumergroup: consumerGroup,
+        });
+    }
+
+    /**
+     * Updates the metrics when a task has been processed.
+     * @param {string} topic - The Kafka topic.
+     * @param {number} partition - The Kafka partition.
+     * @param {string} consumerGroup - The Kafka consumer group.
+     * @param {Error|null} error - The error that occurred during processing, if any.
+     * @param {boolean} slow - Whether the task was processed slowly.
+     * @param {number} durationMs - The duration of the task processing, in milliseconds.
+     * @returns {void}
+     */
+    static onTaskProcessed(topic, partition, consumerGroup, error, slow, durationMs) {
+        if (slow) {
+            slowTasksCountGauge.dec({
+                topic, partition, consumergroup: consumerGroup,
+            });
+        }
+        taskProcessingTime.observe({ topic, partition, consumergroup: consumerGroup, error },
+            durationMs / 1000);
     }
 
     _getPartitionsOffsetsZkPath(topic) {

--- a/lib/KafkaBacklogMetrics.js
+++ b/lib/KafkaBacklogMetrics.js
@@ -37,6 +37,12 @@ const latestConsumeEventTimestampGauge = metrics.ZenkoMetrics.createGauge({
     labelNames: ['topic', 'partition', 'consumergroup'],
 });
 
+const rebalanceTotalCounter = metrics.ZenkoMetrics.createCounter({
+    name: promMetricNames.rebalanceTotal,
+    help: 'Number of rebalance events',
+    labelNames: ['topic', 'consumergroup', 'status'],
+});
+
 const slowTasksCountGauge = metrics.ZenkoMetrics.createGauge({
     name: promMetricNames.slowTasksCount,
     help: 'Current number of slow tasks',
@@ -144,6 +150,26 @@ class KafkaBacklogMetrics extends EventEmitter {
         }, Date.now() / 1000);
     }
 
+    /**
+     * Increments the rebalance total counter
+     * @param {string} topic - The topic being rebalanced.
+     * @param {string} consumerGroup - The consumer group being rebalanced.
+     * @param {string} status - The status of the rebalance.
+     * @returns {void}
+     */
+    static onRebalance(topic, consumerGroup, status) {
+        rebalanceTotalCounter.inc({
+            topic, consumergroup: consumerGroup, status,
+        });
+    }
+
+    /**
+     * Increment the slow tasks count gauge
+     * @param {string} topic - The Kafka topic.
+     * @param {number} partition - The Kafka partition.
+     * @param {string} consumerGroup - The Kafka consumer group.
+     * @returns {void}
+     */
     static onSlowTask(topic, partition, consumerGroup) {
         slowTasksCountGauge.inc({
             topic, partition, consumergroup: consumerGroup,

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -5,6 +5,7 @@ const constants = {
             deliveryReportsTotal: 's3_zenko_queue_delivery_reports_total',
             latestConsumedMessageTimestamp: 's3_zenko_queue_latest_consumed_message_timestamp',
             latestConsumeEventTimestamp: 's3_zenko_queue_latest_consume_event_timestamp',
+            rebalanceTotal: 's3_zenko_queue_rebalance_total',
             slowTasksCount: 's3_zenko_queue_slowTasks_count',
             taskProcessingTime: 's3_zenko_queue_task_processing_time_seconds',
         },

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -5,6 +5,8 @@ const constants = {
             deliveryReportsTotal: 's3_zenko_queue_delivery_reports_total',
             latestConsumedMessageTimestamp: 's3_zenko_queue_latest_consumed_message_timestamp',
             latestConsumeEventTimestamp: 's3_zenko_queue_latest_consume_event_timestamp',
+            slowTasksCount: 's3_zenko_queue_slowTasks_count',
+            taskProcessingTime: 's3_zenko_queue_task_processing_time_seconds',
         },
     },
     statusReady: 'READY',

--- a/monitoring/lifecycle/alerts.test.yaml
+++ b/monitoring/lifecycle/alerts.test.yaml
@@ -117,3 +117,100 @@ tests:
               description: "Less than 50% of lifecycle object processors for expiration are up and healthy"
               summary: "Degraded lifecycle object processor"
 
+  - name: KafkaConsumerSlowTask
+    interval: 1m
+    input_series:
+      - series: s3_zenko_queue_slowTasks_count{namespace="zenko",job="artesca-data-backbeat-object-processor-headless"}
+        values: 0 0 0 0 1 0 0 0 0 0
+      - series: s3_zenko_queue_slowTasks_count{namespace="zenko",job="artesca-data-backbeat-bucket-processor-headless"}
+        values: 0 0 1 1 1 1 1 1 1 0
+    alert_rule_test:
+      - alertname: KafkaConsumerSlowTask
+        eval_time: 1m
+        exp_alerts: []
+      - alertname: KafkaConsumerSlowTask
+        eval_time: 3m
+        exp_alerts: []
+      - alertname: KafkaConsumerSlowTask
+        eval_time: 5m
+        exp_alerts: []
+      - alertname: KafkaConsumerSlowTask
+        eval_time: 6m
+        exp_alerts: []
+      - alertname: KafkaConsumerSlowTask
+        eval_time: 7m
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job: artesca-data-backbeat-bucket-processor-headless
+            exp_annotations:
+              description: >-
+                Some tasks are taking too long to process in artesca-data-backbeat-bucket-processor-headless. This is not expected, and
+                may be a sign that other components are not behaving nominally or may need to be scaled.
+
+                If this alert lasts, it may mean the task is blocked, and that the consumer should be
+                restarted.
+              summary: Some Kafka messages are taking too long to process
+      - alertname: KafkaConsumerSlowTask
+        eval_time: 8m
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job: artesca-data-backbeat-bucket-processor-headless
+            exp_annotations:
+              description: >-
+                Some tasks are taking too long to process in artesca-data-backbeat-bucket-processor-headless. This is not expected, and
+                may be a sign that other components are not behaving nominally or may need to be scaled.
+
+                If this alert lasts, it may mean the task is blocked, and that the consumer should be
+                restarted.
+              summary: Some Kafka messages are taking too long to process
+      - alertname: KafkaConsumerSlowTask
+        eval_time: 9m
+        exp_alerts: []
+
+  - name: KafkaConsumerRebalance
+    interval: 1m
+    input_series:
+      - series: s3_zenko_queue_rebalance_total_count{namespace="zenko",job="artesca-data-backbeat-object-processor-headless",status="drained",pod="foo"}
+        values: 1 2 _ _ stale
+      - series: s3_zenko_queue_rebalance_total_count{namespace="zenko",job="artesca-data-backbeat-object-processor-headless",status="timeout",pod="foo"}
+        values: _ 1 _ _ stale
+      - series: s3_zenko_queue_rebalance_total_count{namespace="zenko",job="artesca-data-backbeat-object-processor-headless",status="drained",pod="bar"}
+        values: _ _ 1 2 3 4 5 6 7
+      - series: s3_zenko_queue_rebalance_total_count{namespace="zenko",job="artesca-data-backbeat-object-processor-headless",status="timeout",pod="bar"}
+        values: _ _ 0 0 0 0 0 0 0
+    alert_rule_test:
+      - alertname: KafkaConsumerRebalanceTimeout
+        eval_time: 0m
+        exp_alerts: []
+      - alertname: KafkaConsumerRebalanceTimeout
+        eval_time: 1m
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              pod: "foo"
+            exp_annotations:
+              summary: Kafka consumer has stopped consuming messages
+              description: Kafka rebalance has timed out for pod `foo`, which indicates that the consumer is not working anymore, and should be restarted.
+      - alertname: KafkaConsumerRebalanceTimeout
+        eval_time: 2m
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              pod: "foo"
+            exp_annotations:
+              summary: Kafka consumer has stopped consuming messages
+              description: Kafka rebalance has timed out for pod `foo`, which indicates that the consumer is not working anymore, and should be restarted.
+      - alertname: KafkaConsumerRebalanceTimeout
+        eval_time: 3m
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              pod: "foo"
+            exp_annotations:
+              summary: Kafka consumer has stopped consuming messages
+              description: Kafka rebalance has timed out for pod `foo`, which indicates that the consumer is not working anymore, and should be restarted.
+      - alertname: KafkaConsumerRebalanceTimeouts
+        eval_time: 4m
+        exp_alerts: []

--- a/monitoring/lifecycle/alerts.yaml
+++ b/monitoring/lifecycle/alerts.yaml
@@ -181,3 +181,28 @@ groups:
       description: "More than 5% of Kafka messages failed to publish to the lifecycle object topic"
       summary: "High rate of failed messages to the object topic"
 
+  - alert: KafkaConsumerSlowTask
+    Expr: |
+      sum(s3_zenko_queue_slowTasks_count{namespace="${namespace}"}) by(job) > 0
+    For: "5m"
+    Labels:
+     severity: warning
+    Annotations:
+      description: >-
+        Some tasks are taking too long to process in {{ $labels.job }}. This is not expected, and
+        may be a sign that other components are not behaving nominally or may need to be scaled.
+
+        If this alert lasts, it may mean the task is blocked, and that the consumer should be
+        restarted.
+      summary: "Some Kafka messages are taking too long to process"
+
+  - alert: KafkaConsumerRebalanceTimeout
+    Expr: |
+      sum(s3_zenko_queue_rebalance_total_count{namespace="${namespace}", status="timeout"}) by(pod) > 0
+    Labels:
+     severity: critical
+    Annotations:
+      description: >-
+        Kafka rebalance has timed out for pod `{{ $labels.pod }}`, which indicates that the consumer
+        is not working anymore, and should be restarted.
+      summary: "Kafka consumer has stopped consuming messages"


### PR DESCRIPTION
Add timeout on rebalance' drain, and disconnect the kafka client from the cluster. We would get kicked out of the cluster anyway (causing the message to be picked'up by another consumer and preventing us from commiting, and in most cases it happens if a task is "stuck": doing it on our side however ensures the consumer is updated about this, and eventually causes the healthcheck to fail, so the process will get restarted.

To give better visibility on this, introduce a few metrics and alerts to detect and warn of "slow" task and rebalance.

Also fix a minor issue, ensuring we always try to fill the queue, even if consume returned a few entries to process.

Issue: BB-440

