### PR TITLE
Move restore-expiration processing to transition processor

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,8 +23,6 @@ jobs:
 
     - name: Set up Docker Buildk
       uses: docker/setup-buildx-action@v2
-      with:
-        buildkitd-flags: --debug
 
     - name: Login to Registry
       uses: docker/login-action@v2
@@ -39,8 +37,8 @@ jobs:
         push: true
         context: .github/dockerfiles/kafka
         tags: "ghcr.io/scality/backbeat/ci-kafka:${{ github.sha }}"
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=gha,scope=ci-kafka
+        cache-to: type=gha,mode=max,scope=ci-kafka
 
     - name: Build and push syntheticbucketd
       uses: docker/build-push-action@v4
@@ -49,8 +47,8 @@ jobs:
         context: .
         file: .github/dockerfiles/syntheticbucketd/Dockerfile
         tags: "ghcr.io/scality/backbeat/syntheticbucketd:${{ github.sha }}"
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=gha,scope=syntheticbucketd
+        cache-to: type=gha,mode=max,scope=syntheticbucketd
 
     - name: Build and push MongoDB
       uses: docker/build-push-action@v4
@@ -58,8 +56,8 @@ jobs:
         push: true
         context: .github/dockerfiles/mongodb
         tags: "ghcr.io/scality/backbeat/ci-mongodb:${{ github.sha }}"
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=gha,scope=ci-mongodb
+        cache-to: type=gha,mode=max,scope=ci-mongodb
 
   tests:
     needs: build

--- a/extensions/lifecycle/objectProcessor/LifecycleObjectExpirationProcessor.js
+++ b/extensions/lifecycle/objectProcessor/LifecycleObjectExpirationProcessor.js
@@ -2,8 +2,7 @@
 
 const LifecycleObjectProcessor = require('./LifecycleObjectProcessor');
 const LifecycleDeleteObjectTask =
-      require('../tasks/LifecycleDeleteObjectTask');
-const LifecycleUpdateExpirationTask = require('../tasks/LifecycleUpdateExpirationTask');
+    require('../tasks/LifecycleDeleteObjectTask');
 
 class LifecycleObjectExpirationProcessor extends LifecycleObjectProcessor {
 
@@ -61,8 +60,6 @@ class LifecycleObjectExpirationProcessor extends LifecycleObjectProcessor {
             case 'deleteObject':
             case 'deleteMPU':
                 return new LifecycleDeleteObjectTask(this);
-            case 'gc':
-                return new LifecycleUpdateExpirationTask(this);
             default:
                 this._log.warn(
                     `skipped unsupported action ${actionType}`,

--- a/extensions/lifecycle/objectProcessor/LifecycleObjectTransitionProcessor.js
+++ b/extensions/lifecycle/objectProcessor/LifecycleObjectTransitionProcessor.js
@@ -3,10 +3,9 @@ const assert = require('assert');
 
 const ColdStorageStatusQueueEntry = require('../../../lib/models/ColdStorageStatusQueueEntry');
 const LifecycleObjectProcessor = require('./LifecycleObjectProcessor');
-const LifecycleUpdateTransitionTask =
-      require('../tasks/LifecycleUpdateTransitionTask');
-const LifecycleColdStatusArchiveTask =
-      require('../tasks/LifecycleColdStatusArchiveTask');
+const LifecycleUpdateExpirationTask = require('../tasks/LifecycleUpdateExpirationTask');
+const LifecycleUpdateTransitionTask = require('../tasks/LifecycleUpdateTransitionTask');
+const LifecycleColdStatusArchiveTask = require('../tasks/LifecycleColdStatusArchiveTask');
 const { LifecycleResetTransitionInProgressTask } =
       require('../tasks/LifecycleResetTransitionInProgressTask');
 const { updateCircuitBreakerConfigForImplicitOutputQueue } = require('../../../lib/CircuitBreaker');
@@ -108,6 +107,8 @@ class LifecycleObjectTransitionProcessor extends LifecycleObjectProcessor {
                 return new LifecycleResetTransitionInProgressTask(this);
             case 'requeueRestore':
                 return new LifecycleRetriggerRestoreTask(this);
+            case 'gc':
+                return new LifecycleUpdateExpirationTask(this);
             case 'copyLocation':
                 if (actionEntry.getContextAttribute('ruleType') === 'transition') {
                     return new LifecycleUpdateTransitionTask(this);

--- a/tests/functional/lifecycle/LifecycleConductor.spec.js
+++ b/tests/functional/lifecycle/LifecycleConductor.spec.js
@@ -185,6 +185,9 @@ describe('lifecycle conductor', function lifecycleConductor() {
                 objectProcessor: {
                     groupId: 'b',
                 },
+                transitionProcessor: {
+                    groupId: 'c',
+                },
             };
 
             // make topic unique so that different tests' bootstrap messages don't interfere
@@ -284,6 +287,9 @@ describe('lifecycle conductor', function lifecycleConductor() {
                 },
                 objectProcessor: {
                     groupId: 'b',
+                },
+                transitionProcessor: {
+                    groupId: 'c',
                 },
             };
 


### PR DESCRIPTION
The conductor checks the lag of the object-processor to detect if the previous lifecycle listing has been processed, i.e. status has been persisted for all triggered operations.

Consequently it must check the bucket-processor lag (e.g. is listing terminated), but also the data-mover topic (for transitions) and object- processor (for expirations). It may check the cold-archive topics, but it is not needed since the object is immediately updated with a "transition in process" flag.

However, it must not check topics/consumers which are not directly linked to the lifecycle listing: in particular the transition-processor, which handles the end of transitions (update status, requeue...).

To be consistent and avoid unexpected throtlling, restored object expiration messages must be ignored by the conductor: hence we move processing to the transition processor.

Issue: BB-449
