### PR TITLE
Use separate topic for lifecycle transition tasks

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -224,6 +224,7 @@
             "zookeeperPath": "/lifecycle",
             "bucketTasksTopic": "backbeat-lifecycle-bucket-tasks",
             "objectTasksTopic": "backbeat-lifecycle-object-tasks",
+            "transitionTasksTopic": "backbeat-lifecycle-transition-tasks",
             "conductor": {
                 "cronRule": "0 */5 * * * *",
                 "concurrency": 10,

--- a/extensions/lifecycle/LifecycleConfigValidator.js
+++ b/extensions/lifecycle/LifecycleConfigValidator.js
@@ -12,6 +12,7 @@ const joiSchema = joi.object({
     zookeeperPath: joi.string().required(),
     bucketTasksTopic: joi.string().required(),
     objectTasksTopic: joi.string().required(),
+    transitionTasksTopic: joi.string().default(parent => parent.objectTasksTopic),
     coldStorageTopics: joi.array().items(joi.string()).unique().default([]),
     auth: authJoi.optional(),
     forceLegacyListing: joi.boolean().default(true),

--- a/extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor.js
+++ b/extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor.js
@@ -173,6 +173,7 @@ class LifecycleBucketProcessor {
             enabledRules: this._supportedRulesObject,
             bucketTasksTopic: this._lcConfig.bucketTasksTopic,
             objectTasksTopic: this._lcConfig.objectTasksTopic,
+            transitionTasksTopic: this._lcConfig.transitionTasksTopic,
             kafkaBacklogMetrics: this._kafkaBacklogMetrics,
             ncvHeap: this.ncvHeap,
             pausedLocations: this._pausedLocations,

--- a/extensions/lifecycle/objectProcessor/LifecycleObjectExpirationProcessor.js
+++ b/extensions/lifecycle/objectProcessor/LifecycleObjectExpirationProcessor.js
@@ -22,6 +22,7 @@ class LifecycleObjectExpirationProcessor extends LifecycleObjectProcessor {
      * @param {Object} lcConfig - lifecycle configuration object
      * @param {String} lcConfig.auth - authentication info
      * @param {String} lcConfig.objectTasksTopic - lifecycle object topic name
+     * @param {String} lcConfig.transitionTasksTopic - lifecycle transition topic name
      * @param {Object} lcConfig.objectProcessor - kafka consumer object
      * @param {String} lcConfig.objectProcessor.groupId - kafka
      * consumer group id

--- a/extensions/lifecycle/objectProcessor/LifecycleObjectProcessor.js
+++ b/extensions/lifecycle/objectProcessor/LifecycleObjectProcessor.js
@@ -41,8 +41,7 @@ class LifecycleObjectProcessor extends EventEmitter {
      * @param {Object} lcConfig - lifecycle configuration object
      * @param {String} lcConfig.auth - authentication info
      * @param {String} lcConfig.objectTasksTopic - lifecycle object topic name
-     * consumer group id
-     *  of max allowed concurrent operations
+     * @param {String} lcConfig.transitionTasksTopic - lifecycle transition topic name
      * @param {Object} s3Config - S3 configuration
      * @param {Object} s3Config.host - s3 endpoint host
      * @param {Number} s3Config.port - s3 endpoint port
@@ -73,7 +72,7 @@ class LifecycleObjectProcessor extends EventEmitter {
         return 'object-processor';
     }
 
-    _getObjecTaskConsumerParams() {
+    _getTopicConsumerParams(topic) {
         return {
             zookeeper: {
                 connectionString: this._zkConfig.connectionString,
@@ -83,7 +82,7 @@ class LifecycleObjectProcessor extends EventEmitter {
                 site: this._kafkaConfig.site,
                 backlogMetrics: this._kafkaConfig.backlogMetrics,
             },
-            topic: this._lcConfig.objectTasksTopic,
+            topic,
             groupId: this._processConfig.groupId,
             concurrency: this._processConfig.concurrency,
             queueProcessor: this.processObjectTaskEntry.bind(this),
@@ -94,9 +93,9 @@ class LifecycleObjectProcessor extends EventEmitter {
         };
     }
 
-    getConsumerParams() {
+    getConsumerParams(topic = this._lcConfig.objectTasksTopic) {
         return {
-            [this._lcConfig.objectTasksTopic]: this._getObjecTaskConsumerParams(),
+            [topic]: this._getTopicConsumerParams(topic),
         };
     }
 

--- a/extensions/lifecycle/objectProcessor/LifecycleObjectTransitionProcessor.js
+++ b/extensions/lifecycle/objectProcessor/LifecycleObjectTransitionProcessor.js
@@ -29,6 +29,7 @@ class LifecycleObjectTransitionProcessor extends LifecycleObjectProcessor {
      * @param {Object} lcConfig - lifecycle configuration object
      * @param {String} lcConfig.auth - authentication info
      * @param {String} lcConfig.objectTasksTopic - lifecycle object topic name
+     * @param {String} lcConfig.transitionTasksTopic - lifecycle transition topic name
      * @param {Object} lcConfig.transitionProcessor - kafka consumer object
      * @param {String} lcConfig.transitionProcessor.groupId - kafka
      * consumer group id
@@ -49,7 +50,8 @@ class LifecycleObjectTransitionProcessor extends LifecycleObjectProcessor {
     }
 
     getConsumerParams() {
-        const consumerParams = super.getConsumerParams();
+        const consumerParams = super.getConsumerParams(this._lcConfig.transitionTasksTopic);
+
         const locations = require('../../../conf/locationConfig.json') || {};
 
         this._lcConfig.coldStorageTopics.forEach(topic => {

--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -1129,7 +1129,7 @@ class LifecycleTask extends BackbeatTask {
             originLabel: 'lifecycle',
             fromLocation: objectMD.getDataStoreName(),
             contentLength: objectMD.getContentLength(),
-            resultsTopic: this.objectTasksTopic,
+            resultsTopic: this.transitionTasksTopic,
             accountId: params.accountId,
             attempt,
         });

--- a/tests/config.json
+++ b/tests/config.json
@@ -156,6 +156,7 @@
             "zookeeperPath": "/lifecycletest",
             "bucketTasksTopic": "backbeat-test-dummy-bucket-task",
             "objectTasksTopic": "backbeat-test-dummy-object-task",
+            "transitionTasksTopic": "backbeat-test-dummy-transition-task",
             "conductor": {
                 "cronRule": "0 */5 * * * *",
                 "probeServer": {
@@ -196,11 +197,29 @@
                     "port": 8554
                 }
             },
+            "transitionProcessor": {
+                "groupId": "backbeat-lifecycle-transition-processor-group",
+                "retry": {
+                    "maxRetries": 5,
+                    "timeoutS": 300,
+                    "backoff": {
+                        "min": 1000,
+                        "max": 300000,
+                        "jitter": 0.1,
+                        "factor": 1.5
+                    }
+                },
+                "concurrency": 10,
+                "probeServer": {
+                    "port": 8554
+                }
+            },
             "auth": {
                 "type": "account",
                 "account": "bart"
             },
-            "coldStorageArchiveTopicPrefix": "cold-archive-req-"
+            "coldStorageArchiveTopicPrefix": "cold-archive-req-",
+            "coldStorageTopics": []
         },
         "gc": {
             "topic": "backbeat-test-gc",

--- a/tests/functional/lifecycle/LifecycleConductor.spec.js
+++ b/tests/functional/lifecycle/LifecycleConductor.spec.js
@@ -95,6 +95,7 @@ const baseLCConfig = {
     zookeeperPath: '/test/lifecycle',
     bucketTasksTopic,
     objectTasksTopic: 'backbeat-lifecycle-object-tasks-spec',
+    transitionTasksTopic: 'backbeat-lifecycle-transition-tasks-spec',
     conductor: {
         cronRule: '*/5 * * * * *',
         backlogControl: {

--- a/tests/functional/lifecycle/LifecycleTaskV2-versioned.js
+++ b/tests/functional/lifecycle/LifecycleTaskV2-versioned.js
@@ -39,9 +39,11 @@ const destinationLocation = 'us-east-2';
 
 const bucketTopic = 'bucket-topic';
 const objectTopic = 'object-topic';
+const transitionTopic = 'transition-topic';
 const dataMoverTopic = 'backbeat-data-mover';
 const testKafkaEntry = new TestKafkaEntry({
     objectTopic,
+    transitionTopic,
     bucketTopic,
     dataMoverTopic,
     ownerId,
@@ -72,6 +74,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
                 producer,
                 bucketTasksTopic: bucketTopic,
                 objectTasksTopic: objectTopic,
+                transitionTasksTopic: transitionTopic,
                 kafkaBacklogMetrics: { snapshotTopicOffsets: () => {} },
                 pausedLocations: new Set(),
                 log,

--- a/tests/functional/lifecycle/LifecycleTaskV2.js
+++ b/tests/functional/lifecycle/LifecycleTaskV2.js
@@ -40,9 +40,11 @@ const destinationLocation = 'us-east-2';
 
 const bucketTopic = 'bucket-topic';
 const objectTopic = 'object-topic';
+const transitionTopic = 'transition-topic';
 const dataMoverTopic = 'backbeat-data-mover';
 const testKafkaEntry = new TestKafkaEntry({
     objectTopic,
+    transitionTopic,
     bucketTopic,
     dataMoverTopic,
     ownerId,
@@ -73,6 +75,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
                 producer,
                 bucketTasksTopic: bucketTopic,
                 objectTasksTopic: objectTopic,
+                transitionTasksTopic: transitionTopic,
                 kafkaBacklogMetrics: { snapshotTopicOffsets: () => {} },
                 pausedLocations: new Set(),
                 log,

--- a/tests/functional/lifecycle/configObjects.js
+++ b/tests/functional/lifecycle/configObjects.js
@@ -1,5 +1,6 @@
 const bucketTasksTopic = 'bucket-tasks';
 const objectTasksTopic = 'object-tasks';
+const transitionTasksTopic = 'transition-tasks';
 
 const zkConfig = {
     connectionString: 'localhost:2181',
@@ -35,6 +36,7 @@ const lcConfig = {
     },
     bucketTasksTopic,
     objectTasksTopic,
+    transitionTasksTopic,
     rules: {
         expiration: {
             enabled: true,
@@ -69,6 +71,7 @@ const timeOptions = {
 module.exports = {
     bucketTasksTopic,
     objectTasksTopic,
+    transitionTasksTopic,
     zkConfig,
     kafkaConfig,
     lcConfig,

--- a/tests/functional/lifecycle/utils.js
+++ b/tests/functional/lifecycle/utils.js
@@ -6,6 +6,7 @@ class TestKafkaEntry {
     constructor(state) {
         const {
             objectTopic,
+            transitionTopic,
             bucketTopic,
             dataMoverTopic,
             ownerId,
@@ -14,6 +15,7 @@ class TestKafkaEntry {
         } = state;
 
         this.objectTopic = objectTopic;
+        this.transitionTopic = transitionTopic;
         this.bucketTopic = bucketTopic;
         this.dataMoverTopic = dataMoverTopic;
         this.ownerId = ownerId;
@@ -96,7 +98,7 @@ class TestKafkaEntry {
         assert.strictEqual(metrics.contentLength, contentLength);
 
         assert.strictEqual(message.toLocation, destinationLocation);
-        assert.strictEqual(message.resultsTopic, this.objectTopic);
+        assert.strictEqual(message.resultsTopic, this.transitionTopic);
     }
 
     expectBucketEntry(e, {

--- a/tests/unit/lifecycle/LifecycleObjectExpirationProcessor.spec.js
+++ b/tests/unit/lifecycle/LifecycleObjectExpirationProcessor.spec.js
@@ -1,0 +1,26 @@
+const assert = require('assert');
+const config = require('../../config.json');
+const LifecycleObjectExpirationProcessor =
+    require('../../../extensions/lifecycle/objectProcessor/LifecycleObjectExpirationProcessor');
+
+describe('LifecycleObjectExpirationProcessor', () => {
+    let objectProcessor;
+
+    beforeEach(() => {
+        objectProcessor = new LifecycleObjectExpirationProcessor(
+            config.zookeeper,
+            config.kafka,
+            config.extensions.lifecycle,
+            config.s3,
+        );
+    });
+
+    it('should contain object tasks topic in consumer params', () => {
+        const consumerParams = objectProcessor.getConsumerParams();
+        assert.deepStrictEqual(Object.keys(consumerParams), [config.extensions.lifecycle.objectTasksTopic]);
+        assert.strictEqual(
+            consumerParams[config.extensions.lifecycle.objectTasksTopic].topic,
+            config.extensions.lifecycle.objectTasksTopic,
+        );
+    });
+});

--- a/tests/unit/lifecycle/LifecycleObjectTransitionProcessor.spec.js
+++ b/tests/unit/lifecycle/LifecycleObjectTransitionProcessor.spec.js
@@ -1,0 +1,26 @@
+const assert = require('assert');
+const config = require('../../config.json');
+const LifecycleObjectTransitionProcessor =
+    require('../../../extensions/lifecycle/objectProcessor/LifecycleObjectTransitionProcessor');
+
+describe('LifecycleObjectExpirationProcessor', () => {
+    let objectProcessor;
+
+    beforeEach(() => {
+        objectProcessor = new LifecycleObjectTransitionProcessor(
+            config.zookeeper,
+            config.kafka,
+            config.extensions.lifecycle,
+            config.s3,
+        );
+    });
+
+    it('should contain transition tasks topic in consumer params', () => {
+        const consumerParams = objectProcessor.getConsumerParams();
+        assert.deepStrictEqual(Object.keys(consumerParams), [config.extensions.lifecycle.transitionTasksTopic]);
+        assert.strictEqual(
+            consumerParams[config.extensions.lifecycle.transitionTasksTopic].topic,
+            config.extensions.lifecycle.transitionTasksTopic
+        );
+    });
+});


### PR DESCRIPTION
The lifecycle conductor uses the lag on the object tasks to throttle the lifecycle scan.
However, the object tasks topic handles events that are not in the direct path and that does not impact the lifecycle scan.
We use a different topic for those events to avoid unwanted throttle.

Issue: BB-467