### PR TITLE
Resume connector change stream using the timestamp of the first event

### DIFF
--- a/extensions/oplogPopulator/constants.js
+++ b/extensions/oplogPopulator/constants.js
@@ -5,6 +5,9 @@ const constants = {
         'connector.class': 'com.mongodb.kafka.connect.MongoSourceConnector',
         'pipeline': '[]',
         'collection': '',
+        // If no timestamp is provided, the startup mode will be equivalent
+        // to 'latest' which will pick up from the latest event in the oplog
+        'startup.mode': 'timestamp',
         // JSON output converter config
         // Using a string converter to avoid getting an over-stringified
         // JSON that is returned by default

--- a/extensions/oplogPopulator/modules/ConnectorsManager.js
+++ b/extensions/oplogPopulator/modules/ConnectorsManager.js
@@ -233,7 +233,7 @@ class ConnectorsManager {
             if (connector.isRunning && connector.bucketCount === 0) {
                 await connector.destroy();
                 this._metricsHandler.onConnectorDestroyed();
-                this._logger.info('Successfully destroyed a connector', {
+                this._logger.info('Successfully spawned a connector', {
                     method: 'ConnectorsManager._spawnOrDestroyConnector',
                     connector: connector.name
                 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "8.6.29",
+  "version": "8.6.30",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/oplogPopulator/ConnectorsManager.js
+++ b/tests/unit/oplogPopulator/ConnectorsManager.js
@@ -19,6 +19,7 @@ const connectorConfig = {
     'connector.class': 'com.mongodb.kafka.connect.MongoSourceConnector',
     'pipeline': '[]',
     'collection': '',
+    'startup.mode': 'timestamp',
     'output.format.value': 'json',
     'value.converter.schemas.enable': false,
     'value.converter': 'org.apache.kafka.connect.storage.StringConverter',


### PR DESCRIPTION
There is currently a lag between when a bucket has a workflow set and when its events get picked up by the oplog populator.

This can cause issues as we might miss the first oplog events of the bucket.

We start the change stream from the first event that triggered the creation of the connector using `startup.mode=timestamp` to avoid loosing the first events.

Issue: BB-471