### PR TITLE
Delete orphaned cold object

### DIFF
--- a/extensions/oplogPopulator/modules/Connector.js
+++ b/extensions/oplogPopulator/modules/Connector.js
@@ -132,7 +132,7 @@ class Connector {
 
         this._config['startup.mode.timestamp.start.at.operation.time'] = eventDate.toISOString();
 
-        this._logger.info('Updating resume date', {
+        this._logger.info('Connector resume point updated', {
             method: 'Connector.updateResumeDate',
             date: eventDate.toISOString(),
             connector: this._name,

--- a/extensions/oplogPopulator/modules/ConnectorsManager.js
+++ b/extensions/oplogPopulator/modules/ConnectorsManager.js
@@ -233,7 +233,7 @@ class ConnectorsManager {
             if (connector.isRunning && connector.bucketCount === 0) {
                 await connector.destroy();
                 this._metricsHandler.onConnectorDestroyed();
-                this._logger.info('Successfully spawned a connector', {
+                this._logger.info('Successfully destroyed a connector', {
                     method: 'ConnectorsManager._spawnOrDestroyConnector',
                     connector: connector.name
                 });
@@ -241,7 +241,7 @@ class ConnectorsManager {
             } else if (!connector.isRunning && connector.bucketCount > 0) {
                 await connector.spawn();
                 this._metricsHandler.onConnectorsInstantiated(false);
-                this._logger.info('Successfully destroyed a connector', {
+                this._logger.info('Successfully spawned a connector', {
                     method: 'ConnectorsManager._spawnOrDestroyConnector',
                     connector: connector.name
                 });

--- a/tests/config.json
+++ b/tests/config.json
@@ -219,6 +219,9 @@
                 "account": "bart"
             },
             "coldStorageArchiveTopicPrefix": "cold-archive-req-",
+            "coldStorageRestoreTopicPrefix": "cold-restore-req-",
+            "coldStorageGCTopicPrefix": "cold-gc-req-",
+            "coldStorageStatusTopicPrefix": "cold-status-",
             "coldStorageTopics": []
         },
         "gc": {

--- a/tests/unit/gc/GarbageCollectorTask.spec.js
+++ b/tests/unit/gc/GarbageCollectorTask.spec.js
@@ -43,9 +43,11 @@ describe('GarbageCollectorTask', () => {
         gcProducer = new GarbageCollectorProducerMock();
         gcProcessor = new ProcessorMock(
             null,
+            null,
             backbeatClient,
             backbeatMetadataProxyClient,
             gcProducer,
+            null,
             new werelogs.Logger('test:GarbageCollectorTask'));
         gcTask = new GarbageCollectorTask(gcProcessor);
     });

--- a/tests/unit/lifecycle/LifecycleDeleteObjectTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleDeleteObjectTask.spec.js
@@ -29,9 +29,11 @@ describe('LifecycleDeleteObjectTask', () => {
         backbeatMdProxyClient = new BackbeatMetadataProxyMock();
         backbeatClient = new BackbeatClientMock();
         objectProcessor = new ProcessorMock(
+            null,
             s3Client,
             backbeatClient,
             backbeatMdProxyClient,
+            null,
             null,
             new werelogs.Logger('test:LifecycleDeleteObjectTask'));
         objMd = new ObjectMD();

--- a/tests/unit/lifecycle/LifecycleResetTransitionInProgressTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleResetTransitionInProgressTask.spec.js
@@ -45,7 +45,9 @@ describe('LifecycleResetTransitionInProgressTask', () => {
         objectProcessor = new ProcessorMock(
             null,
             null,
+            null,
             backbeatMetadataProxyClient,
+            null,
             null,
             new werelogs.Logger('test:LifecycleResetTransitionInProgressTask'));
 

--- a/tests/unit/lifecycle/LifecycleRetriggerRestoreTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleRetriggerRestoreTask.spec.js
@@ -57,7 +57,9 @@ describe('LifecycleResetTransitionInProgressTask', () => {
         objectProcessor = new ProcessorMock(
             null,
             null,
+            null,
             backbeatMetadataProxyClient,
+            null,
             null,
             new werelogs.Logger('test:LifecycleRetriggerRestoreTask'));
 

--- a/tests/unit/lifecycle/LifecycleUpdateExpirationTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleUpdateExpirationTask.spec.js
@@ -35,8 +35,10 @@ describe('LifecycleUpdateExpirationTask', () => {
         objectProcessor = new ProcessorMock(
             null,
             null,
+            null,
             backbeatMetadataProxyClient,
             gcProducer,
+            null,
             new werelogs.Logger('test:LifecycleUpdateExpirationTask'));
         actionEntry = ActionQueueEntry.create('deleteObject')
             .setAttribute('target', {

--- a/tests/unit/lifecycle/LifecycleUpdateTransitionTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleUpdateTransitionTask.spec.js
@@ -46,8 +46,10 @@ describe('LifecycleUpdateTransitionTask', () => {
         objectProcessor = new ProcessorMock(
             null,
             null,
+            null,
             backbeatMetadataProxyClient,
             gcProducer,
+            null,
             new werelogs.Logger('test:LifecycleUpdateTransitionTask'));
         mdObj = new ObjectMD();
         mdObj.setLocation(oldLocation)

--- a/tests/unit/mocks.js
+++ b/tests/unit/mocks.js
@@ -16,6 +16,27 @@ class GarbageCollectorProducerMock {
     }
 }
 
+class BackbeatProducerMock {
+    constructor() {
+        this.receivedEntry = null;
+        this.topic = null;
+    }
+
+    sendToTopic(coldGcTopic, gcEntries, cb) {
+        this.receivedEntry = gcEntries;
+        this.topic = coldGcTopic;
+        cb();
+    }
+
+    getReceivedEntry() {
+        return this.receivedEntry;
+    }
+
+    getReceivedTopic() {
+        return this.topic;
+    }
+}
+
 class MockRequestAPI extends EventEmitter {
     /**
      * @param {object} args -
@@ -116,18 +137,22 @@ class BackbeatMetadataProxyMock {
 }
 
 class ProcessorMock {
-    constructor(s3Client, backbeatClient, backbeatMetadataProxy, gcProducer, logger) {
+    constructor(lcConfig, s3Client, backbeatClient, backbeatMetadataProxy, gcProducer, coldProducer, logger) {
+        this.lcConfig = lcConfig;
         this.s3Client = s3Client;
         this.backbeatMetadataProxy = backbeatMetadataProxy;
         this.backbeatClient = backbeatClient;
         this.gcProducer = gcProducer;
+        this.coldProducer = coldProducer;
         this.logger = logger;
     }
 
     getStateVars() {
         return {
+            lcConfig: this.lcConfig,
             backbeatClient: this.backbeatMetadataProxy,
             gcProducer: this.gcProducer,
+            coldProducer: this.coldProducer,
             logger: this.logger,
             getBackbeatClient: () => this.backbeatClient,
             getBackbeatMetadataProxy: () => this.backbeatMetadataProxy,
@@ -195,4 +220,5 @@ module.exports = {
     BackbeatMetadataProxyMock,
     BackbeatClientMock,
     S3ClientMock,
+    BackbeatProducerMock,
 };


### PR DESCRIPTION
When an object is deleted (from S3) while it was archived, a message is sent to the cold storage backend to notify the removal.

When this is happens during the transition (archival) process, the object is not yet archived, and we cannot sent such message to the backend. In most cases, this should be fine, as the archiving will fail with an error related to the absence of the (removed) object.

However, there is a race condition, and it is possible that the archival succeeds in backend if the object is removed at the end of this process or in between this result from the backend and the update of metadata in backbeat : the metadata update will fail (as expected), but the object will still be in cold storage and remain there forever (not referenced from anywhere, and thus orphaned)

Issue: BB-469