### PR TITLE
BB-468: propagate restore-expiration to cold backend

### DIFF
--- a/extensions/lifecycle/LifecycleConfigValidator.js
+++ b/extensions/lifecycle/LifecycleConfigValidator.js
@@ -64,6 +64,7 @@ const joiSchema = joi.object({
     },
     coldStorageArchiveTopicPrefix: joi.string().default('cold-archive-req-'),
     coldStorageRestoreTopicPrefix: joi.string().default('cold-restore-req-'),
+    coldStorageRestoreAdjustTopicPrefix: joi.string().default('cold-restore-adjust-req-'),
     coldStorageGCTopicPrefix: joi.string().default('cold-gc-req-'),
     coldStorageStatusTopicPrefix: joi.string().default('cold-status-'),
 });


### PR DESCRIPTION
When a `RestoreObject` call is performed on a restored object to update its lifetime, propagate to the backend cold storage.

Issue: BB-468