### PR TITLE
Fix notifications timestamp for non PutObject operations

### DIFF
--- a/extensions/lifecycle/LifecycleQueuePopulator.js
+++ b/extensions/lifecycle/LifecycleQueuePopulator.js
@@ -439,13 +439,13 @@ class LifecycleQueuePopulator extends QueuePopulatorExtension {
             objectVersion: version,
             archiveInfo: value.archive.archiveInfo,
             requestId: uuid(),
-            transitionTime: new Date(entry.timestamp).toISOString(),
+            transitionTime: new Date(entry.overheadFields.commitTimestamp).toISOString(),
         });
 
         const producer = this._producers[topic];
         if (producer) {
             LifecycleMetrics.onLifecycleTriggered(this.log, 'queuePopulator', 'archive:gc',
-                locationName, Date.now() - entry.timestamp);
+                locationName, Date.now() - entry.overheadFields.commitTimestamp);
 
             const kafkaEntry = { key: encodeURIComponent(key), message };
             producer.send([kafkaEntry], err => {

--- a/extensions/notification/constants.js
+++ b/extensions/notification/constants.js
@@ -14,7 +14,6 @@ const constants = {
     deleteEvent: 's3:ObjectRemoved:Delete',
     replicationFailedEvent: 's3:Replication:OperationFailedReplication',
     eventMessageProperty: {
-        dateTime: 'last-modified',
         eventType: 'originOp',
         region: 'dataStoreName',
         schemaVersion: 'md-model-version',

--- a/extensions/oplogPopulator/OplogPopulator.js
+++ b/extensions/oplogPopulator/OplogPopulator.js
@@ -221,12 +221,10 @@ class OplogPopulator {
                     'documentKey._id': 1,
                     'fullDocument.value': 1,
                     // transforming the BSON timestamp
-                    // into a usable date
+                    // into a usable date string
                     'clusterTime': {
-                        $toDate: {
-                            $dateToString: {
-                                date: '$clusterTime'
-                            }
+                        $dateToString: {
+                            date: '$clusterTime'
                         }
                     },
                 },

--- a/extensions/replication/tasks/UpdateReplicationStatus.js
+++ b/extensions/replication/tasks/UpdateReplicationStatus.js
@@ -494,6 +494,7 @@ class UpdateReplicationStatus extends BackbeatTask {
                     key,
                     versionId,
                     eventType,
+                    dateTime: new Date().toISOString(),
                 };
                 log.debug('validating entry', {
                     method: 'UpdateReplicationStatus._publishFailedReplicationStatusNotification',

--- a/lib/queuePopulator/KafkaLogConsumer/ListRecordStream.js
+++ b/lib/queuePopulator/KafkaLogConsumer/ListRecordStream.js
@@ -73,6 +73,24 @@ class ListRecordStream extends stream.Transform {
     }
 
     /**
+     * Mongo timestamp
+     * @typedef {Object} MongoTimestamp
+     * @property {Object} $timestamp
+     * @property {Number} $timestamp.t - Timestamp in seconds
+     * @property {Number} $timestamp.i - Incrementing ordinal for operations within a given second
+     */
+
+    /**
+     * Get mongo operation timestamp as a string
+     * @param {MongoTimestamp} timestamp mongo timestamp
+     * @returns {string} date
+     */
+    _getTimestamp(timestamp) {
+        const ts = new Date(timestamp.$timestamp.t * 1000);
+        return ts.toISOString();
+    }
+
+    /**
      * Formats change stream entries
      * @param {Object} data chunk of data
      * @param {Buffer} data.value message contents as a Buffer
@@ -102,12 +120,15 @@ class ListRecordStream extends stream.Transform {
         const objectMd = this._getObjectMd(changeStreamDocument);
         const opType = this._getType(changeStreamDocument.operationType, objectMd);
         const streamObject = {
+            // timestamp of the kafka message
             timestamp: new Date(data.timestamp),
             db: changeStreamDocument.ns && changeStreamDocument.ns.coll,
             entries: [{
                 key: changeStreamDocument.documentKey && changeStreamDocument.documentKey._id,
                 type: opType,
                 value: JSON.stringify(objectMd),
+                // timestamp of the mongo operation
+                timestamp: this._getTimestamp(changeStreamDocument.clusterTime),
             }],
         };
         return callback(null, streamObject);

--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -496,14 +496,18 @@ class LogReader {
             if (entry.value === undefined) {
                 return next();
             }
+            const overheadFields = {
+                commitTimestamp: record.timestamp,
+                opTimestamp: entry.timestamp,
+            };
             const entryToFilter = {
                 type: entry.type,
                 bucket: record.db,
-                timestamp: record.timestamp,
                 // removing the v1 metadata prefix if it exists
                 key: transformKey(entry.key),
                 value: entry.value,
                 logReader: this,
+                overheadFields,
             };
             return _executeFilter(ext, entryToFilter, next);
         }, cb);

--- a/tests/unit/lib/queuePopulator/LogReader.spec.js
+++ b/tests/unit/lib/queuePopulator/LogReader.spec.js
@@ -90,12 +90,14 @@ describe('LogReader', () => {
         const masterEntry = {
             type: 'example-type',
             key: '\x7fMexample-key',
-            value: 'example-value'
+            value: 'example-value',
+            timestamp: '2023-11-29T15:05:57.065Z',
         };
         const versionEntry = {
             type: 'example-type',
             key: '\x7fVexample-key',
-            value: 'example-value'
+            value: 'example-value',
+            timestamp: '2023-11-29T15:05:57.065Z',
         };
         logReaderWithExtension._processLogEntry({}, record, masterEntry);
         logReaderWithExtension._processLogEntry({}, record, versionEntry);
@@ -105,7 +107,10 @@ describe('LogReader', () => {
             key: 'example-key',
             value: 'example-value',
             logReader: logReaderWithExtension,
-            timestamp: record.timestamp,
+            overheadFields: {
+                commitTimestamp: record.timestamp,
+                opTimestamp: '2023-11-29T15:05:57.065Z',
+            },
         };
         assert(mockExtension.filter.firstCall.calledWith(expectedArgs));
         assert(mockExtension.filter.secondCall.calledWith(expectedArgs));
@@ -130,12 +135,14 @@ describe('LogReader', () => {
         const masterEntry = {
             type: 'example-type',
             key: 'fMexample-key',
-            value: 'example-value'
+            value: 'example-value',
+            timestamp: '2023-11-29T15:05:57.065Z',
         };
         const versionEntry = {
             type: 'example-type',
             key: 'fVexample-key',
-            value: 'example-value'
+            value: 'example-value',
+            timestamp: '2023-11-29T15:05:57.065Z',
         };
         logReaderWithExtension._processLogEntry({}, record, masterEntry);
         logReaderWithExtension._processLogEntry({}, record, versionEntry);
@@ -145,7 +152,10 @@ describe('LogReader', () => {
             key: 'fMexample-key',
             value: 'example-value',
             logReader: logReaderWithExtension,
-            timestamp: record.timestamp,
+            overheadFields: {
+                commitTimestamp: record.timestamp,
+                opTimestamp: '2023-11-29T15:05:57.065Z',
+            },
         };
         assert(mockExtension.filter.firstCall.calledWith(expectedArgs));
         expectedArgs.key = 'fVexample-key';

--- a/tests/unit/lib/queuePopulator/kafkaLogConsumer/ListRecordStream.js
+++ b/tests/unit/lib/queuePopulator/kafkaLogConsumer/ListRecordStream.js
@@ -13,6 +13,12 @@ const changeStreamDocument = {
         _id: 'example-key',
     },
     operationType: 'insert',
+    clusterTime: {
+        $timestamp: {
+            t: 1701270357,
+            i: 1,
+        },
+    },
     fullDocument: {
         value: {
             field: 'value'
@@ -28,7 +34,12 @@ const changeStreamDocumentUpdate = {
         _id: 'example-key',
     },
     operationType: 'update',
-    updateDescription: {
+    clusterTime: {
+        $timestamp: {
+            t: 1701270357,
+            i: 1,
+        },
+    },    updateDescription: {
         updatedFields: {
             value: {
                 field: 'value',
@@ -113,6 +124,7 @@ describe('ListRecordStream', () => {
                         value: JSON.stringify({
                             field: 'value'
                         }),
+                        timestamp: '2023-11-29T15:05:57.000Z',
                     }],
                 });
                 return done();
@@ -139,6 +151,7 @@ describe('ListRecordStream', () => {
                         value: JSON.stringify({
                             field: 'value'
                         }),
+                        timestamp: '2023-11-29T15:05:57.000Z',
                     }],
                 });
                 return done();

--- a/tests/unit/lib/queuePopulator/kafkaLogConsumer/LogConsumer.js
+++ b/tests/unit/lib/queuePopulator/kafkaLogConsumer/LogConsumer.js
@@ -23,6 +23,12 @@ const changeStreamDocument = {
         _id: 'example-key',
     },
     operationType: 'insert',
+    clusterTime: {
+        $timestamp: {
+            t: 1701270357,
+            i: 1,
+        },
+    },
     fullDocument: {
         value: {
             field: 'value'
@@ -115,6 +121,7 @@ describe('LogConsumer', () => {
                             value: JSON.stringify({
                                 field: 'value'
                             }),
+                            timestamp: '2023-11-29T15:05:57.000Z',
                         }],
                     });
                     return done();

--- a/tests/unit/lifecycle/LifecycleQueuePopulator.spec.js
+++ b/tests/unit/lifecycle/LifecycleQueuePopulator.spec.js
@@ -517,7 +517,9 @@ describe('LifecycleQueuePopulator', () => {
                     bucket: 'lc-queue-populator-test-bucket',
                     key: params.key,
                     value: JSON.stringify(params.md),
-                    timestamp,
+                    overheadFields: {
+                        commitTimestamp: timestamp,
+                    },
                 };
                 lcqp._handleDeleteOp(entry);
                 assert.strictEqual(kafkaSendStub.calledOnce, params.called);

--- a/tests/unit/notification/NotificationQueuePopulator.js
+++ b/tests/unit/notification/NotificationQueuePopulator.js
@@ -120,6 +120,9 @@ describe('NotificationQueuePopulator ::', () => {
                 key: 'examlpe-key',
                 type: 'put',
                 value: '}{',
+                overheadFields: {
+                    opTimestamp: new Date().toISOString(),
+                },
             };
             notificationQueuePopulator.filterAsync(entry, err => {
                 assert.ifError(err);
@@ -135,6 +138,9 @@ describe('NotificationQueuePopulator ::', () => {
                 key: 'example-bucket',
                 type: 'put',
                 value: '{}',
+                overheadFields: {
+                    opTimestamp: new Date().toISOString(),
+                },
             };
             notificationQueuePopulator.filterAsync(entry, err => {
                 assert.ifError(err);
@@ -145,12 +151,15 @@ describe('NotificationQueuePopulator ::', () => {
 
         it('Should process the entry', done => {
             const processEntryCbStub = sinon.stub(notificationQueuePopulator, '_processObjectEntryCb')
-                .callsArg(3);
+                .yields();
             const entry = {
                 bucket: 'example-bucket',
                 key: 'example-key',
                 type: 'put',
                 value: '{}',
+                overheadFields: {
+                    opTimestamp: new Date().toISOString(),
+                },
             };
             notificationQueuePopulator.filterAsync(entry, err => {
                 assert.ifError(err);

--- a/tests/unit/oplogPopulator/oplogPopulator.js
+++ b/tests/unit/oplogPopulator/oplogPopulator.js
@@ -597,10 +597,8 @@ describe('OplogPopulator', () => {
                     'documentKey._id': 1,
                     'fullDocument.value': 1,
                     'clusterTime': {
-                        $toDate: {
-                            $dateToString: {
-                                date: '$clusterTime'
-                            }
+                        $dateToString: {
+                            date: '$clusterTime'
                         }
                     },
                 },

--- a/tests/unit/replication/UpdateReplicationStatus.js
+++ b/tests/unit/replication/UpdateReplicationStatus.js
@@ -230,9 +230,16 @@ describe('UpdateReplicationStatus._handleFailedReplicationEntry', () => {
 });
 
 describe('UpdateReplicationStatus._publishFailedReplicationStatusNotification', () => {
+    const date = new Date();
+    let clock;
+
+    beforeEach(() => {
+        clock = sinon.useFakeTimers(date.getTime());
+    });
 
     afterEach(() => {
         sinon.restore();
+        clock.restore();
     });
 
     it('should publish entry to notification destination topic in correct format', done => {
@@ -295,7 +302,6 @@ describe('UpdateReplicationStatus._publishFailedReplicationStatusNotification', 
             'versionId': '1234',
         });
         const message = {
-            dateTime: '0000',
             eventType: 's3:Replication:OperationFailedReplication',
             region: 'metastore',
             schemaVersion: '1',
@@ -303,6 +309,7 @@ describe('UpdateReplicationStatus._publishFailedReplicationStatusNotification', 
             versionId: '123456',
             bucket: 'example-bucket',
             key: 'example-key',
+            dateTime: date.toISOString(),
         };
         const entryPublished = {
             key: 'example-bucket',


### PR DESCRIPTION
We use the lastModified field to set the timestamp of the notifications, however this field is only updated when the object’s data is modified (meaning only on putObject operations).

The change stream entries contains a timestamp, we will use that as a replacement.

Issue: BB-458