### PR TITLE
Fix missing originOp on lifecycle metadata updates

### DIFF
--- a/extensions/gc/tasks/GarbageCollectorTask.js
+++ b/extensions/gc/tasks/GarbageCollectorTask.js
@@ -248,6 +248,7 @@ class GarbageCollectorTask extends BackbeatTask {
                 objMD.setLocation()
                     .setDataStoreName(newLocation)
                     .setAmzStorageClass(newLocation)
+                    .setOriginOp('s3:LifecycleTransition')
                     .setTransitionInProgress(false)
                     .setUserMetadata({
                         'x-amz-meta-scal-s3-transition-attempt': undefined,

--- a/extensions/lifecycle/tasks/LifecycleColdStatusArchiveTask.js
+++ b/extensions/lifecycle/tasks/LifecycleColdStatusArchiveTask.js
@@ -108,11 +108,13 @@ class LifecycleColdStatusArchiveTask extends LifecycleUpdateTransitionTask {
 
                 // set new ObjectMDArchive to ObjectMD
                 objectMD.setArchive(new ObjectMDArchive(entry.archiveInfo));
+                objectMD.setOriginOp('s3:LifecycleTransition:SetArchive');
 
                 if (skipLocationDeletion) {
                     objectMD.setDataStoreName(coldLocation)
                         .setAmzStorageClass(coldLocation)
                         .setTransitionInProgress(false)
+                        .setOriginOp('s3:LifecycleTransition')
                         .setUserMetadata({
                             'x-amz-meta-scal-s3-transition-attempt': undefined,
                         });

--- a/extensions/lifecycle/tasks/LifecycleResetTransitionInProgressTask.js
+++ b/extensions/lifecycle/tasks/LifecycleResetTransitionInProgressTask.js
@@ -17,9 +17,10 @@ class LifecycleResetTransitionInProgressTask extends LifecycleRequeueTask {
         if (this.shouldSkipObject(md, etag, log)) {
             return false;
         }
+        md.setOriginOp('s3:LifecycleTransition:Retry');
         md.setTransitionInProgress(false);
         md.setUserMetadata({
-                'x-amz-meta-scal-s3-transition-attempt': try_,
+            'x-amz-meta-scal-s3-transition-attempt': try_,
         });
         return true;
     }

--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -1248,7 +1248,8 @@ class LifecycleTask extends BackbeatTask {
             (entry, objectMD, next) => {
                 // Update object metadata with "x-amz-scal-transition-in-progress"
                 // to avoid transitioning object a second time from a new batch.
-                objectMD.setTransitionInProgress(true, params.transitionDate);
+                objectMD.setTransitionInProgress(true, params.transitionTime);
+                objectMD.setOriginOp('s3:LifecycleTransition:Start');
                 const putParams = {
                     bucket: params.bucket,
                     objectKey: params.objectKey,

--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -1243,9 +1243,16 @@ class LifecycleTask extends BackbeatTask {
                     entry.setAttribute('metrics.transitionTime', params.transitionTime);
                 }
                 return ReplicationAPI.sendDataMoverAction(this.producer, entry, log,
-                    err => next(err, entry, objectMD));
+                    err => next(err));
             },
-            (entry, objectMD, next) => {
+            (next) =>
+                // Refresh metadata to minimize risk of race condition on ObjectMD update
+                // c.f. https://scality.atlassian.net/browse/ARSN-341
+                this._getObjectMD(params, log, (err, objectMD) => {
+                    LifecycleMetrics.onS3Request(log, 'getMetadata', 'bucket', err);
+                    return next(err, objectMD);
+                }),
+            (objectMD, next) => {
                 // Update object metadata with "x-amz-scal-transition-in-progress"
                 // to avoid transitioning object a second time from a new batch.
                 objectMD.setTransitionInProgress(true, params.transitionTime);

--- a/extensions/replication/tasks/UpdateReplicationStatus.js
+++ b/extensions/replication/tasks/UpdateReplicationStatus.js
@@ -246,6 +246,7 @@ class UpdateReplicationStatus extends BackbeatTask {
         }
         const versionId =
             sourceEntry.getReplicationSiteDataStoreVersionId(site);
+        entry.setOriginOp('');
         entry.setReplicationSiteDataStoreVersionId(site, versionId);
         entry.setSite(site);
         return entry;

--- a/tests/functional/lib/BackbeatConsumer.js
+++ b/tests/functional/lib/BackbeatConsumer.js
@@ -253,13 +253,13 @@ describe('BackbeatConsumer rebalance tests', () => {
         this.timeout(60000);
 
         // Bootstrap just once at the beginning of the test suite
-        consumer = new BackbeatConsumer({
+        const bootstrapConsumer = new BackbeatConsumer({
             zookeeper: zookeeperConf,
             kafka: { hosts: consumerKafkaConf.hosts }, groupId, topic,
             queueProcessor,
             bootstrap: true,
         });
-        consumer.on('ready', () => consumer.close(done));
+        bootstrapConsumer.on('ready', () => bootstrapConsumer.close(done));
     });
 
     beforeEach(function before(done) {
@@ -356,12 +356,11 @@ describe('BackbeatConsumer rebalance tests', () => {
         assert(consumer.isReady());
         assert(consumer2.isReady());
 
-        consumer.on('consumed.message', () => {
-            if (consumedMessages === 0) {
-                // trigger rebalance during processing of first message
-                consumer2.subscribe();
-            }
+        consumer.once('consumed.message', () => {
+            // trigger rebalance during processing of first message
+            consumer2.subscribe();
 
+            // Return true to allow the consumer to "be stuck" on the message
             return true;
         });
 


### PR DESCRIPTION
Incorrect or missing `originOp` causes incorrectly duplicated bucket notifications, missing notifications or wrong notifications being sent.

- Fix bucket notification at the end of archive
- Clear originOp when updating replication status
- Fix flaky BackbeatConsumer rebalance test

Issue: BB-472
