### PR TITLE
BB-473 Probe response logic should be handled in the handler 

### DIFF
--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -23,6 +23,7 @@ const ObjectQueueEntry = require('../utils/ObjectQueueEntry');
 const BucketQueueEntry = require('../utils/BucketQueueEntry');
 const constants = require('../../../lib/constants');
 const { wrapCounterInc, wrapGaugeSet, wrapHistogramObserve } = require('../../../lib/util/metrics');
+const { sendSuccess, sendMultipleErrors } = require('../../../lib/util/probe');
 
 const {
     proxyVaultPath,
@@ -501,7 +502,7 @@ class QueueProcessor extends EventEmitter {
      *
      * @param {http.HTTPServerResponse} res - HTTP Response to respond with
      * @param {Logger} log - Logger
-     * @returns {string} Error response string or undefined
+     * @returns {undefined}
      */
     handleLiveness(res, log) {
         const verboseLiveness = {};
@@ -547,11 +548,11 @@ class QueueProcessor extends EventEmitter {
         log.debug('verbose liveness', verboseLiveness);
 
         if (responses.length > 0) {
-            return JSON.stringify(responses);
+            sendMultipleErrors(res, log, responses);
+            return undefined;
         }
 
-        res.writeHead(200);
-        res.end();
+        sendSuccess(res, log);
         return undefined;
     }
 
@@ -560,7 +561,7 @@ class QueueProcessor extends EventEmitter {
      *
      * @param {http.HTTPServerResponse} res - HTTP Response to respond with
      * @param {Logger} log - Logger
-     * @returns {string} Error response string or undefined
+     * @return {undefined}
      */
     async handleMetrics(res, log) {
         log.debug('metrics requested');

--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -17,6 +17,7 @@ const ObjectQueueEntry = require('../utils/ObjectQueueEntry');
 const FailedCRRProducer = require('../failedCRR/FailedCRRProducer');
 const ReplayProducer = require('../replay/ReplayProducer');
 const promClient = require('prom-client');
+const { sendSuccess, sendMultipleErrors } = require('../../../lib/util/probe');
 const constants = require('../../../lib/constants');
 const {
     wrapCounterInc,
@@ -395,7 +396,7 @@ class ReplicationStatusProcessor {
      *
      * @param {http.HTTPServerResponse} res - HTTP Response to respond with
      * @param {Logger} log - Logger
-     * @returns {string} Error response string or undefined
+     * @returns {undefined}
      */
     handleLiveness(res, log) {
         const verboseLiveness = {};
@@ -430,11 +431,11 @@ class ReplicationStatusProcessor {
         log.debug('verbose liveness', verboseLiveness);
 
         if (responses.length > 0) {
-            return JSON.stringify(responses);
+            sendMultipleErrors(res, log, responses);
+            return undefined;
         }
 
-        res.writeHead(200);
-        res.end();
+        sendSuccess(res, log);
         return undefined;
     }
 
@@ -443,7 +444,7 @@ class ReplicationStatusProcessor {
      *
      * @param {http.HTTPServerResponse} res - HTTP Response to respond with
      * @param {Logger} log - Logger
-     * @returns {string} Error response string or undefined
+     * @return {undefined}
      */
     async handleMetrics(res, log) {
         log.debug('metrics requested');

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -12,6 +12,7 @@ const FailedCRRConsumer =
 const NotificationConfigManager
     = require('../../extensions/notification/NotificationConfigManager');
 const promClient = require('prom-client');
+const { sendSuccess, sendMultipleErrors } = require('../util/probe');
 const constants = require('../constants');
 const { wrapCounterInc, wrapGaugeSet } = require('../util/metrics');
 
@@ -419,7 +420,7 @@ class QueuePopulator {
      *
      * @param {http.HTTPServerResponse} res - HTTP Response to respond with
      * @param {Logger} log - Logger
-     * @returns {string} Error response string or undefined
+     * @returns {undefined}
      */
     handleLiveness(res, log) {
         // log verbose status for all checks
@@ -453,11 +454,11 @@ class QueuePopulator {
         log.debug('verbose liveness', verboseLiveness);
 
         if (responses.length > 0) {
-            return JSON.stringify(responses);
+            sendMultipleErrors(res, log, responses);
+            return undefined;
         }
 
-        res.writeHead(200);
-        res.end();
+        sendSuccess(res, log);
         return undefined;
     }
 
@@ -466,7 +467,7 @@ class QueuePopulator {
      *
      * @param {http.HTTPServerResponse} res - HTTP Response to respond with
      * @param {Logger} log - Logger
-     * @returns {string} Error response string or undefined
+     * @return {undefined}
      */
     async handleMetrics(res, log) {
         log.debug('metrics requested');

--- a/lib/util/probe.js
+++ b/lib/util/probe.js
@@ -32,25 +32,58 @@ function startProbeServer(config, callback) {
     probeServer.start();
 }
 
-function sendError(res, log, error, optMessage) {
-    res.writeHead(error.code);
-    let message;
-    if (optMessage) {
-        message = optMessage;
-    } else {
-        message = error.description || '';
-    }
-    log.debug('sending back error response', { httpCode: error.code,
-        errorType: error.message,
-        error: message });
-    res.end(`${JSON.stringify({ errorType: error.message,
-        errorMessage: message })}\n`);
+/**
+ * Send an Error response with multiple errors
+ * @param {http.HTTPServerResponse} res - HTTP response for writing
+ * @param {Logger} log - Werelogs instance for logging if you choose to
+ * @param {Array} errorMessages - error messages
+ * @return {undefined}
+ */
+function sendMultipleErrors(res, log, errorMessages) {
+    const messages = JSON.stringify(errorMessages);
+    const errorCode = 500;
+    log.error('sending back error response', {
+        httpCode: errorCode,
+        error: errorMessages,
+    });
+    res.writeHead(errorCode);
+    res.end(messages);
 }
 
-function sendSuccess(res, log, msg) {
-    res.writeHead(200);
+/**
+ * Send an Error response
+ * @param {http.HTTPServerResponse} res - HTTP response for writing
+ * @param {Logger} log - Werelogs instance for logging if you choose to
+ * @param {Error} error - Error to send back to the user
+ * @param {String} [optMessage] - Message to use instead of the errors message
+ * @return {undefined}
+ */
+function sendError(res, log, error, optMessage) {
+    const message = optMessage || error.description || '';
+    log.error('sending back error response', {
+        httpCode: error.code,
+        errorType: error.message,
+        error: message,
+    });
+    res.writeHead(error.code);
+    res.end(
+        JSON.stringify({
+            errorType: error.message,
+            errorMessage: message,
+        }),
+    );
+}
+
+/**
+ * Send a successful HTTP response of 200 OK
+ * @param {http.HTTPServerResponse} res - HTTP response for writing
+ * @param {Logger} log - Werelogs instance for logging if you choose to
+ * @param {String} [message] - Message to send as response, defaults to OK
+ * @return {undefined}
+ */
+function sendSuccess(res, log, message = 'OK') {
     log.debug('replying with success');
-    const message = msg || 'OK';
+    res.writeHead(200);
     res.end(message);
 }
 
@@ -58,4 +91,5 @@ module.exports = {
     startProbeServer,
     sendSuccess,
     sendError,
+    sendMultipleErrors,
 };

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/scality/backbeat#readme",
   "dependencies": {
     "@hapi/joi": "^15.1.0",
-    "arsenal": "git+https://github.com/scality/arsenal#7.10.46",
+    "arsenal": "git+https://github.com/scality/arsenal#7.10.50",
     "async": "^2.3.0",
     "aws-sdk": "^2.1326.0",
     "backo": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "7.10.15",
+  "version": "7.10.16",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/replication/ReplicationStatusProcessor.js
+++ b/tests/unit/replication/ReplicationStatusProcessor.js
@@ -1,6 +1,8 @@
 const assert = require('assert');
 const promClient = require('prom-client');
+const sinon = require('sinon');
 
+const constants = require('../../../lib/constants');
 const ReplicationStatusProcessor =
     require('../../../extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor');
 
@@ -135,6 +137,143 @@ describe('ReplicationStatusProcessor', () => {
                 'backbeat-replication-replay-0',
                 'backbeat-replication-replay-1',
             ]);
+        });
+    });
+});
+
+describe('ReplicationStatusProcessor: handlers', () => {
+    let processor;
+    let mockResponse;
+    let logger;
+    const topicName = 'backbeat-replication-replay-0';
+    const replayTopics = [
+        {
+            topicName,
+            retries: 5,
+        },
+    ];
+
+    beforeEach(() => {
+        // Clear register to avoid:
+        // Error: A metric with the name kafka_lag has already been registered.
+        promClient.register.clear();
+
+        processor = makeReplicationStatusProcessor(replayTopics);
+        mockResponse = {
+            writeHead: sinon.stub(),
+            end: sinon.stub(),
+        };
+        logger = {
+            debug: sinon.stub(),
+            error: sinon.stub(),
+        };
+
+        sinon.stub(promClient.register, 'metrics').resolves('metrics_data');
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    describe('handleLiveness', () => {
+        it('should respond with 200 when all components are healthy', () => {
+            processor._consumer = { _consumerReady: true };
+            processor._FailedCRRProducer = { _producer: { isReady: () => true } };
+            processor._ReplayProducers = {
+                [topicName]: { _producer: { isReady: () => true } },
+            };
+
+            processor.handleLiveness(mockResponse, logger);
+
+            assert(mockResponse.writeHead.calledWith(200));
+            assert(mockResponse.end.calledOnce);
+        });
+
+        it('should respond with 500 when consumer is not ready', () => {
+            processor._consumer = { _consumerReady: false };
+            processor._FailedCRRProducer = { _producer: { isReady: () => true } };
+            processor._ReplayProducers = {
+                [topicName]: { _producer: { isReady: () => true } },
+            };
+
+            processor.handleLiveness(mockResponse, logger);
+
+            sinon.assert.calledOnceWithExactly(mockResponse.writeHead, 500);
+
+            const expectedRes = [{
+                component: 'Consumer',
+                status: constants.statusNotReady,
+            }];
+            sinon.assert.calledOnceWithExactly(mockResponse.end, JSON.stringify(expectedRes));
+
+            const expectedLogError = {
+                httpCode: 500,
+                error: expectedRes,
+            };
+            sinon.assert.calledOnceWithExactly(logger.error, 'sending back error response', expectedLogError);
+        });
+
+        it('should respond with 500 when failed CRR Producer is not ready', () => {
+            processor._consumer = { _consumerReady: true };
+            processor._FailedCRRProducer = { _producer: { isReady: () => false } };
+            processor._ReplayProducers = {
+                [topicName]: { _producer: { isReady: () => true } },
+            };
+
+            processor.handleLiveness(mockResponse, logger);
+
+            sinon.assert.calledOnceWithExactly(mockResponse.writeHead, 500);
+
+            const expectedRes = [{
+                component: 'Failed CRR Producer',
+                status: constants.statusNotReady,
+            }];
+            sinon.assert.calledOnceWithExactly(mockResponse.end, JSON.stringify(expectedRes));
+
+            const expectedLogError = {
+                httpCode: 500,
+                error: expectedRes,
+            };
+            sinon.assert.calledOnceWithExactly(logger.error, 'sending back error response', expectedLogError);
+        });
+
+        it('should respond with 500 when Replay Producers is not ready', () => {
+            processor._consumer = { _consumerReady: true };
+            processor._FailedCRRProducer = { _producer: { isReady: () => true } };
+            processor._ReplayProducers = {
+                [topicName]: { _producer: { isReady: () => false } },
+            };
+
+            processor.handleLiveness(mockResponse, logger);
+
+            sinon.assert.calledOnceWithExactly(mockResponse.writeHead, 500);
+
+            const expectedRes = [{
+                component: 'Replay CRR Producer to backbeat-replication-replay-0',
+                status: constants.statusNotReady,
+            }];
+            sinon.assert.calledOnceWithExactly(mockResponse.end, JSON.stringify(expectedRes));
+
+            const expectedLogError = {
+                httpCode: 500,
+                error: expectedRes,
+            };
+            sinon.assert.calledOnceWithExactly(logger.error, 'sending back error response', expectedLogError);
+        });
+    });
+
+    describe('handleMetrics', () => {
+        it('should properly handle metrics response', async () => {
+            const r = await processor.handleMetrics(mockResponse, logger);
+            assert.strictEqual(r, undefined);
+
+            sinon.assert.calledOnce(promClient.register.metrics);
+
+            sinon.assert.calledOnceWithExactly(mockResponse.writeHead, 200, {
+                'Content-Type': promClient.register.contentType,
+            });
+
+            sinon.assert.calledOnceWithExactly(mockResponse.end, 'metrics_data');
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -338,6 +338,11 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
+"@socket.io/component-emitter@~3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz#96116f2a912e0c02817345b3c10751069920d553"
+  integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -353,6 +358,18 @@
   resolved "https://registry.yarnpkg.com/@types/async/-/async-3.2.13.tgz#ec023074c70180d17cbc9117ddc3cec2f3894ea4"
   integrity sha512-7Q3awrhnvm89OzfsmqeqRQh8mh+8Pxfgq1UvSAn2nWQ5y/F3+NrbIF0RbkWq8+5dY99ozgap2b3DNBNwjLVOxw==
 
+"@types/cookie@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.4.1.tgz#bfd02c1f2224567676c1545199f87c3a861d878d"
+  integrity sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q==
+
+"@types/cors@^2.8.12":
+  version "2.8.17"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.17.tgz#5d718a5e494a8166f569d986794e49c48b216b2b"
+  integrity sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/node-fetch@^2.5.0":
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.2.tgz#d1a9c5fd049d9415dce61571557104dec3ec81da"
@@ -365,6 +382,13 @@
   version "18.14.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.14.2.tgz#c076ed1d7b6095078ad3cf21dfeea951842778b1"
   integrity sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA==
+
+"@types/node@>=10.0.0":
+  version "20.10.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.10.0.tgz#16ddf9c0a72b832ec4fcce35b8249cf149214617"
+  integrity sha512-D0WfRmU9TQ8I9PFx9Yc+EBHw+vSpIub4IDvQivcp26PtPrdMGAq5SDcpXEo/epqa/DXotVpekHiLNTg3iaKXBQ==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/tunnel@^0.0.3":
   version "0.0.3"
@@ -682,7 +706,6 @@ arraybuffer.slice@~0.0.7:
 
 "arsenal@git+https://github.com/scality/Arsenal#7.10.46":
   version "7.10.46"
-  uid bd76402586f1b5117ada9857a9e437727562d55a
   resolved "git+https://github.com/scality/Arsenal#bd76402586f1b5117ada9857a9e437727562d55a"
   dependencies:
     "@types/async" "^3.2.12"
@@ -801,9 +824,9 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#7.10.46":
-  version "7.10.46"
-  resolved "git+https://github.com/scality/arsenal#bd76402586f1b5117ada9857a9e437727562d55a"
+"arsenal@git+https://github.com/scality/arsenal#7.10.50":
+  version "7.10.50"
+  resolved "git+https://github.com/scality/arsenal#06244059a824abba008890c98ef20d127344c53a"
   dependencies:
     "@types/async" "^3.2.12"
     "@types/utf8" "^3.0.1"
@@ -819,7 +842,7 @@ arraybuffer.slice@~0.0.7:
     bson "4.0.0"
     debug "~2.6.9"
     diskusage "^1.1.1"
-    fcntl "github:scality/node-fcntl#0.2.0"
+    fcntl "github:scality/node-fcntl#0.2.2"
     hdclient scality/hdclient#1.1.0
     https-proxy-agent "^2.2.0"
     ioredis "^4.28.5"
@@ -831,8 +854,8 @@ arraybuffer.slice@~0.0.7:
     node-forge "^0.7.1"
     prom-client "14.2.0"
     simple-glob "^0.2"
-    socket.io "~2.3.0"
-    socket.io-client "~2.3.0"
+    socket.io "~4.6.1"
+    socket.io-client "~4.6.1"
     sproxydclient "github:scality/sproxydclient#8.0.4"
     utf8 "2.1.2"
     uuid "^3.0.1"
@@ -1077,7 +1100,7 @@ base64-js@^1.0.2, base64-js@^1.3.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
-base64id@2.0.0:
+base64id@2.0.0, base64id@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/base64id/-/base64id-2.0.0.tgz#2770ac6bc47d312af97a8bf9a634342e0cd25cb6"
   integrity sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==
@@ -1547,6 +1570,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+cors@~2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 cron-parser@^2.11.0, cron-parser@^2.15.0, cron-parser@^2.18.0:
   version "2.18.0"
   resolved "https://registry.yarnpkg.com/cron-parser/-/cron-parser-2.18.0.tgz#de1bb0ad528c815548371993f81a54e5a089edcf"
@@ -1644,6 +1675,13 @@ debug@~4.1.0:
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
+
+debug@~4.3.1, debug@~4.3.2:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
+  dependencies:
+    ms "2.1.2"
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -1832,6 +1870,17 @@ engine.io-client@~3.5.0:
     xmlhttprequest-ssl "~1.6.2"
     yeast "0.1.2"
 
+engine.io-client@~6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-6.4.0.tgz#88cd3082609ca86d7d3c12f0e746d12db4f47c91"
+  integrity sha512-GyKPDyoEha+XZ7iEqam49vz6auPnNJ9ZBfy89f+rMMas8AuiMWOZ9PVzu8xb9ZC6rafUqiGHSCfu22ih66E+1g==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.3.1"
+    engine.io-parser "~5.0.3"
+    ws "~8.11.0"
+    xmlhttprequest-ssl "~2.0.0"
+
 engine.io-parser@~2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-2.2.1.tgz#57ce5611d9370ee94f99641b589f94c97e4f5da7"
@@ -1842,6 +1891,11 @@ engine.io-parser@~2.2.0:
     base64-arraybuffer "0.1.4"
     blob "0.0.5"
     has-binary2 "~1.0.2"
+
+engine.io-parser@~5.0.3:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/engine.io-parser/-/engine.io-parser-5.0.7.tgz#ed5eae76c71f398284c578ab6deafd3ba7e4e4f6"
+  integrity sha512-P+jDFbvK6lE3n1OL+q9KuzdOFWkkZ/cMV9gol/SbVfpyqfvrfrFTOFJ6fQm2VC3PZHlU3QPhVwmbsCnauHF2MQ==
 
 engine.io@~3.4.0:
   version "3.4.2"
@@ -1866,6 +1920,22 @@ engine.io@~3.5.0:
     debug "~4.1.0"
     engine.io-parser "~2.2.0"
     ws "~7.4.2"
+
+engine.io@~6.4.2:
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/engine.io/-/engine.io-6.4.2.tgz#ffeaf68f69b1364b0286badddf15ff633476473f"
+  integrity sha512-FKn/3oMiJjrOEOeUub2WCox6JhxBXq/Zn3fZOMCBxKnNYtsdKjxhl7yR3fZhM9PV+rdE75SU5SYMc+2PGzo+Tg==
+  dependencies:
+    "@types/cookie" "^0.4.1"
+    "@types/cors" "^2.8.12"
+    "@types/node" ">=10.0.0"
+    accepts "~1.3.4"
+    base64id "2.0.0"
+    cookie "~0.4.1"
+    cors "~2.8.5"
+    debug "~4.3.1"
+    engine.io-parser "~5.0.3"
+    ws "~8.11.0"
 
 entities@~2.1.0:
   version "2.1.0"
@@ -2257,6 +2327,14 @@ fast-safe-stringify@^2.1.1:
 "fcntl@github:scality/node-fcntl#0.2.0":
   version "0.2.0"
   resolved "https://codeload.github.com/scality/node-fcntl/tar.gz/ae7493da46fb353eff0c4cb79e2cce838197c066"
+  dependencies:
+    bindings "^1.1.1"
+    nan "^2.3.2"
+    node-gyp "^8.0.0"
+
+"fcntl@github:scality/node-fcntl#0.2.2":
+  version "0.2.1"
+  resolved "https://codeload.github.com/scality/node-fcntl/tar.gz/b1335ca204c6265cedc50c26020c4d63aabe920e"
   dependencies:
     bindings "^1.1.1"
     nan "^2.3.2"
@@ -4307,10 +4385,10 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
 object-component@0.0.3:
   version "0.0.3"
@@ -5097,6 +5175,13 @@ socket.io-adapter@~1.1.0:
   resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz#ab3f0d6f66b8fc7fca3959ab5991f82221789be9"
   integrity sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g==
 
+socket.io-adapter@~2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-2.5.2.tgz#5de9477c9182fdc171cd8c8364b9a8894ec75d12"
+  integrity sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==
+  dependencies:
+    ws "~8.11.0"
+
 socket.io-client@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-2.3.0.tgz#14d5ba2e00b9bcd145ae443ab96b3f86cbcc1bb4"
@@ -5151,6 +5236,16 @@ socket.io-client@~2.3.0:
     socket.io-parser "~3.3.0"
     to-array "0.1.4"
 
+socket.io-client@~4.6.1:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-4.6.2.tgz#2bfde952e74625d54e622718a7cb1d591ee62fd6"
+  integrity sha512-OwWrMbbA8wSqhBAR0yoPK6EdQLERQAYjXb3A0zLpgxfM1ZGLKoxHx8gVmCHA6pcclRX5oA/zvQf7bghAS11jRA==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.3.2"
+    engine.io-client "~6.4.0"
+    socket.io-parser "~4.2.4"
+
 socket.io-parser@~3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.3.2.tgz#ef872009d0adcf704f2fbe830191a14752ad50b6"
@@ -5168,6 +5263,14 @@ socket.io-parser@~3.4.0:
     component-emitter "1.2.1"
     debug "~4.1.0"
     isarray "2.0.1"
+
+socket.io-parser@~4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-4.2.4.tgz#c806966cf7270601e47469ddeec30fbdfda44c83"
+  integrity sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==
+  dependencies:
+    "@socket.io/component-emitter" "~3.1.0"
+    debug "~4.3.1"
 
 socket.io@2.4.1:
   version "2.4.1"
@@ -5192,6 +5295,18 @@ socket.io@~2.3.0:
     socket.io-adapter "~1.1.0"
     socket.io-client "2.3.0"
     socket.io-parser "~3.4.0"
+
+socket.io@~4.6.1:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.6.2.tgz#d597db077d4df9cbbdfaa7a9ed8ccc3d49439786"
+  integrity sha512-Vp+lSks5k0dewYTfwgPT9UeGGd+ht7sCpB7p0e83VgO4X/AHYWhXITMrNk/pg8syY2bpx23ptClCQuHhqi2BgQ==
+  dependencies:
+    accepts "~1.3.4"
+    base64id "~2.0.0"
+    debug "~4.3.2"
+    engine.io "~6.4.2"
+    socket.io-adapter "~2.5.2"
+    socket.io-parser "~4.2.4"
 
 socks-proxy-agent@^6.0.0:
   version "6.1.1"
@@ -5667,6 +5782,11 @@ underscore@~1.4.4:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
   integrity sha1-YaajIBBiKvoHljvzJSA88SI51gQ=
 
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
 unique-filename@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unique-filename/-/unique-filename-1.1.1.tgz#1d69769369ada0583103a1e6ae87681b56573230"
@@ -5819,7 +5939,7 @@ validator@^13.0.0, validator@^13.6.0, validator@^13.7.0:
   resolved "https://registry.yarnpkg.com/validator/-/validator-13.7.0.tgz#4f9658ba13ba8f3d82ee881d3516489ea85c0857"
   integrity sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
@@ -6023,6 +6143,11 @@ ws@~7.4.2:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.6.tgz#5654ca8ecdeee47c33a9a4bf6d28e2be2980377c"
   integrity sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==
 
+ws@~8.11.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
+  integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==
+
 xml2js@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
@@ -6065,6 +6190,11 @@ xmlhttprequest-ssl@~1.6.2:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz#03b713873b01659dfa2c1c5d056065b27ddc2de6"
   integrity sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==
+
+xmlhttprequest-ssl@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz#91360c86b914e67f44dce769180027c0da618c67"
+  integrity sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==
 
 xtend@^4.0.0, xtend@^4.0.2, xtend@~4.0.0:
   version "4.0.2"


### PR DESCRIPTION
Currently, the probe response logic is distributed between Backbeat probe handlers and Arsenal's onRequest method.
This scattered approach causes confusion for developers and results in bugs.
The solution is to centralize the probe response logic exclusively within the Backbeat probe handlers.