### PR TITLE
BB-477 [backport 7.10] Clear originOp when updating replication status

### DIFF
--- a/extensions/replication/tasks/UpdateReplicationStatus.js
+++ b/extensions/replication/tasks/UpdateReplicationStatus.js
@@ -234,6 +234,7 @@ class UpdateReplicationStatus extends BackbeatTask {
             updatedSourceEntry.setSite(site);
             updatedSourceEntry.setReplicationSiteDataStoreVersionId(site,
                 sourceEntry.getReplicationSiteDataStoreVersionId(site));
+            updatedSourceEntry.setOriginOp('');
             return this.backbeatSourceClient
             .putMetadata(updatedSourceEntry, log, err => {
                 if (err) {

--- a/tests/unit/replication/UpdateReplicationStatus.spec.js
+++ b/tests/unit/replication/UpdateReplicationStatus.spec.js
@@ -1,0 +1,61 @@
+const assert = require('assert');
+const sinon = require('sinon');
+
+const UpdateReplicationStatus =
+      require('../../../extensions/replication/tasks/UpdateReplicationStatus');
+const ObjectQueueEntry =
+      require('../../../extensions/replication/utils/ObjectQueueEntry');
+
+const Logger = require('werelogs').Logger;
+const logger = new Logger('Backbeat:Replication:UpdateReplicationStatus:tests');
+
+describe('UpdateReplicationStatus', () => {
+    it('should update replication status and reset the "originOp" field', done => {
+        const mockRSP = {
+            getStateVars: sinon.stub().returns({
+                repConfig: {
+                    replicationStatusProcessor: {},
+                },
+                sourceConfig: {
+                    auth: {},
+                },
+            }),
+        };
+        const objMd = {
+            replicationInfo: {
+                status: 'PENDING',
+                backends: [{
+                    site: 'sf',
+                    status: 'PENDING',
+                }],
+            },
+            originOp: 's3:ObjectCreated:Put',
+        };
+        const replicationEntry = {
+            replicationInfo: {
+                status: 'COMPLETED',
+                backends: [{
+                    site: 'sf',
+                    status: 'COMPLETED',
+                }],
+            },
+            originOp: 's3:ObjectCreated:Put',
+        };
+        const task = new UpdateReplicationStatus(mockRSP, {
+            status: sinon.stub(),
+        });
+        task.backbeatSourceClient = {
+            getMetadata: sinon.stub().callsArgWith(2, null, { Body: JSON.stringify(objMd) }),
+            putMetadata: (updatedSourceEntry, log, cb) => {
+                assert.strictEqual(updatedSourceEntry.getReplicationStatus(), 'COMPLETED');
+                // originOp should have been reset before putting metadata
+                assert.strictEqual(updatedSourceEntry.getOriginOp(), '');
+                cb();
+            },
+        };
+        const sourceEntry = new ObjectQueueEntry('mybucket', 'mykey', replicationEntry);
+        sourceEntry.setSite('sf');
+        const log = logger.newRequestLogger();
+        task._updateReplicationStatus(sourceEntry, log, done);
+    });
+});


### PR DESCRIPTION
This ensures no extra bucket notification is sent.

Issue: BB-472
(cherry picked from commit 29c344a42ef2bd06f57d23af0fd102a63f1d0b05)

New (not cherry-picked):

- [test] add UpdateReplicationStatus unit test

  The test checks that the "originOp" field has been reset prior to putting the updated metadata.

**Note for reviews**: I also added this commit on 8.6 integration branch to port the test, please also review it: https://github.com/scality/backbeat/commit/9260afd3cc3bffe23c2f522337e6087627c20840