### PR TITLE
BB-473 Probe response logic should be handled in the handler 

### DIFF
--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -23,6 +23,7 @@ const ObjectQueueEntry = require('../utils/ObjectQueueEntry');
 const BucketQueueEntry = require('../utils/BucketQueueEntry');
 const constants = require('../../../lib/constants');
 const { wrapCounterInc, wrapGaugeSet, wrapHistogramObserve } = require('../../../lib/util/metrics');
+const { sendSuccess, sendMultipleErrors } = require('../../../lib/util/probe');
 
 const {
     proxyVaultPath,
@@ -501,7 +502,7 @@ class QueueProcessor extends EventEmitter {
      *
      * @param {http.HTTPServerResponse} res - HTTP Response to respond with
      * @param {Logger} log - Logger
-     * @returns {string} Error response string or undefined
+     * @returns {undefined}
      */
     handleLiveness(res, log) {
         const verboseLiveness = {};
@@ -547,11 +548,11 @@ class QueueProcessor extends EventEmitter {
         log.debug('verbose liveness', verboseLiveness);
 
         if (responses.length > 0) {
-            return JSON.stringify(responses);
+            sendMultipleErrors(res, log, responses);
+            return undefined;
         }
 
-        res.writeHead(200);
-        res.end();
+        sendSuccess(res, log);
         return undefined;
     }
 
@@ -560,7 +561,7 @@ class QueueProcessor extends EventEmitter {
      *
      * @param {http.HTTPServerResponse} res - HTTP Response to respond with
      * @param {Logger} log - Logger
-     * @returns {string} Error response string or undefined
+     * @return {undefined}
      */
     async handleMetrics(res, log) {
         log.debug('metrics requested');

--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -17,6 +17,7 @@ const ObjectQueueEntry = require('../utils/ObjectQueueEntry');
 const FailedCRRProducer = require('../failedCRR/FailedCRRProducer');
 const ReplayProducer = require('../replay/ReplayProducer');
 const promClient = require('prom-client');
+const { sendSuccess, sendMultipleErrors } = require('../../../lib/util/probe');
 const constants = require('../../../lib/constants');
 const {
     wrapCounterInc,
@@ -395,7 +396,7 @@ class ReplicationStatusProcessor {
      *
      * @param {http.HTTPServerResponse} res - HTTP Response to respond with
      * @param {Logger} log - Logger
-     * @returns {string} Error response string or undefined
+     * @returns {undefined}
      */
     handleLiveness(res, log) {
         const verboseLiveness = {};
@@ -430,11 +431,11 @@ class ReplicationStatusProcessor {
         log.debug('verbose liveness', verboseLiveness);
 
         if (responses.length > 0) {
-            return JSON.stringify(responses);
+            sendMultipleErrors(res, log, responses);
+            return undefined;
         }
 
-        res.writeHead(200);
-        res.end();
+        sendSuccess(res, log);
         return undefined;
     }
 
@@ -443,7 +444,7 @@ class ReplicationStatusProcessor {
      *
      * @param {http.HTTPServerResponse} res - HTTP Response to respond with
      * @param {Logger} log - Logger
-     * @returns {string} Error response string or undefined
+     * @return {undefined}
      */
     async handleMetrics(res, log) {
         log.debug('metrics requested');

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -12,6 +12,7 @@ const FailedCRRConsumer =
 const NotificationConfigManager
     = require('../../extensions/notification/NotificationConfigManager');
 const promClient = require('prom-client');
+const { sendSuccess, sendMultipleErrors } = require('../util/probe');
 const constants = require('../constants');
 const { wrapCounterInc, wrapGaugeSet } = require('../util/metrics');
 
@@ -418,7 +419,7 @@ class QueuePopulator {
      *
      * @param {http.HTTPServerResponse} res - HTTP Response to respond with
      * @param {Logger} log - Logger
-     * @returns {string} Error response string or undefined
+     * @returns {undefined}
      */
     handleLiveness(res, log) {
         // log verbose status for all checks
@@ -452,11 +453,11 @@ class QueuePopulator {
         log.debug('verbose liveness', verboseLiveness);
 
         if (responses.length > 0) {
-            return JSON.stringify(responses);
+            sendMultipleErrors(res, log, responses);
+            return undefined;
         }
 
-        res.writeHead(200);
-        res.end();
+        sendSuccess(res, log);
         return undefined;
     }
 
@@ -465,7 +466,7 @@ class QueuePopulator {
      *
      * @param {http.HTTPServerResponse} res - HTTP Response to respond with
      * @param {Logger} log - Logger
-     * @returns {string} Error response string or undefined
+     * @return {undefined}
      */
     async handleMetrics(res, log) {
         log.debug('metrics requested');

--- a/lib/util/probe.js
+++ b/lib/util/probe.js
@@ -32,25 +32,58 @@ function startProbeServer(config, callback) {
     probeServer.start();
 }
 
-function sendError(res, log, error, optMessage) {
-    res.writeHead(error.code);
-    let message;
-    if (optMessage) {
-        message = optMessage;
-    } else {
-        message = error.description || '';
-    }
-    log.debug('sending back error response', { httpCode: error.code,
-        errorType: error.message,
-        error: message });
-    res.end(`${JSON.stringify({ errorType: error.message,
-        errorMessage: message })}\n`);
+/**
+ * Send an Error response with multiple errors
+ * @param {http.HTTPServerResponse} res - HTTP response for writing
+ * @param {Logger} log - Werelogs instance for logging if you choose to
+ * @param {Array} errorMessages - error messages
+ * @return {undefined}
+ */
+function sendMultipleErrors(res, log, errorMessages) {
+    const messages = JSON.stringify(errorMessages);
+    const errorCode = 500;
+    log.error('sending back error response', {
+        httpCode: errorCode,
+        error: errorMessages,
+    });
+    res.writeHead(errorCode);
+    res.end(messages);
 }
 
-function sendSuccess(res, log, msg) {
-    res.writeHead(200);
+/**
+ * Send an Error response
+ * @param {http.HTTPServerResponse} res - HTTP response for writing
+ * @param {Logger} log - Werelogs instance for logging if you choose to
+ * @param {Error} error - Error to send back to the user
+ * @param {String} [optMessage] - Message to use instead of the errors message
+ * @return {undefined}
+ */
+function sendError(res, log, error, optMessage) {
+    const message = optMessage || error.description || '';
+    log.error('sending back error response', {
+        httpCode: error.code,
+        errorType: error.message,
+        error: message,
+    });
+    res.writeHead(error.code);
+    res.end(
+        JSON.stringify({
+            errorType: error.message,
+            errorMessage: message,
+        }),
+    );
+}
+
+/**
+ * Send a successful HTTP response of 200 OK
+ * @param {http.HTTPServerResponse} res - HTTP response for writing
+ * @param {Logger} log - Werelogs instance for logging if you choose to
+ * @param {String} [message] - Message to send as response, defaults to OK
+ * @return {undefined}
+ */
+function sendSuccess(res, log, message = 'OK') {
     log.debug('replying with success');
-    const message = msg || 'OK';
+    res.writeHead(200);
     res.end(message);
 }
 
@@ -58,4 +91,5 @@ module.exports = {
     startProbeServer,
     sendSuccess,
     sendError,
+    sendMultipleErrors,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "7.70.1-2",
+  "version": "7.70.1-3",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "homepage": "https://github.com/scality/backbeat#readme",
   "dependencies": {
     "@hapi/joi": "^15.1.0",
-    "arsenal": "git+https://github.com/scality/arsenal#7.10.46",
+    "arsenal": "git+https://github.com/scality/arsenal#7.10.46-1",
     "async": "^2.3.0",
     "aws-sdk": "^2.1326.0",
     "backo": "^1.1.0",

--- a/tests/unit/replication/ReplicationStatusProcessor.js
+++ b/tests/unit/replication/ReplicationStatusProcessor.js
@@ -1,6 +1,8 @@
 const assert = require('assert');
 const promClient = require('prom-client');
+const sinon = require('sinon');
 
+const constants = require('../../../lib/constants');
 const ReplicationStatusProcessor =
     require('../../../extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor');
 
@@ -135,6 +137,143 @@ describe('ReplicationStatusProcessor', () => {
                 'backbeat-replication-replay-0',
                 'backbeat-replication-replay-1',
             ]);
+        });
+    });
+});
+
+describe('ReplicationStatusProcessor: handlers', () => {
+    let processor;
+    let mockResponse;
+    let logger;
+    const topicName = 'backbeat-replication-replay-0';
+    const replayTopics = [
+        {
+            topicName,
+            retries: 5,
+        },
+    ];
+
+    beforeEach(() => {
+        // Clear register to avoid:
+        // Error: A metric with the name kafka_lag has already been registered.
+        promClient.register.clear();
+
+        processor = makeReplicationStatusProcessor(replayTopics);
+        mockResponse = {
+            writeHead: sinon.stub(),
+            end: sinon.stub(),
+        };
+        logger = {
+            debug: sinon.stub(),
+            error: sinon.stub(),
+        };
+
+        sinon.stub(promClient.register, 'metrics').resolves('metrics_data');
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    describe('handleLiveness', () => {
+        it('should respond with 200 when all components are healthy', () => {
+            processor._consumer = { _consumerReady: true };
+            processor._FailedCRRProducer = { _producer: { isReady: () => true } };
+            processor._ReplayProducers = {
+                [topicName]: { _producer: { isReady: () => true } },
+            };
+
+            processor.handleLiveness(mockResponse, logger);
+
+            assert(mockResponse.writeHead.calledWith(200));
+            assert(mockResponse.end.calledOnce);
+        });
+
+        it('should respond with 500 when consumer is not ready', () => {
+            processor._consumer = { _consumerReady: false };
+            processor._FailedCRRProducer = { _producer: { isReady: () => true } };
+            processor._ReplayProducers = {
+                [topicName]: { _producer: { isReady: () => true } },
+            };
+
+            processor.handleLiveness(mockResponse, logger);
+
+            sinon.assert.calledOnceWithExactly(mockResponse.writeHead, 500);
+
+            const expectedRes = [{
+                component: 'Consumer',
+                status: constants.statusNotReady,
+            }];
+            sinon.assert.calledOnceWithExactly(mockResponse.end, JSON.stringify(expectedRes));
+
+            const expectedLogError = {
+                httpCode: 500,
+                error: expectedRes,
+            };
+            sinon.assert.calledOnceWithExactly(logger.error, 'sending back error response', expectedLogError);
+        });
+
+        it('should respond with 500 when failed CRR Producer is not ready', () => {
+            processor._consumer = { _consumerReady: true };
+            processor._FailedCRRProducer = { _producer: { isReady: () => false } };
+            processor._ReplayProducers = {
+                [topicName]: { _producer: { isReady: () => true } },
+            };
+
+            processor.handleLiveness(mockResponse, logger);
+
+            sinon.assert.calledOnceWithExactly(mockResponse.writeHead, 500);
+
+            const expectedRes = [{
+                component: 'Failed CRR Producer',
+                status: constants.statusNotReady,
+            }];
+            sinon.assert.calledOnceWithExactly(mockResponse.end, JSON.stringify(expectedRes));
+
+            const expectedLogError = {
+                httpCode: 500,
+                error: expectedRes,
+            };
+            sinon.assert.calledOnceWithExactly(logger.error, 'sending back error response', expectedLogError);
+        });
+
+        it('should respond with 500 when Replay Producers is not ready', () => {
+            processor._consumer = { _consumerReady: true };
+            processor._FailedCRRProducer = { _producer: { isReady: () => true } };
+            processor._ReplayProducers = {
+                [topicName]: { _producer: { isReady: () => false } },
+            };
+
+            processor.handleLiveness(mockResponse, logger);
+
+            sinon.assert.calledOnceWithExactly(mockResponse.writeHead, 500);
+
+            const expectedRes = [{
+                component: 'Replay CRR Producer to backbeat-replication-replay-0',
+                status: constants.statusNotReady,
+            }];
+            sinon.assert.calledOnceWithExactly(mockResponse.end, JSON.stringify(expectedRes));
+
+            const expectedLogError = {
+                httpCode: 500,
+                error: expectedRes,
+            };
+            sinon.assert.calledOnceWithExactly(logger.error, 'sending back error response', expectedLogError);
+        });
+    });
+
+    describe('handleMetrics', () => {
+        it('should properly handle metrics response', async () => {
+            const r = await processor.handleMetrics(mockResponse, logger);
+            assert.strictEqual(r, undefined);
+
+            sinon.assert.calledOnce(promClient.register.metrics);
+
+            sinon.assert.calledOnceWithExactly(mockResponse.writeHead, 200, {
+                'Content-Type': promClient.register.contentType,
+            });
+
+            sinon.assert.calledOnceWithExactly(mockResponse.end, 'metrics_data');
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -682,7 +682,6 @@ arraybuffer.slice@~0.0.7:
 
 "arsenal@git+https://github.com/scality/Arsenal#7.10.46":
   version "7.10.46"
-  uid bd76402586f1b5117ada9857a9e437727562d55a
   resolved "git+https://github.com/scality/Arsenal#bd76402586f1b5117ada9857a9e437727562d55a"
   dependencies:
     "@types/async" "^3.2.12"
@@ -801,9 +800,9 @@ arraybuffer.slice@~0.0.7:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#7.10.46":
-  version "7.10.46"
-  resolved "git+https://github.com/scality/arsenal#bd76402586f1b5117ada9857a9e437727562d55a"
+"arsenal@git+https://github.com/scality/arsenal#7.10.46-1":
+  version "7.10.46-1"
+  resolved "git+https://github.com/scality/arsenal#da3aecdbe1e2f8064b866b2eaba891be9c967256"
   dependencies:
     "@types/async" "^3.2.12"
     "@types/utf8" "^3.0.1"
@@ -4310,7 +4309,7 @@ oauth-sign@~0.9.0:
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
 
 object-component@0.0.3:
   version "0.0.3"


### PR DESCRIPTION
**Note: code has already been reviewed.**

Currently, the probe response logic is distributed between Backbeat probe handlers and Arsenal's onRequest method.
This scattered approach causes confusion for developers and results in bugs.
The solution is to centralize the probe response logic exclusively within the Backbeat probe handlers.