### PR TITLE
Pause consumer on breakbeat trigger

### DIFF
--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -150,6 +150,7 @@ class BackbeatConsumer extends EventEmitter {
 
         this._circuitBreaker = new CircuitBreaker(circuitBreaker);
         this._circuitBreakerMetrics = circuitBreakerMetrics;
+        this._circuitBreaker.on('state-changed', this._onCircuitBreakerStateChanged.bind(this));
 
         this._init();
         return this;
@@ -376,12 +377,6 @@ class BackbeatConsumer extends EventEmitter {
             this._tryConsumedTimeout = null;
         }
 
-        if (this._circuitBreaker.state !== BreakerState.Nominal) {
-            this._log.debug('circuitbreaker tripped, retry in 1s');
-            this._scheduleNextTryConsume();
-            return undefined;
-        }
-
         // use non-flowing mode of consumption to add some flow
         // control: explicit consumption of messages is required,
         // needs explicit polling to get new messages
@@ -536,6 +531,94 @@ class BackbeatConsumer extends EventEmitter {
     }
 
     /**
+     * Pauses consumption of assigned partitions
+     * @returns {undefined}
+     */
+    _pauseAssignments() {
+        try {
+            const assignments = this._consumer?.assignments();
+
+            if (!assignments || assignments.length === 0) {
+                return;
+            }
+
+            const topicPartitions = assignments?.map(assignment => ({
+                topic: assignment.topic,
+                partition: assignment.partition
+            }));
+
+            this._consumer.pause(topicPartitions);
+            this._log.info('circuitbreaker tripped, consumption paused', {
+                method: 'BackbeatConsumer._pauseAssignments',
+            });
+        } catch (error) {
+            this._log.error('failed to pause partitions', {
+                method: 'BackbeatConsumer._pauseAssignments',
+                error,
+            });
+        }
+    }
+
+    /**
+     * Resumes consumption of paused partitions
+     * @returns {undefined}
+     */
+    _resumePausedPartitions() {
+        try {
+            const assignments = this._consumer?.assignments();
+
+            if (!assignments || assignments.length === 0) {
+                return;
+            }
+
+            const topicPartitions = assignments?.map(assignment => ({
+                topic: assignment.topic,
+                partition: assignment.partition
+            }));
+
+            this._consumer.resume(topicPartitions);
+            this._log.info('Resumed consumption', {
+                method: 'BackbeatConsumer._resumePausedPartitions',
+                reason: this._circuitBreaker.state === BreakerState.Nominal ?
+                    'circuitbreaker state is nominal' : 'partitions unassigned',
+            });
+        } catch (error) {
+            this._log.error('failed to resume partitions', {
+                method: 'BackbeatConsumer._resumePausedPartitions',
+                error,
+            });
+        }
+    }
+
+    /**
+     * Circuit breaker state change handler
+     * Pauses consumption when circuit breaker is tripped
+     * @param {BreakerState} state circuit breaker state
+     * @returns {undefined}
+     */
+    _onCircuitBreakerStateChanged(state) {
+        switch (state) {
+        case BreakerState.Nominal:
+            this._resumePausedPartitions();
+            break;
+        case BreakerState.Tripped:
+            this._pauseAssignments();
+            break;
+        case BreakerState.Stabilizing:
+            // Nothing to do, wait for state
+            // to become nominal
+            break;
+        default:
+            // this should never happen
+            this._log.warn('unsupported circuit breaker state', {
+                method: 'BackbeatConsumer._onCircuitBreakerStateChanged',
+                state,
+            });
+            break;
+        }
+    }
+
+    /**
      * @param {kafka.KafkaError} err Rebalance event
      * @param {TopicPartition[]} assignment List of (un)assigned partitions
      * @returns {void}
@@ -546,6 +629,9 @@ class BackbeatConsumer extends EventEmitter {
 
             try {
                 this._consumer.assign(assignment);
+                if (this._circuitBreaker.state !== BreakerState.Nominal) {
+                    this._pauseAssignments();
+                }
             } catch (e) {
                 // Ignore exceptions if we are not connected
                 const logger = this._consumer.isConnected() ? this._log.error : this._log.debug;
@@ -586,6 +672,8 @@ class BackbeatConsumer extends EventEmitter {
                 }
 
                 const doUnassign = () => {
+                    this._resumePausedPartitions();
+
                     try {
                         this._consumer.unassign();
                     } catch (e) {
@@ -920,7 +1008,7 @@ class BackbeatConsumer extends EventEmitter {
         this._circuitBreaker.stop();
         return async.waterfall([
             next => {
-                if (this._consumer.isConnected()) {
+                if (this._consumer?.isConnected()) {
                     const subscription = this._consumer.subscription() || [];
                     if (subscription.length > 0) {
                         this._consumer.unsubscribe();
@@ -938,7 +1026,7 @@ class BackbeatConsumer extends EventEmitter {
                 if (this._zookeeper) {
                     this._zookeeper.close();
                 }
-                if (this._consumer.isConnected()) {
+                if (this._consumer?.isConnected()) {
                     this._consumer.disconnect();
                     this._consumer.once('disconnected', () => next());
                 } else {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "async": "^2.3.0",
     "aws-sdk": "^2.938.0",
     "backo": "^1.1.0",
-    "breakbeat": "scality/breakbeat#v1.0.1",
+    "breakbeat": "scality/breakbeat#v1.0.2",
     "bucketclient": "scality/bucketclient#8.1.9",
     "commander": "^2.11.0",
     "fcntl": "github:scality/node-fcntl#0.2.2",

--- a/tests/unit/backbeatConsumer.js
+++ b/tests/unit/backbeatConsumer.js
@@ -1,10 +1,20 @@
 const assert = require('assert');
+const sinon = require('sinon');
 
 const BackbeatConsumer = require('../../lib/BackbeatConsumer');
 
 const { kafka } = require('../config.json');
+const { BreakerState } = require('breakbeat').CircuitBreaker;
+
+class BackbeatConsumerMock extends BackbeatConsumer {
+    _init() {}
+}
 
 describe('backbeatConsumer', () => {
+    afterEach(() => {
+        process.env.KAFKA_TOPIC_PREFIX = '';
+    });
+
     it('should use default topic name without prefix', () => {
         const backbeatConsumer = new BackbeatConsumer({
             kafka,
@@ -23,9 +33,127 @@ describe('backbeatConsumer', () => {
         });
         assert.strictEqual(backbeatConsumer._topic, 'testing.my-test-topic');
     });
-
-    afterEach(() => {
-        process.env.KAFKA_TOPIC_PREFIX = '';
-    });
 });
 
+describe('pause/resume topic partitions on circuit breaker', () => {
+    let consumer;
+
+    beforeEach(() => {
+        consumer = new BackbeatConsumerMock({
+            kafka,
+            groupId: 'unittest-group',
+            topic: 'my-test-topic',
+        });
+
+        const mockConsumer = {
+            pause: sinon.stub().returns(),
+            resume: sinon.stub().returns(),
+            isConnected: () => false,
+        };
+        consumer._consumer = mockConsumer;
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    describe('_pauseAssignments', () => {
+        it('should not pause when consumer not connected', () => {
+            consumer._consumer.isConnected = () => false;
+            consumer._consumer.subscription = () => ['example-topic'];
+            consumer._pauseAssignments();
+            assert(consumer._consumer.pause.notCalled);
+        });
+
+        it('should not call pause when no paritions assigned', () => {
+            consumer._consumer.isConnected = () => true;
+            consumer._consumer.subscription = () => ['example-topic'];
+            consumer._consumer.assignments = () => [];
+            consumer._pauseAssignments();
+            assert(consumer._consumer.pause.notCalled);
+        });
+
+        it('should pause all assignments', () => {
+            consumer._consumer.isConnected = () => true;
+            consumer._consumer.subscription = () => ['example-topic'];
+
+            const assignments = [
+                { topic: 'my-test-topic', partition: 0 },
+                { topic: 'my-test-topic', partition: 1 },
+                { topic: 'my-test-topic', partition: 2 },
+            ];
+            consumer._consumer.assignments = () => assignments;
+
+            consumer._pauseAssignments();
+            assert(consumer._consumer.pause.calledWithMatch([
+                { topic: 'my-test-topic', partition: 0 },
+                { topic: 'my-test-topic', partition: 1 },
+                { topic: 'my-test-topic', partition: 2 },
+            ]));
+        });
+    });
+
+    describe('_resumePausedPartitions', () => {
+        it('should not resume when consumer not connected', () => {
+            consumer._consumer.isConnected = () => false;
+            consumer._consumer.subscription = () => ['example-topic'];
+            consumer._resumePausedPartitions();
+            assert(consumer._consumer.resume.notCalled);
+        });
+
+        it('should not call resume when no paritions are paused', () => {
+            consumer._consumer.isConnected = () => true;
+            consumer._consumer.subscription = () => ['example-topic'];
+            consumer._consumer.assignments = () => [];
+            consumer._resumePausedPartitions();
+            assert(consumer._consumer.resume.notCalled);
+        });
+
+        it('should resume all paused partitions', () => {
+            consumer._consumer.isConnected = () => true;
+            consumer._consumer.subscription = () => ['example-topic'];
+            consumer._consumer.assignments = () => [
+                { topic: 'my-test-topic', partition: 0 },
+                { topic: 'my-test-topic', partition: 1 },
+                { topic: 'my-test-topic', partition: 2 },
+            ];
+
+            consumer._resumePausedPartitions();
+            assert(consumer._consumer.resume.calledWithMatch([
+                { topic: 'my-test-topic', partition: 0 },
+                { topic: 'my-test-topic', partition: 1 },
+                { topic: 'my-test-topic', partition: 2 },
+            ]));
+        });
+    });
+
+    describe('_onCircuitBreakerStateChanged', () => {
+        it('should resume consumption when circuit breaker state is nominal', () => {
+            const stub = sinon.stub(consumer, '_resumePausedPartitions');
+            consumer._onCircuitBreakerStateChanged(BreakerState.Nominal);
+            assert(stub.calledOnce);
+        });
+
+        it('should pause consumption when circuit breaker state got tripped', () => {
+            const stub = sinon.stub(consumer, '_pauseAssignments');
+            consumer._onCircuitBreakerStateChanged(BreakerState.Tripped);
+            assert(stub.calledOnce);
+        });
+
+        it('should keep old state when circuit breaker state is stabilizing', () => {
+            const resumeStub = sinon.stub(consumer, '_resumePausedPartitions');
+            const pauseStub = sinon.stub(consumer, '_pauseAssignments');
+            consumer._onCircuitBreakerStateChanged(BreakerState.Stabilizing);
+            assert(resumeStub.notCalled);
+            assert(pauseStub.notCalled);
+        });
+
+        it('should do nothing when state is unknown', () => {
+            const resumeStub = sinon.stub(consumer, '_resumePausedPartitions');
+            const pauseStub = sinon.stub(consumer, '_pauseAssignments');
+            consumer._onCircuitBreakerStateChanged(-1);
+            assert(resumeStub.notCalled);
+            assert(pauseStub.notCalled);
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1452,9 +1452,9 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-breakbeat@scality/breakbeat#v1.0.1:
-  version "1.0.1"
-  resolved "https://codeload.github.com/scality/breakbeat/tar.gz/c85885488597cb1f30ece57c8272525fd2c7ae8b"
+breakbeat@scality/breakbeat#v1.0.2:
+  version "1.0.2"
+  resolved "https://codeload.github.com/scality/breakbeat/tar.gz/4d3844424e424a3e0174a70f19715c57f2ae9c1c"
   dependencies:
     "@hapi/joi" "^17.1.1"
     "@types/node" "^18.11.11"


### PR DESCRIPTION
Pause consumer when breakbeat is triggered
    
The current implementation just skips the call to consume() when breakbeat is triggered, this will cause the consumer to be kicked out of the consumer group after the max poll delay is reached.

Polling is only done when calling consume(), hence we should keep calling that function and instead use the pause/resume methods that pause/resume the partition fetchers.

Pre-fetched messages are supposedly not purged from the internal queue, however they are not returned when calling consume() in a paused state.

The pause/resume state of the partitions is only kept locally, so this implementation is safe in case of forced shutdown or restart.

Issue: BB-456