### PR TITLE
Fix lifecycle late scan alerts

### DIFF
--- a/extensions/lifecycle/LifecycleMetrics.js
+++ b/extensions/lifecycle/LifecycleMetrics.js
@@ -9,7 +9,7 @@ const LIFECYCLE_LABEL_TYPE = 'type';
 const conductorLatestBatchStartTime = ZenkoMetrics.createGauge({
     name: 's3_lifecycle_latest_batch_start_time',
     help: 'Timestamp of latest lifecycle batch start time',
-    labelNames: [],
+    labelNames: [LIFECYCLE_LABEL_ORIGIN],
 });
 
 // const lifecycleVaultOperations = ZenkoMetrics.createCounter({
@@ -22,12 +22,12 @@ const conductorBucketListings = {
     success: ZenkoMetrics.createCounter({
         name: 's3_lifecycle_conductor_bucket_list_success_total',
         help: 'Total number of successful bucket listings by lifecycle conductor',
-        labelNames: [],
+        labelNames: [LIFECYCLE_LABEL_ORIGIN],
     }),
     error: ZenkoMetrics.createCounter({
         name: 's3_lifecycle_conductor_bucket_list_error_total',
         help: 'Total number of failed bucket listings by lifecycle conductor',
-        labelNames: [],
+        labelNames: [LIFECYCLE_LABEL_ORIGIN],
     }),
 };
 
@@ -86,7 +86,7 @@ class LifecycleMetrics {
 
     static onProcessBuckets(log) {
         try {
-            conductorLatestBatchStartTime.set({}, Date.now());
+            conductorLatestBatchStartTime.set({ origin: 'conductor' }, Date.now());
         } catch (err) {
             LifecycleMetrics.handleError(log, err, 'LifecycleMetrics.onProcessBuckets');
         }
@@ -107,7 +107,7 @@ class LifecycleMetrics {
 
     static onBucketListing(log, err) {
         try {
-            conductorBucketListings[err ? 'error' : 'success'].inc({});
+            conductorBucketListings[err ? 'error' : 'success'].inc({ origin: 'conductor' });
         } catch (err) {
             LifecycleMetrics.handleError(log, err, 'LifecycleMetrics.onBucketListing');
         }

--- a/monitoring/lifecycle/alerts.test.yaml
+++ b/monitoring/lifecycle/alerts.test.yaml
@@ -168,7 +168,7 @@ tests:
     interval: 1m
     input_series:
       - series: kube_service_created{namespace="zenko",service="artesca-data-backbeat-lifecycle-producer-headless",job="kube-state-metrics"}
-        values: 5000+0x14
+        values: 5+0x14
       - series: s3_lifecycle_latest_batch_start_time{namespace="zenko",job="artesca-data-backbeat-lifecycle-producer-headless",pod="foo"}
         values: _    0 0 0 240000 299000 299000 299000 480000 stale
       - series: s3_lifecycle_latest_batch_start_time{namespace="zenko",job="artesca-data-backbeat-lifecycle-producer-headless",pod="bar"}
@@ -251,7 +251,7 @@ tests:
     interval: 1m
     input_series:
       - series: kube_service_created{namespace="zenko",service="artesca-data-backbeat-lifecycle-producer-headless",job="kube-state-metrics"}
-        values: 5000+0x13
+        values: 5+0x13
       - series: s3_lifecycle_latest_batch_start_time{namespace="zenko",job="artesca-data-backbeat-lifecycle-producer-headless", pod="foo"}
         values: _    _ 0 0 0 60000 180000 240000 stale
       - series: s3_lifecycle_latest_batch_start_time{namespace="zenko",job="artesca-data-backbeat-lifecycle-producer-headless",pod="bar"}

--- a/monitoring/lifecycle/alerts.yaml
+++ b/monitoring/lifecycle/alerts.yaml
@@ -48,9 +48,9 @@ groups:
             s3_lifecycle_latest_batch_start_time{
               namespace="${namespace}", job="${job_lifecycle_producer}"
             }[${lifecycle_latency_warning_threshold}s]
-          ))
+          )) / 1000
           > 0 or max(kube_service_created{namespace="${namespace}", service="${job_lifecycle_producer}"})
-        ) / 1000
+        )
       ) / ${lifecycle_latency_warning_threshold} > 1
     Labels:
       severity: warning
@@ -69,9 +69,9 @@ groups:
             s3_lifecycle_latest_batch_start_time{
               namespace="${namespace}", job="${job_lifecycle_producer}"
             }[${lifecycle_latency_warning_threshold}s]
-          ))
+          )) / 1000
           > 0 or max(kube_service_created{namespace="${namespace}", service="${job_lifecycle_producer}"})
-        ) / 1000
+        )
       ) / ${lifecycle_latency_critical_threshold} > 1
     Labels:
       severity: critical

--- a/monitoring/lifecycle/alerts.yaml
+++ b/monitoring/lifecycle/alerts.yaml
@@ -65,7 +65,7 @@ groups:
     Expr: |
       (
         time() - (
-          max(last_over_time(
+          max(max_over_time(
             s3_lifecycle_latest_batch_start_time{
               namespace="${namespace}", job="${job_lifecycle_producer}"
             }[${lifecycle_latency_warning_threshold}s]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "8.6.32",
+  "version": "8.6.33",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Add label to lifecycle conductor metrics
- Fix handling of `kube_service_created` in LifecycleLateScan
- Use `max_over_time` for LifecycleLateScan instead of `last_over_time`
- Release backbeat 8.6.33

Issue: BB-479
