### PR TITLE
Restart connectors on task failure

### DIFF
--- a/extensions/oplogPopulator/OplogPopulatorMetrics.js
+++ b/extensions/oplogPopulator/OplogPopulatorMetrics.js
@@ -58,6 +58,11 @@ class OplogPopulatorMetrics {
             help: 'Total number of connector configuration submissions to kafka-connect',
             labelNames: ['connector', 'success'],
         });
+        this.connectorRestarts = ZenkoMetrics.createCounter({
+            name: 's3_oplog_populator_connector_restarts',
+            help: 'Total number of connector restarts',
+            labelNames: ['connector'],
+        });
     }
 
     /**
@@ -169,6 +174,24 @@ class OplogPopulatorMetrics {
         } catch (error) {
             this._logger.error('An error occured while pushing metrics', {
                 method: 'OplogPopulatorMetrics.onConnectorReconfiguration',
+                error: error.message,
+            });
+        }
+    }
+
+    /**
+     * updates s3_oplog_populator_connector_restarts metric
+     * @param {string} connector connector name
+     * @returns {undefined}
+     */
+    onConnectorRestart(connector) {
+        try {
+            this.connectorRestarts.inc({
+                connector: connector.name,
+            });
+        } catch (error) {
+            this._logger.error('An error occured while pushing metric', {
+                method: 'OplogPopulatorMetrics.onConnectorRestarted',
                 error: error.message,
             });
         }

--- a/extensions/oplogPopulator/modules/Allocator.js
+++ b/extensions/oplogPopulator/modules/Allocator.js
@@ -117,7 +117,7 @@ class Allocator {
                 this._bucketsToConnectors.delete(bucket);
                 this._metricsHandler.onConnectorConfigured(connector, 'delete');
                 this._logger.info('Stopped listening to bucket', {
-                    method: 'Allocator.listenToBucket',
+                    method: 'Allocator.stopListeningToBucket',
                     bucket,
                     connector: connector.name,
                 });

--- a/extensions/oplogPopulator/modules/Connector.js
+++ b/extensions/oplogPopulator/modules/Connector.js
@@ -199,6 +199,32 @@ class Connector {
     }
 
     /**
+     * Restarts the Kafka-connect mongo connector
+     * @returns {Promise|undefined} undefined
+     * @throws {InternalError}
+     */
+    async restart() {
+        if (!this._isRunning) {
+            this._logger.error('tried restarting a destroyed connector', {
+                method: 'Connector.restart',
+                connector: this._name,
+            });
+            return;
+        }
+        try {
+            // only restarting failed instances of tasks and connector
+            await this._kafkaConnect.restartConnector(this._name, true, true);
+        } catch (err) {
+            this._logger.error('Error while restarting connector', {
+                method: 'Connector.restart',
+                connector: this._name,
+                error: err.description || err.message,
+            });
+            throw errors.InternalError.customizeDescription(err.description);
+        }
+    }
+
+    /**
      * Add bucket to this connector
      * Connector is updated with the new bucket list
      * @param {string} bucket bucket to add

--- a/lib/wrappers/KafkaConnectWrapper.js
+++ b/lib/wrappers/KafkaConnectWrapper.js
@@ -300,6 +300,34 @@ class KafkaConnectWrapper {
             throw err;
         }
     }
+
+    /**
+     * Restarts a connector
+     * @param {string} connectorName connector name
+     * @param {boolean} includeTasks Specifies whether to restart
+     * the connector instance and task instances or just the connector
+     * instance
+     * @param {boolean} onlyFailed Specifies whether to restart just
+     * the instances with a FAILED status
+     * @returns {Promise|undefined} undefined
+     * @throws {InternalError}
+     */
+    async restartConnector(connectorName, includeTasks, onlyFailed) {
+        try {
+            await this.makeRequest({
+                method: 'POST',
+                path: `/connectors/${connectorName}/restart?includeTasks=${includeTasks}&onlyFailed=${onlyFailed}`,
+            });
+            return undefined;
+        } catch (err) {
+            this._logger.error('Error when restarting connector', {
+                method: 'KafkaConnectManager.restartConnector',
+                connector: connectorName,
+                error: err.description,
+            });
+            throw err;
+        }
+    }
  }
 
 module.exports = KafkaConnectWrapper;

--- a/monitoring/oplog-populator/alerts.test.yaml
+++ b/monitoring/oplog-populator/alerts.test.yaml
@@ -29,9 +29,9 @@ tests:
   - name: Connector Configuration Failure
     interval: 1m
     input_series:
-      - series: oplog_populator_reconfiguration{connector="example-connector",success="false",job="artesca-data-backbeat-oplog-populator-headless",namespace="zenko"}
+      - series: s3_oplog_populator_reconfiguration{connector="example-connector",success="false",job="artesca-data-backbeat-oplog-populator-headless",namespace="zenko"}
         values: 0+0x4 0+40x4 160+50x6
-      - series: oplog_populator_reconfiguration{connector="example-connector",job="artesca-data-backbeat-oplog-populator-headless",namespace="zenko"}
+      - series: s3_oplog_populator_reconfiguration{connector="example-connector",job="artesca-data-backbeat-oplog-populator-headless",namespace="zenko"}
         values: 100+100x16
     alert_rule_test:
       - alertname: KafkaConnectFailedConnectorConfiguration
@@ -50,3 +50,26 @@ tests:
               zenko_service: backbeat-oplog-populator
               description: "Oplog populator failed to configure connector"
               summary: "Oplog populator couldn't update kafka connect connector"
+
+  - name: Connector Failures
+    interval: 1m
+    input_series:
+      - series: s3_oplog_populator_connector_restarts{connector="example-connector",job="artesca-data-backbeat-oplog-populator-headless",namespace="zenko"}
+        values: 0+0x9 0+10x9 90+20x11
+    alert_rule_test:
+      - alertname: KafkaConnectFailedConnectors
+        eval_time: 10m
+        exp_alerts: []
+      - alertname: KafkaConnectFailedConnectors
+        eval_time: 20m
+        exp_alerts: []
+      - alertname: KafkaConnectFailedConnectors
+        eval_time: 31m
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              connector: example-connector
+            exp_annotations:
+              zenko_service: backbeat-oplog-populator
+              description: "Oplog populator restarted connectors too many times"
+              summary: "Oplog populator connectors keep failing after restarts"

--- a/monitoring/oplog-populator/alerts.yaml
+++ b/monitoring/oplog-populator/alerts.yaml
@@ -26,7 +26,7 @@ groups:
 
   - alert: KafkaConnectFailedConnectorConfiguration
     Expr: |
-        sum by(connector) (increase(oplog_populator_reconfiguration{success="false",job="${oplog_populator_job}",namespace="${namespace}"}[1m]))
+        sum by(connector) (increase(s3_oplog_populator_reconfiguration{success="false",job="${oplog_populator_job}",namespace="${namespace}"}[1m]))
         > 0
     For: "5m"
     Labels:
@@ -51,3 +51,14 @@ groups:
       description: "Oplog populator metastore change stream lag is too big"
       summary: "Oplog populator configuration lag is above threshold"
 
+  - alert: KafkaConnectFailedConnectors
+    Expr: |
+        sum by(connector) (increase(s3_oplog_populator_connector_restarts{job="${oplog_populator_job}",namespace="${namespace}"}[1m]))
+        > 0
+    For: "10m"
+    Labels:
+     severity: critical
+    Annotations:
+      zenko_service: backbeat-oplog-populator
+      description: "Oplog populator restarted connectors too many times"
+      summary: "Oplog populator connectors keep failing after restarts"

--- a/tests/unit/lib/wrappers/kafkaConnectWrapper.js
+++ b/tests/unit/lib/wrappers/kafkaConnectWrapper.js
@@ -308,7 +308,7 @@ describe('KafkaConnectWrapper', () => {
     });
 
     describe('deleteConnector', () => {
-        it('should only restart connector', async () => {
+        it('should delete a connector', async () => {
             const makeRequestStub = sinon.stub(wrapper, 'makeRequest').resolves();
             await wrapper.deleteConnector('mongo-source')
             .then(() =>  assert(makeRequestStub.calledOnceWith({
@@ -321,6 +321,24 @@ describe('KafkaConnectWrapper', () => {
         it('should throw error when request fails', async () => {
             sinon.stub(wrapper, 'makeRequest').rejects(errors.InternalError);
             await wrapper.deleteConnector('mongo-source')
+            .catch(err => assert.deepEqual(err, errors.InternalError));
+        });
+    });
+
+    describe('restartConnector', () => {
+        it('should restart a connector', async () => {
+            const makeRequestStub = sinon.stub(wrapper, 'makeRequest').resolves();
+            await wrapper.restartConnector('mongo-source', true, true)
+            .then(() =>  assert(makeRequestStub.calledOnceWith({
+                method: 'POST',
+                path: '/connectors/mongo-source/restart?includeTasks=true&onlyFailed=true',
+            })))
+            .catch(err => assert.ifError(err));
+        });
+
+        it('should throw error when request fails', async () => {
+            sinon.stub(wrapper, 'makeRequest').rejects(errors.InternalError);
+            await wrapper.restartConnector('mongo-source')
             .catch(err => assert.deepEqual(err, errors.InternalError));
         });
     });


### PR DESCRIPTION
Restart Kafka-Connect connectors when they are in a failed state or if their tasks are in a failed state.

Issue: BB-480