### PR TITLE
BB-484 update error handler when GC object is not found 

### DIFF
--- a/extensions/gc/tasks/GarbageCollectorTask.js
+++ b/extensions/gc/tasks/GarbageCollectorTask.js
@@ -267,7 +267,11 @@ class GarbageCollectorTask extends BackbeatTask {
             },
         ], err => {
             if (err) {
-                // if error occurs, do not commit offset
+                // if error occurs, do not commit offset unless the error is ObjNotFound
+                // because it means the object has been deleted by other means and we don't need to retry
+                if (err.code === 'ObjNotFound') {
+                    return done(err, { committable: true });
+                }
                 return done(err, { committable: false });
             }
             return done();

--- a/tests/unit/mocks.js
+++ b/tests/unit/mocks.js
@@ -107,6 +107,9 @@ class BackbeatMetadataProxyMock {
     }
 
     getMetadata(params, log, cb) {
+        if (this.error) {
+            return cb(this.error);
+        }
         return cb(null, { Body: this.mdObj.getSerialized() });
     }
 


### PR DESCRIPTION
When we want to GC an object, if this one is not found, it means that it already has been deleted, so there is not point continuing to try deleting it, changeing the behavior to  make this specific error commitable