### PR TITLE
Fix LifecycleLateScanWarning alert on pod shutdown

### DIFF
--- a/monitoring/lifecycle/alerts.yaml
+++ b/monitoring/lifecycle/alerts.yaml
@@ -44,7 +44,7 @@ groups:
     Expr: |
       (
         time() - (
-          max(last_over_time(
+          max(max_over_time(
             s3_lifecycle_latest_batch_start_time{
               namespace="${namespace}", job="${job_lifecycle_producer}"
             }[${lifecycle_latency_warning_threshold}s]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "8.6.33",
+  "version": "8.6.34",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Use max_over_time for LifecycleLateScan warning

The `s3_lifecycle_latest_batch_start_time` metric sometimes gets reset on shutdown, which breaks `last_over_time`: use `max_over_time` for now instead, a it should have roughly the same behavior, possibly with a slighly higher load, but avoids this issue.

This was handled already for the critical alert, but not for the warning

Issue: BB-485
