### PR TITLE
Add lifecycle lateness dashboard

### DIFF
--- a/extensions/gc/GarbageCollectorMetrics.js
+++ b/extensions/gc/GarbageCollectorMetrics.js
@@ -2,6 +2,7 @@ const { ZenkoMetrics } = require('arsenal').metrics;
 
 const GC_LABEL_ORIGIN =  'origin';
 const GC_LABEL_OP = 'op';
+const GC_LABEL_LOCATION = 'location';
 const GC_LABEL_STATUS = 'status';
 
 const gcS3Operations = ZenkoMetrics.createCounter({
@@ -18,7 +19,7 @@ const gcDuration = ZenkoMetrics.createHistogram({
     name: 's3_gc_duration_seconds',
     help: 'Duration of the garbage collector operation, calculated from the time when the GC is ' +
         'requested to the end of the operation',
-    labelNames: [GC_LABEL_ORIGIN],
+    labelNames: [GC_LABEL_ORIGIN, GC_LABEL_OP, GC_LABEL_LOCATION],
     buckets: [0.2, 0.1, 0.5, 2.5, 10, 50],
 });
 
@@ -42,10 +43,11 @@ class GarbageCollectorMetrics {
         }
     }
 
-    static onGcCompleted(log, process, duration) {
+    static onGcCompleted(log, process, location, duration) {
         try {
             gcDuration.observe({
                 [GC_LABEL_ORIGIN]: process,
+                [GC_LABEL_LOCATION]: location,
             }, duration / 1000);
         } catch (err) {
             GarbageCollectorMetrics.handleError(log, err, 'GarbageCollectorMetrics.onGcComplete');

--- a/extensions/gc/tasks/GarbageCollectorTask.js
+++ b/extensions/gc/tasks/GarbageCollectorTask.js
@@ -178,7 +178,7 @@ class GarbageCollectorTask extends BackbeatTask {
             }
 
             GarbageCollectorMetrics.onGcCompleted(log, entry.ruleType,
-                Date.now() - entry.getAttribute('timestamp'));
+                locations[0]?.dataStoreName, Date.now() - entry.getAttribute('timestamp'));
             return done();
         });
     }
@@ -259,6 +259,7 @@ class GarbageCollectorTask extends BackbeatTask {
                         log.end().info('completed expiration of archived data',
                             entry.getLogInfo());
                         GarbageCollectorMetrics.onGcCompleted(log, 'archive',
+                            entry.getAttribute('target.oldLocation'),
                             Date.now() - entry.getAttribute('timestamp'));
                     }
 

--- a/extensions/gc/tasks/GarbageCollectorTask.js
+++ b/extensions/gc/tasks/GarbageCollectorTask.js
@@ -136,6 +136,7 @@ class GarbageCollectorTask extends BackbeatTask {
 
     _executeDeleteData(entry, log, done) {
         const { locations } = entry.getAttribute('target');
+        const ruleType = entry.getContextAttribute('ruleType');
         const params = {
             Locations: locations.map(location => ({
                 key: location.key,
@@ -155,7 +156,7 @@ class GarbageCollectorTask extends BackbeatTask {
 
         this._batchDeleteData(params, entry, log, err => {
             // ruleType can be either `transition` or `restore` (for restore-expiration)
-            GarbageCollectorMetrics.onS3Request(log, 'batchdelete', entry.ruleType, err);
+            GarbageCollectorMetrics.onS3Request(log, 'batchdelete', ruleType, err);
             entry.setEnd(err);
             log.info('action execution ended', entry.getLogInfo());
             if (err && err.statusCode === 412) {
@@ -177,7 +178,7 @@ class GarbageCollectorTask extends BackbeatTask {
                 return done(err);
             }
 
-            GarbageCollectorMetrics.onGcCompleted(log, entry.ruleType,
+            GarbageCollectorMetrics.onGcCompleted(log, ruleType,
                 locations[0]?.dataStoreName, Date.now() - entry.getAttribute('timestamp'));
             return done();
         });

--- a/extensions/lifecycle/LifecycleMetrics.js
+++ b/extensions/lifecycle/LifecycleMetrics.js
@@ -97,7 +97,7 @@ const lifecycleKafkaPublish = {
 class LifecycleMetrics {
     static handleError(log, err, method) {
         if (log) {
-            log.error('failed to update prometheus metrics', { error: err, method });
+            log.error('failed to update prometheus metrics', { error: Object.assign({}, err), method });
         }
     }
 

--- a/extensions/lifecycle/LifecycleMetrics.js
+++ b/extensions/lifecycle/LifecycleMetrics.js
@@ -29,7 +29,24 @@ const conductorBucketListings = {
         help: 'Total number of failed bucket listings by lifecycle conductor',
         labelNames: [LIFECYCLE_LABEL_ORIGIN],
     }),
+    throttling: ZenkoMetrics.createCounter({
+        name: 's3_lifecycle_conductor_bucket_list_throttling_total',
+        help: 'Total number of throttled bucket listings by lifecycle conductor',
+        labelNames: [LIFECYCLE_LABEL_ORIGIN],
+    }),
 };
+
+const lifecycleActiveIndexingJobs = ZenkoMetrics.createGauge({
+    name: 's3_lifecycle_active_indexing_jobs',
+    help: 'Number of active indexing jobs',
+    labelNames: [LIFECYCLE_LABEL_ORIGIN],
+});
+
+const lifecycleLegacyTask = ZenkoMetrics.createCounter({
+    name: 's3_lifecycle_legacy_tasks_total',
+    help: 'Number of legacy tasks triggered by lifecycle',
+    labelNames: [LIFECYCLE_LABEL_ORIGIN, LIFECYCLE_LABEL_STATUS],
+});
 
 const lifecycleS3Operations = ZenkoMetrics.createCounter({
     name: 's3_lifecycle_s3_operations_total',
@@ -107,9 +124,39 @@ class LifecycleMetrics {
 
     static onBucketListing(log, err) {
         try {
-            conductorBucketListings[err ? 'error' : 'success'].inc({ origin: 'conductor' });
+            if (!err) {
+                conductorBucketListings.success.inc({ origin: 'conductor' });
+            } else if (err.Throttling) {
+                conductorBucketListings.throttling.inc({ origin: 'conductor' });
+            } else {
+                conductorBucketListings.error.inc({ origin: 'conductor' });
+            }
         } catch (err) {
             LifecycleMetrics.handleError(log, err, 'LifecycleMetrics.onBucketListing');
+        }
+    }
+
+    static onActiveIndexingJobsFailed(log) {
+        try {
+            lifecycleActiveIndexingJobs.reset();
+        } catch (err) {
+            LifecycleMetrics.handleError(log, err, 'LifecycleMetrics.onActiveIndexingJobsFailed');
+        }
+    }
+
+    static onActiveIndexingJobs(log, count) {
+        try {
+            lifecycleActiveIndexingJobs.set({ origin: 'conductor' }, count);
+        } catch (err) {
+            LifecycleMetrics.handleError(log, err, 'LifecycleMetrics.onActiveIndexingJobs');
+        }
+    }
+
+    static onLegacyTask(log, status) {
+        try {
+            lifecycleLegacyTask.inc({ origin: 'conductor', status });
+        } catch (err) {
+            LifecycleMetrics.handleError(log, err, 'LifecycleMetrics.onLegacyTask');
         }
     }
 

--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -1146,6 +1146,7 @@ class LifecycleTask extends BackbeatTask {
             contentLength: objectMD.getContentLength(),
             resultsTopic: this.transitionTasksTopic,
             accountId: params.accountId,
+            transitionTime: new Date(params.transitionTime).toISOString(),
             attempt,
         });
         entry.addContext({
@@ -1239,9 +1240,6 @@ class LifecycleTask extends BackbeatTask {
                 LifecycleMetrics.onLifecycleTriggered(this.log, 'bucket',
                     isCold ? 'archive' : 'transition',
                     locationName, Date.now() - params.transitionTime);
-                if (isCold) {
-                    entry.setAttribute('metrics.transitionTime', params.transitionTime);
-                }
                 return ReplicationAPI.sendDataMoverAction(this.producer, entry, log,
                     err => next(err));
             },

--- a/extensions/lifecycle/tasks/LifecycleUpdateTransitionTask.js
+++ b/extensions/lifecycle/tasks/LifecycleUpdateTransitionTask.js
@@ -203,11 +203,13 @@ class LifecycleUpdateTransitionTask extends BackbeatTask {
                     }
                     locationToGC = oldLocation;
 
-                    const transitionTime = objMD.getTransitionTime();
                     this._updateMdWithTransition(entry, objMD);
                     return this._putMetadata(entry, objMD, log, err => {
+                        const transitionTime = entry.getAttribute('metrics.transitionTime') ||
+                            objMD.getTransitionTime();
+                        const locationName = entry.getAttribute('toLocation');
                         LifecycleMetrics.onLifecycleCompleted(log, 'transition',
-                            newLocation, Date.now() - Date.parse(transitionTime));
+                            locationName, Date.now() - Date.parse(transitionTime));
                         next(err);
                     });
                 },

--- a/extensions/replication/ReplicationAPI.js
+++ b/extensions/replication/ReplicationAPI.js
@@ -32,6 +32,7 @@ class ReplicationAPI {
      * metrics accounting)
      * @param {string} [params.resultsTopic] - name of topic to get
      * result message (no result will be published if not provided)
+     * @param {string} params.transitionTime - transition time
      * @return {ActionQueueEntry} new action entry
      */
     static createCopyLocationAction(params) {
@@ -52,6 +53,7 @@ class ReplicationAPI {
                 origin: params.originLabel,
                 fromLocation: params.fromLocation,
                 contentLength: params.contentLength,
+                transitionTime: params.transitionTime,
             });
         if (params.resultsTopic) {
             action.setResultsTopic(params.resultsTopic);
@@ -97,7 +99,7 @@ class ReplicationAPI {
                 size: contentLength,
                 eTag,
                 try: attempt,
-                transitionTime: new Date(transitionTime).toISOString(),
+                transitionTime,
             };
             kafkaEntry.message = JSON.stringify(message);
         }

--- a/extensions/replication/tasks/CopyLocationTask.js
+++ b/extensions/replication/tasks/CopyLocationTask.js
@@ -122,9 +122,11 @@ class CopyLocationTask extends BackbeatTask {
                     return next(err);
                 }
 
+                const transitionTime = actionEntry.getAttribute('metrics.transitionTime') ||
+                    objMD.getTransitionTime();
                 LifecycleMetrics.onLifecycleStarted(log, 'transition',
                     actionEntry.getAttribute('toLocation'),
-                    startTime - Date.parse(objMD.getTransitionTime));
+                    startTime - Date.parse(transitionTime));
 
                 // Do a multipart upload when either the size is above
                 // a threshold or the source object is itself a MPU.

--- a/extensions/replication/tasks/UpdateReplicationStatus.js
+++ b/extensions/replication/tasks/UpdateReplicationStatus.js
@@ -270,6 +270,7 @@ class UpdateReplicationStatus extends BackbeatTask {
                   .addContext({
                       origin: 'transientSource',
                       reqId: log.getSerializedUids(),
+                      ruleType: 'transient',
                   })
                   .addContext(entry.getLogInfo())
                   .setAttribute('source', sourceAttr)

--- a/lib/KafkaBacklogMetrics.js
+++ b/lib/KafkaBacklogMetrics.js
@@ -26,7 +26,7 @@ const latestConsumedMessageTimestampGauge = metrics.ZenkoMetrics.createGauge({
     help: 'Timestamp of latest consumed message',
     // "consumergroup" is lowercase to match convention of metrics
     // exposed by Kafka.
-    labelNames: ['topic', 'partition', 'consumergroup'],
+    labelNames: ['topic', 'partition', 'group'],
 });
 
 const latestConsumeEventTimestampGauge = metrics.ZenkoMetrics.createGauge({
@@ -34,25 +34,25 @@ const latestConsumeEventTimestampGauge = metrics.ZenkoMetrics.createGauge({
     help: 'Timestamp of last time a consumer consumed a message',
     // "consumergroup" is lowercase to match convention of metrics
     // exposed by Kafka.
-    labelNames: ['topic', 'partition', 'consumergroup'],
+    labelNames: ['topic', 'partition', 'group'],
 });
 
 const rebalanceTotalCounter = metrics.ZenkoMetrics.createCounter({
     name: promMetricNames.rebalanceTotal,
     help: 'Number of rebalance events',
-    labelNames: ['topic', 'consumergroup', 'status'],
+    labelNames: ['topic', 'group', 'status'],
 });
 
 const slowTasksCountGauge = metrics.ZenkoMetrics.createGauge({
     name: promMetricNames.slowTasksCount,
     help: 'Current number of slow tasks',
-    labelNames: ['topic', 'partition', 'consumergroup'],
+    labelNames: ['topic', 'partition', 'group'],
 });
 
 const taskProcessingTime = metrics.ZenkoMetrics.createHistogram({
     name: promMetricNames.taskProcessingTime,
     help: 'Duration of a task',
-    labelNames: ['topic', 'partition', 'consumergroup', 'error'],
+    labelNames: ['topic', 'partition', 'group', 'error'],
     buckets: [0.01, 0.1, 1, 10, 50, 100, 200, 300],
 });
 
@@ -141,11 +141,11 @@ class KafkaBacklogMetrics extends EventEmitter {
      */
     static onMessageConsumed(topic, partition, consumerGroup, timestamp) {
         latestConsumedMessageTimestampGauge.set({
-            topic, partition, consumergroup: consumerGroup,
+            topic, partition, group: consumerGroup,
         }, timestamp);
 
         latestConsumeEventTimestampGauge.set({
-            topic, partition, consumergroup: consumerGroup,
+            topic, partition, group: consumerGroup,
         }, Date.now() / 1000);
     }
 
@@ -158,7 +158,7 @@ class KafkaBacklogMetrics extends EventEmitter {
      */
     static onRebalance(topic, consumerGroup, status) {
         rebalanceTotalCounter.inc({
-            topic, consumergroup: consumerGroup, status,
+            topic, group: consumerGroup, status,
         });
     }
 
@@ -171,7 +171,7 @@ class KafkaBacklogMetrics extends EventEmitter {
      */
     static onSlowTask(topic, partition, consumerGroup) {
         slowTasksCountGauge.inc({
-            topic, partition, consumergroup: consumerGroup,
+            topic, partition, group: consumerGroup,
         });
     }
 
@@ -188,10 +188,10 @@ class KafkaBacklogMetrics extends EventEmitter {
     static onTaskProcessed(topic, partition, consumerGroup, error, slow, durationMs) {
         if (slow) {
             slowTasksCountGauge.dec({
-                topic, partition, consumergroup: consumerGroup,
+                topic, partition, group: consumerGroup,
             });
         }
-        taskProcessingTime.observe({ topic, partition, consumergroup: consumerGroup, error },
+        taskProcessingTime.observe({ topic, partition, group: consumerGroup, error },
             durationMs / 1000);
     }
 

--- a/monitoring/__init__.py
+++ b/monitoring/__init__.py
@@ -16,7 +16,9 @@ CB_HIGH_RANGE_STALLED = 20
 def s3_circuit_breaker_expr(process, job):
     labelSelector = 'namespace="${namespace}"'
 
-    if job is not None:
+    if isinstance(job, list) and len(job) > 0:
+        labelSelector += f',job=~"{ "|".join(job) }"'
+    elif job is not None:
         labelSelector += f',job="{job}"'
 
     return f'avg(s3_circuit_breaker{{{labelSelector}}})'

--- a/monitoring/__init__.py
+++ b/monitoring/__init__.py
@@ -68,6 +68,7 @@ def s3_circuit_breaker_over_time(title=None, process=None, job=None):
         targets=[
             Target(
                 expr=expr,
+                legendFormat='{{ job }}',
             ),
         ],
         minValue=0,

--- a/monitoring/lifecycle/dashboard.json
+++ b/monitoring/lifecycle/dashboard.json
@@ -16,6 +16,13 @@
       "value": "zenko"
     },
     {
+      "description": "Name of the Zenko instance",
+      "label": "zenko instance name",
+      "name": "zenkoName",
+      "type": "constant",
+      "value": "artesca-data"
+    },
+    {
       "description": "Name of the lifecycle conductor job, used to filter only lifecycle conductor instances",
       "label": "job lifecycle producer",
       "name": "job_lifecycle_producer",
@@ -42,6 +49,13 @@
       "name": "job_lifecycle_transition_processor",
       "type": "constant",
       "value": "artesca-data-backbeat-lifecycle-transition-headless"
+    },
+    {
+      "description": "Prefix of the sorbet forwarder jobs, used to filter only sorbet forwarder instances",
+      "label": "job sorbet forwarder",
+      "name": "job_sorbet_forwarder",
+      "type": "constant",
+      "value": "artesca-data-backbeat-cold-sorbet-fwd"
     },
     {
       "description": "Name of the lifecycle populator job, used to filter only lifecycle populator instances",
@@ -818,7 +832,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "avg(s3_circuit_breaker{namespace=\"${namespace}\",job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\"})*10",
+          "expr": "avg(s3_circuit_breaker{namespace=\"${namespace}\",job=~\"$jobs\"})*10",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1005,7 +1019,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{namespace=\"${namespace}\", type=~\"expiration|expiration:mpu\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{job=~\"$jobs\", namespace=\"${namespace}\", type=~\"expiration|expiration:mpu\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1077,7 +1091,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{namespace=\"${namespace}\", type=~\"transition\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{job=~\"$jobs\", namespace=\"${namespace}\", type=~\"transition\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1149,7 +1163,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{namespace=\"${namespace}\", type=~\"archive|archive:gc\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{job=~\"$jobs\", namespace=\"${namespace}\", type=~\"archive|archive:gc\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1221,7 +1235,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{namespace=\"${namespace}\", type=~\"restore\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{job=~\"$jobs\", namespace=\"${namespace}\", type=~\"restore\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1293,7 +1307,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1408,7 +1422,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "100 / (1 + (sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status!=\"200\"}[$__rate_interval])) or vector(0))\n           /\n           (sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=\"200\"}[$__rate_interval])) > 0)\n      )",
+          "expr": "100 / (1 + (sum(rate(s3_lifecycle_s3_operations_total{job=~\"$jobs\", namespace=\"${namespace}\", status!=\"200\"}[$__rate_interval])) or vector(0))\n           /\n           (sum(rate(s3_lifecycle_s3_operations_total{job=~\"$jobs\", namespace=\"${namespace}\", status=\"200\"}[$__rate_interval])) > 0)\n      )",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1511,13 +1525,13 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "label_replace(\nlabel_replace(\n  avg(s3_circuit_breaker{namespace=\"${namespace}\",job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\"})by(job) * 10\n, \"job\", \"$1\", \"job\", \"${zenkoName}-backbeat-(?:lifecycle-)?(.*?)-headless\")\n, \"job\", \"$1-processor\", \"job\", \"(gc|transition)\")",
+          "expr": "label_replace(\nlabel_replace(\n  avg(s3_circuit_breaker{namespace=\"${namespace}\",job=~\"$jobs\"})by(job) * 10\n, \"job\", \"$1\", \"job\", \"${zenkoName}-backbeat-(?:lifecycle-)?(.*?)-headless\")\n, \"job\", \"$1-processor\", \"job\", \"(gc|transition)\")",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "",
+          "legendFormat": "{{ job }}",
           "metric": "",
           "refId": "",
           "step": 10,
@@ -1627,7 +1641,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{namespace=\"${namespace}\"}[$__rate_interval])) by (type)",
+          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (type)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1709,7 +1723,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{namespace=\"${namespace}\"}[$__rate_interval])) by (type)",
+          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (type)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1777,7 +1791,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{namespace=\"${namespace}\"}[$__rate_interval])) by (location)",
+          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (location)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1864,7 +1878,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "histogram_quantile(0.95, sum(rate(s3_lifecycle_latency_seconds_bucket{namespace=\"${namespace}\"}[$__rate_interval])) by (le, type))",
+          "expr": "histogram_quantile(0.95, sum(rate(s3_lifecycle_latency_seconds_bucket{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (le, type))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1928,7 +1942,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_latency_seconds_bucket{namespace=\"${namespace}\"}[$__rate_interval])) by(le)",
+          "expr": "sum(increase(s3_lifecycle_latency_seconds_bucket{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by(le)",
           "format": "heatmap",
           "hide": false,
           "instant": false,
@@ -2034,7 +2048,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "histogram_quantile(0.95, sum(rate(s3_lifecycle_duration_seconds_bucket{namespace=\"${namespace}\"}[$__rate_interval])) by (le, type))",
+          "expr": "histogram_quantile(0.95, sum(rate(s3_lifecycle_duration_seconds_bucket{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (le, type))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2135,7 +2149,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "histogram_quantile(0.95, sum(rate(s3_lifecycle_duration_seconds_bucket{namespace=\"${namespace}\"}[$__rate_interval])) by (le, location))",
+          "expr": "histogram_quantile(0.95, sum(rate(s3_lifecycle_duration_seconds_bucket{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (le, location))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2199,7 +2213,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_duration_seconds_bucket{namespace=\"${namespace}\", type=\"expiration\"}[$__rate_interval])) by(le)",
+          "expr": "sum(increase(s3_lifecycle_duration_seconds_bucket{job=~\"$jobs\", namespace=\"${namespace}\", type=\"expiration\"}[$__rate_interval])) by(le)",
           "format": "heatmap",
           "hide": false,
           "instant": false,
@@ -2282,7 +2296,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_duration_seconds_bucket{namespace=\"${namespace}\", type=\"transition\"}[$__rate_interval])) by(le)",
+          "expr": "sum(increase(s3_lifecycle_duration_seconds_bucket{job=~\"$jobs\", namespace=\"${namespace}\", type=\"transition\"}[$__rate_interval])) by(le)",
           "format": "heatmap",
           "hide": false,
           "instant": false,
@@ -2365,7 +2379,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_duration_seconds_bucket{namespace=\"${namespace}\", type=\"archive\"}[$__rate_interval])) by(le)",
+          "expr": "sum(increase(s3_lifecycle_duration_seconds_bucket{job=~\"$jobs\", namespace=\"${namespace}\", type=\"archive\"}[$__rate_interval])) by(le)",
           "format": "heatmap",
           "hide": false,
           "instant": false,
@@ -2448,7 +2462,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_duration_seconds_bucket{namespace=\"${namespace}\", type=\"restore\"}[$__rate_interval])) by(le)",
+          "expr": "sum(increase(s3_lifecycle_duration_seconds_bucket{job=~\"$jobs\", namespace=\"${namespace}\", type=\"restore\"}[$__rate_interval])) by(le)",
           "format": "heatmap",
           "hide": false,
           "instant": false,
@@ -2581,7 +2595,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\"}[$__rate_interval])) by(op)",
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", job=~\"$jobs\"}[$__rate_interval])) by(op)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2666,7 +2680,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "(sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\"}[$__rate_interval])) by(op)\n  or 0 * group(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\"}) by(op))",
+          "expr": "(sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", job=~\"$jobs\"}[$__rate_interval])) by(op)\n  or 0 * group(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", job=~\"$jobs\"}) by(op))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2762,7 +2776,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "100 / (1 + (sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\"}[$__rate_interval])) by(op)\n             or 0 * group(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\"}) by(op))\n           /\n           (sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\"}[$__rate_interval])) by(op) > 0))",
+          "expr": "100 / (1 + (sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", job=~\"$jobs\"}[$__rate_interval])) by(op)\n             or 0 * group(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", job=~\"$jobs\"}) by(op))\n           /\n           (sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", job=~\"$jobs\"}[$__rate_interval])) by(op) > 0))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2847,7 +2861,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "label_replace(\nlabel_replace(\n  sum(   label_replace(kafka_consumergroup_group_max_lag,\n                 \"consumergroup\", \"$1\", \"group\", \"(.*)\")\n   * on(consumergroup) group_right\n   group(s3_zenko_queue_latest_consumed_message_timestamp{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}) by(consumergroup, job)\n) by(job)\n, \"job\", \"$1\", \"job\", \"${zenkoName}-backbeat-(?:lifecycle-)?(.*?)-headless\")\n, \"job\", \"$1-processor\", \"job\", \"(gc|transition)\")",
+          "expr": "label_replace(\nlabel_replace(\n  sum(   label_replace(kafka_consumergroup_group_max_lag,\n                 \"consumergroup\", \"$1\", \"group\", \"(.*)\")\n   * on(consumergroup) group_right\n   group(s3_zenko_queue_latest_consumed_message_timestamp{job=~\"$jobs\", namespace=\"${namespace}\"}) by(consumergroup, job)\n) by(job)\n, \"job\", \"$1\", \"job\", \"${zenkoName}-backbeat-(?:lifecycle-)?(.*?)-headless\")\n, \"job\", \"$1-processor\", \"job\", \"(gc|transition)\")",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2936,7 +2950,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "label_replace(\nlabel_replace(\n  max(s3_zenko_queue_latest_consume_event_timestamp{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"} - s3_zenko_queue_latest_consumed_message_timestamp{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}) by(job)\n, \"job\", \"$1\", \"job\", \"${zenkoName}-backbeat-(?:lifecycle-)?(.*?)-headless\")\n, \"job\", \"$1-processor\", \"job\", \"(gc|transition)\")",
+          "expr": "label_replace(\nlabel_replace(\n  max(s3_zenko_queue_latest_consume_event_timestamp{job=~\"$jobs\", namespace=\"${namespace}\"} - s3_zenko_queue_latest_consumed_message_timestamp{job=~\"$jobs\", namespace=\"${namespace}\"}) by(job)\n, \"job\", \"$1\", \"job\", \"${zenkoName}-backbeat-(?:lifecycle-)?(.*?)-headless\")\n, \"job\", \"$1-processor\", \"job\", \"(gc|transition)\")",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3021,7 +3035,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "label_replace(\nlabel_replace(\n  sum(rate(s3_zenko_queue_task_processing_time_seconds_sum{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}[$__rate_interval])) by (job)\n  /sum(rate(s3_zenko_queue_task_processing_time_seconds_count{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}[$__rate_interval])) by (job)\n, \"job\", \"$1\", \"job\", \"${zenkoName}-backbeat-(?:lifecycle-)?(.*?)-headless\")\n, \"job\", \"$1-processor\", \"job\", \"(gc|transition)\")",
+          "expr": "label_replace(\nlabel_replace(\n  sum(rate(s3_zenko_queue_task_processing_time_seconds_sum{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (job)\n  /sum(rate(s3_zenko_queue_task_processing_time_seconds_count{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (job)\n, \"job\", \"$1\", \"job\", \"${zenkoName}-backbeat-(?:lifecycle-)?(.*?)-headless\")\n, \"job\", \"$1-processor\", \"job\", \"(gc|transition)\")",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3085,7 +3099,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(increase(s3_zenko_queue_task_processing_time_seconds_bucket{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}[$__rate_interval])) by(le)",
+          "expr": "sum(increase(s3_zenko_queue_task_processing_time_seconds_bucket{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by(le)",
           "format": "heatmap",
           "hide": false,
           "instant": false,
@@ -3189,7 +3203,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "label_replace(\nlabel_replace(\n  sum(s3_zenko_queue_slowTasks_count{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}) by (job)\n, \"job\", \"$1\", \"job\", \"${zenkoName}-backbeat-(?:lifecycle-)?(.*?)-headless\")\n, \"job\", \"$1-processor\", \"job\", \"(gc|transition)\")",
+          "expr": "label_replace(\nlabel_replace(\n  sum(s3_zenko_queue_slowTasks_count{job=~\"$jobs\", namespace=\"${namespace}\"}) by (job)\n, \"job\", \"$1\", \"job\", \"${zenkoName}-backbeat-(?:lifecycle-)?(.*?)-headless\")\n, \"job\", \"$1-processor\", \"job\", \"(gc|transition)\")",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3274,7 +3288,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "label_replace(\nlabel_replace(\n  sum(increase(s3_zenko_queue_rebalance_total{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}[$__rate_interval])) by (job)\n, \"job\", \"$1\", \"job\", \"${zenkoName}-backbeat-(?:lifecycle-)?(.*?)-headless\")\n, \"job\", \"$1-processor\", \"job\", \"(gc|transition)\")",
+          "expr": "label_replace(\nlabel_replace(\n  sum(increase(s3_zenko_queue_rebalance_total{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (job)\n, \"job\", \"$1\", \"job\", \"${zenkoName}-backbeat-(?:lifecycle-)?(.*?)-headless\")\n, \"job\", \"$1-processor\", \"job\", \"(gc|transition)\")",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3388,7 +3402,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval])) by (status)",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (status)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3522,7 +3536,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"2..\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{job=~\"$jobs\", namespace=\"${namespace}\", status=~\"2..\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3536,7 +3550,7 @@
         },
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"4..\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{job=~\"$jobs\", namespace=\"${namespace}\", status=~\"4..\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3550,7 +3564,7 @@
         },
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"5..\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{job=~\"$jobs\", namespace=\"${namespace}\", status=~\"5..\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3659,7 +3673,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "(sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status!=\"200\"}[$__rate_interval])) or vector(0))\n /\n(sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval])) > 0)",
+          "expr": "(sum(rate(s3_lifecycle_s3_operations_total{job=~\"$jobs\", namespace=\"${namespace}\", status!=\"200\"}[$__rate_interval])) or vector(0))\n /\n(sum(rate(s3_lifecycle_s3_operations_total{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) > 0)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3673,7 +3687,7 @@
         },
         {
           "datasource": null,
-          "expr": "(sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"4..\"}[$__rate_interval])) or vector(0))\n /\n(sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval])) > 0)",
+          "expr": "(sum(rate(s3_lifecycle_s3_operations_total{job=~\"$jobs\", namespace=\"${namespace}\", status=~\"4..\"}[$__rate_interval])) or vector(0))\n /\n(sum(rate(s3_lifecycle_s3_operations_total{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) > 0)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3687,7 +3701,7 @@
         },
         {
           "datasource": null,
-          "expr": "(sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"5..\"}[$__rate_interval])) or vector(0))\n /\n(sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval])) > 0)",
+          "expr": "(sum(rate(s3_lifecycle_s3_operations_total{job=~\"$jobs\", namespace=\"${namespace}\", status=~\"5..\"}[$__rate_interval])) or vector(0))\n /\n(sum(rate(s3_lifecycle_s3_operations_total{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) > 0)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3776,7 +3790,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval])) by(origin)",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by(origin)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3846,7 +3860,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status!=\"200\"}[$__rate_interval])) by(origin)",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{job=~\"$jobs\", namespace=\"${namespace}\", status!=\"200\"}[$__rate_interval])) by(origin)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3965,7 +3979,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status!=\"200\", op=\"deleteObject\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{job=\"${job_lifecycle_object_processor}\", namespace=\"${namespace}\", status!=\"200\", op=\"deleteObject\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3979,7 +3993,7 @@
         },
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=\"200\", op=\"deleteObject\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{job=\"${job_lifecycle_object_processor}\", namespace=\"${namespace}\", status=\"200\", op=\"deleteObject\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -4098,7 +4112,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status!=\"200\", op=\"abortMultipartUpload\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{job=\"${job_lifecycle_object_processor}\", namespace=\"${namespace}\", status!=\"200\", op=\"abortMultipartUpload\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -4112,7 +4126,7 @@
         },
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=\"200\", op=\"abortMultipartUpload\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{job=\"${job_lifecycle_object_processor}\", namespace=\"${namespace}\", status=\"200\", op=\"abortMultipartUpload\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -4313,7 +4327,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "histogram_quantile(0.95, sum(rate(s3_lifecycle_trigger_latency_seconds_bucket{namespace=\"${namespace}\"}[$__rate_interval])) by (le, type))",
+          "expr": "histogram_quantile(0.95, sum(rate(s3_lifecycle_trigger_latency_seconds_bucket{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (le, type))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -4674,7 +4688,35 @@
     "lifecycle"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allValue": ".*",
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "selected": false,
+          "tags": [],
+          "text": null,
+          "value": null
+        },
+        "datasource": "${DS_PROMETHEUS}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Service",
+        "multi": true,
+        "name": "jobs",
+        "options": [],
+        "query": "label_values(up{namespace=\"${namespace}\", job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}|${job_sorbet_forwarder}.*\"}, job)",
+        "refresh": 1,
+        "regex": "/^${zenkoName}-(?:backbeat-|cold-sorbet-)?(?:lifecycle-)?(.*?)(?:-processor)?(?:-headless)?$/",
+        "sort": 1,
+        "tagValuesQuery": null,
+        "tagsQuery": null,
+        "type": "query",
+        "useTags": false
+      }
+    ]
   },
   "time": {
     "from": "now-1h",

--- a/monitoring/lifecycle/dashboard.json
+++ b/monitoring/lifecycle/dashboard.json
@@ -1511,7 +1511,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "avg(s3_circuit_breaker{namespace=\"${namespace}\",job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\"})by(job) * 10",
+          "expr": "label_replace(\nlabel_replace(\n  avg(s3_circuit_breaker{namespace=\"${namespace}\",job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\"})by(job) * 10\n, \"job\", \"$1\", \"job\", \"${zenkoName}-backbeat-(?:lifecycle-)?(.*?)-headless\")\n, \"job\", \"$1-processor\", \"job\", \"(gc|transition)\")",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2847,7 +2847,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(   label_replace(kafka_consumergroup_group_max_lag,\n                 \"consumergroup\", \"$1\", \"group\", \"(.*)\")\n   * on(consumergroup) group_right\n   group(s3_zenko_queue_latest_consumed_message_timestamp{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}) by(consumergroup, job)\n) by(job)",
+          "expr": "label_replace(\nlabel_replace(\n  sum(   label_replace(kafka_consumergroup_group_max_lag,\n                 \"consumergroup\", \"$1\", \"group\", \"(.*)\")\n   * on(consumergroup) group_right\n   group(s3_zenko_queue_latest_consumed_message_timestamp{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}) by(consumergroup, job)\n) by(job)\n, \"job\", \"$1\", \"job\", \"${zenkoName}-backbeat-(?:lifecycle-)?(.*?)-headless\")\n, \"job\", \"$1-processor\", \"job\", \"(gc|transition)\")",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2936,13 +2936,13 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "max(s3_zenko_queue_latest_consume_event_timestamp{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"} - s3_zenko_queue_latest_consumed_message_timestamp{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}) by(service)",
+          "expr": "label_replace(\nlabel_replace(\n  max(s3_zenko_queue_latest_consume_event_timestamp{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"} - s3_zenko_queue_latest_consumed_message_timestamp{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}) by(job)\n, \"job\", \"$1\", \"job\", \"${zenkoName}-backbeat-(?:lifecycle-)?(.*?)-headless\")\n, \"job\", \"$1-processor\", \"job\", \"(gc|transition)\")",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "{{ service }}",
+          "legendFormat": "{{ job }}",
           "metric": "",
           "refId": "",
           "step": 10,
@@ -3021,7 +3021,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_zenko_queue_task_processing_time_seconds_sum{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}[$__rate_interval])) by (job)\n/sum(rate(s3_zenko_queue_task_processing_time_seconds_count{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}[$__rate_interval])) by (job)",
+          "expr": "label_replace(\nlabel_replace(\n  sum(rate(s3_zenko_queue_task_processing_time_seconds_sum{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}[$__rate_interval])) by (job)\n  /sum(rate(s3_zenko_queue_task_processing_time_seconds_count{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}[$__rate_interval])) by (job)\n, \"job\", \"$1\", \"job\", \"${zenkoName}-backbeat-(?:lifecycle-)?(.*?)-headless\")\n, \"job\", \"$1-processor\", \"job\", \"(gc|transition)\")",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3189,7 +3189,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(s3_zenko_queue_slowTasks_count{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}) by (job)",
+          "expr": "label_replace(\nlabel_replace(\n  sum(s3_zenko_queue_slowTasks_count{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}) by (job)\n, \"job\", \"$1\", \"job\", \"${zenkoName}-backbeat-(?:lifecycle-)?(.*?)-headless\")\n, \"job\", \"$1-processor\", \"job\", \"(gc|transition)\")",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3274,7 +3274,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(increase(s3_zenko_queue_rebalance_total{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}[$__rate_interval])) by (job)",
+          "expr": "label_replace(\nlabel_replace(\n  sum(increase(s3_zenko_queue_rebalance_total{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}[$__rate_interval])) by (job)\n, \"job\", \"$1\", \"job\", \"${zenkoName}-backbeat-(?:lifecycle-)?(.*?)-headless\")\n, \"job\", \"$1-processor\", \"job\", \"(gc|transition)\")",
           "format": "time_series",
           "hide": false,
           "instant": false,

--- a/monitoring/lifecycle/dashboard.json
+++ b/monitoring/lifecycle/dashboard.json
@@ -13,7 +13,7 @@
       "label": "namespace",
       "name": "namespace",
       "type": "constant",
-      "value": "default"
+      "value": "zenko"
     },
     {
       "description": "Name of the lifecycle conductor job, used to filter only lifecycle conductor instances",
@@ -2432,7 +2432,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -2814,7 +2814,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -2913,7 +2913,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -3012,7 +3012,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -3111,7 +3111,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -3210,7 +3210,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -3309,7 +3309,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -3408,7 +3408,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -3507,7 +3507,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -3871,7 +3871,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -4373,7 +4373,7 @@
               "tooltip": false,
               "viz": false
             },
-            "lineInterpolation": "linear",
+            "lineInterpolation": "smooth",
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
@@ -5067,7 +5067,7 @@
     ]
   },
   "timezone": "",
-  "title": "Backbeat Lifecycle",
+  "title": "Lifecycle",
   "uid": null,
   "version": 0
 }

--- a/monitoring/lifecycle/dashboard.json
+++ b/monitoring/lifecycle/dashboard.json
@@ -4160,20 +4160,52 @@
       "type": "row"
     },
     {
-      "collapsed": false,
+      "datasource": "${DS_PROMETHEUS}",
       "editable": true,
       "error": false,
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "bars",
+            "fillOpacity": 50,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 0,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": []
-          }
-        }
+          },
+          "unit": "ms"
+        },
+        "overrides": []
       },
       "gridPos": {
-        "h": 1,
-        "w": 24,
+        "h": 7,
+        "w": 12,
         "x": 0,
         "y": 104
       },
@@ -4181,12 +4213,36 @@
       "id": 48,
       "links": [],
       "maxDataPoints": 100,
-      "panels": [],
-      "targets": [],
-      "title": "Lifecycle Bucket Processors",
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "max(\n  increase(s3_lifecycle_latest_batch_start_time{job=\"${job_lifecycle_producer}\", namespace=\"${namespace}\"}[$__rate_interval])\n  /\n  changes(s3_lifecycle_latest_batch_start_time{job=\"${job_lifecycle_producer}\", namespace=\"${namespace}\"}[$__rate_interval] offset 30s)\n) > 0",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Scan",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Lifecycle Scan Period",
       "transformations": [],
       "transparent": false,
-      "type": "row"
+      "type": "timeseries"
     },
     {
       "datasource": "${DS_PROMETHEUS}",
@@ -4234,9 +4290,9 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 105
+        "w": 12,
+        "x": 12,
+        "y": 104
       },
       "hideTimeOverride": false,
       "id": 49,
@@ -4271,6 +4327,338 @@
         }
       ],
       "title": "Trigger Latency",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 50,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "opm"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Throttling"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Success"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 111
+      },
+      "hideTimeOverride": false,
+      "id": 50,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(irate(s3_lifecycle_conductor_bucket_list_error_total{job=\"${job_lifecycle_producer}\", namespace=\"${namespace}\"}[$__rate_interval])) * 60",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Error",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(irate(s3_lifecycle_conductor_bucket_list_throttling_total{job=\"${job_lifecycle_producer}\", namespace=\"${namespace}\"}[$__rate_interval])) * 60",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Throttling",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(irate(s3_lifecycle_conductor_bucket_list_success_total{job=\"${job_lifecycle_producer}\", namespace=\"${namespace}\"}[$__rate_interval])) * 60",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Success",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Lifecycle Scan Rate",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 111
+      },
+      "hideTimeOverride": false,
+      "id": 51,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(s3_lifecycle_active_indexing_jobs{job=\"${job_lifecycle_producer}\", namespace=\"${namespace}\"}) or vector(0)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Active Indexing jobs",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 111
+      },
+      "hideTimeOverride": false,
+      "id": 52,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(increase(s3_lifecycle_legacy_tasks_total{job=\"${job_lifecycle_producer}\", namespace=\"${namespace}\"}[$__rate_interval])) by(status)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ status }}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Legacy Tasks",
       "transformations": [],
       "transparent": false,
       "type": "timeseries"

--- a/monitoring/lifecycle/dashboard.json
+++ b/monitoring/lifecycle/dashboard.json
@@ -2406,6 +2406,813 @@
       "maxDataPoints": 100,
       "panels": [],
       "targets": [],
+      "title": "Lifecycle Tasks",
+      "transformations": [],
+      "transparent": false,
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 10,
+        "x": 0,
+        "y": 45
+      },
+      "hideTimeOverride": false,
+      "id": 29,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\"}[$__rate_interval])) by(op)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ op }}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Message published",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 10,
+        "x": 10,
+        "y": 45
+      },
+      "hideTimeOverride": false,
+      "id": 30,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "(sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\"}[$__rate_interval])) by(op)\n  or 0 * group(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\"}) by(op))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ op }}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Publish errors",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 2,
+          "mappings": [],
+          "noValue": "none",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              },
+              {
+                "color": "yellow",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              },
+              {
+                "color": "orange",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              },
+              {
+                "color": "red",
+                "index": 1,
+                "line": true,
+                "op": "gt",
+                "value": 1.0,
+                "yaxis": "left"
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 20,
+        "y": 45
+      },
+      "hideTimeOverride": false,
+      "id": 31,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "100 / (1 + (sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\"}[$__rate_interval])) by(op)\n             or 0 * group(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\"}) by(op))\n           /\n           (sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\"}[$__rate_interval])) by(op) > 0))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ op }}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Publish success rate",
+      "transformations": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 10,
+        "x": 0,
+        "y": 52
+      },
+      "hideTimeOverride": false,
+      "id": 32,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(   label_replace(kafka_consumergroup_group_max_lag,\n                 \"consumergroup\", \"$1\", \"group\", \"(.*)\")\n   * on(consumergroup) group_right\n   group(s3_zenko_queue_latest_consumed_message_timestamp{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}) by(consumergroup, job)\n) by(job)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ job }}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Kafka Lag",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 14,
+        "x": 10,
+        "y": 52
+      },
+      "hideTimeOverride": false,
+      "id": 33,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "max(s3_zenko_queue_latest_consume_event_timestamp{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"} - s3_zenko_queue_latest_consumed_message_timestamp{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}) by(service)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ service }}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Tasks latency",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 59
+      },
+      "hideTimeOverride": false,
+      "id": 34,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_zenko_queue_task_processing_time_seconds_sum{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}[$__rate_interval])) by (job)\n/sum(rate(s3_zenko_queue_task_processing_time_seconds_count{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}[$__rate_interval])) by (job)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ job }}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Average task processing time",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": 2
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "max": null,
+        "min": null,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 59
+      },
+      "heatmap": {},
+      "hideTimeOverride": false,
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 35,
+      "legend": {
+        "show": false
+      },
+      "links": [],
+      "maxDataPoints": 30,
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(increase(s3_zenko_queue_task_processing_time_seconds_bucket{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}[$__rate_interval])) by(le)",
+          "format": "heatmap",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ le }}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Task processing time",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "transformations": [],
+      "transparent": false,
+      "type": "heatmap",
+      "xAxis": {
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yAxis": {
+        "decimals": 0,
+        "format": "s",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true
+      }
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 66
+      },
+      "hideTimeOverride": false,
+      "id": 36,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(s3_zenko_queue_slowTasks_count{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}) by (job)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ job }}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Slow tasks",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 66
+      },
+      "hideTimeOverride": false,
+      "id": 37,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(increase(s3_zenko_queue_rebalance_total{job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\", namespace=\"${namespace}\"}[$__rate_interval])) by (job)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ job }}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Rebalance",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        }
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 73
+      },
+      "hideTimeOverride": false,
+      "id": 38,
+      "links": [],
+      "maxDataPoints": 100,
+      "panels": [],
+      "targets": [],
       "title": "S3 Operations",
       "transformations": [],
       "transparent": false,
@@ -2459,10 +3266,10 @@
         "h": 8,
         "w": 11,
         "x": 0,
-        "y": 45
+        "y": 74
       },
       "hideTimeOverride": false,
-      "id": 29,
+      "id": 39,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2593,10 +3400,10 @@
         "h": 8,
         "w": 11,
         "x": 11,
-        "y": 45
+        "y": 74
       },
       "hideTimeOverride": false,
-      "id": 30,
+      "id": 40,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2726,10 +3533,10 @@
         "h": 8,
         "w": 2,
         "x": 22,
-        "y": 45
+        "y": 74
       },
       "hideTimeOverride": false,
-      "id": 31,
+      "id": 41,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2843,10 +3650,10 @@
         "h": 8,
         "w": 17,
         "x": 0,
-        "y": 53
+        "y": 82
       },
       "hideTimeOverride": false,
-      "id": 32,
+      "id": 42,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2907,10 +3714,10 @@
         "h": 8,
         "w": 7,
         "x": 17,
-        "y": 53
+        "y": 82
       },
       "hideTimeOverride": false,
-      "id": 33,
+      "id": 43,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3036,10 +3843,10 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 61
+        "y": 90
       },
       "hideTimeOverride": false,
-      "id": 34,
+      "id": 44,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3169,10 +3976,10 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 61
+        "y": 90
       },
       "hideTimeOverride": false,
-      "id": 35,
+      "id": 45,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3236,831 +4043,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 69
+        "y": 98
       },
       "hideTimeOverride": false,
-      "id": 36,
-      "links": [],
-      "maxDataPoints": 100,
-      "panels": [],
-      "targets": [],
-      "title": "Kafka Message Produced",
-      "transformations": [],
-      "transparent": false,
-      "type": "row"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {},
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 70
-      },
-      "hideTimeOverride": false,
-      "id": 37,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"BucketTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Successful",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"BucketTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Failed",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "Bucket Task",
-      "transformations": [],
-      "transparent": false,
-      "type": "timeseries"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {},
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 70
-      },
-      "hideTimeOverride": false,
-      "id": 38,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"ObjectTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Successful",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"ObjectTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Failed",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "Expiration Task",
-      "transformations": [],
-      "transparent": false,
-      "type": "timeseries"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {},
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 78
-      },
-      "hideTimeOverride": false,
-      "id": 39,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"DataMoverTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Successful",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"DataMoverTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Failed",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "Data Mover Task",
-      "transformations": [],
-      "transparent": false,
-      "type": "timeseries"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {},
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 78
-      },
-      "hideTimeOverride": false,
-      "id": 40,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"GcTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Successful",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"GcTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Failed",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "Gc Task",
-      "transformations": [],
-      "transparent": false,
-      "type": "timeseries"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {},
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 86
-      },
-      "hideTimeOverride": false,
-      "id": 41,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"ColdStorageArchiveTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Successful",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"ColdStorageArchiveTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Failed",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "Cold Storage Archive",
-      "transformations": [],
-      "transparent": false,
-      "type": "timeseries"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {},
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 86
-      },
-      "hideTimeOverride": false,
-      "id": 42,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"ColdStorageGcTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Successful",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"ColdStorageGcTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Failed",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "Cold Storage Gc",
-      "transformations": [],
-      "transparent": false,
-      "type": "timeseries"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {},
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 94
-      },
-      "hideTimeOverride": false,
-      "id": 43,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"ColdStorageRestoreTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Successful",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"ColdStorageRestoreTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Failed",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "Cold Storage Restore",
-      "transformations": [],
-      "transparent": false,
-      "type": "timeseries"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {},
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 94
-      },
-      "hideTimeOverride": false,
-      "id": 44,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"ColdStorageRestoreAdjustTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Successful",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"ColdStorageRestoreAdjustTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Failed",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "Cold Storage Restore Adjust",
-      "transformations": [],
-      "transparent": false,
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          }
-        }
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 102
-      },
-      "hideTimeOverride": false,
-      "id": 45,
+      "id": 46,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -4163,10 +4149,10 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 103
+        "y": 99
       },
       "hideTimeOverride": false,
-      "id": 46,
+      "id": 47,
       "links": [],
       "maxDataPoints": 100,
       "targets": [
@@ -4206,10 +4192,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 113
+        "y": 109
       },
       "hideTimeOverride": false,
-      "id": 47,
+      "id": 48,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -4267,10 +4253,10 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 114
+        "y": 110
       },
       "hideTimeOverride": false,
-      "id": 48,
+      "id": 49,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -4399,10 +4385,10 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 121
+        "y": 117
       },
       "hideTimeOverride": false,
-      "id": 49,
+      "id": 50,
       "links": [],
       "maxDataPoints": 100,
       "targets": [
@@ -4442,10 +4428,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 131
+        "y": 127
       },
       "hideTimeOverride": false,
-      "id": 50,
+      "id": 51,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -4548,10 +4534,10 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 132
+        "y": 128
       },
       "hideTimeOverride": false,
-      "id": 51,
+      "id": 52,
       "links": [],
       "maxDataPoints": 100,
       "targets": [

--- a/monitoring/lifecycle/dashboard.json
+++ b/monitoring/lifecycle/dashboard.json
@@ -168,7 +168,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(up{namespace=\"${namespace}\",job=\"${job_lifecycle_producer}})",
+          "expr": "sum(up{namespace=\"${namespace}\", job=\"${job_lifecycle_producer}\"})",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -258,7 +258,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(up{namespace=\"${namespace}\",job=\"${job_lifecycle_bucket_processor}})",
+          "expr": "sum(up{namespace=\"${namespace}\", job=\"${job_lifecycle_bucket_processor}\"})",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -348,7 +348,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(up{namespace=\"${namespace}\",job=\"${job_lifecycle_object_processor}})",
+          "expr": "sum(up{namespace=\"${namespace}\", job=\"${job_lifecycle_object_processor}\"})",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -438,7 +438,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(up{namespace=\"${namespace}\",job=\"${job_lifecycle_transition_processor}})",
+          "expr": "sum(up{namespace=\"${namespace}\", job=\"${job_lifecycle_transition_processor}\"})",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -528,7 +528,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(up{namespace=\"${namespace}\",job=\"${job_lifecycle_gc_processor}})",
+          "expr": "sum(up{namespace=\"${namespace}\", job=\"${job_lifecycle_gc_processor}\"})",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -618,7 +618,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(up{namespace=\"${namespace}\",job=\"${job_lifecycle_populator}})",
+          "expr": "sum(up{namespace=\"${namespace}\", job=\"${job_lifecycle_populator}\"})",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -676,7 +676,7 @@
             "mode": "absolute",
             "steps": []
           },
-          "unit": ""
+          "unit": "reqps"
         },
         "overrides": []
       },
@@ -703,13 +703,13 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"2..\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"2..\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "HTTP 2xx",
+          "legendFormat": "Success",
           "metric": "",
           "refId": "",
           "step": 10,
@@ -717,13 +717,13 @@
         },
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"3..\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"4..\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "HTTP 3xx",
+          "legendFormat": "User errors",
           "metric": "",
           "refId": "",
           "step": 10,
@@ -731,27 +731,13 @@
         },
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"4..\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"5..\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "HTTP 4xx",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"5..\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "HTTP 5xx",
+          "legendFormat": "System errors",
           "metric": "",
           "refId": "",
           "step": 10,
@@ -800,7 +786,7 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
+        "w": 8,
         "x": 0,
         "y": 14
       },
@@ -825,7 +811,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status!=\"200\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval]) > 0)",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status!=\"200\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval]) > 0)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -838,7 +824,7 @@
           "target": ""
         }
       ],
-      "title": "S3 All Errors",
+      "title": "Error rate",
       "transformations": [],
       "transparent": false,
       "type": "stat"
@@ -880,8 +866,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 6,
+        "w": 8,
+        "x": 8,
         "y": 14
       },
       "hideTimeOverride": false,
@@ -905,7 +891,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"3..\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval]) > 0)",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"4..\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval]) > 0)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -918,7 +904,7 @@
           "target": ""
         }
       ],
-      "title": "S3 3xx Errors",
+      "title": "User Error rate",
       "transformations": [],
       "transparent": false,
       "type": "stat"
@@ -960,8 +946,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 12,
+        "w": 8,
+        "x": 16,
         "y": 14
       },
       "hideTimeOverride": false,
@@ -985,7 +971,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"4..\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval]) > 0)",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"5..\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval]) > 0)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -998,87 +984,7 @@
           "target": ""
         }
       ],
-      "title": "S3 4xx Errors",
-      "transformations": [],
-      "transparent": false,
-      "type": "stat"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": null,
-          "mappings": [],
-          "noValue": "none",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "index": 0,
-                "line": true,
-                "op": "gt",
-                "value": "null",
-                "yaxis": "left"
-              },
-              {
-                "color": "red",
-                "index": 1,
-                "line": true,
-                "op": "gt",
-                "value": 0.05,
-                "yaxis": "left"
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 18,
-        "y": 14
-      },
-      "hideTimeOverride": false,
-      "id": 11,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"5..\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval]) > 0)",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "S3 5xx Errors",
+      "title": "System Error rate",
       "transformations": [],
       "transparent": false,
       "type": "stat"
@@ -1102,12 +1008,12 @@
         "y": 18
       },
       "hideTimeOverride": false,
-      "id": 12,
+      "id": 11,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
       "targets": [],
-      "title": "Kafka",
+      "title": "Kafka Message Produced",
       "transformations": [],
       "transparent": false,
       "type": "row"
@@ -1137,8 +1043,8 @@
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
-              "log": 10,
-              "type": "log"
+              "log": 2,
+              "type": "linear"
             },
             "showPoints": "auto",
             "spanNulls": false,
@@ -1152,14 +1058,113 @@
             "mode": "absolute",
             "steps": []
           },
-          "unit": ""
+          "unit": "reqps"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 12,
         "x": 0,
+        "y": 19
+      },
+      "hideTimeOverride": false,
+      "id": 12,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"BucketTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Successful",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"BucketTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Failed",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Bucket Task",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
         "y": 19
       },
       "hideTimeOverride": false,
@@ -1169,7 +1174,7 @@
       "options": {
         "legend": {
           "calcs": [],
-          "displayMode": "hidden",
+          "displayMode": "list",
           "placement": "bottom"
         },
         "tooltip": {
@@ -1179,20 +1184,34 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_kafka_publish_success_total{op=\"BucketTopic\",namespace=\"${namespace}\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"ObjectTopic\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "messages",
+          "legendFormat": "Successful",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"ObjectTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Failed",
           "metric": "",
           "refId": "",
           "step": 10,
           "target": ""
         }
       ],
-      "title": "Lifecycle Bucket Task Messages in Queue",
+      "title": "Expiration Task",
       "transformations": [],
       "transparent": false,
       "type": "timeseries"
@@ -1222,8 +1241,8 @@
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
-              "log": 10,
-              "type": "log"
+              "log": 2,
+              "type": "linear"
             },
             "showPoints": "auto",
             "spanNulls": false,
@@ -1237,15 +1256,15 @@
             "mode": "absolute",
             "steps": []
           },
-          "unit": ""
+          "unit": "reqps"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 19
+        "x": 0,
+        "y": 27
       },
       "hideTimeOverride": false,
       "id": 14,
@@ -1254,7 +1273,7 @@
       "options": {
         "legend": {
           "calcs": [],
-          "displayMode": "hidden",
+          "displayMode": "list",
           "placement": "bottom"
         },
         "tooltip": {
@@ -1264,20 +1283,34 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_kafka_publish_error_total{op=\"BucketTopic\",namespace=\"${namespace}\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"DataMoverTopic\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "messages",
+          "legendFormat": "Successful",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"DataMoverTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Failed",
           "metric": "",
           "refId": "",
           "step": 10,
           "target": ""
         }
       ],
-      "title": "Lifecycle Bucket Task Failed Messages",
+      "title": "Data Mover Task",
       "transformations": [],
       "transparent": false,
       "type": "timeseries"
@@ -1307,8 +1340,8 @@
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
-              "log": 10,
-              "type": "log"
+              "log": 2,
+              "type": "linear"
             },
             "showPoints": "auto",
             "spanNulls": false,
@@ -1322,15 +1355,15 @@
             "mode": "absolute",
             "steps": []
           },
-          "unit": ""
+          "unit": "reqps"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 29
+        "x": 12,
+        "y": 27
       },
       "hideTimeOverride": false,
       "id": 15,
@@ -1339,7 +1372,7 @@
       "options": {
         "legend": {
           "calcs": [],
-          "displayMode": "hidden",
+          "displayMode": "list",
           "placement": "bottom"
         },
         "tooltip": {
@@ -1349,20 +1382,34 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_kafka_publish_success_total{op=\"ObjectTopic\",namespace=\"${namespace}\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"GcTopic\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "messages",
+          "legendFormat": "Successful",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"GcTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Failed",
           "metric": "",
           "refId": "",
           "step": 10,
           "target": ""
         }
       ],
-      "title": "Expiration Object Task Messages in Queue",
+      "title": "Gc Task",
       "transformations": [],
       "transparent": false,
       "type": "timeseries"
@@ -1392,8 +1439,8 @@
             "lineWidth": 1,
             "pointSize": 5,
             "scaleDistribution": {
-              "log": 10,
-              "type": "log"
+              "log": 2,
+              "type": "linear"
             },
             "showPoints": "auto",
             "spanNulls": false,
@@ -1407,15 +1454,15 @@
             "mode": "absolute",
             "steps": []
           },
-          "unit": ""
+          "unit": "reqps"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 29
+        "x": 0,
+        "y": 35
       },
       "hideTimeOverride": false,
       "id": 16,
@@ -1424,7 +1471,7 @@
       "options": {
         "legend": {
           "calcs": [],
-          "displayMode": "hidden",
+          "displayMode": "list",
           "placement": "bottom"
         },
         "tooltip": {
@@ -1434,20 +1481,331 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_kafka_publish_error_total{op=\"ObjectTopic\",namespace=\"${namespace}\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"ColdStorageArchiveTopic\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "messages",
+          "legendFormat": "Successful",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"ColdStorageArchiveTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Failed",
           "metric": "",
           "refId": "",
           "step": 10,
           "target": ""
         }
       ],
-      "title": "Expiration Object Task Failed Messages",
+      "title": "Cold Storage Archive",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "hideTimeOverride": false,
+      "id": 17,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"ColdStorageGcTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Successful",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"ColdStorageGcTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Failed",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Cold Storage Gc",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 43
+      },
+      "hideTimeOverride": false,
+      "id": 18,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"ColdStorageRestoreTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Successful",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"ColdStorageRestoreTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Failed",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Cold Storage Restore",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 43
+      },
+      "hideTimeOverride": false,
+      "id": 19,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"ColdStorageRestoreAdjustTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Successful",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"ColdStorageRestoreAdjustTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Failed",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Cold Storage Restore Adjust",
       "transformations": [],
       "transparent": false,
       "type": "timeseries"
@@ -1468,10 +1826,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 51
       },
       "hideTimeOverride": false,
-      "id": 17,
+      "id": 20,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -1493,9 +1851,26 @@
           "noValue": "none",
           "thresholds": {
             "mode": "absolute",
-            "steps": ""
+            "steps": [
+              {
+                "color": "#808080",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              },
+              {
+                "color": "blue",
+                "index": 1,
+                "line": true,
+                "op": "gt",
+                "value": 0.0,
+                "yaxis": "left"
+              }
+            ]
           },
-          "unit": "dateTimeAsLocal"
+          "unit": "dateTimeAsLocalNoDateIfToday"
         },
         "overrides": []
       },
@@ -1503,10 +1878,10 @@
         "h": 4,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 52
       },
       "hideTimeOverride": false,
-      "id": 18,
+      "id": 21,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -1526,7 +1901,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "s3_lifecycle_latest_batch_start_time{job=\"${job_lifecycle_producer}\",namespace=\"${namespace}\"}",
+          "expr": "max(max_over_time(s3_lifecycle_latest_batch_start_time{job=\"${job_lifecycle_producer}\", namespace=\"${namespace}\"}[24h]) > 0)",
           "format": "time_series",
           "hide": false,
           "instant": true,
@@ -1637,10 +2012,10 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 56
       },
       "hideTimeOverride": false,
-      "id": 19,
+      "id": 22,
       "links": [],
       "maxDataPoints": 100,
       "targets": [
@@ -1680,10 +2055,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 54
+        "y": 66
       },
       "hideTimeOverride": false,
-      "id": 20,
+      "id": 23,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -1733,7 +2108,7 @@
             "mode": "absolute",
             "steps": []
           },
-          "unit": ""
+          "unit": "reqps"
         },
         "overrides": []
       },
@@ -1741,10 +2116,10 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 55
+        "y": 67
       },
       "hideTimeOverride": false,
-      "id": 21,
+      "id": 24,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -1760,13 +2135,13 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"2..\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"2..\", origin=\"bucket\", job=\"${job_lifecycle_bucket_processor}\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "HTTP 2xx",
+          "legendFormat": "Success",
           "metric": "",
           "refId": "",
           "step": 10,
@@ -1774,13 +2149,13 @@
         },
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"3..\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"4..\", origin=\"bucket\", job=\"${job_lifecycle_bucket_processor}\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "HTTP 3xx",
+          "legendFormat": "User errors",
           "metric": "",
           "refId": "",
           "step": 10,
@@ -1788,27 +2163,13 @@
         },
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"4..\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"5..\", origin=\"bucket\", job=\"${job_lifecycle_bucket_processor}\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "HTTP 4xx",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"5..\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "HTTP 5xx",
+          "legendFormat": "System errors",
           "metric": "",
           "refId": "",
           "step": 10,
@@ -1857,249 +2218,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
+        "w": 8,
         "x": 0,
-        "y": 65
-      },
-      "hideTimeOverride": false,
-      "id": 22,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status!=\"200\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]) > 0)",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "S3 All Errors",
-      "transformations": [],
-      "transparent": false,
-      "type": "stat"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": null,
-          "mappings": [],
-          "noValue": "none",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "index": 0,
-                "line": true,
-                "op": "gt",
-                "value": "null",
-                "yaxis": "left"
-              },
-              {
-                "color": "red",
-                "index": 1,
-                "line": true,
-                "op": "gt",
-                "value": 0.05,
-                "yaxis": "left"
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 6,
-        "y": 65
-      },
-      "hideTimeOverride": false,
-      "id": 23,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"3..\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]) > 0)",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "S3 3xx Errors",
-      "transformations": [],
-      "transparent": false,
-      "type": "stat"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": null,
-          "mappings": [],
-          "noValue": "none",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "index": 0,
-                "line": true,
-                "op": "gt",
-                "value": "null",
-                "yaxis": "left"
-              },
-              {
-                "color": "red",
-                "index": 1,
-                "line": true,
-                "op": "gt",
-                "value": 0.05,
-                "yaxis": "left"
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 12,
-        "y": 65
-      },
-      "hideTimeOverride": false,
-      "id": 24,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"4..\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]) > 0)",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "S3 4xx Errors",
-      "transformations": [],
-      "transparent": false,
-      "type": "stat"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": null,
-          "mappings": [],
-          "noValue": "none",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "index": 0,
-                "line": true,
-                "op": "gt",
-                "value": "null",
-                "yaxis": "left"
-              },
-              {
-                "color": "red",
-                "index": 1,
-                "line": true,
-                "op": "gt",
-                "value": 0.05,
-                "yaxis": "left"
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 18,
-        "y": 65
+        "y": 77
       },
       "hideTimeOverride": false,
       "id": 25,
@@ -2122,7 +2243,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"5..\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]) > 0)",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status!=\"200\", origin=\"bucket\", job=\"${job_lifecycle_bucket_processor}\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", origin=\"bucket\", job=\"${job_lifecycle_bucket_processor}\"}[$__rate_interval]) > 0)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2135,7 +2256,167 @@
           "target": ""
         }
       ],
-      "title": "S3 5xx Errors",
+      "title": "Error rate",
+      "transformations": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": null,
+          "mappings": [],
+          "noValue": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              },
+              {
+                "color": "red",
+                "index": 1,
+                "line": true,
+                "op": "gt",
+                "value": 0.05,
+                "yaxis": "left"
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 77
+      },
+      "hideTimeOverride": false,
+      "id": 26,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"4..\", origin=\"bucket\", job=\"${job_lifecycle_bucket_processor}\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", origin=\"bucket\", job=\"${job_lifecycle_bucket_processor}\"}[$__rate_interval]) > 0)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "User Error rate",
+      "transformations": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": null,
+          "mappings": [],
+          "noValue": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              },
+              {
+                "color": "red",
+                "index": 1,
+                "line": true,
+                "op": "gt",
+                "value": 0.05,
+                "yaxis": "left"
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 77
+      },
+      "hideTimeOverride": false,
+      "id": 27,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"5..\", origin=\"bucket\", job=\"${job_lifecycle_bucket_processor}\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", origin=\"bucket\", job=\"${job_lifecycle_bucket_processor}\"}[$__rate_interval]) > 0)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "System Error rate",
       "transformations": [],
       "transparent": false,
       "type": "stat"
@@ -2233,10 +2514,10 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 69
+        "y": 81
       },
       "hideTimeOverride": false,
-      "id": 26,
+      "id": 28,
       "links": [],
       "maxDataPoints": 100,
       "targets": [
@@ -2276,10 +2557,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 79
+        "y": 91
       },
       "hideTimeOverride": false,
-      "id": 27,
+      "id": 29,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -2329,7 +2610,7 @@
             "mode": "absolute",
             "steps": []
           },
-          "unit": ""
+          "unit": "reqps"
         },
         "overrides": []
       },
@@ -2337,10 +2618,10 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 80
+        "y": 92
       },
       "hideTimeOverride": false,
-      "id": 28,
+      "id": 30,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2356,13 +2637,13 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"2..\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"2..\", origin=\"expiration\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "HTTP 2xx",
+          "legendFormat": "Success",
           "metric": "",
           "refId": "",
           "step": 10,
@@ -2370,13 +2651,13 @@
         },
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"3..\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"4..\", origin=\"expiration\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "HTTP 3xx",
+          "legendFormat": "User errors",
           "metric": "",
           "refId": "",
           "step": 10,
@@ -2384,27 +2665,13 @@
         },
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"4..\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"5..\", origin=\"expiration\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "HTTP 4xx",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"5..\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "HTTP 5xx",
+          "legendFormat": "System errors",
           "metric": "",
           "refId": "",
           "step": 10,
@@ -2453,169 +2720,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
+        "w": 8,
         "x": 0,
-        "y": 90
-      },
-      "hideTimeOverride": false,
-      "id": 29,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status!=\"200\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]) > 0)",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "S3 All Errors",
-      "transformations": [],
-      "transparent": false,
-      "type": "stat"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": null,
-          "mappings": [],
-          "noValue": "none",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "index": 0,
-                "line": true,
-                "op": "gt",
-                "value": "null",
-                "yaxis": "left"
-              },
-              {
-                "color": "red",
-                "index": 1,
-                "line": true,
-                "op": "gt",
-                "value": 0.05,
-                "yaxis": "left"
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 6,
-        "y": 90
-      },
-      "hideTimeOverride": false,
-      "id": 30,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"3..\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]) > 0)",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "S3 3xx Errors",
-      "transformations": [],
-      "transparent": false,
-      "type": "stat"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": null,
-          "mappings": [],
-          "noValue": "none",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "index": 0,
-                "line": true,
-                "op": "gt",
-                "value": "null",
-                "yaxis": "left"
-              },
-              {
-                "color": "red",
-                "index": 1,
-                "line": true,
-                "op": "gt",
-                "value": 0.05,
-                "yaxis": "left"
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 6,
-        "x": 12,
-        "y": 90
+        "y": 102
       },
       "hideTimeOverride": false,
       "id": 31,
@@ -2638,7 +2745,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"4..\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]) > 0)",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status!=\"200\", origin=\"expiration\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", origin=\"expiration\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]) > 0)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2651,7 +2758,7 @@
           "target": ""
         }
       ],
-      "title": "S3 4xx Errors",
+      "title": "Error rate",
       "transformations": [],
       "transparent": false,
       "type": "stat"
@@ -2693,9 +2800,9 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 18,
-        "y": 90
+        "w": 8,
+        "x": 8,
+        "y": 102
       },
       "hideTimeOverride": false,
       "id": 32,
@@ -2718,7 +2825,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"5..\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]) > 0)",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"4..\", origin=\"expiration\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", origin=\"expiration\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]) > 0)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2731,7 +2838,87 @@
           "target": ""
         }
       ],
-      "title": "S3 5xx Errors",
+      "title": "User Error rate",
+      "transformations": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": null,
+          "mappings": [],
+          "noValue": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              },
+              {
+                "color": "red",
+                "index": 1,
+                "line": true,
+                "op": "gt",
+                "value": 0.05,
+                "yaxis": "left"
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 102
+      },
+      "hideTimeOverride": false,
+      "id": 33,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"5..\", origin=\"expiration\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", origin=\"expiration\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]) > 0)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "System Error rate",
       "transformations": [],
       "transparent": false,
       "type": "stat"
@@ -2784,10 +2971,10 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 94
+        "y": 106
       },
       "hideTimeOverride": false,
-      "id": 33,
+      "id": 34,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2803,7 +2990,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{status=\"200\",op=\"deleteObject\",namespace=\"${namespace}\",job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=\"200\", op=\"deleteObject\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2817,7 +3004,7 @@
         },
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{status!=\"200\",op=\"deleteObject\",namespace=\"${namespace}\",job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status!=\"200\", op=\"deleteObject\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2883,10 +3070,10 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 104
+        "y": 116
       },
       "hideTimeOverride": false,
-      "id": 34,
+      "id": 35,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2902,7 +3089,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{status=\"200\",op=\"abortMultipartUpload\",namespace=\"${namespace}\",job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=\"200\", op=\"abortMultipartUpload\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2916,7 +3103,7 @@
         },
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{status!=\"200\",op=\"abortMultipartUpload\",namespace=\"${namespace}\",job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status!=\"200\", op=\"abortMultipartUpload\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -3027,10 +3214,10 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 114
+        "y": 126
       },
       "hideTimeOverride": false,
-      "id": 35,
+      "id": 36,
       "links": [],
       "maxDataPoints": 100,
       "targets": [

--- a/monitoring/lifecycle/dashboard.json
+++ b/monitoring/lifecycle/dashboard.json
@@ -2425,7 +2425,7 @@
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "line",
-            "fillOpacity": 5,
+            "fillOpacity": 30,
             "gradientMode": "none",
             "hideFrom": {
               "legend": false,
@@ -2451,13 +2451,13 @@
             "mode": "absolute",
             "steps": []
           },
-          "unit": "reqps"
+          "unit": "ops"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 10,
-        "w": 24,
+        "h": 8,
+        "w": 11,
         "x": 0,
         "y": 45
       },
@@ -2468,11 +2468,145 @@
       "options": {
         "legend": {
           "calcs": [],
-          "displayMode": "table",
+          "displayMode": "list",
           "placement": "bottom"
         },
         "tooltip": {
           "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval])) by (status)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ status }}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "S3 Requests status over time",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 39,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "log"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "ops"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Success"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "User errors"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "System errors"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 11,
+        "x": 11,
+        "y": 45
+      },
+      "hideTimeOverride": false,
+      "id": 30,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi"
         }
       },
       "targets": [
@@ -2519,7 +2653,7 @@
           "target": ""
         }
       ],
-      "title": "S3 Requests",
+      "title": "S3 Requests Aggregated status over time",
       "transformations": [],
       "transparent": false,
       "type": "timeseries"
@@ -2536,44 +2670,73 @@
           "noValue": "none",
           "thresholds": {
             "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "index": 0,
-                "line": true,
-                "op": "gt",
-                "value": "null",
-                "yaxis": "left"
-              },
-              {
-                "color": "red",
-                "index": 1,
-                "line": true,
-                "op": "gt",
-                "value": 0.05,
-                "yaxis": "left"
-              }
-            ]
+            "steps": ""
           },
           "unit": "percentunit"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "All errors"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "User errors"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "System errors"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 0,
-        "y": 55
+        "h": 8,
+        "w": 2,
+        "x": 22,
+        "y": 45
       },
       "hideTimeOverride": false,
-      "id": 30,
+      "id": 31,
       "links": [],
       "maxDataPoints": 100,
       "options": {
         "colorMode": "value",
         "graphMode": "area",
         "justifyMode": "auto",
-        "orientation": "auto",
+        "orientation": "horizontal",
         "reduceOptions": {
           "calcs": [
             "mean"
@@ -2586,13 +2749,41 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status!=\"200\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval]) > 0)",
+          "expr": "(sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status!=\"200\"}[$__rate_interval])) or vector(0))\n /\n(sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval])) > 0)",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "",
+          "legendFormat": "All errors",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "(sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"4..\"}[$__rate_interval])) or vector(0))\n /\n(sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval])) > 0)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "User errors",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "(sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"5..\"}[$__rate_interval])) or vector(0))\n /\n(sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval])) > 0)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "System errors",
           "metric": "",
           "refId": "",
           "step": 10,
@@ -2610,79 +2801,88 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "custom": {},
-          "decimals": null,
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
           "mappings": [],
-          "noValue": "none",
           "thresholds": {
             "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "index": 0,
-                "line": true,
-                "op": "gt",
-                "value": "null",
-                "yaxis": "left"
-              },
-              {
-                "color": "red",
-                "index": 1,
-                "line": true,
-                "op": "gt",
-                "value": 0.05,
-                "yaxis": "left"
-              }
-            ]
+            "steps": []
           },
-          "unit": "percentunit"
+          "unit": "ops"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 8,
-        "y": 55
+        "h": 8,
+        "w": 17,
+        "x": 0,
+        "y": 53
       },
       "hideTimeOverride": false,
-      "id": 31,
+      "id": 32,
       "links": [],
       "maxDataPoints": 100,
       "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
+        "legend": {
           "calcs": [
-            "mean"
+            "min",
+            "mean",
+            "max"
           ],
-          "fields": "",
-          "values": false
+          "displayMode": "table",
+          "placement": "right"
         },
-        "textMode": "auto"
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"4..\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval]) > 0)",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval])) by(origin)",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "",
+          "legendFormat": "{{ origin }}",
           "metric": "",
           "refId": "",
           "step": 10,
           "target": ""
         }
       ],
-      "title": "User Error rate",
+      "title": "S3 Request rate per workflow",
       "transformations": [],
       "transparent": false,
-      "type": "stat"
+      "type": "timeseries"
     },
     {
       "datasource": "${DS_PROMETHEUS}",
@@ -2690,50 +2890,38 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
           "custom": {},
-          "decimals": null,
           "mappings": [],
-          "noValue": "none",
           "thresholds": {
             "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "index": 0,
-                "line": true,
-                "op": "gt",
-                "value": "null",
-                "yaxis": "left"
-              },
-              {
-                "color": "red",
-                "index": 1,
-                "line": true,
-                "op": "gt",
-                "value": 0.05,
-                "yaxis": "left"
-              }
-            ]
+            "steps": []
           },
-          "unit": "percentunit"
+          "unit": "ops"
         },
         "overrides": []
       },
       "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 16,
-        "y": 55
+        "h": 8,
+        "w": 7,
+        "x": 17,
+        "y": 53
       },
       "hideTimeOverride": false,
-      "id": 32,
+      "id": 33,
       "links": [],
       "maxDataPoints": 100,
       "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "percent"
+          ]
+        },
+        "pieType": "donut",
         "reduceOptions": {
           "calcs": [
             "mean"
@@ -2741,28 +2929,296 @@
           "fields": "",
           "values": false
         },
-        "textMode": "auto"
+        "tooltip": {
+          "mode": "single"
+        }
       },
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"5..\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval]) > 0)",
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status!=\"200\"}[$__rate_interval])) by(origin)",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "",
+          "legendFormat": "{{ origin }}",
           "metric": "",
           "refId": "",
           "step": 10,
           "target": ""
         }
       ],
-      "title": "System Error rate",
+      "title": "S3 errors distribution",
       "transformations": [],
       "transparent": false,
-      "type": "stat"
+      "type": "piechart"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Success"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 61
+      },
+      "hideTimeOverride": false,
+      "id": 34,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status!=\"200\", op=\"deleteObject\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Error",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=\"200\", op=\"deleteObject\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Success",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "deleteObject Request Rate",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Success"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 61
+      },
+      "hideTimeOverride": false,
+      "id": 35,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status!=\"200\", op=\"abortMultipartUpload\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Error",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=\"200\", op=\"abortMultipartUpload\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Success",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "abortMultipartUpload Request Rate",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
     },
     {
       "collapsed": false,
@@ -2780,10 +3236,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 69
       },
       "hideTimeOverride": false,
-      "id": 33,
+      "id": 36,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -2841,10 +3297,10 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 60
+        "y": 70
       },
       "hideTimeOverride": false,
-      "id": 34,
+      "id": 37,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2940,10 +3396,10 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 60
+        "y": 70
       },
       "hideTimeOverride": false,
-      "id": 35,
+      "id": 38,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3039,10 +3495,10 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 68
+        "y": 78
       },
       "hideTimeOverride": false,
-      "id": 36,
+      "id": 39,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3138,10 +3594,10 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 68
+        "y": 78
       },
       "hideTimeOverride": false,
-      "id": 37,
+      "id": 40,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3237,10 +3693,10 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 76
+        "y": 86
       },
       "hideTimeOverride": false,
-      "id": 38,
+      "id": 41,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3336,10 +3792,10 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 76
+        "y": 86
       },
       "hideTimeOverride": false,
-      "id": 39,
+      "id": 42,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3435,10 +3891,10 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 84
+        "y": 94
       },
       "hideTimeOverride": false,
-      "id": 40,
+      "id": 43,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3534,10 +3990,10 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 84
+        "y": 94
       },
       "hideTimeOverride": false,
-      "id": 41,
+      "id": 44,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3601,10 +4057,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 92
+        "y": 102
       },
       "hideTimeOverride": false,
-      "id": 42,
+      "id": 45,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -3707,10 +4163,10 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 93
+        "y": 103
       },
       "hideTimeOverride": false,
-      "id": 43,
+      "id": 46,
       "links": [],
       "maxDataPoints": 100,
       "targets": [
@@ -3750,10 +4206,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 103
+        "y": 113
       },
       "hideTimeOverride": false,
-      "id": 44,
+      "id": 47,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -3811,10 +4267,10 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 104
+        "y": 114
       },
       "hideTimeOverride": false,
-      "id": 45,
+      "id": 48,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3856,359 +4312,6 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {},
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 111
-      },
-      "hideTimeOverride": false,
-      "id": 46,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"2..\", origin=\"bucket\", job=\"${job_lifecycle_bucket_processor}\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Success",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"4..\", origin=\"bucket\", job=\"${job_lifecycle_bucket_processor}\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "User errors",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"5..\", origin=\"bucket\", job=\"${job_lifecycle_bucket_processor}\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "System errors",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "S3 Requests",
-      "transformations": [],
-      "transparent": false,
-      "type": "timeseries"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": null,
-          "mappings": [],
-          "noValue": "none",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "index": 0,
-                "line": true,
-                "op": "gt",
-                "value": "null",
-                "yaxis": "left"
-              },
-              {
-                "color": "red",
-                "index": 1,
-                "line": true,
-                "op": "gt",
-                "value": 0.05,
-                "yaxis": "left"
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 0,
-        "y": 121
-      },
-      "hideTimeOverride": false,
-      "id": 47,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status!=\"200\", origin=\"bucket\", job=\"${job_lifecycle_bucket_processor}\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", origin=\"bucket\", job=\"${job_lifecycle_bucket_processor}\"}[$__rate_interval]) > 0)",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "Error rate",
-      "transformations": [],
-      "transparent": false,
-      "type": "stat"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": null,
-          "mappings": [],
-          "noValue": "none",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "index": 0,
-                "line": true,
-                "op": "gt",
-                "value": "null",
-                "yaxis": "left"
-              },
-              {
-                "color": "red",
-                "index": 1,
-                "line": true,
-                "op": "gt",
-                "value": 0.05,
-                "yaxis": "left"
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 8,
-        "y": 121
-      },
-      "hideTimeOverride": false,
-      "id": 48,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"4..\", origin=\"bucket\", job=\"${job_lifecycle_bucket_processor}\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", origin=\"bucket\", job=\"${job_lifecycle_bucket_processor}\"}[$__rate_interval]) > 0)",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "User Error rate",
-      "transformations": [],
-      "transparent": false,
-      "type": "stat"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": null,
-          "mappings": [],
-          "noValue": "none",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "index": 0,
-                "line": true,
-                "op": "gt",
-                "value": "null",
-                "yaxis": "left"
-              },
-              {
-                "color": "red",
-                "index": 1,
-                "line": true,
-                "op": "gt",
-                "value": 0.05,
-                "yaxis": "left"
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 16,
-        "y": 121
-      },
-      "hideTimeOverride": false,
-      "id": 49,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"5..\", origin=\"bucket\", job=\"${job_lifecycle_bucket_processor}\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", origin=\"bucket\", job=\"${job_lifecycle_bucket_processor}\"}[$__rate_interval]) > 0)",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "System Error rate",
-      "transformations": [],
-      "transparent": false,
-      "type": "stat"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
           "calcs": [
             "mean"
           ],
@@ -4296,10 +4399,10 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 125
+        "y": 121
       },
       "hideTimeOverride": false,
-      "id": 50,
+      "id": 49,
       "links": [],
       "maxDataPoints": 100,
       "targets": [
@@ -4339,10 +4442,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 135
+        "y": 131
       },
       "hideTimeOverride": false,
-      "id": 51,
+      "id": 50,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -4351,557 +4454,6 @@
       "transformations": [],
       "transparent": false,
       "type": "row"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "smooth",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {},
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 136
-      },
-      "hideTimeOverride": false,
-      "id": 52,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"2..\", origin=\"expiration\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Success",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"4..\", origin=\"expiration\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "User errors",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"5..\", origin=\"expiration\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "System errors",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "S3 Requests",
-      "transformations": [],
-      "transparent": false,
-      "type": "timeseries"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": null,
-          "mappings": [],
-          "noValue": "none",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "index": 0,
-                "line": true,
-                "op": "gt",
-                "value": "null",
-                "yaxis": "left"
-              },
-              {
-                "color": "red",
-                "index": 1,
-                "line": true,
-                "op": "gt",
-                "value": 0.05,
-                "yaxis": "left"
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 0,
-        "y": 146
-      },
-      "hideTimeOverride": false,
-      "id": 53,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status!=\"200\", origin=\"expiration\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", origin=\"expiration\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]) > 0)",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "Error rate",
-      "transformations": [],
-      "transparent": false,
-      "type": "stat"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": null,
-          "mappings": [],
-          "noValue": "none",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "index": 0,
-                "line": true,
-                "op": "gt",
-                "value": "null",
-                "yaxis": "left"
-              },
-              {
-                "color": "red",
-                "index": 1,
-                "line": true,
-                "op": "gt",
-                "value": 0.05,
-                "yaxis": "left"
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 8,
-        "y": 146
-      },
-      "hideTimeOverride": false,
-      "id": 54,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"4..\", origin=\"expiration\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", origin=\"expiration\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]) > 0)",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "User Error rate",
-      "transformations": [],
-      "transparent": false,
-      "type": "stat"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": null,
-          "mappings": [],
-          "noValue": "none",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "index": 0,
-                "line": true,
-                "op": "gt",
-                "value": "null",
-                "yaxis": "left"
-              },
-              {
-                "color": "red",
-                "index": 1,
-                "line": true,
-                "op": "gt",
-                "value": 0.05,
-                "yaxis": "left"
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 16,
-        "y": 146
-      },
-      "hideTimeOverride": false,
-      "id": 55,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"5..\", origin=\"expiration\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", origin=\"expiration\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]) > 0)",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "System Error rate",
-      "transformations": [],
-      "transparent": false,
-      "type": "stat"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {},
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 150
-      },
-      "hideTimeOverride": false,
-      "id": 56,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=\"200\", op=\"deleteObject\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "success",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status!=\"200\", op=\"deleteObject\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "error",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "deleteObject Request Rate",
-      "transformations": [],
-      "transparent": false,
-      "type": "timeseries"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {},
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 160
-      },
-      "hideTimeOverride": false,
-      "id": 57,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=\"200\", op=\"abortMultipartUpload\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "success",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status!=\"200\", op=\"abortMultipartUpload\", job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "error",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "abortMultipartUpload Request Rate",
-      "transformations": [],
-      "transparent": false,
-      "type": "timeseries"
     },
     {
       "datasource": "${DS_PROMETHEUS}",
@@ -4996,10 +4548,10 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 170
+        "y": 132
       },
       "hideTimeOverride": false,
-      "id": 58,
+      "id": 51,
       "links": [],
       "maxDataPoints": 100,
       "targets": [

--- a/monitoring/lifecycle/dashboard.json
+++ b/monitoring/lifecycle/dashboard.json
@@ -1427,6 +1427,109 @@
       "type": "gauge"
     },
     {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "custom": {
+            "fillOpacity": 70,
+            "lineWidth": 0
+          },
+          "mappings": [
+            {
+              "options": {
+                "from": 0,
+                "result": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "OK"
+                },
+                "to": 2
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 2,
+                "result": {
+                  "color": "orange",
+                  "index": 1,
+                  "text": "Throttled"
+                },
+                "to": 10
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 10,
+                "result": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "Stalled"
+                },
+                "to": 20
+              },
+              "type": "range"
+            }
+          ],
+          "max": 20,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "hideTimeOverride": false,
+      "id": 16,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "alignValue": "left",
+        "legend": {
+          "displayMode": "hidden",
+          "placement": "bottom"
+        },
+        "mergeValues": true,
+        "rowHeight": 0.9,
+        "showValue": "never",
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "avg(s3_circuit_breaker{namespace=\"${namespace}\",job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\"})by(job) * 10",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Flow Control over time",
+      "transformations": [],
+      "transparent": false,
+      "type": "state-timeline"
+    },
+    {
       "collapsed": false,
       "editable": true,
       "error": false,
@@ -1442,10 +1545,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 13
       },
       "hideTimeOverride": false,
-      "id": 16,
+      "id": 17,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -1503,10 +1606,10 @@
         "h": 7,
         "w": 14,
         "x": 0,
-        "y": 9
+        "y": 14
       },
       "hideTimeOverride": false,
-      "id": 17,
+      "id": 18,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -1579,10 +1682,10 @@
         "h": 7,
         "w": 5,
         "x": 14,
-        "y": 9
+        "y": 14
       },
       "hideTimeOverride": false,
-      "id": 18,
+      "id": 19,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -1647,10 +1750,10 @@
         "h": 7,
         "w": 5,
         "x": 19,
-        "y": 9
+        "y": 14
       },
       "hideTimeOverride": false,
-      "id": 19,
+      "id": 20,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -1740,10 +1843,10 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 16
+        "y": 21
       },
       "hideTimeOverride": false,
-      "id": 20,
+      "id": 21,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -1809,13 +1912,13 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 16
+        "y": 21
       },
       "heatmap": {},
       "hideTimeOverride": false,
       "hideZeroBuckets": true,
       "highlightCards": true,
-      "id": 21,
+      "id": 22,
       "legend": {
         "show": false
       },
@@ -1910,10 +2013,10 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 23
+        "y": 28
       },
       "hideTimeOverride": false,
-      "id": 22,
+      "id": 23,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2011,10 +2114,10 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 23
+        "y": 28
       },
       "hideTimeOverride": false,
-      "id": 23,
+      "id": 24,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2080,13 +2183,13 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 30
+        "y": 35
       },
       "heatmap": {},
       "hideTimeOverride": false,
       "hideZeroBuckets": true,
       "highlightCards": true,
-      "id": 24,
+      "id": 25,
       "legend": {
         "show": false
       },
@@ -2163,13 +2266,13 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 30
+        "y": 35
       },
       "heatmap": {},
       "hideTimeOverride": false,
       "hideZeroBuckets": true,
       "highlightCards": true,
-      "id": 25,
+      "id": 26,
       "legend": {
         "show": false
       },
@@ -2246,13 +2349,13 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 37
+        "y": 42
       },
       "heatmap": {},
       "hideTimeOverride": false,
       "hideZeroBuckets": true,
       "highlightCards": true,
-      "id": 26,
+      "id": 27,
       "legend": {
         "show": false
       },
@@ -2329,13 +2432,13 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 37
+        "y": 42
       },
       "heatmap": {},
       "hideTimeOverride": false,
       "hideZeroBuckets": true,
       "highlightCards": true,
-      "id": 27,
+      "id": 28,
       "legend": {
         "show": false
       },
@@ -2398,10 +2501,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 49
       },
       "hideTimeOverride": false,
-      "id": 28,
+      "id": 29,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -2459,10 +2562,10 @@
         "h": 7,
         "w": 10,
         "x": 0,
-        "y": 45
+        "y": 50
       },
       "hideTimeOverride": false,
-      "id": 29,
+      "id": 30,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2544,10 +2647,10 @@
         "h": 7,
         "w": 10,
         "x": 10,
-        "y": 45
+        "y": 50
       },
       "hideTimeOverride": false,
-      "id": 30,
+      "id": 31,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2636,10 +2739,10 @@
         "h": 7,
         "w": 4,
         "x": 20,
-        "y": 45
+        "y": 50
       },
       "hideTimeOverride": false,
-      "id": 31,
+      "id": 32,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2725,10 +2828,10 @@
         "h": 7,
         "w": 10,
         "x": 0,
-        "y": 52
+        "y": 57
       },
       "hideTimeOverride": false,
-      "id": 32,
+      "id": 33,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2810,10 +2913,10 @@
         "h": 7,
         "w": 14,
         "x": 10,
-        "y": 52
+        "y": 57
       },
       "hideTimeOverride": false,
-      "id": 33,
+      "id": 34,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2899,10 +3002,10 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 59
+        "y": 64
       },
       "hideTimeOverride": false,
-      "id": 34,
+      "id": 35,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2966,13 +3069,13 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 59
+        "y": 64
       },
       "heatmap": {},
       "hideTimeOverride": false,
       "hideZeroBuckets": true,
       "highlightCards": true,
-      "id": 35,
+      "id": 36,
       "legend": {
         "show": false
       },
@@ -3067,10 +3170,10 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 66
+        "y": 71
       },
       "hideTimeOverride": false,
-      "id": 36,
+      "id": 37,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3152,10 +3255,10 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 66
+        "y": 71
       },
       "hideTimeOverride": false,
-      "id": 37,
+      "id": 38,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3205,10 +3308,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 73
+        "y": 78
       },
       "hideTimeOverride": false,
-      "id": 38,
+      "id": 39,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -3266,10 +3369,10 @@
         "h": 8,
         "w": 11,
         "x": 0,
-        "y": 74
+        "y": 79
       },
       "hideTimeOverride": false,
-      "id": 39,
+      "id": 40,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3400,10 +3503,10 @@
         "h": 8,
         "w": 11,
         "x": 11,
-        "y": 74
+        "y": 79
       },
       "hideTimeOverride": false,
-      "id": 40,
+      "id": 41,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3533,10 +3636,10 @@
         "h": 8,
         "w": 2,
         "x": 22,
-        "y": 74
+        "y": 79
       },
       "hideTimeOverride": false,
-      "id": 41,
+      "id": 42,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3650,10 +3753,10 @@
         "h": 8,
         "w": 17,
         "x": 0,
-        "y": 82
+        "y": 87
       },
       "hideTimeOverride": false,
-      "id": 42,
+      "id": 43,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3714,10 +3817,10 @@
         "h": 8,
         "w": 7,
         "x": 17,
-        "y": 82
+        "y": 87
       },
       "hideTimeOverride": false,
-      "id": 43,
+      "id": 44,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3843,10 +3946,10 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 90
+        "y": 95
       },
       "hideTimeOverride": false,
-      "id": 44,
+      "id": 45,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3976,10 +4079,10 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 90
+        "y": 95
       },
       "hideTimeOverride": false,
-      "id": 45,
+      "id": 46,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -4043,10 +4146,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 98
+        "y": 103
       },
       "hideTimeOverride": false,
-      "id": 46,
+      "id": 47,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -4055,126 +4158,6 @@
       "transformations": [],
       "transparent": false,
       "type": "row"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "calcs": [
-            "mean"
-          ],
-          "decimals": null,
-          "limit": null,
-          "links": [],
-          "mappings": [
-            {
-              "options": {
-                "from": 0,
-                "result": {
-                  "color": "green",
-                  "index": 0,
-                  "text": "OK"
-                },
-                "to": 2
-              },
-              "type": "range"
-            },
-            {
-              "options": {
-                "from": 2,
-                "result": {
-                  "color": "orange",
-                  "index": 1,
-                  "text": "Throttled"
-                },
-                "to": 10
-              },
-              "type": "range"
-            },
-            {
-              "options": {
-                "from": 10,
-                "result": {
-                  "color": "red",
-                  "index": 2,
-                  "text": "Stalled"
-                },
-                "to": 20
-              },
-              "type": "range"
-            }
-          ],
-          "max": 20,
-          "min": 0,
-          "override": {},
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "index": 0,
-                "line": true,
-                "op": "gt",
-                "value": "null",
-                "yaxis": "left"
-              },
-              {
-                "color": "orange",
-                "index": 1,
-                "line": true,
-                "op": "gt",
-                "value": 2.0,
-                "yaxis": "left"
-              },
-              {
-                "color": "red",
-                "index": 2,
-                "line": true,
-                "op": "gt",
-                "value": 10.0,
-                "yaxis": "left"
-              }
-            ]
-          },
-          "title": null,
-          "unit": "none",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 99
-      },
-      "hideTimeOverride": false,
-      "id": 47,
-      "links": [],
-      "maxDataPoints": 100,
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "avg(s3_circuit_breaker{namespace=\"${namespace}\",job=\"${job_lifecycle_producer}\"})*10",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "Flow Control",
-      "transformations": [],
-      "transparent": false,
-      "type": "gauge"
     },
     {
       "collapsed": false,
@@ -4192,7 +4175,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 109
+        "y": 104
       },
       "hideTimeOverride": false,
       "id": 48,
@@ -4253,7 +4236,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 110
+        "y": 105
       },
       "hideTimeOverride": false,
       "id": 49,
@@ -4291,275 +4274,6 @@
       "transformations": [],
       "transparent": false,
       "type": "timeseries"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "calcs": [
-            "mean"
-          ],
-          "decimals": null,
-          "limit": null,
-          "links": [],
-          "mappings": [
-            {
-              "options": {
-                "from": 0,
-                "result": {
-                  "color": "green",
-                  "index": 0,
-                  "text": "OK"
-                },
-                "to": 2
-              },
-              "type": "range"
-            },
-            {
-              "options": {
-                "from": 2,
-                "result": {
-                  "color": "orange",
-                  "index": 1,
-                  "text": "Throttled"
-                },
-                "to": 10
-              },
-              "type": "range"
-            },
-            {
-              "options": {
-                "from": 10,
-                "result": {
-                  "color": "red",
-                  "index": 2,
-                  "text": "Stalled"
-                },
-                "to": 20
-              },
-              "type": "range"
-            }
-          ],
-          "max": 20,
-          "min": 0,
-          "override": {},
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "index": 0,
-                "line": true,
-                "op": "gt",
-                "value": "null",
-                "yaxis": "left"
-              },
-              {
-                "color": "orange",
-                "index": 1,
-                "line": true,
-                "op": "gt",
-                "value": 2.0,
-                "yaxis": "left"
-              },
-              {
-                "color": "red",
-                "index": 2,
-                "line": true,
-                "op": "gt",
-                "value": 10.0,
-                "yaxis": "left"
-              }
-            ]
-          },
-          "title": null,
-          "unit": "none",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 117
-      },
-      "hideTimeOverride": false,
-      "id": 50,
-      "links": [],
-      "maxDataPoints": 100,
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "avg(s3_circuit_breaker{namespace=\"${namespace}\",job=\"${job_lifecycle_bucket_processor}\"})*10",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "Flow Control",
-      "transformations": [],
-      "transparent": false,
-      "type": "gauge"
-    },
-    {
-      "collapsed": false,
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          }
-        }
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 127
-      },
-      "hideTimeOverride": false,
-      "id": 51,
-      "links": [],
-      "maxDataPoints": 100,
-      "panels": [],
-      "targets": [],
-      "title": "Lifecycle Expiration Processors",
-      "transformations": [],
-      "transparent": false,
-      "type": "row"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "calcs": [
-            "mean"
-          ],
-          "decimals": null,
-          "limit": null,
-          "links": [],
-          "mappings": [
-            {
-              "options": {
-                "from": 0,
-                "result": {
-                  "color": "green",
-                  "index": 0,
-                  "text": "OK"
-                },
-                "to": 2
-              },
-              "type": "range"
-            },
-            {
-              "options": {
-                "from": 2,
-                "result": {
-                  "color": "orange",
-                  "index": 1,
-                  "text": "Throttled"
-                },
-                "to": 10
-              },
-              "type": "range"
-            },
-            {
-              "options": {
-                "from": 10,
-                "result": {
-                  "color": "red",
-                  "index": 2,
-                  "text": "Stalled"
-                },
-                "to": 20
-              },
-              "type": "range"
-            }
-          ],
-          "max": 20,
-          "min": 0,
-          "override": {},
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "index": 0,
-                "line": true,
-                "op": "gt",
-                "value": "null",
-                "yaxis": "left"
-              },
-              {
-                "color": "orange",
-                "index": 1,
-                "line": true,
-                "op": "gt",
-                "value": 2.0,
-                "yaxis": "left"
-              },
-              {
-                "color": "red",
-                "index": 2,
-                "line": true,
-                "op": "gt",
-                "value": 10.0,
-                "yaxis": "left"
-              }
-            ]
-          },
-          "title": null,
-          "unit": "none",
-          "values": false
-        },
-        "showThresholdLabels": false,
-        "showThresholdMarkers": true
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 128
-      },
-      "hideTimeOverride": false,
-      "id": 52,
-      "links": [],
-      "maxDataPoints": 100,
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "avg(s3_circuit_breaker{namespace=\"${namespace}\",job=\"${job_lifecycle_object_processor}\"})*10",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "Flow Control",
-      "transformations": [],
-      "transparent": false,
-      "type": "gauge"
     }
   ],
   "refresh": "30s",

--- a/monitoring/lifecycle/dashboard.json
+++ b/monitoring/lifecycle/dashboard.json
@@ -1019,7 +1019,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{job=~\"$jobs\", namespace=\"${namespace}\", type=~\"expiration|expiration:mpu\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{location=~\"$locations\", job=~\"$jobs\", namespace=\"${namespace}\", type=~\"expiration|expiration:mpu\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1091,7 +1091,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{job=~\"$jobs\", namespace=\"${namespace}\", type=~\"transition\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{location=~\"$locations\", job=~\"$jobs\", namespace=\"${namespace}\", type=~\"transition\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1163,7 +1163,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{job=~\"$jobs\", namespace=\"${namespace}\", type=~\"archive|archive:gc\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{location=~\"$locations\", job=~\"$jobs\", namespace=\"${namespace}\", type=~\"archive|archive:gc\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1235,7 +1235,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{job=~\"$jobs\", namespace=\"${namespace}\", type=~\"restore\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{location=~\"$locations\", job=~\"$jobs\", namespace=\"${namespace}\", type=~\"restore\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1641,7 +1641,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (type)",
+          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{location=~\"$locations\", job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (type)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1723,7 +1723,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (type)",
+          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{location=~\"$locations\", job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (type)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1791,7 +1791,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (location)",
+          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{location=~\"$locations\", job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (location)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1878,7 +1878,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "histogram_quantile(0.95, sum(rate(s3_lifecycle_latency_seconds_bucket{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (le, type))",
+          "expr": "histogram_quantile(0.95, sum(rate(s3_lifecycle_latency_seconds_bucket{location=~\"$locations\", job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (le, type))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -1942,7 +1942,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_latency_seconds_bucket{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by(le)",
+          "expr": "sum(increase(s3_lifecycle_latency_seconds_bucket{location=~\"$locations\", job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by(le)",
           "format": "heatmap",
           "hide": false,
           "instant": false,
@@ -2048,7 +2048,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "histogram_quantile(0.95, sum(rate(s3_lifecycle_duration_seconds_bucket{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (le, type))",
+          "expr": "histogram_quantile(0.95, sum(rate(s3_lifecycle_duration_seconds_bucket{location=~\"$locations\", job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (le, type))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2149,7 +2149,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "histogram_quantile(0.95, sum(rate(s3_lifecycle_duration_seconds_bucket{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (le, location))",
+          "expr": "histogram_quantile(0.95, sum(rate(s3_lifecycle_duration_seconds_bucket{location=~\"$locations\", job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (le, location))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2213,7 +2213,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_duration_seconds_bucket{job=~\"$jobs\", namespace=\"${namespace}\", type=\"expiration\"}[$__rate_interval])) by(le)",
+          "expr": "sum(increase(s3_lifecycle_duration_seconds_bucket{location=~\"$locations\", job=~\"$jobs\", namespace=\"${namespace}\", type=\"expiration\"}[$__rate_interval])) by(le)",
           "format": "heatmap",
           "hide": false,
           "instant": false,
@@ -2296,7 +2296,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_duration_seconds_bucket{job=~\"$jobs\", namespace=\"${namespace}\", type=\"transition\"}[$__rate_interval])) by(le)",
+          "expr": "sum(increase(s3_lifecycle_duration_seconds_bucket{location=~\"$locations\", job=~\"$jobs\", namespace=\"${namespace}\", type=\"transition\"}[$__rate_interval])) by(le)",
           "format": "heatmap",
           "hide": false,
           "instant": false,
@@ -2379,7 +2379,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_duration_seconds_bucket{job=~\"$jobs\", namespace=\"${namespace}\", type=\"archive\"}[$__rate_interval])) by(le)",
+          "expr": "sum(increase(s3_lifecycle_duration_seconds_bucket{location=~\"$locations\", job=~\"$jobs\", namespace=\"${namespace}\", type=\"archive\"}[$__rate_interval])) by(le)",
           "format": "heatmap",
           "hide": false,
           "instant": false,
@@ -2462,7 +2462,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(increase(s3_lifecycle_duration_seconds_bucket{job=~\"$jobs\", namespace=\"${namespace}\", type=\"restore\"}[$__rate_interval])) by(le)",
+          "expr": "sum(increase(s3_lifecycle_duration_seconds_bucket{location=~\"$locations\", job=~\"$jobs\", namespace=\"${namespace}\", type=\"restore\"}[$__rate_interval])) by(le)",
           "format": "heatmap",
           "hide": false,
           "instant": false,
@@ -4327,7 +4327,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "histogram_quantile(0.95, sum(rate(s3_lifecycle_trigger_latency_seconds_bucket{job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (le, type))",
+          "expr": "histogram_quantile(0.95, sum(rate(s3_lifecycle_trigger_latency_seconds_bucket{location=~\"$locations\", job=~\"$jobs\", namespace=\"${namespace}\"}[$__rate_interval])) by (le, type))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -4690,7 +4690,7 @@
   "templating": {
     "list": [
       {
-        "allValue": ".*",
+        "allValue": "${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}|${job_sorbet_forwarder}",
         "auto": false,
         "auto_count": 30,
         "auto_min": "10s",
@@ -4710,6 +4710,33 @@
         "query": "label_values(up{namespace=\"${namespace}\", job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}|${job_sorbet_forwarder}.*\"}, job)",
         "refresh": 1,
         "regex": "/^${zenkoName}-(?:backbeat-|cold-sorbet-)?(?:lifecycle-)?(.*?)(?:-processor)?(?:-headless)?$/",
+        "sort": 1,
+        "tagValuesQuery": null,
+        "tagsQuery": null,
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "selected": false,
+          "tags": [],
+          "text": null,
+          "value": null
+        },
+        "datasource": "${DS_PROMETHEUS}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Location",
+        "multi": true,
+        "name": "locations",
+        "options": [],
+        "query": "label_values({namespace=\"${namespace}\", job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}|${job_sorbet_forwarder}\", location!=\"\"}, location)",
+        "refresh": 2,
+        "regex": null,
         "sort": 1,
         "tagValuesQuery": null,
         "tagsQuery": null,

--- a/monitoring/lifecycle/dashboard.json
+++ b/monitoring/lifecycle/dashboard.json
@@ -2861,7 +2861,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "label_replace(\nlabel_replace(\n  sum(   label_replace(kafka_consumergroup_group_max_lag,\n                 \"consumergroup\", \"$1\", \"group\", \"(.*)\")\n   * on(consumergroup) group_right\n   group(s3_zenko_queue_latest_consumed_message_timestamp{job=~\"$jobs\", namespace=\"${namespace}\"}) by(consumergroup, job)\n) by(job)\n, \"job\", \"$1\", \"job\", \"${zenkoName}-backbeat-(?:lifecycle-)?(.*?)-headless\")\n, \"job\", \"$1-processor\", \"job\", \"(gc|transition)\")",
+          "expr": "label_replace(\nlabel_replace(\n  sum(\n   kafka_consumergroup_group_max_lag\n   * on(group) group_right\n   group(s3_zenko_queue_latest_consumed_message_timestamp{job=~\"$jobs\", namespace=\"${namespace}\"}) by(group, job)\n) by(job)\n, \"job\", \"$1\", \"job\", \"${zenkoName}-backbeat-(?:lifecycle-)?(.*?)-headless\")\n, \"job\", \"$1-processor\", \"job\", \"(gc|transition)\")",
           "format": "time_series",
           "hide": false,
           "instant": false,

--- a/monitoring/lifecycle/dashboard.json
+++ b/monitoring/lifecycle/dashboard.json
@@ -1427,6 +1427,991 @@
       "type": "gauge"
     },
     {
+      "collapsed": false,
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        }
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "hideTimeOverride": false,
+      "id": 16,
+      "links": [],
+      "maxDataPoints": 100,
+      "panels": [],
+      "targets": [],
+      "title": "Lifecycle Workflows",
+      "transformations": [],
+      "transparent": false,
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 14,
+        "x": 0,
+        "y": 9
+      },
+      "hideTimeOverride": false,
+      "id": 17,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{namespace=\"${namespace}\"}[$__rate_interval])) by (type)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{type}}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_gc_duration_seconds_count{job=\"${job_lifecycle_gc_processor}\", namespace=\"${namespace}\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "gc",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Rate over time",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 14,
+        "y": 9
+      },
+      "hideTimeOverride": false,
+      "id": 18,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "displayMode": "hidden",
+          "placement": "bottom",
+          "values": []
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{namespace=\"${namespace}\"}[$__rate_interval])) by (type)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{type}}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "By type",
+      "transformations": [],
+      "transparent": false,
+      "type": "piechart"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 5,
+        "x": 19,
+        "y": 9
+      },
+      "hideTimeOverride": false,
+      "id": 19,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "displayMode": "hidden",
+          "placement": "bottom",
+          "values": []
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{namespace=\"${namespace}\"}[$__rate_interval])) by (location)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{location}}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "By location",
+      "transformations": [],
+      "transparent": false,
+      "type": "piechart"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "hideTimeOverride": false,
+      "id": 20,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "histogram_quantile(0.95, sum(rate(s3_lifecycle_latency_seconds_bucket{namespace=\"${namespace}\"}[$__rate_interval])) by (le, type))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{type}}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Latency over time",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": 2
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "max": null,
+        "min": null,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "heatmap": {},
+      "hideTimeOverride": false,
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 21,
+      "legend": {
+        "show": false
+      },
+      "links": [],
+      "maxDataPoints": 25,
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(increase(s3_lifecycle_latency_seconds_bucket{namespace=\"${namespace}\"}[$__rate_interval])) by(le)",
+          "format": "heatmap",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{le}}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Latency Distribution",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "transformations": [],
+      "transparent": false,
+      "type": "heatmap",
+      "xAxis": {
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yAxis": {
+        "decimals": 0,
+        "format": "s",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true
+      }
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "hideTimeOverride": false,
+      "id": 22,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "histogram_quantile(0.95, sum(rate(s3_lifecycle_duration_seconds_bucket{namespace=\"${namespace}\"}[$__rate_interval])) by (le, type))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{type}}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "histogram_quantile(0.95, sum(rate(s3_gc_duration_seconds_bucket{job=\"${job_lifecycle_gc_processor}\", namespace=\"${namespace}\"}[$__rate_interval])) by (le))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "gc",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Duration by Type",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "hideTimeOverride": false,
+      "id": 23,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "histogram_quantile(0.95, sum(rate(s3_lifecycle_duration_seconds_bucket{namespace=\"${namespace}\"}[$__rate_interval])) by (le, location))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{location}}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Duration by Location",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": 2
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "max": null,
+        "min": null,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "heatmap": {},
+      "hideTimeOverride": false,
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 24,
+      "legend": {
+        "show": false
+      },
+      "links": [],
+      "maxDataPoints": 25,
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(increase(s3_lifecycle_duration_seconds_bucket{namespace=\"${namespace}\", type=\"expiration\"}[$__rate_interval])) by(le)",
+          "format": "heatmap",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{le}}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Expiration Duration Distribution",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "transformations": [],
+      "transparent": false,
+      "type": "heatmap",
+      "xAxis": {
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yAxis": {
+        "decimals": 0,
+        "format": "s",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true
+      }
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": 2
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "max": null,
+        "min": null,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "heatmap": {},
+      "hideTimeOverride": false,
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 25,
+      "legend": {
+        "show": false
+      },
+      "links": [],
+      "maxDataPoints": 25,
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(increase(s3_lifecycle_duration_seconds_bucket{namespace=\"${namespace}\", type=\"transition\"}[$__rate_interval])) by(le)",
+          "format": "heatmap",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{le}}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Transition Duration Distribution",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "transformations": [],
+      "transparent": false,
+      "type": "heatmap",
+      "xAxis": {
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yAxis": {
+        "decimals": 0,
+        "format": "s",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true
+      }
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": 2
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "max": null,
+        "min": null,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 37
+      },
+      "heatmap": {},
+      "hideTimeOverride": false,
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 26,
+      "legend": {
+        "show": false
+      },
+      "links": [],
+      "maxDataPoints": 25,
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(increase(s3_lifecycle_duration_seconds_bucket{namespace=\"${namespace}\", type=\"archive\"}[$__rate_interval])) by(le)",
+          "format": "heatmap",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{le}}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Archive Duration Distribution",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "transformations": [],
+      "transparent": false,
+      "type": "heatmap",
+      "xAxis": {
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yAxis": {
+        "decimals": 0,
+        "format": "s",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true
+      }
+    },
+    {
+      "cards": {
+        "cardPadding": 1,
+        "cardRound": 2
+      },
+      "color": {
+        "cardColor": "#b4ff00",
+        "colorScale": "sqrt",
+        "colorScheme": "interpolateOranges",
+        "exponent": 0.5,
+        "max": null,
+        "min": null,
+        "mode": "opacity"
+      },
+      "dataFormat": "tsbuckets",
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 37
+      },
+      "heatmap": {},
+      "hideTimeOverride": false,
+      "hideZeroBuckets": true,
+      "highlightCards": true,
+      "id": 27,
+      "legend": {
+        "show": false
+      },
+      "links": [],
+      "maxDataPoints": 25,
+      "reverseYBuckets": false,
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(increase(s3_lifecycle_duration_seconds_bucket{namespace=\"${namespace}\", type=\"restore\"}[$__rate_interval])) by(le)",
+          "format": "heatmap",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{le}}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Restore Duration Distribution",
+      "tooltip": {
+        "show": true,
+        "showHistogram": true
+      },
+      "transformations": [],
+      "transparent": false,
+      "type": "heatmap",
+      "xAxis": {
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yAxis": {
+        "decimals": 0,
+        "format": "s",
+        "label": null,
+        "logBase": 1,
+        "max": null,
+        "min": null,
+        "show": true
+      }
+    },
+    {
+      "collapsed": false,
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        }
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "hideTimeOverride": false,
+      "id": 28,
+      "links": [],
+      "maxDataPoints": 100,
+      "panels": [],
+      "targets": [],
+      "title": "S3 Operations",
+      "transformations": [],
+      "transparent": false,
+      "type": "row"
+    },
+    {
       "datasource": "${DS_PROMETHEUS}",
       "editable": true,
       "error": false,
@@ -1474,10 +2459,10 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 8
+        "y": 45
       },
       "hideTimeOverride": false,
-      "id": 16,
+      "id": 29,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -1578,10 +2563,10 @@
         "h": 4,
         "w": 8,
         "x": 0,
-        "y": 18
+        "y": 55
       },
       "hideTimeOverride": false,
-      "id": 17,
+      "id": 30,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -1658,10 +2643,10 @@
         "h": 4,
         "w": 8,
         "x": 8,
-        "y": 18
+        "y": 55
       },
       "hideTimeOverride": false,
-      "id": 18,
+      "id": 31,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -1738,10 +2723,10 @@
         "h": 4,
         "w": 8,
         "x": 16,
-        "y": 18
+        "y": 55
       },
       "hideTimeOverride": false,
-      "id": 19,
+      "id": 32,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -1795,10 +2780,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 22
+        "y": 59
       },
       "hideTimeOverride": false,
-      "id": 20,
+      "id": 33,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -1856,10 +2841,10 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 23
+        "y": 60
       },
       "hideTimeOverride": false,
-      "id": 21,
+      "id": 34,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -1955,10 +2940,10 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 23
+        "y": 60
       },
       "hideTimeOverride": false,
-      "id": 22,
+      "id": 35,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2054,10 +3039,10 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 31
+        "y": 68
       },
       "hideTimeOverride": false,
-      "id": 23,
+      "id": 36,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2153,10 +3138,10 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 31
+        "y": 68
       },
       "hideTimeOverride": false,
-      "id": 24,
+      "id": 37,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2252,10 +3237,10 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 39
+        "y": 76
       },
       "hideTimeOverride": false,
-      "id": 25,
+      "id": 38,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2351,10 +3336,10 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 39
+        "y": 76
       },
       "hideTimeOverride": false,
-      "id": 26,
+      "id": 39,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2450,10 +3435,10 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 47
+        "y": 84
       },
       "hideTimeOverride": false,
-      "id": 27,
+      "id": 40,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2549,10 +3534,10 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 47
+        "y": 84
       },
       "hideTimeOverride": false,
-      "id": 28,
+      "id": 41,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2616,10 +3601,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 55
+        "y": 92
       },
       "hideTimeOverride": false,
-      "id": 29,
+      "id": 42,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -2722,10 +3707,10 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 56
+        "y": 93
       },
       "hideTimeOverride": false,
-      "id": 30,
+      "id": 43,
       "links": [],
       "maxDataPoints": 100,
       "targets": [
@@ -2765,10 +3750,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 66
+        "y": 103
       },
       "hideTimeOverride": false,
-      "id": 31,
+      "id": 44,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -2777,6 +3762,93 @@
       "transformations": [],
       "transparent": false,
       "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 104
+      },
+      "hideTimeOverride": false,
+      "id": 45,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "histogram_quantile(0.95, sum(rate(s3_lifecycle_trigger_latency_seconds_bucket{namespace=\"${namespace}\"}[$__rate_interval])) by (le, type))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{type}}",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Trigger Latency",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
     },
     {
       "datasource": "${DS_PROMETHEUS}",
@@ -2826,10 +3898,10 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 67
+        "y": 111
       },
       "hideTimeOverride": false,
-      "id": 32,
+      "id": 46,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2930,10 +4002,10 @@
         "h": 4,
         "w": 8,
         "x": 0,
-        "y": 77
+        "y": 121
       },
       "hideTimeOverride": false,
-      "id": 33,
+      "id": 47,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3010,10 +4082,10 @@
         "h": 4,
         "w": 8,
         "x": 8,
-        "y": 77
+        "y": 121
       },
       "hideTimeOverride": false,
-      "id": 34,
+      "id": 48,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3090,10 +4162,10 @@
         "h": 4,
         "w": 8,
         "x": 16,
-        "y": 77
+        "y": 121
       },
       "hideTimeOverride": false,
-      "id": 35,
+      "id": 49,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3224,10 +4296,10 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 81
+        "y": 125
       },
       "hideTimeOverride": false,
-      "id": 36,
+      "id": 50,
       "links": [],
       "maxDataPoints": 100,
       "targets": [
@@ -3267,10 +4339,10 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 91
+        "y": 135
       },
       "hideTimeOverride": false,
-      "id": 37,
+      "id": 51,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -3328,10 +4400,10 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 92
+        "y": 136
       },
       "hideTimeOverride": false,
-      "id": 38,
+      "id": 52,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3432,10 +4504,10 @@
         "h": 4,
         "w": 8,
         "x": 0,
-        "y": 102
+        "y": 146
       },
       "hideTimeOverride": false,
-      "id": 39,
+      "id": 53,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3512,10 +4584,10 @@
         "h": 4,
         "w": 8,
         "x": 8,
-        "y": 102
+        "y": 146
       },
       "hideTimeOverride": false,
-      "id": 40,
+      "id": 54,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3592,10 +4664,10 @@
         "h": 4,
         "w": 8,
         "x": 16,
-        "y": 102
+        "y": 146
       },
       "hideTimeOverride": false,
-      "id": 41,
+      "id": 55,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3681,10 +4753,10 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 106
+        "y": 150
       },
       "hideTimeOverride": false,
-      "id": 42,
+      "id": 56,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3780,10 +4852,10 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 116
+        "y": 160
       },
       "hideTimeOverride": false,
-      "id": 43,
+      "id": 57,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3924,10 +4996,10 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 126
+        "y": 170
       },
       "hideTimeOverride": false,
-      "id": 44,
+      "id": 58,
       "links": [],
       "maxDataPoints": 100,
       "targets": [

--- a/monitoring/lifecycle/dashboard.json
+++ b/monitoring/lifecycle/dashboard.json
@@ -1655,7 +1655,7 @@
         },
         {
           "datasource": null,
-          "expr": "sum(rate(s3_gc_duration_seconds_count{job=\"${job_lifecycle_gc_processor}\", namespace=\"${namespace}\"}[$__rate_interval]))",
+          "expr": "sum(rate(s3_gc_duration_seconds_count{location=~\"$locations\", job=\"${job_lifecycle_gc_processor}\", namespace=\"${namespace}\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -2062,7 +2062,7 @@
         },
         {
           "datasource": null,
-          "expr": "histogram_quantile(0.95, sum(rate(s3_gc_duration_seconds_bucket{job=\"${job_lifecycle_gc_processor}\", namespace=\"${namespace}\"}[$__rate_interval])) by (le))",
+          "expr": "histogram_quantile(0.95, sum(rate(s3_gc_duration_seconds_bucket{location=~\"$locations\", job=\"${job_lifecycle_gc_processor}\", namespace=\"${namespace}\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -4690,7 +4690,7 @@
   "templating": {
     "list": [
       {
-        "allValue": "${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}|${job_sorbet_forwarder}",
+        "allValue": "${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}|${job_sorbet_forwarder}.*",
         "auto": false,
         "auto_count": 30,
         "auto_min": "10s",
@@ -4734,7 +4734,7 @@
         "multi": true,
         "name": "locations",
         "options": [],
-        "query": "label_values({namespace=\"${namespace}\", job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}|${job_sorbet_forwarder}\", location!=\"\"}, location)",
+        "query": "label_values({namespace=\"${namespace}\", job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}|${job_sorbet_forwarder}.*\", location!=\"\"}, location)",
         "refresh": 2,
         "regex": null,
         "sort": 1,

--- a/monitoring/lifecycle/dashboard.json
+++ b/monitoring/lifecycle/dashboard.json
@@ -35,6 +35,55 @@
       "name": "job_lifecycle_object_processor",
       "type": "constant",
       "value": "artesca-data-backbeat-lifecycle-object-processor-headless"
+    },
+    {
+      "description": "Name of the lifecycle transition processor job, used to filter only lifecycle transition processor instances",
+      "label": "job lifecycle transition processor",
+      "name": "job_lifecycle_transition_processor",
+      "type": "constant",
+      "value": "artesca-data-backbeat-lifecycle-transition-headless"
+    },
+    {
+      "description": "Name of the lifecycle populator job, used to filter only lifecycle populator instances",
+      "label": "job lifecycle populator",
+      "name": "job_lifecycle_populator",
+      "type": "constant",
+      "value": "artesca-data-backbeat-lifecycle-populator-headless"
+    },
+    {
+      "description": "Name of the lifecycle gc processor job, used to filter only lifecycle gc processor instances",
+      "label": "job lifecycle gc processor",
+      "name": "job_lifecycle_gc_processor",
+      "type": "constant",
+      "value": "artesca-data-backbeat-gc-headless"
+    },
+    {
+      "description": "Number of bucket processor replicas",
+      "label": "bucket processor replicas",
+      "name": "bucket_processor_replicas",
+      "type": "constant",
+      "value": "1"
+    },
+    {
+      "description": "Number of object processor replicas",
+      "label": "object processor replicas",
+      "name": "object_processor_replicas",
+      "type": "constant",
+      "value": "1"
+    },
+    {
+      "description": "Number of transition processor replicas",
+      "label": "transition processor replicas",
+      "name": "transition_processor_replicas",
+      "type": "constant",
+      "value": "1"
+    },
+    {
+      "description": "Number of gc processor replicas",
+      "label": "gc processor replicas",
+      "name": "gc_processor_replicas",
+      "type": "constant",
+      "value": "1"
     }
   ],
   "annotations": {
@@ -43,7 +92,6 @@
   "description": "",
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
   "hideControls": false,
   "id": null,
   "links": [],
@@ -57,16 +105,34 @@
           "custom": {},
           "decimals": null,
           "mappings": [],
+          "max": "1",
+          "min": "0",
           "noValue": "0",
           "thresholds": {
-            "mode": "absolute",
+            "mode": "percentage",
             "steps": [
               {
-                "color": "green",
+                "color": "red",
                 "index": 0,
                 "line": true,
                 "op": "gt",
                 "value": "null",
+                "yaxis": "left"
+              },
+              {
+                "color": "yellow",
+                "index": 1,
+                "line": true,
+                "op": "gt",
+                "value": 50.0,
+                "yaxis": "left"
+              },
+              {
+                "color": "green",
+                "index": 2,
+                "line": true,
+                "op": "gt",
+                "value": 100.0,
                 "yaxis": "left"
               }
             ]
@@ -77,7 +143,7 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 24,
+        "w": 4,
         "x": 0,
         "y": 0
       },
@@ -102,51 +168,470 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "sum(up{namespace=\"${namespace}\",job=\"${job_lifecycle_producer}\"})",
+          "expr": "sum(up{namespace=\"${namespace}\",job=\"${job_lifecycle_producer}})",
           "format": "time_series",
           "hide": false,
           "instant": false,
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Conductor",
+          "legendFormat": "",
           "metric": "",
-          "query": "sum(up{namespace=\"${namespace}\",job=\"${job_lifecycle_producer}\"})",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(up{namespace=\"${namespace}\",job=\"${job_lifecycle_bucket_processor}\"})",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Bucket Processor",
-          "metric": "",
-          "query": "sum(up{namespace=\"${namespace}\",job=\"${job_lifecycle_bucket_processor}\"})",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(up{namespace=\"${namespace}\",job=\"${job_lifecycle_object_processor}\"})",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Expiration Processor",
-          "metric": "",
-          "query": "sum(up{namespace=\"${namespace}\",job=\"${job_lifecycle_object_processor}\"})",
           "refId": "",
           "step": 10,
           "target": ""
         }
       ],
-      "title": "Up",
+      "title": "Conductor",
+      "transformations": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": null,
+          "mappings": [],
+          "max": "${bucket_processor_replicas}",
+          "min": "0",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "red",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              },
+              {
+                "color": "yellow",
+                "index": 1,
+                "line": true,
+                "op": "gt",
+                "value": 50.0,
+                "yaxis": "left"
+              },
+              {
+                "color": "green",
+                "index": 2,
+                "line": true,
+                "op": "gt",
+                "value": 100.0,
+                "yaxis": "left"
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "hideTimeOverride": false,
+      "id": 2,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(up{namespace=\"${namespace}\",job=\"${job_lifecycle_bucket_processor}})",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Bucket Processor",
+      "transformations": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": null,
+          "mappings": [],
+          "max": "${object_processor_replicas}",
+          "min": "0",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "red",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              },
+              {
+                "color": "yellow",
+                "index": 1,
+                "line": true,
+                "op": "gt",
+                "value": 50.0,
+                "yaxis": "left"
+              },
+              {
+                "color": "green",
+                "index": 2,
+                "line": true,
+                "op": "gt",
+                "value": 100.0,
+                "yaxis": "left"
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "hideTimeOverride": false,
+      "id": 3,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(up{namespace=\"${namespace}\",job=\"${job_lifecycle_object_processor}})",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Expiration Processor",
+      "transformations": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": null,
+          "mappings": [],
+          "max": "${transition_processor_replicas}",
+          "min": "0",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "red",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              },
+              {
+                "color": "yellow",
+                "index": 1,
+                "line": true,
+                "op": "gt",
+                "value": 50.0,
+                "yaxis": "left"
+              },
+              {
+                "color": "green",
+                "index": 2,
+                "line": true,
+                "op": "gt",
+                "value": 100.0,
+                "yaxis": "left"
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "hideTimeOverride": false,
+      "id": 4,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(up{namespace=\"${namespace}\",job=\"${job_lifecycle_transition_processor}})",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Transition Processor",
+      "transformations": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": null,
+          "mappings": [],
+          "max": "${gc_processor_replicas}",
+          "min": "0",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "red",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              },
+              {
+                "color": "yellow",
+                "index": 1,
+                "line": true,
+                "op": "gt",
+                "value": 50.0,
+                "yaxis": "left"
+              },
+              {
+                "color": "green",
+                "index": 2,
+                "line": true,
+                "op": "gt",
+                "value": 100.0,
+                "yaxis": "left"
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "hideTimeOverride": false,
+      "id": 5,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(up{namespace=\"${namespace}\",job=\"${job_lifecycle_gc_processor}})",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "GC Processor",
+      "transformations": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": null,
+          "mappings": [],
+          "max": "1",
+          "min": "0",
+          "noValue": "0",
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "red",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              },
+              {
+                "color": "yellow",
+                "index": 1,
+                "line": true,
+                "op": "gt",
+                "value": 50.0,
+                "yaxis": "left"
+              },
+              {
+                "color": "green",
+                "index": 2,
+                "line": true,
+                "op": "gt",
+                "value": 100.0,
+                "yaxis": "left"
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "hideTimeOverride": false,
+      "id": 6,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(up{namespace=\"${namespace}\",job=\"${job_lifecycle_populator}})",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Populator",
       "transformations": [],
       "transparent": false,
       "type": "stat"
@@ -202,7 +687,7 @@
         "y": 4
       },
       "hideTimeOverride": false,
-      "id": 2,
+      "id": 7,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -226,7 +711,6 @@
           "intervalFactor": 1,
           "legendFormat": "HTTP 2xx",
           "metric": "",
-          "query": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"2..\"}[$__rate_interval]))",
           "refId": "",
           "step": 10,
           "target": ""
@@ -241,7 +725,6 @@
           "intervalFactor": 1,
           "legendFormat": "HTTP 3xx",
           "metric": "",
-          "query": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"3..\"}[$__rate_interval]))",
           "refId": "",
           "step": 10,
           "target": ""
@@ -256,7 +739,6 @@
           "intervalFactor": 1,
           "legendFormat": "HTTP 4xx",
           "metric": "",
-          "query": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"4..\"}[$__rate_interval]))",
           "refId": "",
           "step": 10,
           "target": ""
@@ -271,7 +753,6 @@
           "intervalFactor": 1,
           "legendFormat": "HTTP 5xx",
           "metric": "",
-          "query": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"5..\"}[$__rate_interval]))",
           "refId": "",
           "step": 10,
           "target": ""
@@ -324,7 +805,7 @@
         "y": 14
       },
       "hideTimeOverride": false,
-      "id": 3,
+      "id": 8,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -352,7 +833,6 @@
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "",
-          "query": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status!=\"200\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval]) > 0)",
           "refId": "",
           "step": 10,
           "target": ""
@@ -405,7 +885,7 @@
         "y": 14
       },
       "hideTimeOverride": false,
-      "id": 4,
+      "id": 9,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -433,7 +913,6 @@
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "",
-          "query": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"3..\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval]) > 0)",
           "refId": "",
           "step": 10,
           "target": ""
@@ -486,7 +965,7 @@
         "y": 14
       },
       "hideTimeOverride": false,
-      "id": 5,
+      "id": 10,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -514,7 +993,6 @@
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "",
-          "query": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"4..\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval]) > 0)",
           "refId": "",
           "step": 10,
           "target": ""
@@ -567,7 +1045,7 @@
         "y": 14
       },
       "hideTimeOverride": false,
-      "id": 6,
+      "id": 11,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -595,7 +1073,6 @@
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "",
-          "query": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"5..\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval]) > 0)",
           "refId": "",
           "step": 10,
           "target": ""
@@ -625,7 +1102,7 @@
         "y": 18
       },
       "hideTimeOverride": false,
-      "id": 7,
+      "id": 12,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -686,7 +1163,7 @@
         "y": 19
       },
       "hideTimeOverride": false,
-      "id": 8,
+      "id": 13,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -710,7 +1187,6 @@
           "intervalFactor": 1,
           "legendFormat": "messages",
           "metric": "",
-          "query": "sum(increase(s3_lifecycle_kafka_publish_success_total{op=\"BucketTopic\",namespace=\"${namespace}\"}[$__rate_interval]))",
           "refId": "",
           "step": 10,
           "target": ""
@@ -772,7 +1248,7 @@
         "y": 19
       },
       "hideTimeOverride": false,
-      "id": 9,
+      "id": 14,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -796,7 +1272,6 @@
           "intervalFactor": 1,
           "legendFormat": "messages",
           "metric": "",
-          "query": "sum(increase(s3_lifecycle_kafka_publish_error_total{op=\"BucketTopic\",namespace=\"${namespace}\"}[$__rate_interval]))",
           "refId": "",
           "step": 10,
           "target": ""
@@ -858,7 +1333,7 @@
         "y": 29
       },
       "hideTimeOverride": false,
-      "id": 10,
+      "id": 15,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -882,7 +1357,6 @@
           "intervalFactor": 1,
           "legendFormat": "messages",
           "metric": "",
-          "query": "sum(increase(s3_lifecycle_kafka_publish_success_total{op=\"ObjectTopic\",namespace=\"${namespace}\"}[$__rate_interval]))",
           "refId": "",
           "step": 10,
           "target": ""
@@ -944,7 +1418,7 @@
         "y": 29
       },
       "hideTimeOverride": false,
-      "id": 11,
+      "id": 16,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -968,7 +1442,6 @@
           "intervalFactor": 1,
           "legendFormat": "messages",
           "metric": "",
-          "query": "sum(increase(s3_lifecycle_kafka_publish_error_total{op=\"ObjectTopic\",namespace=\"${namespace}\"}[$__rate_interval]))",
           "refId": "",
           "step": 10,
           "target": ""
@@ -998,7 +1471,7 @@
         "y": 39
       },
       "hideTimeOverride": false,
-      "id": 12,
+      "id": 17,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -1033,7 +1506,7 @@
         "y": 40
       },
       "hideTimeOverride": false,
-      "id": 13,
+      "id": 18,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -1061,7 +1534,6 @@
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "",
-          "query": "s3_lifecycle_latest_batch_start_time{job=\"${job_lifecycle_producer}\",namespace=\"${namespace}\"}",
           "refId": "",
           "step": 10,
           "target": ""
@@ -1168,7 +1640,7 @@
         "y": 44
       },
       "hideTimeOverride": false,
-      "id": 14,
+      "id": 19,
       "links": [],
       "maxDataPoints": 100,
       "targets": [
@@ -1182,7 +1654,6 @@
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "",
-          "query": "avg(s3_circuit_breaker{namespace=\"${namespace}\",job=\"${job_lifecycle_producer}\"})*10",
           "refId": "",
           "step": 10,
           "target": ""
@@ -1212,7 +1683,7 @@
         "y": 54
       },
       "hideTimeOverride": false,
-      "id": 15,
+      "id": 20,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -1273,7 +1744,7 @@
         "y": 55
       },
       "hideTimeOverride": false,
-      "id": 16,
+      "id": 21,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -1297,7 +1768,6 @@
           "intervalFactor": 1,
           "legendFormat": "HTTP 2xx",
           "metric": "",
-          "query": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"2..\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]))",
           "refId": "",
           "step": 10,
           "target": ""
@@ -1312,7 +1782,6 @@
           "intervalFactor": 1,
           "legendFormat": "HTTP 3xx",
           "metric": "",
-          "query": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"3..\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]))",
           "refId": "",
           "step": 10,
           "target": ""
@@ -1327,7 +1796,6 @@
           "intervalFactor": 1,
           "legendFormat": "HTTP 4xx",
           "metric": "",
-          "query": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"4..\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]))",
           "refId": "",
           "step": 10,
           "target": ""
@@ -1342,7 +1810,6 @@
           "intervalFactor": 1,
           "legendFormat": "HTTP 5xx",
           "metric": "",
-          "query": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"5..\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]))",
           "refId": "",
           "step": 10,
           "target": ""
@@ -1395,7 +1862,7 @@
         "y": 65
       },
       "hideTimeOverride": false,
-      "id": 17,
+      "id": 22,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -1423,7 +1890,6 @@
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "",
-          "query": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status!=\"200\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]) > 0)",
           "refId": "",
           "step": 10,
           "target": ""
@@ -1476,7 +1942,7 @@
         "y": 65
       },
       "hideTimeOverride": false,
-      "id": 18,
+      "id": 23,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -1504,7 +1970,6 @@
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "",
-          "query": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"3..\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]) > 0)",
           "refId": "",
           "step": 10,
           "target": ""
@@ -1557,7 +2022,7 @@
         "y": 65
       },
       "hideTimeOverride": false,
-      "id": 19,
+      "id": 24,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -1585,7 +2050,6 @@
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "",
-          "query": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"4..\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]) > 0)",
           "refId": "",
           "step": 10,
           "target": ""
@@ -1638,7 +2102,7 @@
         "y": 65
       },
       "hideTimeOverride": false,
-      "id": 20,
+      "id": 25,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -1666,7 +2130,6 @@
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "",
-          "query": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"5..\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",job=\"${job_lifecycle_bucket_processor}\",origin=\"bucket\"}[$__rate_interval]) > 0)",
           "refId": "",
           "step": 10,
           "target": ""
@@ -1773,7 +2236,7 @@
         "y": 69
       },
       "hideTimeOverride": false,
-      "id": 21,
+      "id": 26,
       "links": [],
       "maxDataPoints": 100,
       "targets": [
@@ -1787,7 +2250,6 @@
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "",
-          "query": "avg(s3_circuit_breaker{namespace=\"${namespace}\",job=\"${job_lifecycle_bucket_processor}\"})*10",
           "refId": "",
           "step": 10,
           "target": ""
@@ -1817,7 +2279,7 @@
         "y": 79
       },
       "hideTimeOverride": false,
-      "id": 22,
+      "id": 27,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -1878,7 +2340,7 @@
         "y": 80
       },
       "hideTimeOverride": false,
-      "id": 23,
+      "id": 28,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -1902,7 +2364,6 @@
           "intervalFactor": 1,
           "legendFormat": "HTTP 2xx",
           "metric": "",
-          "query": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"2..\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]))",
           "refId": "",
           "step": 10,
           "target": ""
@@ -1917,7 +2378,6 @@
           "intervalFactor": 1,
           "legendFormat": "HTTP 3xx",
           "metric": "",
-          "query": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"3..\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]))",
           "refId": "",
           "step": 10,
           "target": ""
@@ -1932,7 +2392,6 @@
           "intervalFactor": 1,
           "legendFormat": "HTTP 4xx",
           "metric": "",
-          "query": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"4..\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]))",
           "refId": "",
           "step": 10,
           "target": ""
@@ -1947,7 +2406,6 @@
           "intervalFactor": 1,
           "legendFormat": "HTTP 5xx",
           "metric": "",
-          "query": "sum(increase(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"5..\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]))",
           "refId": "",
           "step": 10,
           "target": ""
@@ -2000,7 +2458,7 @@
         "y": 90
       },
       "hideTimeOverride": false,
-      "id": 24,
+      "id": 29,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2028,7 +2486,6 @@
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "",
-          "query": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status!=\"200\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]) > 0)",
           "refId": "",
           "step": 10,
           "target": ""
@@ -2081,7 +2538,7 @@
         "y": 90
       },
       "hideTimeOverride": false,
-      "id": 25,
+      "id": 30,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2109,7 +2566,6 @@
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "",
-          "query": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"3..\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]) > 0)",
           "refId": "",
           "step": 10,
           "target": ""
@@ -2162,7 +2618,7 @@
         "y": 90
       },
       "hideTimeOverride": false,
-      "id": 26,
+      "id": 31,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2190,7 +2646,6 @@
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "",
-          "query": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"4..\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]) > 0)",
           "refId": "",
           "step": 10,
           "target": ""
@@ -2243,7 +2698,7 @@
         "y": 90
       },
       "hideTimeOverride": false,
-      "id": 27,
+      "id": 32,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2271,7 +2726,6 @@
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "",
-          "query": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",status=~\"5..\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]))/sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\",job=\"${job_lifecycle_object_processor}\",origin=\"expiration\"}[$__rate_interval]) > 0)",
           "refId": "",
           "step": 10,
           "target": ""
@@ -2333,7 +2787,7 @@
         "y": 94
       },
       "hideTimeOverride": false,
-      "id": 28,
+      "id": 33,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2357,7 +2811,6 @@
           "intervalFactor": 1,
           "legendFormat": "success",
           "metric": "",
-          "query": "sum(rate(s3_lifecycle_s3_operations_total{status=\"200\",op=\"deleteObject\",namespace=\"${namespace}\",job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
           "refId": "",
           "step": 10,
           "target": ""
@@ -2372,7 +2825,6 @@
           "intervalFactor": 1,
           "legendFormat": "error",
           "metric": "",
-          "query": "sum(rate(s3_lifecycle_s3_operations_total{status!=\"200\",op=\"deleteObject\",namespace=\"${namespace}\",job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
           "refId": "",
           "step": 10,
           "target": ""
@@ -2434,7 +2886,7 @@
         "y": 104
       },
       "hideTimeOverride": false,
-      "id": 29,
+      "id": 34,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2458,7 +2910,6 @@
           "intervalFactor": 1,
           "legendFormat": "success",
           "metric": "",
-          "query": "sum(rate(s3_lifecycle_s3_operations_total{status=\"200\",op=\"abortMultipartUpload\",namespace=\"${namespace}\",job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
           "refId": "",
           "step": 10,
           "target": ""
@@ -2473,7 +2924,6 @@
           "intervalFactor": 1,
           "legendFormat": "error",
           "metric": "",
-          "query": "sum(rate(s3_lifecycle_s3_operations_total{status!=\"200\",op=\"abortMultipartUpload\",namespace=\"${namespace}\",job=\"${job_lifecycle_object_processor}\"}[$__rate_interval]))",
           "refId": "",
           "step": 10,
           "target": ""
@@ -2580,7 +3030,7 @@
         "y": 114
       },
       "hideTimeOverride": false,
-      "id": 30,
+      "id": 35,
       "links": [],
       "maxDataPoints": 100,
       "targets": [
@@ -2594,7 +3044,6 @@
           "intervalFactor": 1,
           "legendFormat": "",
           "metric": "",
-          "query": "avg(s3_circuit_breaker{namespace=\"${namespace}\",job=\"${job_lifecycle_object_processor}\"})*10",
           "refId": "",
           "step": 10,
           "target": ""

--- a/monitoring/lifecycle/dashboard.json
+++ b/monitoring/lifecycle/dashboard.json
@@ -143,7 +143,7 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
+        "w": 3,
         "x": 0,
         "y": 0
       },
@@ -233,8 +233,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 4,
+        "w": 3,
+        "x": 3,
         "y": 0
       },
       "hideTimeOverride": false,
@@ -323,8 +323,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 8,
+        "w": 3,
+        "x": 6,
         "y": 0
       },
       "hideTimeOverride": false,
@@ -413,8 +413,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 12,
+        "w": 3,
+        "x": 9,
         "y": 0
       },
       "hideTimeOverride": false,
@@ -503,8 +503,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 16,
+        "w": 3,
+        "x": 12,
         "y": 0
       },
       "hideTimeOverride": false,
@@ -593,8 +593,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 20,
+        "w": 3,
+        "x": 15,
         "y": 0
       },
       "hideTimeOverride": false,
@@ -642,1209 +642,6 @@
       "error": false,
       "fieldConfig": {
         "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {},
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 4
-      },
-      "hideTimeOverride": false,
-      "id": 7,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "table",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"2..\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Success",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"4..\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "User errors",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"5..\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "System errors",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "S3 Requests",
-      "transformations": [],
-      "transparent": false,
-      "type": "timeseries"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": null,
-          "mappings": [],
-          "noValue": "none",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "index": 0,
-                "line": true,
-                "op": "gt",
-                "value": "null",
-                "yaxis": "left"
-              },
-              {
-                "color": "red",
-                "index": 1,
-                "line": true,
-                "op": "gt",
-                "value": 0.05,
-                "yaxis": "left"
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 0,
-        "y": 14
-      },
-      "hideTimeOverride": false,
-      "id": 8,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status!=\"200\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval]) > 0)",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "Error rate",
-      "transformations": [],
-      "transparent": false,
-      "type": "stat"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": null,
-          "mappings": [],
-          "noValue": "none",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "index": 0,
-                "line": true,
-                "op": "gt",
-                "value": "null",
-                "yaxis": "left"
-              },
-              {
-                "color": "red",
-                "index": 1,
-                "line": true,
-                "op": "gt",
-                "value": 0.05,
-                "yaxis": "left"
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 8,
-        "y": 14
-      },
-      "hideTimeOverride": false,
-      "id": 9,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"4..\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval]) > 0)",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "User Error rate",
-      "transformations": [],
-      "transparent": false,
-      "type": "stat"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "custom": {},
-          "decimals": null,
-          "mappings": [],
-          "noValue": "none",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "index": 0,
-                "line": true,
-                "op": "gt",
-                "value": "null",
-                "yaxis": "left"
-              },
-              {
-                "color": "red",
-                "index": 1,
-                "line": true,
-                "op": "gt",
-                "value": 0.05,
-                "yaxis": "left"
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 4,
-        "w": 8,
-        "x": 16,
-        "y": 14
-      },
-      "hideTimeOverride": false,
-      "id": 10,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "colorMode": "value",
-        "graphMode": "area",
-        "justifyMode": "auto",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "textMode": "auto"
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"5..\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval]) > 0)",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "System Error rate",
-      "transformations": [],
-      "transparent": false,
-      "type": "stat"
-    },
-    {
-      "collapsed": false,
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          }
-        }
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 18
-      },
-      "hideTimeOverride": false,
-      "id": 11,
-      "links": [],
-      "maxDataPoints": 100,
-      "panels": [],
-      "targets": [],
-      "title": "Kafka Message Produced",
-      "transformations": [],
-      "transparent": false,
-      "type": "row"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {},
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 19
-      },
-      "hideTimeOverride": false,
-      "id": 12,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"BucketTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Successful",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"BucketTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Failed",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "Bucket Task",
-      "transformations": [],
-      "transparent": false,
-      "type": "timeseries"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {},
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 19
-      },
-      "hideTimeOverride": false,
-      "id": 13,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"ObjectTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Successful",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"ObjectTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Failed",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "Expiration Task",
-      "transformations": [],
-      "transparent": false,
-      "type": "timeseries"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {},
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 27
-      },
-      "hideTimeOverride": false,
-      "id": 14,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"DataMoverTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Successful",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"DataMoverTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Failed",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "Data Mover Task",
-      "transformations": [],
-      "transparent": false,
-      "type": "timeseries"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {},
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 27
-      },
-      "hideTimeOverride": false,
-      "id": 15,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"GcTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Successful",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"GcTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Failed",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "Gc Task",
-      "transformations": [],
-      "transparent": false,
-      "type": "timeseries"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {},
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 35
-      },
-      "hideTimeOverride": false,
-      "id": 16,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"ColdStorageArchiveTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Successful",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"ColdStorageArchiveTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Failed",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "Cold Storage Archive",
-      "transformations": [],
-      "transparent": false,
-      "type": "timeseries"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {},
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 35
-      },
-      "hideTimeOverride": false,
-      "id": 17,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"ColdStorageGcTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Successful",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"ColdStorageGcTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Failed",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "Cold Storage Gc",
-      "transformations": [],
-      "transparent": false,
-      "type": "timeseries"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {},
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 0,
-        "y": 43
-      },
-      "hideTimeOverride": false,
-      "id": 18,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"ColdStorageRestoreTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Successful",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"ColdStorageRestoreTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Failed",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "Cold Storage Restore",
-      "transformations": [],
-      "transparent": false,
-      "type": "timeseries"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 5,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "log": 2,
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {},
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          },
-          "unit": "reqps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 43
-      },
-      "hideTimeOverride": false,
-      "id": 19,
-      "links": [],
-      "maxDataPoints": 100,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "bottom"
-        },
-        "tooltip": {
-          "mode": "single"
-        }
-      },
-      "targets": [
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"ColdStorageRestoreAdjustTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Successful",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        },
-        {
-          "datasource": null,
-          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"ColdStorageRestoreAdjustTopic\"}[$__rate_interval]))",
-          "format": "time_series",
-          "hide": false,
-          "instant": false,
-          "interval": "",
-          "intervalFactor": 1,
-          "legendFormat": "Failed",
-          "metric": "",
-          "refId": "",
-          "step": 10,
-          "target": ""
-        }
-      ],
-      "title": "Cold Storage Restore Adjust",
-      "transformations": [],
-      "transparent": false,
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
-          "thresholds": {
-            "mode": "absolute",
-            "steps": []
-          }
-        }
-      },
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 51
-      },
-      "hideTimeOverride": false,
-      "id": 20,
-      "links": [],
-      "maxDataPoints": 100,
-      "panels": [],
-      "targets": [],
-      "title": "Lifecycle Conductor",
-      "transformations": [],
-      "transparent": false,
-      "type": "row"
-    },
-    {
-      "datasource": "${DS_PROMETHEUS}",
-      "editable": true,
-      "error": false,
-      "fieldConfig": {
-        "defaults": {
           "custom": {},
           "decimals": null,
           "mappings": [],
@@ -1876,12 +673,12 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 24,
-        "x": 0,
-        "y": 52
+        "w": 6,
+        "x": 18,
+        "y": 0
       },
       "hideTimeOverride": false,
-      "id": 21,
+      "id": 7,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2009,13 +806,1926 @@
         "showThresholdMarkers": true
       },
       "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 0,
+        "y": 4
+      },
+      "hideTimeOverride": false,
+      "id": 8,
+      "links": [],
+      "maxDataPoints": 100,
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "avg(s3_circuit_breaker{namespace=\"${namespace}\",job=~\"${job_lifecycle_producer}|${job_lifecycle_bucket_processor}|${job_lifecycle_object_processor}|${job_lifecycle_transition_processor}|${job_lifecycle_gc_processor}|${job_lifecycle_populator}\"})*10",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Flow Control",
+      "transformations": [],
+      "transparent": false,
+      "type": "gauge"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "calcs": [
+            "mean"
+          ],
+          "decimals": 2,
+          "limit": null,
+          "links": [],
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "-",
+          "override": {},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#808080",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              },
+              {
+                "color": "red",
+                "index": 1,
+                "line": true,
+                "op": "gt",
+                "value": 0.0,
+                "yaxis": "left"
+              },
+              {
+                "color": "orange",
+                "index": 2,
+                "line": true,
+                "op": "gt",
+                "value": 95.0,
+                "yaxis": "left"
+              },
+              {
+                "color": "super-light-yellow",
+                "index": 3,
+                "line": true,
+                "op": "gt",
+                "value": 99.0,
+                "yaxis": "left"
+              },
+              {
+                "color": "light-green",
+                "index": 4,
+                "line": true,
+                "op": "gt",
+                "value": 99.5,
+                "yaxis": "left"
+              },
+              {
+                "color": "green",
+                "index": 5,
+                "line": true,
+                "op": "gt",
+                "value": 99.995,
+                "yaxis": "left"
+              }
+            ]
+          },
+          "title": null,
+          "unit": "percent",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 3,
+        "y": 4
+      },
+      "hideTimeOverride": false,
+      "id": 9,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "100 / (1 + (sum(rate(s3_lifecycle_conductor_bucket_list_error_total{job=\"${job_lifecycle_producer}\", namespace=\"${namespace}\"}[$__rate_interval])) or vector(0))\n           /\n           (sum(rate(s3_lifecycle_conductor_bucket_list_success_total{job=\"${job_lifecycle_producer}\", namespace=\"${namespace}\"}[$__rate_interval])) > 0)\n      )",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Listings success rate",
+      "transformations": [],
+      "transparent": false,
+      "type": "gauge"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": null,
+          "mappings": [],
+          "noValue": "-",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-blue",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 6,
+        "y": 4
+      },
+      "hideTimeOverride": false,
+      "id": 10,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{namespace=\"${namespace}\", type=~\"expiration|expiration:mpu\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Expiration",
+      "transformations": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": null,
+          "mappings": [],
+          "noValue": "-",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-blue",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 9,
+        "y": 4
+      },
+      "hideTimeOverride": false,
+      "id": 11,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{namespace=\"${namespace}\", type=~\"transition\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Transition",
+      "transformations": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": null,
+          "mappings": [],
+          "noValue": "-",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-blue",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 12,
+        "y": 4
+      },
+      "hideTimeOverride": false,
+      "id": 12,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{namespace=\"${namespace}\", type=~\"archive|archive:gc\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Archive",
+      "transformations": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": null,
+          "mappings": [],
+          "noValue": "-",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-blue",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 15,
+        "y": 4
+      },
+      "hideTimeOverride": false,
+      "id": 13,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_duration_seconds_count{namespace=\"${namespace}\", type=~\"restore\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Restore",
+      "transformations": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": null,
+          "mappings": [],
+          "noValue": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-purple",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 18,
+        "y": 4
+      },
+      "hideTimeOverride": false,
+      "id": 14,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "S3 Requests",
+      "transformations": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "calcs": [
+            "mean"
+          ],
+          "decimals": 2,
+          "limit": null,
+          "links": [],
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "noValue": "-",
+          "override": {},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#808080",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              },
+              {
+                "color": "red",
+                "index": 1,
+                "line": true,
+                "op": "gt",
+                "value": 0.0,
+                "yaxis": "left"
+              },
+              {
+                "color": "orange",
+                "index": 2,
+                "line": true,
+                "op": "gt",
+                "value": 95.0,
+                "yaxis": "left"
+              },
+              {
+                "color": "super-light-yellow",
+                "index": 3,
+                "line": true,
+                "op": "gt",
+                "value": 99.0,
+                "yaxis": "left"
+              },
+              {
+                "color": "light-green",
+                "index": 4,
+                "line": true,
+                "op": "gt",
+                "value": 99.5,
+                "yaxis": "left"
+              },
+              {
+                "color": "green",
+                "index": 5,
+                "line": true,
+                "op": "gt",
+                "value": 99.995,
+                "yaxis": "left"
+              }
+            ]
+          },
+          "title": null,
+          "unit": "percent",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 21,
+        "y": 4
+      },
+      "hideTimeOverride": false,
+      "id": 15,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "100 / (1 + (sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status!=\"200\"}[$__rate_interval])) or vector(0))\n           /\n           (sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=\"200\"}[$__rate_interval])) > 0)\n      )",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "S3 success rate",
+      "transformations": [],
+      "transparent": false,
+      "type": "gauge"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "hideTimeOverride": false,
+      "id": 16,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"2..\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Success",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"4..\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "User errors",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"5..\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "System errors",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "S3 Requests",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": null,
+          "mappings": [],
+          "noValue": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              },
+              {
+                "color": "red",
+                "index": 1,
+                "line": true,
+                "op": "gt",
+                "value": 0.05,
+                "yaxis": "left"
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 0,
+        "y": 18
+      },
+      "hideTimeOverride": false,
+      "id": 17,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status!=\"200\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval]) > 0)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Error rate",
+      "transformations": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": null,
+          "mappings": [],
+          "noValue": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              },
+              {
+                "color": "red",
+                "index": 1,
+                "line": true,
+                "op": "gt",
+                "value": 0.05,
+                "yaxis": "left"
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 8,
+        "y": 18
+      },
+      "hideTimeOverride": false,
+      "id": 18,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"4..\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval]) > 0)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "User Error rate",
+      "transformations": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": null,
+          "mappings": [],
+          "noValue": "none",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              },
+              {
+                "color": "red",
+                "index": 1,
+                "line": true,
+                "op": "gt",
+                "value": 0.05,
+                "yaxis": "left"
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "hideTimeOverride": false,
+      "id": 19,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\", status=~\"5..\"}[$__rate_interval]))\n/\nsum(rate(s3_lifecycle_s3_operations_total{namespace=\"${namespace}\"}[$__rate_interval]) > 0)",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "System Error rate",
+      "transformations": [],
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        }
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "hideTimeOverride": false,
+      "id": 20,
+      "links": [],
+      "maxDataPoints": 100,
+      "panels": [],
+      "targets": [],
+      "title": "Kafka Message Produced",
+      "transformations": [],
+      "transparent": false,
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "hideTimeOverride": false,
+      "id": 21,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"BucketTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Successful",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"BucketTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Failed",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Bucket Task",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "hideTimeOverride": false,
+      "id": 22,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"ObjectTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Successful",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"ObjectTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Failed",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Expiration Task",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 31
+      },
+      "hideTimeOverride": false,
+      "id": 23,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"DataMoverTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Successful",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"DataMoverTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Failed",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Data Mover Task",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 31
+      },
+      "hideTimeOverride": false,
+      "id": 24,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"GcTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Successful",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"GcTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Failed",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Gc Task",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 39
+      },
+      "hideTimeOverride": false,
+      "id": 25,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"ColdStorageArchiveTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Successful",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"ColdStorageArchiveTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Failed",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Cold Storage Archive",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 39
+      },
+      "hideTimeOverride": false,
+      "id": 26,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"ColdStorageGcTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Successful",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"ColdStorageGcTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Failed",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Cold Storage Gc",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 47
+      },
+      "hideTimeOverride": false,
+      "id": 27,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"ColdStorageRestoreTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Successful",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"ColdStorageRestoreTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Failed",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Cold Storage Restore",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "log": 2,
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {},
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 47
+      },
+      "hideTimeOverride": false,
+      "id": 28,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single"
+        }
+      },
+      "targets": [
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_success_total{namespace=\"${namespace}\", op=\"ColdStorageRestoreAdjustTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Successful",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        },
+        {
+          "datasource": null,
+          "expr": "sum(rate(s3_lifecycle_kafka_publish_error_total{namespace=\"${namespace}\", op=\"ColdStorageRestoreAdjustTopic\"}[$__rate_interval]))",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Failed",
+          "metric": "",
+          "refId": "",
+          "step": 10,
+          "target": ""
+        }
+      ],
+      "title": "Cold Storage Restore Adjust",
+      "transformations": [],
+      "transparent": false,
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          }
+        }
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 55
+      },
+      "hideTimeOverride": false,
+      "id": 29,
+      "links": [],
+      "maxDataPoints": 100,
+      "panels": [],
+      "targets": [],
+      "title": "Lifecycle Conductor",
+      "transformations": [],
+      "transparent": false,
+      "type": "row"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "calcs": [
+            "mean"
+          ],
+          "decimals": null,
+          "limit": null,
+          "links": [],
+          "mappings": [
+            {
+              "options": {
+                "from": 0,
+                "result": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "OK"
+                },
+                "to": 2
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 2,
+                "result": {
+                  "color": "orange",
+                  "index": 1,
+                  "text": "Throttled"
+                },
+                "to": 10
+              },
+              "type": "range"
+            },
+            {
+              "options": {
+                "from": 10,
+                "result": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "Stalled"
+                },
+                "to": 20
+              },
+              "type": "range"
+            }
+          ],
+          "max": 20,
+          "min": 0,
+          "override": {},
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "index": 0,
+                "line": true,
+                "op": "gt",
+                "value": "null",
+                "yaxis": "left"
+              },
+              {
+                "color": "orange",
+                "index": 1,
+                "line": true,
+                "op": "gt",
+                "value": 2.0,
+                "yaxis": "left"
+              },
+              {
+                "color": "red",
+                "index": 2,
+                "line": true,
+                "op": "gt",
+                "value": 10.0,
+                "yaxis": "left"
+              }
+            ]
+          },
+          "title": null,
+          "unit": "none",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "gridPos": {
         "h": 10,
         "w": 24,
         "x": 0,
         "y": 56
       },
       "hideTimeOverride": false,
-      "id": 22,
+      "id": 30,
       "links": [],
       "maxDataPoints": 100,
       "targets": [
@@ -2058,7 +2768,7 @@
         "y": 66
       },
       "hideTimeOverride": false,
-      "id": 23,
+      "id": 31,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -2119,7 +2829,7 @@
         "y": 67
       },
       "hideTimeOverride": false,
-      "id": 24,
+      "id": 32,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2223,7 +2933,7 @@
         "y": 77
       },
       "hideTimeOverride": false,
-      "id": 25,
+      "id": 33,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2303,7 +3013,7 @@
         "y": 77
       },
       "hideTimeOverride": false,
-      "id": 26,
+      "id": 34,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2383,7 +3093,7 @@
         "y": 77
       },
       "hideTimeOverride": false,
-      "id": 27,
+      "id": 35,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2517,7 +3227,7 @@
         "y": 81
       },
       "hideTimeOverride": false,
-      "id": 28,
+      "id": 36,
       "links": [],
       "maxDataPoints": 100,
       "targets": [
@@ -2560,7 +3270,7 @@
         "y": 91
       },
       "hideTimeOverride": false,
-      "id": 29,
+      "id": 37,
       "links": [],
       "maxDataPoints": 100,
       "panels": [],
@@ -2621,7 +3331,7 @@
         "y": 92
       },
       "hideTimeOverride": false,
-      "id": 30,
+      "id": 38,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2725,7 +3435,7 @@
         "y": 102
       },
       "hideTimeOverride": false,
-      "id": 31,
+      "id": 39,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2805,7 +3515,7 @@
         "y": 102
       },
       "hideTimeOverride": false,
-      "id": 32,
+      "id": 40,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2885,7 +3595,7 @@
         "y": 102
       },
       "hideTimeOverride": false,
-      "id": 33,
+      "id": 41,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2974,7 +3684,7 @@
         "y": 106
       },
       "hideTimeOverride": false,
-      "id": 34,
+      "id": 42,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3073,7 +3783,7 @@
         "y": 116
       },
       "hideTimeOverride": false,
-      "id": 35,
+      "id": 43,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -3217,7 +3927,7 @@
         "y": 126
       },
       "hideTimeOverride": false,
-      "id": 36,
+      "id": 44,
       "links": [],
       "maxDataPoints": 100,
       "targets": [

--- a/monitoring/lifecycle/dashboard.py
+++ b/monitoring/lifecycle/dashboard.py
@@ -108,7 +108,7 @@ class GcMetrics:
 
     DURATION = metrics.BucketMetric(
        's3_gc_duration_seconds',
-       'origin', job='${job_lifecycle_gc_processor}', namespace='${namespace}'
+       'origin', 'op', location=['$locations'], job='${job_lifecycle_gc_processor}', namespace='${namespace}'
     )
 
 

--- a/monitoring/lifecycle/dashboard.py
+++ b/monitoring/lifecycle/dashboard.py
@@ -7,6 +7,7 @@ from grafanalib.core import (
     Heatmap,
     HeatmapColor,
     RowPanel,
+    REFRESH_ON_TIME_RANGE_CHANGE,
     Template,
     Templating,
     Threshold,
@@ -79,7 +80,7 @@ class Metrics:
 
     TRIGGER_LATENCY, LATENCY, DURATION = [
         metrics.BucketMetric(
-            name, 'location', 'type', job=['$jobs'], namespace='${namespace}',
+            name, 'type', location=['$locations'], job=['$jobs'], namespace='${namespace}',
         )
         for name in [
             's3_lifecycle_trigger_latency_seconds',
@@ -861,7 +862,17 @@ dashboard = (
                 regex='/^${zenkoName}-(?:backbeat-|cold-sorbet-)?(?:lifecycle-)?(.*?)(?:-processor)?(?:-headless)?$/',
                 includeAll=True,
                 multi=True,
+                allValue="|".join(ALL_JOBS),
+            ),
+            Template(
+                dataSource='${DS_PROMETHEUS}',
+                label='Location',
+                name='locations',
+                query=f'label_values({{namespace="${{namespace}}", job=~"{"|".join(ALL_JOBS)}", location!=""}}, location)',
+                includeAll=True,
+                multi=True,
                 allValue='.*',
+                refresh=REFRESH_ON_TIME_RANGE_CHANGE,
             ),
         ]),
         panels=layout.column([

--- a/monitoring/lifecycle/dashboard.py
+++ b/monitoring/lifecycle/dashboard.py
@@ -125,7 +125,7 @@ class BacklogMetrics:
 
     LATEST_CONSUMED_MESSAGE_TS, LATEST_CONSUME_EVENT_TS = [
         metrics.Metric(
-            name, 'topic', 'partition', 'consumergroup', job=['$jobs'], namespace='${namespace}',
+            name, 'topic', 'partition', 'group', job=['$jobs'], namespace='${namespace}',
         )
         for name in [
             's3_zenko_queue_latest_consumed_message_timestamp',
@@ -135,17 +135,17 @@ class BacklogMetrics:
 
     REBALANCE_TOTAL = metrics.CounterMetric(
         's3_zenko_queue_rebalance_total',
-        'topic', 'partition', 'status', job=['$jobs'], namespace='${namespace}',
+        'topic', 'group', 'status', job=['$jobs'], namespace='${namespace}',
     )
 
     SLOW_TASKS = metrics.Metric(
         's3_zenko_queue_slowTasks_count',
-        'topic', 'partition', 'consumergroup', job=['$jobs'], namespace='${namespace}',
+        'topic', 'partition', 'group', job=['$jobs'], namespace='${namespace}',
     )
 
     TASK_PROCESSING_TIME = metrics.BucketMetric(
         's3_zenko_queue_task_processing_time_seconds',
-        'topic', 'partition', 'consumergroup', 'error', job=['$jobs'], namespace='${namespace}',
+        'topic', 'partition', 'group', 'error', job=['$jobs'], namespace='${namespace}',
     )
 
 
@@ -488,11 +488,10 @@ kafka_lag = TimeSeries(
     targets=[
         Target(
             expr=relabel_job('\n'.join([
-                'sum('
-                '   label_replace(kafka_consumergroup_group_max_lag,',
-                '                 "consumergroup", "$1", "group", "(.*)")',
-                '   * on(consumergroup) group_right',
-                '   group(' + BacklogMetrics.LATEST_CONSUMED_MESSAGE_TS() + ') by(consumergroup, job)',
+                'sum(',
+                '   kafka_consumergroup_group_max_lag',
+                '   * on(group) group_right',
+                '   group(' + BacklogMetrics.LATEST_CONSUMED_MESSAGE_TS() + ') by(group, job)',
                 ') by(job)',
             ])),
             legendFormat="{{ job }}",

--- a/monitoring/lifecycle/dashboard.py
+++ b/monitoring/lifecycle/dashboard.py
@@ -11,9 +11,10 @@ from grafanalib.core import (
 from grafanalib import formatunits as UNITS
 from scalgrafanalib import layout, metrics, GaugePanel, PieChart, Stat, Target, TimeSeries, Tooltip, Dashboard
 
-import os, sys
+import os
+import sys
 sys.path.append(os.path.abspath(f'{__file__}/../../..'))
-from monitoring import s3_circuit_breaker
+from monitoring import s3_circuit_breaker # noqa: E402
 
 
 STATUS_CODE_2XX = '2..'
@@ -82,6 +83,7 @@ def s3_request_timeseries(title, **kwargs):
         dataSource="${DS_PROMETHEUS}",
         fillOpacity=5,
         legendDisplayMode='table',
+        lineInterpolation='smooth',
         unit=UNITS.REQUESTS_PER_SEC,
         targets=[
             Target(
@@ -129,6 +131,7 @@ def kafka_message_produced(title, op):
         title=title,
         dataSource="${DS_PROMETHEUS}",
         fillOpacity=5,
+        lineInterpolation='smooth',
         unit=UNITS.REQUESTS_PER_SEC,
         targets=[
             Target(
@@ -435,7 +438,7 @@ lifecycle_expiration_processor_s3_delete_object_ops, lifecycle_expiration_proces
 
 dashboard = (
     Dashboard(
-        title="Backbeat Lifecycle",
+        title="Lifecycle",
         editable=True,
         refresh="30s",
         tags=["backbeat", "lifecycle"],
@@ -451,7 +454,7 @@ dashboard = (
                 name="namespace",
                 label="namespace",
                 description="Namespace associated with the Zenko instance",
-                value="default",
+                value="zenko",
             ),
             ConstantInput(
                 name="job_lifecycle_producer",

--- a/tests/unit/replication/ReplicationAPI.spec.js
+++ b/tests/unit/replication/ReplicationAPI.spec.js
@@ -35,7 +35,7 @@ describe('ReplicationAPI', () => {
 
     describe('::sendDataMoverAction ', () => {
         it('should publish to archive topic', done => {
-            const transitionTime = Date.now();
+            const transitionTime = new Date().toISOString();
             const action = ActionQueueEntry.create('copyLocation');
             action
                 .setAttribute('target', {
@@ -67,7 +67,7 @@ describe('ReplicationAPI', () => {
                             objectVersion: versionId,
                             size: contentLength,
                             eTag,
-                            transitionTime: new Date(transitionTime).toISOString(),
+                            transitionTime,
                         },
                     },
                 ];


### PR DESCRIPTION
General refactoring & improvement of lifecycle cleanup, to provide better visibility:
* Overview of the processes
* Workflows
* Kafka ops
* S3 ops
* Conductor/bucket scanning

<img width="1919" alt="1-overview" src="https://github.com/scality/backbeat/assets/3909027/ef9d4422-daa1-4b94-8176-ee41286f656b">
<img width="1919" alt="2-workflows" src="https://github.com/scality/backbeat/assets/3909027/8bd38c18-9159-4bd4-bb71-69f5769170b6">
<img width="1919" alt="3-tasks" src="https://github.com/scality/backbeat/assets/3909027/20d6c5e4-e7db-41d9-9588-cbea1a0feb5e">
<img width="1919" alt="4-s3" src="https://github.com/scality/backbeat/assets/3909027/5c2efaf6-7b3f-480a-aec4-38af065cc2f2">
<img width="1919" alt="5-conductor" src="https://github.com/scality/backbeat/assets/3909027/75d148f8-9736-4dc2-ad45-80321500d4f9">

Issue: BB-476