### PR TITLE
simplify handling of replication failure notification

### DIFF
--- a/extensions/notification/constants.js
+++ b/extensions/notification/constants.js
@@ -12,7 +12,6 @@ const constants = {
     authFilesFolder: 'ssl',
     supportedAuthTypes: ['kerberos'],
     deleteEvent: 's3:ObjectRemoved:Delete',
-    replicationFailedEvent: 's3:Replication:OperationFailedReplication',
     eventMessageProperty: {
         eventType: 'originOp',
         region: 'dataStoreName',

--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -7,7 +7,6 @@ const { errors, jsutil } = require('arsenal');
 const { StatsModel, ZenkoMetrics } = require('arsenal').metrics;
 const { sendSuccess } = require('arsenal').network.probe.Utils;
 
-const BackbeatProducer = require('../../../lib/BackbeatProducer');
 const BackbeatConsumer = require('../../../lib/BackbeatConsumer');
 const GarbageCollectorProducer = require('../../gc/GarbageCollectorProducer');
 const VaultClientCache = require('../../../lib/clients/VaultClientCache');
@@ -19,8 +18,6 @@ const FailedCRRProducer = require('../failedCRR/FailedCRRProducer');
 const ReplayProducer = require('../replay/ReplayProducer');
 const MetricsProducer = require('../../../lib/MetricsProducer');
 const { http: HttpAgent, https: HttpsAgent } = require('httpagent');
-
-const NotificationConfigManager = require('../../notification/NotificationConfigManager');
 
 // StatsClient constant default for site metrics
 const INTERVAL = 300; // 5 minutes;
@@ -207,12 +204,9 @@ class ReplicationStatusProcessor {
      *   in PEM format
      * @param {Object} mConfig - metrics config
      * @param {String} mConfig.topic - metrics config kafka topic
-     * @param {Object} bucketNotificationConfig - bucket notification config
-     * @param {Object} mongoConfig - mongodb connection config
      */
     constructor(kafkaConfig, sourceConfig, repConfig,
-                internalHttpsConfig, mConfig, bucketNotificationConfig,
-                mongoConfig) {
+                internalHttpsConfig, mConfig) {
         this.kafkaConfig = kafkaConfig;
         this.sourceConfig = sourceConfig;
         this.repConfig = repConfig;
@@ -221,11 +215,6 @@ class ReplicationStatusProcessor {
         this._consumer = null;
         this._gcProducer = null;
         this._mProducer = null;
-        // bucket notification related
-        this.bucketNotificationConfig = bucketNotificationConfig;
-        this.mongoConfig = mongoConfig;
-        this.notificationConfigManager = null;
-        this.notificationProducers = {};
 
         this.logger =
             new Logger('Backbeat:Replication:ReplicationStatusProcessor');
@@ -352,68 +341,7 @@ class ReplicationStatusProcessor {
             logger: this.logger,
             replayTopics: this._replayTopics,
             replayTopicNames: this._replayTopicNames,
-            bucketNotificationConfig: this.bucketNotificationConfig,
-            notificationConfigManager: this.notificationConfigManager,
-            notificationProducers: this.notificationProducers,
         };
-    }
-
-    _setupNotificationConfigManager(done) {
-        // setup notification configuration manager only if notification
-        // extension is available
-        if (this.bucketNotificationConfig) {
-            try {
-                this.notificationConfigManager = new NotificationConfigManager({
-                    mongoConfig: this.mongoConfig,
-                    logger: this.logger,
-                });
-                return this.notificationConfigManager.setup(done);
-            } catch (err) {
-                return done(err);
-            }
-        }
-        return done();
-    }
-
-    _setupNotificationProducers(done) {
-        // setup notification producers only when
-        // extension is available
-        if (this.bucketNotificationConfig) {
-            // we set one producer per notification target
-            return async.each(this.bucketNotificationConfig.destinations,
-            (destination, cb) => {
-                const internalTopic = destination.internalTopic ||
-                    this.bucketNotificationConfig.topic;
-                const producer = new BackbeatProducer({
-                    kafka: { hosts: this.kafkaConfig.hosts },
-                    maxRequestSize: this.kafkaConfig.maxRequestSize,
-                    topic: internalTopic,
-                });
-                producer.once('error', done);
-                producer.once('ready', () => {
-                    producer.removeAllListeners('error');
-                    producer.on('error', err => {
-                        this.logger.error('error setting replication notification producer', {
-                            destination: destination.resource,
-                            topic: internalTopic,
-                            error: err,
-                        });
-                    });
-                    this.notificationProducers[destination.resource] = producer;
-                    return cb();
-                });
-            },
-            err => {
-                if (err) {
-                    this.logger.error('error setting replication notification producers', {
-                        error: err,
-                    });
-                    return done(err);
-                }
-                return done();
-            });
-        }
-        return done();
     }
 
     /**
@@ -450,22 +378,6 @@ class ReplicationStatusProcessor {
                     this.mConfig);
                 this._mProducer.setupProducer(done);
             },
-            done => this._setupNotificationConfigManager(err => {
-                if (err) {
-                    this.logger.info('error setting up notification config manager',
-                                     { error: err.message });
-                    process.exit(1);
-                }
-                return done();
-            }),
-            done => this._setupNotificationProducers(err => {
-                if (err) {
-                    this.logger.info('error setting up kafka notification producers',
-                                     { error: err.message });
-                    process.exit(1);
-                }
-                return done();
-            }),
             done => {
                 let consumerReady = false;
                 this._consumer = new BackbeatConsumer({

--- a/extensions/replication/replicationStatusProcessor/task.js
+++ b/extensions/replication/replicationStatusProcessor/task.js
@@ -10,17 +10,14 @@ const { DEFAULT_LIVE_ROUTE, DEFAULT_METRICS_ROUTE, DEFAULT_READY_ROUTE } =
 const config = require('../../../lib/Config');
 const kafkaConfig = config.kafka;
 const repConfig = config.extensions.replication;
-const notificationConfig = config.extensions.notification;
 const sourceConfig = repConfig.source;
 const internalHttpsConfig = config.internalHttps;
 const mConfig = config.metrics;
-const mongoConfig = config.queuePopulator.mongo;
 
 const { initManagement } = require('../../../lib/management/index');
 
 const replicationStatusProcessor = new ReplicationStatusProcessor(
-    kafkaConfig, sourceConfig, repConfig, internalHttpsConfig, mConfig,
-    notificationConfig, mongoConfig);
+    kafkaConfig, sourceConfig, repConfig, internalHttpsConfig, mConfig);
 
 werelogs.configure({ level: config.log.logLevel,
      dump: config.log.dumpLevel });

--- a/extensions/replication/tasks/UpdateReplicationStatus.js
+++ b/extensions/replication/tasks/UpdateReplicationStatus.js
@@ -1,7 +1,5 @@
 const errors = require('arsenal').errors;
 const assert = require('assert');
-const async = require('async');
-const util = require('util');
 
 const config = require('../../../lib/Config');
 
@@ -9,10 +7,6 @@ const ObjectQueueEntry = require('../../../lib/models/ObjectQueueEntry');
 const ActionQueueEntry = require('../../../lib/models/ActionQueueEntry');
 const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
 const BackbeatMetadataProxy = require('../../../lib/BackbeatMetadataProxy');
-
-const notifConstants = require('../../notification/constants');
-const messageUtil = require('../../notification/utils/message');
-const configUtil = require('../../notification/utils/config');
 
 const {
     metricsExtension,
@@ -45,11 +39,6 @@ class UpdateReplicationStatus extends BackbeatTask {
         this.backbeatSourceClient = new BackbeatMetadataProxy(
             `${transport}://${s3.host}:${s3.port}`, auth, this.sourceHTTPAgent);
 
-        if (this.notificationConfigManager) {
-            // callback version of notificationConfigManager's getConfig function
-            this.getNotificationConfig = util.callbackify(this.notificationConfigManager.getConfig
-                .bind(this.notificationConfigManager));
-        }
     }
 
     processQueueEntry(sourceEntry, done) {
@@ -246,7 +235,6 @@ class UpdateReplicationStatus extends BackbeatTask {
         }
         const versionId =
             sourceEntry.getReplicationSiteDataStoreVersionId(site);
-        entry.setOriginOp('');
         entry.setReplicationSiteDataStoreVersionId(site, versionId);
         entry.setSite(site);
         return entry;
@@ -378,9 +366,6 @@ class UpdateReplicationStatus extends BackbeatTask {
             if (this.repConfig.monitorReplicationFailures) {
                 this._pushFailedEntry(queueEntry, log);
             }
-            if (this.bucketNotificationConfig) {
-                this._publishFailedReplicationStatusNotification(queueEntry, log);
-            }
             const labels = {
                 location: site,
                 replayCount: totalAttempts - count,
@@ -464,110 +449,6 @@ class UpdateReplicationStatus extends BackbeatTask {
                         updatedSourceEntry, log, done);
                 });
             });
-    }
-
-    /**
-     * Publishes the failed replication event
-     * into the notification topic
-     * @param {Object} sourceEntry the object entry
-     * @param {Logger} log the logger instance
-     * @param {Function} done optional callback when all notification have been posted
-     * @return {undefined}
-     */
-    _publishFailedReplicationStatusNotification(sourceEntry, log, done) {
-        const bucket = sourceEntry.getBucket();
-        const key = sourceEntry.getObjectKey();
-        const value = sourceEntry.getValue();
-        const versionId = sourceEntry.getVersionId();
-        this.getNotificationConfig(bucket, (err, config) => {
-            if (err) {
-                log.error('error while getting bucket notification configuration', {
-                    method: 'UpdateReplicationStatus._publishFailedReplicationStatusNotification',
-                    entry: sourceEntry.getLogInfo(),
-                    error: err,
-                });
-            }
-            // we skip if no config is available for the bucket
-            if (config && Object.keys(config).length > 0) {
-                const eventType = notifConstants.replicationFailedEvent;
-                const ent = {
-                    bucket,
-                    key,
-                    versionId,
-                    eventType,
-                    dateTime: new Date().toISOString(),
-                };
-                log.debug('validating entry', {
-                    method: 'UpdateReplicationStatus._publishFailedReplicationStatusNotification',
-                    bucket,
-                    key,
-                    versionId,
-                    eventType,
-                });
-                // validate and push kafka message to each destination internal topic
-                async.each(this.bucketNotificationConfig.destinations,
-                    (destination, cb) => {
-                        // get destination specific notification config
-                        const destBnConf = config.queueConfig.find(
-                            c => c.queueArn.split(':').pop()
-                            === destination.resource);
-                        if (!destBnConf) {
-                            // skip, if there is no config for the current
-                            // destination resource
-                            return cb();
-                        }
-                        // pass only destination specific config to
-                        // validate entry
-                        const bnConfig = {
-                            queueConfig: [destBnConf],
-                        };
-                        // skip if entry doesn't match config
-                        if (!configUtil.validateEntry(bnConfig, ent)) {
-                            return cb();
-                        }
-                        const message
-                            = messageUtil.addLogAttributes(value, ent);
-                        log.info('publishing replication failed notification', {
-                            method: 'UpdateReplicationStatus._publishFailedReplicationStatusNotification',
-                            bucket,
-                            key: message.key,
-                            eventType,
-                            eventTime: message.dateTime,
-                        });
-                        const entry = {
-                            key: encodeURIComponent(bucket),
-                            message: JSON.stringify(message)
-                        };
-                        return this.notificationProducers[destination.resource].send([entry], err => {
-                            if (err) {
-                                log.error('error in entry delivery to notification topic', {
-                                    method: 'UpdateReplicationStatus._publishFailedReplicationStatusNotification',
-                                    destination: destination.resource,
-                                    entry: sourceEntry.getLogInfo(),
-                                    error: err,
-                                });
-                            }
-                            return cb();
-                        });
-                }, err => {
-                    if (err) {
-                        log.error('error while pushing replication failed notification', {
-                            method: 'UpdateReplicationStatus._publishFailedReplicationStatusNotification',
-                            entry: sourceEntry.getLogInfo(),
-                            error: err,
-                        });
-                    }
-                    log.info('Successfully pushed failed replication event to notification topic', {
-                        method: 'UpdateReplicationStatus._publishFailedReplicationStatusNotification',
-                        bucket,
-                        key,
-                    });
-                    if (done) {
-                        done(err);
-                    }
-                });
-            }
-        });
     }
 }
 

--- a/lib/models/ObjectQueueEntry.js
+++ b/lib/models/ObjectQueueEntry.js
@@ -193,21 +193,24 @@ class ObjectQueueEntry extends ObjectMD {
         return this.clone()
             .setAccountId(this.getAccountId())
             .setReplicationSiteStatus(site, 'COMPLETED')
-            .setReplicationStatus(this._getGlobalReplicationStatus());
+            .setReplicationStatus(this._getGlobalReplicationStatus())
+            .setOriginOp('s3:Replication:OperationCompletedReplication');
     }
 
     toFailedEntry(site) {
         return this.clone()
             .setAccountId(this.getAccountId())
             .setReplicationSiteStatus(site, 'FAILED')
-            .setReplicationStatus('FAILED');
+            .setReplicationStatus('FAILED')
+            .setOriginOp('s3:Replication:OperationFailedReplication');
     }
 
     toPendingEntry(site) {
         return this.clone()
             .setAccountId(this.getAccountId())
             .setReplicationSiteStatus(site, 'PENDING')
-            .setReplicationStatus(this._getGlobalReplicationStatus());
+            .setReplicationStatus(this._getGlobalReplicationStatus())
+            .setOriginOp('s3:Replication:OperationPendingReplication');
     }
 
     toRetryEntry(site) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "8.6.38",
+  "version": "8.6.39",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/notification/NotificationQueuePopulator.js
+++ b/tests/unit/notification/NotificationQueuePopulator.js
@@ -249,6 +249,31 @@ describe('NotificationQueuePopulator ::', () => {
             assert.strictEqual(publishStub.getCall(1).args.at(0), 'internal-notification-topic-destination2');
             assert.strictEqual(publishStub.getCall(2).args.at(0), 'backbeat-bucket-notification');
         });
+
+        it('Should not publish object entry in notification topic if ' +
+            'notification is non standard', async () => {
+            sinon.stub(bnConfigManager, 'getConfig').returns({
+                queueConfig: [
+                    {
+                        events: ['s3:ObjectCreated:*'],
+                        queueArn: 'arn:scality:bucketnotif:::destination1',
+                        filterRules: [],
+                    },
+                ],
+            });
+            const publishStub = sinon.stub(notificationQueuePopulator, 'publish');
+            await notificationQueuePopulator._processObjectEntry(
+                'example-bucket',
+                'example-key',
+                {
+                    'originOp': 's3:ObjectCreated:non-standard',
+                    'dataStoreName': 'metastore',
+                    'content-length': '100',
+                    'last-modified': '0000',
+                    'md-model-version': '1',
+                });
+            assert(publishStub.notCalled);
+        });
     });
 
     describe('filterAsync ::', () => {


### PR DESCRIPTION
Instead of duplicating the notification logic we set the correct originOp when updating the metadata to trigger the replication failure notification. (Bucket notification listens to the oplog and sends notification based on the originOp field in the metadata)

At the end of a failed replication we update the metadata with the failure status that ends up in the oplog topic. So this does not add any overhead in terms of extra Kafka messages being pushed to any of the topics.

This also fixes the duplicate notifications bug where we send as many notifications as destinations we have in case they use the same internal topic (bug already fixed in notification code).

Issue: BB-507