### PR TITLE
bucket processor circuit breaker: replace all instances of template variables

### DIFF
--- a/extensions/lifecycle/CircuitBreakerGroup.js
+++ b/extensions/lifecycle/CircuitBreakerGroup.js
@@ -247,7 +247,7 @@ function extractBucketProcessorCircuitBreakerConfigs(cbConf, lcConfig, repConfig
             topics.forEach(tp => {
                 circuitBreakerGroup.addCircuitBreaker(
                     probe,
-                    query.replace('${topic}', tp).replace('${location}', location ? location[1] : ''),
+                    query.replaceAll('${topic}', tp).replaceAll('${location}', location ? location[1] : ''),
                     useForTransition,
                     useForExpiration,
                     tp,
@@ -262,7 +262,7 @@ function extractBucketProcessorCircuitBreakerConfigs(cbConf, lcConfig, repConfig
             locationNames.forEach(loc => {
                 circuitBreakerGroup.addCircuitBreaker(
                     probe,
-                    query.replace('${location}', loc).replace('${topic}', topic ? topic[1] : ''),
+                    query.replaceAll('${location}', loc).replaceAll('${topic}', topic ? topic[1] : ''),
                     useForTransition,
                     useForExpiration,
                     topic ? topic[1] : '',

--- a/tests/unit/lifecycle/CircuitBreakerGroup.spec.js
+++ b/tests/unit/lifecycle/CircuitBreakerGroup.spec.js
@@ -14,7 +14,7 @@ describe('extractBucketProcessorCircuitBreakerConfigs', () => {
         const withClause = probe.query.match(/^when\s?\(\{(.*?)\}\)\sand\s/);
         let query = withClause ? probe.query.replace(withClause[0], '') : probe.query;
         if (template) {
-            query = query.replace(template, value);
+            query = query.replaceAll(template, value);
         }
         return {
             nominalEvaluateIntervalMs: 60000,
@@ -48,7 +48,8 @@ describe('extractBucketProcessorCircuitBreakerConfigs', () => {
 
     const topicSpecificTemplatedProbe = {
         type: 'prometheusQuery',
-        query: 'when({topic="cold-archive-req-location-dmf-v1"}) and kafka_consumergroup_group_lag{topic="${topic}"}',
+        query: 'when({topic="cold-archive-req-location-dmf-v1"}) ' +
+            'and kafka_consumergroup_group_lag{group="${topic}",topic="${topic}"}',
         threshold: 100,
         prometheus: {
             endpoint: 'http://prometheus:9090',
@@ -84,7 +85,7 @@ describe('extractBucketProcessorCircuitBreakerConfigs', () => {
 
     const locationSpecificTemplatedProbe = {
         type: 'prometheusQuery',
-        query: 'when({location="dmf-v1"}) and s3_sorbet_is_throttled{location="${location}"}',
+        query: 'when({location="dmf-v1"}) and kafka_consumergroup_group_lag{group="${location}", topic="${location}"}',
         threshold: 100,
         prometheus: {
             endpoint: 'http://prometheus:9090',


### PR DESCRIPTION
The bucket processor's circuit breaker config currently only replaces the first instance of a template variable. We should replace all of them.

```
Example Query:
when({location="dmf-v1"}) and kafka_consumergroup_group_lag{group="group-${location}", topic="${location}"}

Old behaviour -> kafka_consumergroup_group_lag{group="group-dmf-v1", topic="${location}"}
New behaviour -> kafka_consumergroup_group_lag{group="group-dmf-v1", topic="dmf-v1"}
```

Issue: BB-513