### PR TITLE
oplog populator should not listen to buckets with bucket notification disabled

### DIFF
--- a/extensions/notification/NotificationOplogPopulatorUtils.js
+++ b/extensions/notification/NotificationOplogPopulatorUtils.js
@@ -10,7 +10,10 @@ class NotificationOplogPopulatorUtils extends OplogPopulatorUtils {
      static getExtensionMongoDBFilter() {
         return {
             'value.notificationConfiguration': {
-                $type: 3
+                $type: 3,
+                $not: {
+                    $size: 0
+                }
             }
         };
     }
@@ -23,7 +26,7 @@ class NotificationOplogPopulatorUtils extends OplogPopulatorUtils {
      * current extension enabled
      */
     static isBucketExtensionEnabled(bucketMD) {
-        return Boolean(bucketMD.notificationConfiguration !== null);
+        return bucketMD.notificationConfiguration && Object.keys(bucketMD.notificationConfiguration).length > 0;
     }
 }
 module.exports = NotificationOplogPopulatorUtils;

--- a/tests/unit/oplogPopulator/oplogPopulator.js
+++ b/tests/unit/oplogPopulator/oplogPopulator.js
@@ -221,6 +221,9 @@ describe('OplogPopulator', () => {
         const notificationFilter = {
             'value.notificationConfiguration': {
                 $type: 3,
+                $not: {
+                    $size: 0,
+                },
             },
         };
         const lifecycleFilter = {
@@ -388,7 +391,16 @@ describe('OplogPopulator', () => {
                 desc: 'all extensions active',
                 exts: ['notification', 'lifecycle', 'replication'],
                 metadata: {
-                    notificationConfiguration: {},
+                    notificationConfiguration: {
+                        queueConfig: [
+                            {
+                                events: [
+                                    's3:ObjectCreated:*',
+                                ],
+                                queueArn: 'arn:scality:bucketnotif:::dest1',
+                            }
+                        ]
+                    },
                     lifecycleConfiguration: {
                         rules: [
                             {
@@ -421,12 +433,32 @@ describe('OplogPopulator', () => {
                 desc: 'notification active',
                 exts: ['notification'],
                 metadata: {
-                    notificationConfiguration: {},
+                    notificationConfiguration: {
+                        queueConfig: [
+                            {
+                                events: [
+                                    's3:ObjectCreated:*',
+                                ],
+                                queueArn: 'arn:scality:bucketnotif:::dest1',
+                            }
+                        ]
+                    },
                     replicationConfiguration: null,
                     lifecycleConfiguration: null,
                     ingestion: null,
                 },
                 result: true,
+            },
+            {
+                desc: 'notification disabled',
+                exts: ['notification'],
+                metadata: {
+                    notificationConfiguration: {},
+                    replicationConfiguration: null,
+                    lifecycleConfiguration: null,
+                    ingestion: null,
+                },
+                result: false,
             },
             {
                 desc: 'replication mixed rules',


### PR DESCRIPTION
Bucket notification is disabled by setting an empty object as the config. The oplog populator should detect that and avoid listening to those buckets.

Issue: BB-512