### PR TITLE
Fix incorrect computation for Lifecycle****ProcessorRequest alerts

### DIFF
--- a/monitoring/lifecycle/alerts.test.yaml
+++ b/monitoring/lifecycle/alerts.test.yaml
@@ -33,13 +33,10 @@ tests:
       - series: up{namespace="zenko",job="artesca-data-backbeat-lifecycle-bucket-processor-headless",pod="bucket-3"}
         values: 1 0 0
     alert_rule_test:
-      - alertname: LifecycleBucketProcessorDegraded
+      - alertname: LifecycleBucketProcessorDown
         eval_time: 1m
         exp_alerts: []
-      - alertname: LifecycleBucketProcessorCritical
-        eval_time: 1m
-        exp_alerts: []
-      - alertname: LifecycleBucketProcessorDegraded
+      - alertname: LifecycleBucketProcessorDown
         eval_time: 2m
         exp_alerts:
           - exp_labels:
@@ -48,10 +45,7 @@ tests:
               zenko_service: backbeat-lifecycle-bucket-processor
               description: "Less than 100% of lifecycle bucket processors are up and healthy"
               summary: "Degraded lifecycle bucket processor"
-      - alertname: LifecycleBucketProcessorCritical
-        eval_time: 2m
-        exp_alerts: []
-      - alertname: LifecycleBucketProcessorDegraded
+      - alertname: LifecycleBucketProcessorDown
         eval_time: 3m
         exp_alerts:
           - exp_labels:
@@ -60,9 +54,6 @@ tests:
               zenko_service: backbeat-lifecycle-bucket-processor
               description: "Less than 100% of lifecycle bucket processors are up and healthy"
               summary: "Degraded lifecycle bucket processor"
-      - alertname: LifecycleBucketProcessorCritical
-        eval_time: 3m
-        exp_alerts:
           - exp_labels:
               severity: critical
             exp_annotations:
@@ -80,13 +71,10 @@ tests:
       - series: up{namespace="zenko",job="artesca-data-backbeat-lifecycle-object-processor-headless",pod="object-3"}
         values: 1 0 0
     alert_rule_test:
-      - alertname: LifecycleObjectProcessorDegraded
+      - alertname: LifecycleObjectProcessorDown
         eval_time: 1m
         exp_alerts: []
-      - alertname: LifecycleObjectProcessorCritical
-        eval_time: 1m
-        exp_alerts: []
-      - alertname: LifecycleObjectProcessorDegraded
+      - alertname: LifecycleObjectProcessorDown
         eval_time: 2m
         exp_alerts:
           - exp_labels:
@@ -95,10 +83,7 @@ tests:
               zenko_service: backbeat-lifecycle-object-processor
               description: "Less than 100% of lifecycle object processors for expiration are up and healthy"
               summary: "Degraded lifecycle object processor"
-      - alertname: LifecycleObjectProcessorCritical
-        eval_time: 2m
-        exp_alerts: []
-      - alertname: LifecycleObjectProcessorDegraded
+      - alertname: LifecycleObjectProcessorDown
         eval_time: 3m
         exp_alerts:
           - exp_labels:
@@ -107,9 +92,6 @@ tests:
               zenko_service: backbeat-lifecycle-object-processor
               description: "Less than 100% of lifecycle object processors for expiration are up and healthy"
               summary: "Degraded lifecycle object processor"
-      - alertname: LifecycleObjectProcessorCritical
-        eval_time: 3m
-        exp_alerts:
           - exp_labels:
               severity: critical
             exp_annotations:

--- a/monitoring/lifecycle/alerts.test.yaml
+++ b/monitoring/lifecycle/alerts.test.yaml
@@ -117,3 +117,114 @@ tests:
               description: "Less than 50% of lifecycle object processors for expiration are up and healthy"
               summary: "Degraded lifecycle object processor"
 
+  - name: LifecycleBucketProcessorRequest
+    interval: 1m
+    input_series:
+      - series: s3_lifecycle_s3_operations_total{namespace="zenko", job="artesca-data-backbeat-lifecycle-bucket-processor-headless", status="200", process="bucket"}
+        values: 0+99x4 495+97x4 980+95x4 1455+98x4
+      - series: s3_lifecycle_s3_operations_total{namespace="zenko", job="artesca-data-backbeat-lifecycle-bucket-processor-headless", status="413", process="bucket"}
+        values: 0+1x4    5+3x4   20+5x4    45+2x4
+      - series: s3_lifecycle_s3_operations_total{namespace="zenko", job="artesca-data-backbeat-lifecycle-object-processor-headless", status="200", process="expiration"}
+        values: 0+100x19
+    alert_rule_test:
+      - alertname: LifecycleBucketProcessorRequest
+        eval_time: 1m
+        exp_alerts: []
+      - alertname: LifecycleBucketProcessorRequest
+        eval_time: 5m
+        exp_alerts: []
+      - alertname: LifecycleBucketProcessorRequest
+        eval_time: 9m
+        exp_alerts: []
+      - alertname: LifecycleBucketProcessorRequest
+        eval_time: 10m
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              zenko_service: backbeat-lifecycle-bucket-processor
+              description: "More than 3% of S3 requests by bucket processors resulting in errors"
+              summary: "High rate of S3 request errors"
+      - alertname: LifecycleBucketProcessorRequest
+        eval_time: 14m
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              zenko_service: backbeat-lifecycle-bucket-processor
+              description: "More than 3% of S3 requests by bucket processors resulting in errors"
+              summary: "High rate of S3 request errors"
+      - alertname: LifecycleBucketProcessorRequest
+        eval_time: 15m
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              zenko_service: backbeat-lifecycle-bucket-processor
+              description: "More than 3% of S3 requests by bucket processors resulting in errors"
+              summary: "High rate of S3 request errors"
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              zenko_service: backbeat-lifecycle-bucket-processor
+              description: "More than 5% of S3 requests by bucket processors resulting in errors"
+              summary: "Very high rate of S3 request errors"
+      - alertname: LifecycleBucketProcessorRequest
+        eval_time: 19m
+        exp_alerts: []
+
+  - name: LifecycleObjectProcessorRequest
+    interval: 1m
+    input_series:
+      - series: s3_lifecycle_s3_operations_total{namespace="zenko", job="artesca-data-backbeat-lifecycle-object-processor-headless", status="200", process="expiration"}
+        values: 0+99x4 495+97x4 980+95x4 1455+98x4
+      - series: s3_lifecycle_s3_operations_total{namespace="zenko", job="artesca-data-backbeat-lifecycle-object-processor-headless", status="413", process="expiration"}
+        values: 0+1x4    5+3x4   20+5x4    45+2x4
+      - series: s3_lifecycle_s3_operations_total{namespace="zenko", job="artesca-data-backbeat-lifecycle-bucket-processor-headless", status="200", process="bucket"}
+        values: 0+100x19
+    alert_rule_test:
+      - alertname: LifecycleObjectProcessorRequest
+        eval_time: 1m
+        exp_alerts: []
+      - alertname: LifecycleObjectProcessorRequest
+        eval_time: 5m
+        exp_alerts: []
+      - alertname: LifecycleObjectProcessorRequest
+        eval_time: 9m
+        exp_alerts: []
+      - alertname: LifecycleObjectProcessorRequest
+        eval_time: 10m
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              zenko_service: backbeat-lifecycle-object-processor
+              description: "More than 3% of S3 requests by object processors resulting in errors"
+              summary: "High rate of S3 request errors"
+      - alertname: LifecycleObjectProcessorRequest
+        eval_time: 14m
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              zenko_service: backbeat-lifecycle-object-processor
+              description: "More than 3% of S3 requests by object processors resulting in errors"
+              summary: "High rate of S3 request errors"
+      - alertname: LifecycleObjectProcessorRequest
+        eval_time: 15m
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+            exp_annotations:
+              zenko_service: backbeat-lifecycle-object-processor
+              description: "More than 3% of S3 requests by object processors resulting in errors"
+              summary: "High rate of S3 request errors"
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              zenko_service: backbeat-lifecycle-object-processor
+              description: "More than 5% of S3 requests by object processors resulting in errors"
+              summary: "Very high rate of S3 request errors"
+      - alertname: LifecycleObjectProcessorRequest
+        eval_time: 19m
+        exp_alerts: []

--- a/monitoring/lifecycle/alerts.yaml
+++ b/monitoring/lifecycle/alerts.yaml
@@ -31,7 +31,7 @@ groups:
 - name: LifecycleBucketProcessor
   rules:
 
-  - alert: LifecycleBucketProcessorDegraded
+  - alert: LifecycleBucketProcessorDown
     Expr: sum(up{namespace="${namespace}", job="${job_lifecycle_bucket_processor}"}) < ${lifecycle_bucket_replicas}
     For: "30s"
     Labels:
@@ -41,7 +41,7 @@ groups:
       description: "Less than 100% of lifecycle bucket processors are up and healthy"
       summary: "Degraded lifecycle bucket processor"
 
-  - alert: LifecycleBucketProcessorCritical
+  - alert: LifecycleBucketProcessorDown
     Expr: sum(up{namespace="${namespace}", job="${job_lifecycle_bucket_processor}"}) * 2 < ${lifecycle_bucket_replicas}
     For: "30s"
     Labels:
@@ -78,7 +78,7 @@ groups:
 - name: LifecycleObjectProcessor
   rules:
 
-  - alert: LifecycleObjectProcessorDegraded
+  - alert: LifecycleObjectProcessorDown
     Expr: sum(up{namespace="${namespace}", job="${job_lifecycle_object_processor}"}) < ${lifecycle_object_replicas}
     For: "30s"
     Labels:
@@ -88,7 +88,7 @@ groups:
       description: "Less than 100% of lifecycle object processors for expiration are up and healthy"
       summary: "Degraded lifecycle object processor"
   
-  - alert: LifecycleObjectProcessorCritical
+  - alert: LifecycleObjectProcessorDown
     Expr: sum(up{namespace="${namespace}", job="${job_lifecycle_object_processor}"}) * 2 < ${lifecycle_object_replicas}
     For: "30s"
     Labels:
@@ -125,7 +125,7 @@ groups:
 - name: Kafka Messages
   rules:
 
-  - alert: LifecycleKafkaBucketMessagesWarning
+  - alert: LifecycleKafkaBucketMessages
     Expr: |
       sum(rate(s3_lifecycle_kafka_publish_error_total{namespace="${namespace}",op="BucketTopic"}[5m]) > 0)
         / (sum(rate(s3_lifecycle_kafka_publish_error_total{namespace="${namespace}",op="BucketTopic"}[5m]) > 0)
@@ -138,7 +138,7 @@ groups:
       description: "More than 3% of Kafka messages failed to publish to the lifecycle bucket topic"
       summary: "High rate of failed messages to the bucket topic"
 
-  - alert: LifecycleKafkaBucketMessagesCritical
+  - alert: LifecycleKafkaBucketMessages
     Expr: |
       sum(rate(s3_lifecycle_kafka_publish_error_total{namespace="${namespace}",op="BucketTopic"}[5m]) > 0)
         / (sum(rate(s3_lifecycle_kafka_publish_error_total{namespace="${namespace}",op="BucketTopic"}[5m]) > 0)
@@ -151,7 +151,7 @@ groups:
       description: "More than 5% of Kafka messages failed to publish to the lifecycle bucket topic"
       summary: "High rate of failed messages to the bucket topic"
 
-  - alert: LifecycleKafkaObjectMessagesWarning
+  - alert: LifecycleKafkaObjectMessages
     Expr: |
       sum(rate(s3_lifecycle_kafka_publish_error_total{namespace="${namespace}",op="ObjectTopic"}[5m]) > 0)
         / (sum(rate(s3_lifecycle_kafka_publish_error_total{namespace="${namespace}",op="ObjectTopic"}[5m]) > 0)
@@ -164,7 +164,7 @@ groups:
       description: "More than 3% of Kafka messages failed to publish to the lifecycle object topic"
       summary: "High rate of failed messages to the object topic"
 
-  - alert: LifecycleKafkaObjectMessagesCritical
+  - alert: LifecycleKafkaObjectMessages
     Expr: |
       sum(rate(s3_lifecycle_kafka_publish_error_total{namespace="${namespace}",op="ObjectTopic"}[5m]) > 0)
         / (sum(rate(s3_lifecycle_kafka_publish_error_total{namespace="${namespace}",op="ObjectTopic"}[5m]) > 0)

--- a/monitoring/lifecycle/alerts.yaml
+++ b/monitoring/lifecycle/alerts.yaml
@@ -51,12 +51,11 @@ groups:
       description: "Less than 50% of lifecycle bucket processors are up and healthy"
       summary: "Degraded lifecycle bucket processor"
 
-  - alert: LifecycleBucketProcessorRequestWarning
+  - alert: LifecycleBucketProcessorRequest
     Expr: |
-      sum(rate(s3_lifecycle_s3_operations_total{namespace="${namespace}", job="${job_lifecycle_bucket_processor}", status!="2xx", process="bucket"}[5m]))
+      sum(rate(s3_lifecycle_s3_operations_total{namespace="${namespace}", job="${job_lifecycle_bucket_processor}", status!~"^2..", process="bucket"}[5m]))
         / sum(rate(s3_lifecycle_s3_operations_total{namespace="${namespace}", job="${job_lifecycle_bucket_processor}", process="bucket"}[5m]))
         >= 0.03
-    For: "5m"
     Labels:
      severity: warning
     Annotations:
@@ -64,12 +63,11 @@ groups:
       description: "More than 3% of S3 requests by bucket processors resulting in errors"
       summary: "High rate of S3 request errors"
 
-  - alert: LifecycleBucketProcessorRequestCritical
+  - alert: LifecycleBucketProcessorRequest
     Expr: |
-      sum(rate(s3_lifecycle_s3_operations_total{namespace="${namespace}", job="${job_lifecycle_bucket_processor}", status!="2xx", process="bucket"}[5m]))
+      sum(rate(s3_lifecycle_s3_operations_total{namespace="${namespace}", job="${job_lifecycle_bucket_processor}", status!~"^2..", process="bucket"}[5m]))
         / sum(rate(s3_lifecycle_s3_operations_total{namespace="${namespace}", job="${job_lifecycle_bucket_processor}", process="bucket"}[5m]))
         >= 0.05
-    For: "5m"
     Labels:
      severity: critical
     Annotations:
@@ -100,12 +98,11 @@ groups:
       description: "Less than 50% of lifecycle object processors for expiration are up and healthy"
       summary: "Degraded lifecycle object processor"
   
-  - alert: LifecycleObjectProcessorRequestWarning
+  - alert: LifecycleObjectProcessorRequest
     Expr: |
-      sum(rate(s3_lifecycle_s3_operations_total{namespace="${namespace}", job="${job_lifecycle_object_processor}", status!="2xx", process="expiration"}[5m]))
+      sum(rate(s3_lifecycle_s3_operations_total{namespace="${namespace}", job="${job_lifecycle_object_processor}", status!~"^2..", process="expiration"}[5m]))
         / sum(rate(s3_lifecycle_s3_operations_total{namespace="${namespace}", job="${job_lifecycle_object_processor}", process="expiration"}[5m]))
         >= 0.03
-    For: "5m"
     Labels:
      severity: warning
     Annotations:
@@ -113,12 +110,11 @@ groups:
       description: "More than 3% of S3 requests by object processors resulting in errors"
       summary: "High rate of S3 request errors"
 
-  - alert: LifecycleObjectProcessorRequestCritical
+  - alert: LifecycleObjectProcessorRequest
     Expr: |
-      sum(rate(s3_lifecycle_s3_operations_total{namespace="${namespace}", job="${job_lifecycle_object_processor}", status!="2xx", process="expiration"}[5m]))
+      sum(rate(s3_lifecycle_s3_operations_total{namespace="${namespace}", job="${job_lifecycle_object_processor}", status!~"^2..", process="expiration"}[5m]))
         / sum(rate(s3_lifecycle_s3_operations_total{namespace="${namespace}", job="${job_lifecycle_object_processor}", process="expiration"}[5m]))
         >= 0.05
-    For: "5m"
     Labels:
      severity: critical
     Annotations:


### PR DESCRIPTION
- Fix Lifecycle Object/Bucket Processor Request alerts
- Dedup the warning & critical lifecycle alerts
- Fix Lifecycle Transition Processor Request alerts

See also https://github.com/scality/backbeat/compare/development/8.6...w/8.6/bugfix/BB-575 for the full changes, as some alerts were added on 8.6.

Issue: BB-575
