### PR TITLE
Add bypassExpirationCheck in expiration command

### DIFF
--- a/extensions/lifecycle/tasks/LifecycleUpdateExpirationTask.js
+++ b/extensions/lifecycle/tasks/LifecycleUpdateExpirationTask.js
@@ -164,7 +164,7 @@ class LifecycleUpdateExpirationTask extends BackbeatTask {
                 // expiration date is updated while the expiry was "in-flight" (e.g.
                 // queued for expiry but not yet expired)
                 const restoreExpirationDate = new Date(archive.restoreWillExpireAt);
-                if (restoreExpirationDate > new Date()) {
+                if (restoreExpirationDate > new Date() && !entry.getAttribute('bypassExpirationCheck')) {
                     return process.nextTick(done);
                 }
 

--- a/tests/unit/lifecycle/LifecycleUpdateExpirationTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleUpdateExpirationTask.spec.js
@@ -40,7 +40,7 @@ describe('LifecycleUpdateExpirationTask', () => {
             gcProducer,
             null,
             new werelogs.Logger('test:LifecycleUpdateExpirationTask'));
-        actionEntry = ActionQueueEntry.create('deleteObject')
+        actionEntry = ActionQueueEntry.create('gc')
             .setAttribute('target', {
                 owner: 'eab6642741045d0ae7cb3333962ad56f847ce0d9bb73de98eb4959428fc28108',
                 bucket: 'somebucket',
@@ -123,6 +123,45 @@ describe('LifecycleUpdateExpirationTask', () => {
             assert.strictEqual(receivedMd, null);
             const receivedGcEntry = gcProducer.getReceivedEntry();
             assert.strictEqual(receivedGcEntry, null);
+            done();
+        });
+    });
+
+    it('should force expire restored object even when the expire delay got updated', done => {
+        const requestedAt = new Date();
+        const restoreCompletedAt = new Date();
+        const expireDate = new Date();
+        const mdObj = new ObjectMD();
+        actionEntry.setAttribute('bypassExpirationCheck', true);
+        mdObj.setKey('somekey')
+            .setLocation(oldLocation)
+            .setContentMd5('1ccc7006b902a4d30ec26e9ddcf759d8')
+            .setLastModified('1970-01-01T00:00:00.000Z')
+            .setArchive({
+                archiveInfo: {
+                    archiveId: '7206409b-7a26-484f-8452-494a0f0ba708',
+                    archiveVersion: 5577006791947779,
+                },
+                restoreRequestedAt: requestedAt.setDate(requestedAt.getDate() - 2),
+                restoreRequestedDays: 1,
+                restoreCompletedAt: restoreCompletedAt.setDate(restoreCompletedAt.getDate() - 1),
+                restoreWillExpireAt: expireDate.setDate(expireDate.getDate() + 2),
+            });
+        backbeatMetadataProxyClient.setMdObj(mdObj);
+        task.processActionEntry(actionEntry, err => {
+            assert.ifError(err);
+            const receivedMd = backbeatMetadataProxyClient.getReceivedMd();
+            assert.deepStrictEqual(receivedMd.archive, {
+                archiveInfo: {
+                    archiveId: '7206409b-7a26-484f-8452-494a0f0ba708',
+                    archiveVersion: 5577006791947779
+                }
+            });
+            assert.strictEqual(receivedMd['x-amz-storage-class'], 'location-dmf-v1');
+            assert.strictEqual(receivedMd.dataStoreName, 'location-dmf-v1');
+            const receivedGcEntry = gcProducer.getReceivedEntry();
+            assert.strictEqual(receivedGcEntry.getActionType(), 'deleteData');
+            assert.deepStrictEqual(receivedGcEntry.getAttribute('target.locations'), oldLocation);
             done();
         });
     });


### PR DESCRIPTION
When this flag is present, we won't skip the message when expiration
date is not reached. This is usefull to handle mass-cleanup of expired
objects, depending on platform state.

Issue: BB-589
