### PR TITLE
INTEGRATION [PR#2521 > development/8.7] Timeout setup in data mover s3 client

### DIFF
--- a/extensions/replication/tasks/CopyLocationTask.js
+++ b/extensions/replication/tasks/CopyLocationTask.js
@@ -10,7 +10,7 @@ const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
 const { LifecycleMetrics } = require('../../lifecycle/LifecycleMetrics');
 const ReplicationMetric = require('../ReplicationMetric');
 const ReplicationMetrics = require('../ReplicationMetrics');
-const { attachReqUids } = require('../../../lib/clients/utils');
+const { attachReqUids, TIMEOUT_MS } = require('../../../lib/clients/utils');
 const { getAccountCredentials } =
           require('../../../lib/credentials/AccountCredentials');
 const RoleCredentials =
@@ -77,7 +77,7 @@ class CopyLocationTask extends BackbeatTask {
             endpoint: `${transport}://${s3.host}:${s3.port}`,
             credentials: s3Credentials,
             sslEnabled: transport === 'https',
-            httpOptions: { agent: this.sourceHTTPAgent, timeout: 0 },
+            httpOptions: { agent: this.sourceHTTPAgent, timeout: TIMEOUT_MS },
             maxRetries: 0,
         });
         this.backbeatMetadataProxy = new BackbeatMetadataProxy(


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2521.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/8.7/improvement/BB-594-Data-mover-S3-clients-timeout`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/8.7/improvement/BB-594-Data-mover-S3-clients-timeout
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/8.7/improvement/BB-594-Data-mover-S3-clients-timeout
```

Please always comment pull request #2521 instead of this one.