### PR TITLE
reset transition-in-progress flag in the MD after a failed transition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "8.6.44",
+  "version": "8.6.45",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Failed hot transitions should be retried. For that to happen we need to reset the transition-in-progress flag in the MD.

Issue: BB-595