### PR TITLE
BB-598 Validate Kafka messages against all bucket notification rules

### DIFF
--- a/extensions/notification/NotificationQueuePopulator.js
+++ b/extensions/notification/NotificationQueuePopulator.js
@@ -221,7 +221,8 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
                 key,
                 eventType,
             });
-            if (configUtil.validateEntry(config, ent)) {
+            const { isValid } = configUtil.validateEntry(config, ent);
+            if (isValid) {
                 const message
                     = messageUtil.addLogAttributes(value, ent);
                 this.log.info('publishing message', {

--- a/extensions/notification/utils/config.js
+++ b/extensions/notification/utils/config.js
@@ -65,39 +65,37 @@ function filterConfigsByEvent(bnConfigs, event) {
 /**
  * Validates an entry from log against bucket notification configurations to see
  * if the entry has to be published. Validations include, bucket specific
- * configuration check, event type check, object name specific filter checks
- * @param  {Object} bnConfig - Bucket notification configuration
- * @param  {Object} entry - An entry from the log
- * @return {boolean} true if event qualifies for notification
+ * configuration check, event type check, object name specific filter checks.
+ * @param {Object} bnConfig - Bucket notification configuration.
+ * @param {Object} entry - An entry from the log.
+ * @return {Object} Result with validity boolean and matching configuration rule.
  */
 function validateEntry(bnConfig, entry) {
     const { bucket, eventType } = entry;
-    /**
-     * if the event type is unavailable, it is an entry that is a
-     * placeholder for deletion or cleanup, these entries should be ignored and
-     * not be processed.
-    */
+
     if (!eventType) {
-        return false;
+        return { isValid: false, matchingConfig: null };
     }
-    const notifConf = bnConfig.notificationConfiguration;
-    // check if the entry belongs to the bucket in the configuration
+
     if (bucket !== bnConfig.bucket) {
-        return false;
+        return { isValid: false, matchingConfig: null };
     }
-    // check if the event type matches
+
+    const notifConf = bnConfig.notificationConfiguration;
     const qConfigs = filterConfigsByEvent(notifConf.queueConfig, eventType);
+
     if (qConfigs.length > 0) {
-        const qConfigWithFilters
-            = qConfigs.filter(c => c.filterRules && c.filterRules.length > 0);
-        // if there are configs without filters, make the entry valid
-        if (qConfigs.length > qConfigWithFilters.length) {
-            return true;
-        }
-        return qConfigWithFilters.some(
-            c => validateEntryWithFilter(c.filterRules, entry));
+        const matchingConfig = qConfigs.find(c => {
+            if (!c.filterRules || c.filterRules.length === 0) {
+                return true;
+            }
+            return validateEntryWithFilter(c.filterRules, entry);
+        });
+
+        return { isValid: !!matchingConfig, matchingConfig };
     }
-    return false;
+
+    return { isValid: false, matchingConfig: null };
 }
 
 module.exports = {

--- a/tests/unit/notification/utils/config.js
+++ b/tests/unit/notification/utils/config.js
@@ -57,10 +57,26 @@ const testConfigs = [
         notificationConfiguration: {
             queueConfig: [
                 {
-                    events: ['s3:ObjectCreated:Copy'],
+                    events: ['s3:ObjectCreated:Put'],
                     queueArn: 'q4',
-                    filterRules: [],
+                    filterRules: [
+                        {
+                            name: 'Prefix',
+                            value: 'abcd',
+                        },
+                    ],
                     id: 'config4',
+                },
+                {
+                    events: ['s3:ObjectRemoved:Delete'],
+                    queueArn: 'q4',
+                    filterRules: [
+                        {
+                            name: 'Suffix',
+                            value: '.png',
+                        },
+                    ],
+                    id: 'config4.1',
                 },
             ],
         },
@@ -140,6 +156,35 @@ const testConfigs = [
             ],
         },
     },
+    {
+        bucket: 'bucket9',
+        notificationConfiguration: {
+            queueConfig: [
+                {
+                    events: ['s3:ObjectCreated:Put'],
+                    queueArn: 'q9',
+                    filterRules: [
+                        {
+                            name: 'Prefix',
+                            value: '0833/epolicy/',
+                        },
+                    ],
+                    id: 'config9',
+                },
+                {
+                    events: ['s3:ObjectCreated:Put'],
+                    queueArn: 'q9',
+                    filterRules: [
+                        {
+                            name: 'Prefix',
+                            value: '0394/ars/',
+                        },
+                    ],
+                    id: 'config9.1',
+                },
+            ],
+        },
+    },
 ];
 
 const tests = [
@@ -151,6 +196,12 @@ const tests = [
             key: 'test.png',
         },
         pass: true,
+        expectedMatchingConfig: {
+            events: ['s3:ObjectCreated:Put'],
+            queueArn: 'q1',
+            filterRules: [],
+            id: 'config1',
+        },
     },
     {
         desc: 'pass if the object key prefix matches the configuration',
@@ -160,6 +211,17 @@ const tests = [
             key: 'abcd.png',
         },
         pass: true,
+        expectedMatchingConfig: {
+            events: ['s3:ObjectRemoved:Delete'],
+            queueArn: 'q2',
+            filterRules: [
+                {
+                    name: 'Prefix',
+                    value: 'abcd',
+                },
+            ],
+            id: 'config2',
+        },
     },
     {
         desc: 'pass if the object key suffix matches the configuration',
@@ -169,6 +231,77 @@ const tests = [
             key: 'test.png',
         },
         pass: true,
+        expectedMatchingConfig: {
+            events: ['s3:ObjectRemoved:DeleteMarkerCreated'],
+            queueArn: 'q3',
+            filterRules: [
+                {
+                    name: 'Suffix',
+                    value: '.png',
+                },
+            ],
+            id: 'config3',
+        },
+    },
+    {
+        desc: 'pass if the object key prefix matches the first of the configuration',
+        entry: {
+            eventType: 's3:ObjectCreated:Put',
+            bucket: 'bucket4',
+            key: 'abcdefgh',
+        },
+        pass: true,
+        expectedMatchingConfig: {
+            events: ['s3:ObjectCreated:Put'],
+            queueArn: 'q4',
+            filterRules: [
+                {
+                    name: 'Prefix',
+                    value: 'abcd',
+                },
+            ],
+            id: 'config4',
+        },
+    },
+    {
+        desc: 'pass if the object key suffix matches the second of the configuration',
+        entry: {
+            eventType: 's3:ObjectRemoved:Delete',
+            bucket: 'bucket4',
+            key: 'toto.png',
+        },
+        pass: true,
+        expectedMatchingConfig: {
+            events: ['s3:ObjectRemoved:Delete'],
+            queueArn: 'q4',
+            filterRules: [
+                {
+                    name: 'Suffix',
+                    value: '.png',
+                },
+            ],
+            id: 'config4.1',
+        },
+    },
+    {
+        desc: 'pass if the object key matches both configuration rules',
+        entry: {
+            eventType: 's3:ObjectRemoved:Delete',
+            bucket: 'bucket4',
+            key: 'abcd.png',
+        },
+        pass: true,
+        expectedMatchingConfig: {
+            events: ['s3:ObjectRemoved:Delete'],
+            queueArn: 'q4',
+            filterRules: [
+                {
+                    name: 'Suffix',
+                    value: '.png',
+                },
+            ],
+            id: 'config4.1',
+        },
     },
     {
         desc: 'pass if object key prefix & suffix matches the configuration',
@@ -178,6 +311,21 @@ const tests = [
             key: 'abcdef.png',
         },
         pass: true,
+        expectedMatchingConfig: {
+            events: ['s3:ObjectCreated:CompleteMultipartUpload'],
+            queueArn: 'q5',
+            filterRules: [
+                {
+                    name: 'Prefix',
+                    value: 'abcd',
+                },
+                {
+                    name: 'Suffix',
+                    value: '.png',
+                },
+            ],
+            id: 'config5',
+        },
     },
     {
         desc: 'pass if object passes at least one notification configuration',
@@ -187,6 +335,11 @@ const tests = [
             key: 'test.jpg',
         },
         pass: true,
+        expectedMatchingConfig: {
+            events: ['s3:ObjectCreated:Copy'],
+            queueArn: 'q61',
+            id: 'config61',
+        },
     },
     {
         desc: 'pass if the event matches wildcard event',
@@ -196,6 +349,48 @@ const tests = [
             key: 'abcd.png',
         },
         pass: true,
+        expectedMatchingConfig: {
+            events: ['s3:ObjectCreated:*'],
+            queueArn: 'q7',
+            filterRules: [],
+            id: 'config7',
+        },
+    },
+    {
+        desc: 'pass if match the first configuration',
+        entry: {
+            eventType: 's3:ObjectCreated:Put',
+            bucket: 'bucket9',
+            key: '0833/epolicy/1',
+        },
+        pass: true,
+        expectedMatchingConfig: {
+            events: ['s3:ObjectCreated:Put'],
+            queueArn: 'q9',
+            filterRules: [{
+                name: 'Prefix',
+                value: '0833/epolicy/',
+            }],
+            id: 'config9',
+        },
+    },
+    {
+        desc: 'pass if match the second configuration',
+        entry: {
+            eventType: 's3:ObjectCreated:Put',
+            bucket: 'bucket9',
+            key: '0394/ars/1',
+        },
+        pass: true,
+        expectedMatchingConfig: {
+            events: ['s3:ObjectCreated:Put'],
+            queueArn: 'q9',
+            filterRules: [{
+                name: 'Prefix',
+                value: '0394/ars/',
+            }],
+            id: 'config9.1',
+        },
     },
     {
         desc: 'fail if the event type does not match the configuration',
@@ -278,6 +473,15 @@ const tests = [
         },
         pass: false,
     },
+    {
+        desc: 'fail if key does not match any configuration',
+        entry: {
+            eventType: undefined,
+            bucket: 'bucket9',
+            key: 'abcd.png',
+        },
+        pass: false,
+    },
 ];
 
 describe('Notification configuration util', () => {
@@ -315,7 +519,12 @@ describe('Notification configuration util', () => {
                     = getBucketNotifConfig(test.entry.bucket, configMap);
                 const result
                     = notifConfUtil.validateEntry(bnConfig, test.entry);
-                assert.strictEqual(test.pass, result);
+                assert.strictEqual(test.pass, result.isValid);
+                if (test.pass) {
+                    assert.deepStrictEqual(test.expectedMatchingConfig, result.matchingConfig);
+                } else {
+                    assert(!result.matchingConfig);
+                }
             });
         });
     });


### PR DESCRIPTION
This PR addresses an issue in the bucket notification queue processor where consumed Kafka messages were only being validated against the first defined bucket notification rule (for a given destination queue: `queueArn`). 
So, notifications were not being sent out for objects/versions that matched the other defined rules.

Fix details:

- Updated the validation logic to ensure that each consumed Kafka message is validated against all defined bucket notification rules.
- Ensured that notifications are correctly sent out for objects/versions matching any of the rules with the correct matching rule id.