### PR TITLE
Add metric for timestamp of last lifecycle operation completed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "8.6.46",
+  "version": "8.6.47",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This is tracked per location and type of workflow.

Issue: BB-597
