### PR TITLE
Fallback into checking the forceLegacyListing parameter when the listing type is not included in the Kafka message

### DIFF
--- a/extensions/lifecycle/LifecycleConfigValidator.js
+++ b/extensions/lifecycle/LifecycleConfigValidator.js
@@ -15,7 +15,7 @@ const joiSchema = joi.object({
     transitionTasksTopic: joi.string().default(parent => parent.objectTasksTopic),
     coldStorageTopics: joi.array().items(joi.string()).unique().default([]),
     auth: authJoi.optional(),
-    forceLegacyListing: joi.boolean().default(true),
+    forceLegacyListing: joi.boolean().default(false),
     autoCreateIndexes: joi.boolean().default(false),
     conductor: {
         auth: inheritedAuthJoi,

--- a/extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor.js
+++ b/extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor.js
@@ -330,7 +330,7 @@ class LifecycleBucketProcessor {
 
             let task;
 
-            if (taskVersion === lifecycleTaskVersions.v1 || !taskVersion) {
+            if (taskVersion === lifecycleTaskVersions.v1 || (!taskVersion && this._lcConfig.forceLegacyListing)) {
                 task = new LifecycleTask(this);
             } else {
                 task = new LifecycleTaskV2(this);

--- a/tests/utils/kafkaEntries.js
+++ b/tests/utils/kafkaEntries.js
@@ -6,4 +6,24 @@ const replicationEntry = {
     value: '{"type":"put","bucket":"queue-populator-test-bucket","key":"hosts\\u000098500086134471999999RG001  0","value":"{\\"md-model-version\\":2,\\"owner-display-name\\":\\"Bart\\",\\"owner-id\\":\\"79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be\\",\\"content-length\\":542,\\"content-type\\":\\"text/plain\\",\\"last-modified\\":\\"2017-07-13T02:44:25.519Z\\",\\"content-md5\\":\\"01064f35c238bd2b785e34508c3d27f4\\",\\"x-amz-version-id\\":\\"null\\",\\"x-amz-server-version-id\\":\\"\\",\\"x-amz-storage-class\\":\\"sf\\",\\"x-amz-server-side-encryption\\":\\"\\",\\"x-amz-server-side-encryption-aws-kms-key-id\\":\\"\\",\\"x-amz-server-side-encryption-customer-algorithm\\":\\"\\",\\"x-amz-website-redirect-location\\":\\"\\",\\"acl\\":{\\"Canned\\":\\"private\\",\\"FULL_CONTROL\\":[],\\"WRITE_ACP\\":[],\\"READ\\":[],\\"READ_ACP\\":[]},\\"key\\":\\"\\",\\"location\\":[{\\"key\\":\\"29258f299ddfd65f6108e6cd7bd2aea9fbe7e9e0\\",\\"size\\":542,\\"start\\":0,\\"dataStoreName\\":\\"file\\",\\"dataStoreETag\\":\\"1:01064f35c238bd2b785e34508c3d27f4\\"}],\\"isDeleteMarker\\":false,\\"tags\\":{},\\"replicationInfo\\":{\\"status\\":\\"PENDING\\",\\"backends\\":[{\\"site\\":\\"sf\\",\\"status\\":\\"PENDING\\",\\"dataStoreVersionId\\":\\"B2AqTml1DtEKWJwRiOTh0tgkm8AlyH7W\\"},{\\"site\\":\\"replicationaws\\",\\"status\\":\\"PENDING\\",\\"dataStoreVersionId\\":\\"ob.rop0jdndzwVioi7v.6Q9.v9.6QOGv\\"}],\\"content\\":[\\"DATA\\",\\"METADATA\\"],\\"destination\\":\\"arn:aws:s3:::dummy-dest-bucket\\",\\"storageClass\\":\\"sf\\",\\"role\\":\\"arn:aws:iam::123456789012:role/backbeat\\"},\\"x-amz-meta-s3cmd-attrs\\":\\"uid:0/gname:root/uname:root/gid:0/mode:33188/mtime:1490807629/atime:1499845478/md5:01064f35c238bd2b785e34508c3d27f4/ctime:1490807629\\",\\"versionId\\":\\"98500086134471999999RG001  0\\",\\"isNFS\\":true}"}',
 };
 
-module.exports = { replicationEntry };
+const bucketProcessorEntry = {
+    key: null,
+    value: '{"action":"processObjects","contextInfo":{"reqId":"5d37f38aef4b81d3b306"},"target":{"bucket":"bucket","owner":"48ff9529e073aeb075a00f6ba571638698f39cfa2778ebf0ac098da7030b11c5","accountId":"979878005795"},"details":{}}'
+};
+
+const bucketProcessorV1Entry = {
+    key: null,
+    value: '{"action":"processObjects","contextInfo":{"reqId":"5d37f38aef4b81d3b307"},"target":{"bucket":"v1-bucket","owner":"48ff9529e073aeb075a00f6ba571638698f39cfa2778ebf0ac098da7030b11c5","accountId":"979878005795","taskVersion":"v1"},"details":{}}'
+};
+
+const bucketProcessorV2Entry = {
+    key: null,
+    value: '{"action":"processObjects","contextInfo":{"reqId":"5d37f38aef4b81d3b308"},"target":{"bucket":"v2-bucket","owner":"48ff9529e073aeb075a00f6ba571638698f39cfa2778ebf0ac098da7030b11c5","accountId":"979878005795","taskVersion":"v2"},"details":{}}'
+};
+
+module.exports = {
+    replicationEntry,
+    bucketProcessorEntry,
+    bucketProcessorV1Entry,
+    bucketProcessorV2Entry
+};


### PR DESCRIPTION
The check of forceLegacyListing in the bucket processor was moved to the conductor as the listing type also depends on the MongoDB indexes, which is not something used in S3C.

Lifecycle conductor in 7.x doesn't set the listing type in the bucketProcessor messages. So we now fallback to the forceLegacyListing param inside the config when encountering this case during the transition phase from backbeat 7.x to 8.x/9.x.

Also changed the default value of forceLegacyListing to how it's set in Backbeat 7.x. This is done to avoid any behaviour change in S3C in case the value is not set (which should in theory not be the case in RING10 but just in case)

Issue: BB-550