### PR TITLE
fix ambiguous redis connection config

### DIFF
--- a/conf/config.json
+++ b/conf/config.json
@@ -332,6 +332,10 @@
         "host": "127.0.0.1",
         "port": 6379
     },
+    "redis": {
+        "host": "localhost",
+        "port": 6379
+    },
     "certFilePaths": {
         "key": "",
         "cert": "",

--- a/lib/config.joi.js
+++ b/lib/config.joi.js
@@ -67,8 +67,16 @@ const joiSchema = joi.object({
         port: joi.number().default(8900),
     },
     redis: {
-        host: joi.string().default('localhost'),
-        port: joi.number().default(6379),
+        host: joi.string().when('sentinels', {
+            is: joi.exist(),
+            then: joi.forbidden(),
+            otherwise: joi.required(),
+        }),
+        port: joi.number().when('sentinels', {
+            is: joi.exist(),
+            then: joi.forbidden(),
+            otherwise: joi.required(),
+        }),
         name: joi.string().default('backbeat'),
         password: joi.string().default('').allow(''),
         sentinels: joi.alternatives([joi.string(), joi.array().items(


### PR DESCRIPTION
Redis sentinel is what's deployed in S3C, to connect to it we use "sentinels" field in redis config that contains the host/port of each sentinel.

In Artesca we use the "host" and "port" fields to connect to the redis instance.

The config rules were adapted to make sure we don't pass all the fields at once which might make the config ambiguous to understand, although the redis client seems to handle this case well, as it first checks the sentinel config before connecting using the host/port fields.

Default values for redis host/port were removed from the config definition and put inside the default/dev config file.

Issue: BB-522