### PR TITLE
forward port workarround for queue populator batch getting stuck

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -14,6 +14,7 @@ const constants = {
     statusUndefined: 'UNDEFINED',
     statusNotReady: 'NOT_READY',
     statusNotConnected: 'NOT_CONNECTED',
+    statusTimedOut: 'TIMED_OUT',
     authTypeAssumeRole: 'assumeRole',
     authTypeAccount: 'account',
     authTypeService: 'service',

--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -54,6 +54,7 @@ class LogReader {
         this._zkMetricsHandler = params.zkMetricsHandler;
 
         this._batchTimeoutSeconds = parseInt(process.env.BATCH_TIMEOUT_SECONDS, 10) || 300;
+        this._batchTimedOut = false;
     }
 
     _setEntryBatch(entryBatch) {
@@ -300,6 +301,9 @@ class LogReader {
             this.log.error('queue populator batch timeout', {
                 logStats: batchState.logStats,
             });
+            this._batchTimedOut = true;
+            // S3C doesn't currently support restarts on healthcheck failure,
+            // so we just crash for now.
             process.emit('SIGTERM');
         },  this._batchTimeoutSeconds * 1000);
         async.waterfall([
@@ -737,6 +741,10 @@ class LogReader {
             statuses[topic] = this._producers[topic].isReady();
         });
         return statuses;
+    }
+
+    batchProcessTimedOut() {
+        return this._batchTimedOut;
     }
 }
 

--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -301,10 +301,13 @@ class LogReader {
             this.log.error('queue populator batch timeout', {
                 logStats: batchState.logStats,
             });
-            this._batchTimedOut = true;
             // S3C doesn't currently support restarts on healthcheck failure,
             // so we just crash for now.
-            process.emit('SIGTERM');
+            if (process.env.CRASH_ON_BATCH_TIMEOUT) {
+                process.emit('SIGTERM');
+            } else {
+                this._batchTimedOut = true;
+            }
         },  this._batchTimeoutSeconds * 1000);
         async.waterfall([
             next => this._processReadRecords(params, batchState, next),

--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -52,6 +52,8 @@ class LogReader {
         this._metricsHandler = params.metricsHandler;
         // TODO: use a common handler for zk metrics from all extensions
         this._zkMetricsHandler = params.zkMetricsHandler;
+
+        this._batchTimeoutSeconds = parseInt(process.env.BATCH_TIMEOUT_SECONDS, 10) || 300;
     }
 
     _setEntryBatch(entryBatch) {
@@ -291,6 +293,15 @@ class LogReader {
             timeoutMs: params.timeoutMs,
             logger: this.log.newRequestLogger(),
         };
+        // When using the RaftLogReader log consumer, The batch
+        // processing can get stuck sometimes for unknown reasons.
+        // As a temporary fix we set a timeout to kill the process.
+        const batchTimeoutTimer = setTimeout(() => {
+            this.log.error('queue populator batch timeout', {
+                logStats: batchState.logStats,
+            });
+            process.emit('SIGTERM');
+        },  this._batchTimeoutSeconds * 1000);
         async.waterfall([
             next => this._processReadRecords(params, batchState, next),
             next => this._processPrepareEntries(batchState, next),
@@ -299,6 +310,7 @@ class LogReader {
             next => this._processSaveLogOffset(batchState, next),
         ],
             err => {
+                clearTimeout(batchTimeoutTimer);
                 if (err) {
                     return done(err);
                 }

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -592,6 +592,12 @@ class QueuePopulator {
                     });
                 }
             });
+            if (reader.batchProcessTimedOut()) {
+                responses.push({
+                    component: 'log reader',
+                    status: constants.statusTimedOut,
+                });
+            }
         });
 
         log.debug('verbose liveness', verboseLiveness);

--- a/tests/unit/lib/queuePopulator/LogReader.spec.js
+++ b/tests/unit/lib/queuePopulator/LogReader.spec.js
@@ -309,6 +309,7 @@ describe('LogReader', () => {
             logReader.processLogEntries({}, () => {});
             setTimeout(() => {
                 assert.strictEqual(emmitted, true);
+                assert.strictEqual(logReader.batchProcessTimedOut(), true);
                 done();
             }, 2000);
         }).timeout(4000);
@@ -325,6 +326,7 @@ describe('LogReader', () => {
             });
             logReader.processLogEntries({}, () => {
                 assert.strictEqual(emmitted, false);
+                assert.strictEqual(logReader.batchProcessTimedOut(), false);
                 done();
             });
         });

--- a/tests/unit/lib/queuePopulator/LogReader.spec.js
+++ b/tests/unit/lib/queuePopulator/LogReader.spec.js
@@ -296,8 +296,11 @@ describe('LogReader', () => {
                 });
             });
         });
+    });
 
-        it('should shutdown when batch processing is stuck', done => {
+    describe('processLogEntries', () => {
+        it('should shutdown when batch processing is stuck and CRASH_ON_BATCH_TIMEOUT is set', done => {
+            process.env.CRASH_ON_BATCH_TIMEOUT = true;
             logReader._batchTimeoutSeconds = 1;
             // logReader will become stuck as _processReadRecords will never
             // call the callback
@@ -309,12 +312,31 @@ describe('LogReader', () => {
             logReader.processLogEntries({}, () => {});
             setTimeout(() => {
                 assert.strictEqual(emmitted, true);
+                delete process.env.CRASH_ON_BATCH_TIMEOUT;
+                done();
+            }, 2000);
+        }).timeout(4000);
+
+        it('should fail healthcheck when batch processing is stuck', done => {
+            delete process.env.CRASH_ON_BATCH_TIMEOUT;
+            logReader._batchTimeoutSeconds = 1;
+            // logReader will become stuck as _processReadRecords will never
+            // call the callback
+            sinon.stub(logReader, '_processReadRecords').returns();
+            let emmitted = false;
+            process.once('SIGTERM', () => {
+                emmitted = true;
+            });
+            logReader.processLogEntries({}, () => {});
+            setTimeout(() => {
+                assert.strictEqual(emmitted, false);
                 assert.strictEqual(logReader.batchProcessTimedOut(), true);
                 done();
             }, 2000);
         }).timeout(4000);
 
         it('should not shutdown if timeout not reached', done => {
+            process.env.CRASH_ON_BATCH_TIMEOUT = true;
             sinon.stub(logReader, '_processReadRecords').yields();
             sinon.stub(logReader, '_processPrepareEntries').yields();
             sinon.stub(logReader, '_processFilterEntries').yields();
@@ -326,6 +348,19 @@ describe('LogReader', () => {
             });
             logReader.processLogEntries({}, () => {
                 assert.strictEqual(emmitted, false);
+                delete process.env.CRASH_ON_BATCH_TIMEOUT;
+                done();
+            });
+        });
+
+        it('should not fail healthcheck if timeout not reached', done => {
+            delete process.env.CRASH_ON_BATCH_TIMEOUT;
+            sinon.stub(logReader, '_processReadRecords').yields();
+            sinon.stub(logReader, '_processPrepareEntries').yields();
+            sinon.stub(logReader, '_processFilterEntries').yields();
+            sinon.stub(logReader, '_processPublishEntries').yields();
+            sinon.stub(logReader, '_processSaveLogOffset').yields();
+            logReader.processLogEntries({}, () => {
                 assert.strictEqual(logReader.batchProcessTimedOut(), false);
                 done();
             });


### PR DESCRIPTION
7.x fix was not forward ported to avoid introducing memory leaks into the code. Instead of just unblocking the next batch processing call and leaving the stuck one alive, now we shutdown the whole process.

7.x fix commit: https://github.com/scality/backbeat/commit/dfcc2f5786ab6da8bd3e2fc893d897aed0a77fe8

Issue: BB-526