### PR TITLE
add missing overhead field used in S3C

### DIFF
--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -499,6 +499,7 @@ class LogReader {
             const overheadFields = {
                 commitTimestamp: record.timestamp,
                 opTimestamp: entry.timestamp,
+                versionId: entry.overhead?.versionId,
             };
             const entryToFilter = {
                 type: entry.type,


### PR DESCRIPTION
Metadata adds `versionId` as an extra field in the oplog's delete events as they originally contain no metadata. These are needed for Bucket notification.

Note: Updating Bucket Notifications to use this field will be addressed in another ticket.

Issue: BB-535