### PR TITLE
Support setting a site name for Kafka consumers

### DIFF
--- a/lib/config.joi.js
+++ b/lib/config.joi.js
@@ -29,6 +29,7 @@ const joiSchema = joi.object({
             intervalS: joi.number().default(60),
         },
         maxRequestSize: joi.number().default(KAFKA_PRODUCER_MESSAGE_MAX_BYTES),
+        site: joi.string(),
     },
     transport: transportJoi,
     s3: hostPortJoi.required(),


### PR DESCRIPTION
Code in `backbeatConsumer` already supports setting the `client.rack` consumer parameter from the config. So here i just allow passing that field in the config as we do in S3C

Issue: BB-521