### PR TITLE
Bucket Notifications Unification

### DIFF
--- a/bin/ingestion.js
+++ b/bin/ingestion.js
@@ -28,7 +28,7 @@ const qpConfig = config.queuePopulator;
 const mConfig = config.metrics;
 const rConfig = config.redis;
 const s3Config = config.s3;
-const { connectionString, autoCreateNamespace } = zkConfig;
+const { connectionString, autoCreateNamespace, retries } = zkConfig;
 
 const RESUME_NODE = 'scheduledResume';
 
@@ -316,6 +316,7 @@ function initAndStart(zkClient) {
 
 const zkClient = new ZookeeperManager(connectionString, {
     autoCreateNamespace,
+    retries,
 }, log);
 zkClient.once('error', err => {
     log.fatal('error connecting to zookeeper', {

--- a/extensions/notification/NotificationConfigManager.js
+++ b/extensions/notification/NotificationConfigManager.js
@@ -10,7 +10,7 @@ class NotificationConfigManager {
 
     constructor(params) {
         const {
-            mongoConfig, bucketMetastore, maxCachedConfigs, zkClient, zkConfig, zkPath, logger,
+            mongoConfig, bucketMetastore, maxCachedConfigs, zkClient, zkConfig, zkPath, zkConcurrency, logger,
         } = params;
         if (mongoConfig) {
             this._configManagerBackend = new MongoConfigManager({
@@ -25,6 +25,7 @@ class NotificationConfigManager {
                 zkClient,
                 zkConfig,
                 zkPath,
+                zkConcurrency,
                 logger,
             });
         }

--- a/extensions/notification/NotificationConfigManager.js
+++ b/extensions/notification/NotificationConfigManager.js
@@ -1,283 +1,79 @@
-const joi = require('joi');
-const semver = require('semver');
-
-const { ZenkoMetrics } = require('arsenal').metrics;
-const LRUCache = require('arsenal').algorithms
-    .cache.LRUCache;
-const MongoClient = require('mongodb').MongoClient;
-const ChangeStream = require('../../lib/wrappers/ChangeStream');
-const constants = require('./constants');
-const { constructConnectionString, getMongoVersion } = require('../utils/MongoUtils');
-
-const paramsJoi = joi.object({
-    mongoConfig: joi.object().required(),
-    logger: joi.object().required(),
-}).required();
-
-const MAX_CACHED_ENTRIES = Number(process.env.MAX_CACHED_BUCKET_NOTIFICATION_CONFIGS)
-    || 1000;
-
-// should equal true if config manager's cache was hit during a get operation
-const CONFIG_MANAGER_CACHE_HIT = 'cache_hit';
-// Type of operation performed on the cache
-const CONFIG_MANAGER_OPERATION_TYPE = 'op';
-
-const cacheUpdates = ZenkoMetrics.createCounter({
-    name: 's3_notification_config_manager_cache_updates_total',
-    help: 'Total number of cache updates',
-    labelNames: [
-        CONFIG_MANAGER_OPERATION_TYPE,
-    ],
-});
-
-const configGetLag = ZenkoMetrics.createHistogram({
-    name: 's3_notification_config_manager_config_get_seconds',
-    help: 'Time it takes in seconds to get a bucket notification config from MongoDB',
-    labelNames: [
-        CONFIG_MANAGER_CACHE_HIT,
-    ],
-    buckets: [0.001, 0.01, 1, 10, 100, 1000],
-});
-
-const cachedBuckets = ZenkoMetrics.createGauge({
-    name: 's3_notification_config_manager_cached_buckets_count',
-    help: 'Total number of cached buckets in the notification config manager',
-});
-
-function onConfigManagerCacheUpdate(op) {
-    cacheUpdates.inc({
-        [CONFIG_MANAGER_OPERATION_TYPE]: op,
-    });
-    if (op === 'add') {
-        cachedBuckets.inc({});
-    } else if (op === 'delete') {
-        cachedBuckets.dec({});
-    }
-}
-
-function onConfigManagerConfigGet(cacheHit, delay) {
-    configGetLag.observe({
-        [CONFIG_MANAGER_CACHE_HIT]: cacheHit,
-    }, delay);
-}
+const MongoConfigManager = require('./configManager/MongoConfigManager');
+const ZookeeperConfigManager = require('./configManager/ZookeeperConfigManager');
 
 /**
  * @class NotificationConfigManager
  *
- * @classdesc Manages bucket notification configurations, the configurations
- * are directly retrieved from the metastore, and are locally cached. Cache
- * is invalidated using MongoDB change streams.
+ * @classdesc Manages bucket notification configurations
  */
 class NotificationConfigManager {
-    /**
-     * @constructor
-     * @param {Object} params - constructor params
-     * @param {Object} params.mongoConfig - mongoDB config
-     * @param {Logger} params.logger - logger object
-     */
+
     constructor(params) {
-        joi.attempt(params, paramsJoi);
-        this._logger = params.logger;
-        this._mongoConfig = params.mongoConfig;
-        this._cachedConfigs = new LRUCache(MAX_CACHED_ENTRIES);
-        this._mongoClient = null;
-        this._metastore = null;
-        this._metastoreChangeStream = null;
-    }
-
-    /**
-     * Connects to MongoDB using the MongoClientInterface
-     * and retreives the metastore collection
-     * @param {Function} cb callback
-     * @returns {undefined}
-     */
-    _setupMongoClient(cb) {
-        const mongoUrl = constructConnectionString(this._mongoConfig);
-        MongoClient.connect(mongoUrl, {
-            replicaSet: this._mongoConfig.replicaSet,
-            useNewUrlParser: true,
-        },
-        (err, client) => {
-            if (err) {
-                this._logger.error('Could not connect to MongoDB', {
-                    method: 'NotificationConfigManager._setupMongoClient',
-                    error: err.message,
-                });
-                return cb(err);
-            }
-            this._logger.debug('Connected to MongoDB', {
-                method: 'NotificationConfigManager._setupMongoClient',
+        const { mongoConfig, bucketMetastore, zkClient, zkConfig, zkPath, logger } = params;
+        if (mongoConfig) {
+            this._configManagerBackend = new MongoConfigManager({
+                mongoConfig,
+                bucketMetastore,
+                logger,
             });
-            try {
-                this._mongoClient = client.db(this._mongoConfig.database, {
-                    ignoreUndefined: true,
-                });
-                this._metastore = this._mongoClient.collection(constants.bucketMetastore);
-                // get mongodb version
-                getMongoVersion(this._mongoClient, (err, version) => {
-                    if (err) {
-                        this._logger.error('Could not get MongoDB version', {
-                            method: 'NotificationConfigManager._setupMongoClient',
-                            error: err.message,
-                        });
-                        return cb(err);
-                    }
-                    this._mongoVersion = version;
-                    return cb();
-                });
-                return undefined;
-            } catch (error) {
-                return cb(error);
-            }
-        });
-    }
-
-    /**
-     * Handler for the change stream "change" event.
-     * Invalidates cached bucket configs based on the change.
-     * @param {ChangeStreamDocument} change Change stream change object
-     * @returns {undefined}
-     */
-    _handleChangeStreamChangeEvent(change) {
-        // invalidating cached notification configs
-        const cachedConfig = this._cachedConfigs.get(change.documentKey._id);
-        const bucketNotificationConfiguration = change.fullDocument ? change.fullDocument.value.
-            notificationConfiguration : null;
-        switch (change.operationType) {
-            case 'delete':
-                if (cachedConfig) {
-                    this._cachedConfigs.remove(change.documentKey._id);
-                    onConfigManagerCacheUpdate('delete');
-                }
-                break;
-            case 'replace':
-            case 'update':
-                if (cachedConfig) {
-                    // add() replaces the value of an entry if it exists in cache
-                    this._cachedConfigs.add(change.documentKey._id, bucketNotificationConfiguration);
-                    onConfigManagerCacheUpdate('update');
-                }
-                break;
-            default:
-                this._logger.debug('Skipping unsupported change stream event', {
-                    method: 'NotificationConfigManager._handleChangeStreamChange',
-                });
-                break;
+        } else {
+            this._usesZookeeperBackend = true;
+            this._configManagerBackend = new ZookeeperConfigManager({
+                zkClient,
+                zkConfig,
+                zkPath,
+                logger,
+            });
         }
-        this._logger.debug('Change stream event processed', {
-            method: 'NotificationConfigManager._handleChangeStreamChange',
-        });
-    }
-
-    /**
-     * Initializes a change stream on the metastore collection
-     * Only document delete and update/replace operations are
-     * taken into consideration to invalidate cache.
-     * Newly created buckets (insert operations) are not cached
-     * as queue populator instances read from different kafka
-     * partitions and so don't need the configs for all buckets
-     * @returns {undefined}
-     */
-    _setMetastoreChangeStream() {
-        /**
-         * To avoid processing irrelevant events
-         * we filter by the operation types and
-         * only project the fields needed
-         */
-        const changeStreamPipeline = [
-            {
-                $match: {
-                    $or: [
-                        { operationType: 'delete' },
-                        { operationType: 'replace' },
-                        { operationType: 'update' },
-                    ]
-                }
-            },
-            {
-                $project: {
-                    '_id': 1,
-                    'operationType': 1,
-                    'documentKey._id': 1,
-                    'fullDocument._id': 1,
-                    'fullDocument.value.notificationConfiguration': 1
-                },
-            },
-        ];
-        this._metastoreChangeStream = new ChangeStream({
-            logger: this._logger,
-            collection: this._metastore,
-            pipeline: changeStreamPipeline,
-            handler: this._handleChangeStreamChangeEvent.bind(this),
-            throwOnError: false,
-            useStartAfter: semver.gte(this._mongoVersion, '4.2.0'),
-        });
-        // start watching metastore
-        this._metastoreChangeStream.start();
-    }
-
-    /**
-     * Sets up the NotificationConfigManager by
-     * connecting to mongo and initializing the
-     * change stream
-     * @param {Function} cb callback
-     * @returns {undefined}
-     */
-    setup(cb) {
-        this._setupMongoClient(err => {
-            if (err) {
-                this._logger.error('An error occured while setting up mongo client', {
-                    method: 'NotificationConfigManager.setup',
-                });
-                return cb(err);
-            }
-            try {
-                this._setMetastoreChangeStream();
-            } catch (error) {
-                this._logger.error('An error occured while establishing the change stream', {
-                    method: 'NotificationConfigManager._setMetastoreChangeStream',
-                });
-                return cb(error);
-            }
-            return cb();
-        });
     }
 
     /**
      * Get bucket notification configuration
      *
      * @param {String} bucket - bucket
+     * @param {function} [cb] - callback
      * @return {Object|undefined} - configuration if available or undefined
      */
-    async getConfig(bucket) {
-        const startTime = Date.now();
-        // return cached config for bucket if it exists
-        const cachedConfig = this._cachedConfigs.get(bucket);
-        if (cachedConfig) {
-            const delay = (Date.now() - startTime) / 1000;
-            onConfigManagerConfigGet(true, delay);
-            return cachedConfig;
+    getConfig(bucket, cb) {
+        const val = this._configManagerBackend.getConfig(bucket);
+        if (!cb) {
+            return val;
         }
-        try {
-            // retreiving bucket metadata from the metastore
-            const bucketMetadata = await this._metastore.findOne({ _id: bucket });
-            const bucketNotificationConfiguration = (bucketMetadata && bucketMetadata.value &&
-                bucketMetadata.value.notificationConfiguration) || undefined;
-            // caching the bucket configuration
-            this._cachedConfigs.add(bucket, bucketNotificationConfiguration);
-            const delay = (Date.now() - startTime) / 1000;
-            onConfigManagerConfigGet(false, delay);
-            onConfigManagerCacheUpdate('add');
-            return bucketNotificationConfiguration;
-        } catch (err) {
-            this._logger.error('An error occured when getting notification ' +
-                'configuration of bucket', {
-                method: 'NotificationConfigManager.getConfig',
-                bucket,
-                error: err.message,
-            });
-            return undefined;
+        if (val instanceof Promise) {
+            return val.then(res => cb(null, res)).catch(err => cb(err));
         }
+        return cb(null, val);
+    }
+
+    /**
+     * Add/update bucket notification configuration.
+     *
+     * @param {String} bucket - bucket
+     * @param {Object} config - bucket notification configuration
+     * @return {boolean} - true if set
+     */
+    setConfig(bucket, config) {
+        return this._configManagerBackend.setConfig(bucket, config);
+    }
+
+    /**
+     * Remove bucket notification configuration
+     *
+     * @param {String} bucket - bucket
+     * @return {undefined}
+     */
+    removeConfig(bucket) {
+        return this._configManagerBackend.removeConfig(bucket);
+    }
+
+    /**
+     * Setup bucket notification configuration manager
+     *
+     * @param {function} [cb] - callback
+     * @return {undefined}
+     */
+    setup(cb) {
+        return this._configManagerBackend.setup(cb);
     }
 }
 

--- a/extensions/notification/NotificationConfigManager.js
+++ b/extensions/notification/NotificationConfigManager.js
@@ -9,11 +9,14 @@ const ZookeeperConfigManager = require('./configManager/ZookeeperConfigManager')
 class NotificationConfigManager {
 
     constructor(params) {
-        const { mongoConfig, bucketMetastore, zkClient, zkConfig, zkPath, logger } = params;
+        const {
+            mongoConfig, bucketMetastore, maxCachedConfigs, zkClient, zkConfig, zkPath, logger,
+        } = params;
         if (mongoConfig) {
             this._configManagerBackend = new MongoConfigManager({
                 mongoConfig,
                 bucketMetastore,
+                maxCachedConfigs,
                 logger,
             });
         } else {

--- a/extensions/notification/NotificationConfigValidator.js
+++ b/extensions/notification/NotificationConfigValidator.js
@@ -18,7 +18,7 @@ const destinationSchema = joi.object({
     resource: joi.string().required(),
     type: joi.string().required(),
     host: joi.string().required(),
-    port: joi.number().required(),
+    port: joi.number().optional(),
     internalTopic: joi.string(),
     topic: joi.string().required(),
     auth: authSchema.default({}),

--- a/extensions/notification/NotificationConfigValidator.js
+++ b/extensions/notification/NotificationConfigValidator.js
@@ -28,6 +28,7 @@ const joiSchema = joi.object({
     topic: joi.string(),
     monitorNotificationFailures: joi.boolean().default(true),
     notificationFailedTopic: joi.string().optional(),
+    zookeeperPath: joi.string().optional(),
     queueProcessor: {
         groupId: joi.string().required(),
         concurrency: joi.number().greater(0).default(1000),

--- a/extensions/notification/NotificationConfigValidator.js
+++ b/extensions/notification/NotificationConfigValidator.js
@@ -38,6 +38,7 @@ const joiSchema = joi.object({
     // for bucket notification proceses
     probeServer: probeServerJoi.optional(),
     bucketMetastore: joi.string().default('__metastore'),
+    maxCachedConfigs: joi.number().default(1000),
 });
 
 function configValidator(backbeatConfig, extConfig) {

--- a/extensions/notification/NotificationConfigValidator.js
+++ b/extensions/notification/NotificationConfigValidator.js
@@ -39,6 +39,9 @@ const joiSchema = joi.object({
     probeServer: probeServerJoi.optional(),
     bucketMetastore: joi.string().default('__metastore'),
     maxCachedConfigs: joi.number().default(1000),
+    // Conrrency to use when updating all local bucket notification configs
+    // from zookeeper
+    zookeeperOpConcurrency: joi.number().default(10),
 });
 
 function configValidator(backbeatConfig, extConfig) {

--- a/extensions/notification/NotificationConfigValidator.js
+++ b/extensions/notification/NotificationConfigValidator.js
@@ -36,7 +36,8 @@ const joiSchema = joi.object({
     destinations: joi.array().items(destinationSchema).default([]),
     // TODO: BB-625 reset to being required after supporting probeserver in S3C
     // for bucket notification proceses
-    probeServer: probeServerJoi.optional()
+    probeServer: probeServerJoi.optional(),
+    bucketMetastore: joi.string().default('__metastore'),
 });
 
 function configValidator(backbeatConfig, extConfig) {

--- a/extensions/notification/NotificationQueuePopulator.js
+++ b/extensions/notification/NotificationQueuePopulator.js
@@ -39,7 +39,7 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
      * @return {boolean} - true if bucket entry
      */
     _isBucketEntry(bucket, key) {
-        return ((bucket.toLowerCase() === notifConstants.bucketMetastore && !!key)
+        return ((bucket.toLowerCase() === this.notificationConfig.bucketMetastore && !!key)
             || key === undefined);
     }
 

--- a/extensions/notification/NotificationQueuePopulator.js
+++ b/extensions/notification/NotificationQueuePopulator.js
@@ -218,20 +218,23 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
                     return undefined;
                 }
                 // get destination specific notification config
-                const destBnConf = config.queueConfig.filter(
-                    c => c.queueArn.split(':').pop()
-                        === destination.resource);
-                if (!destBnConf.length) {
+                const queueConfig = config.notificationConfiguration.queueConfig.filter(
+                    c => c.queueArn.split(':').pop() === destination.resource
+                );
+                if (!queueConfig.length) {
                     // skip, if there is no config for the current
                     // destination resource
                     return undefined;
                 }
                 // pass only destination resource specific config to
                 // validate entry
-                const bnConfig = {
-                    queueConfig: destBnConf,
+                const destConfig = {
+                    bucket,
+                    notificationConfiguration: {
+                        queueConfig,
+                    },
                 };
-                const { isValid, matchingConfig } = configUtil.validateEntry(bnConfig, ent);
+                const { isValid, matchingConfig } = configUtil.validateEntry(destConfig, ent);
                 if (isValid) {
                     const message
                         = messageUtil.addLogAttributes(value, ent);

--- a/extensions/notification/NotificationQueuePopulator.js
+++ b/extensions/notification/NotificationQueuePopulator.js
@@ -3,7 +3,7 @@ const util = require('util');
 
 const { isMasterKey } = require('arsenal').versioning;
 const { usersBucket, mpuBucketPrefix, supportedNotificationEvents } = require('arsenal').constants;
-const VID_SEP = require('arsenal').versioning.VersioningConstants.VersionId.Separator;
+const VID_SEPERATOR = require('arsenal').versioning.VersioningConstants.VersionId.Separator;
 const configUtil = require('./utils/config');
 const safeJsonParse = require('./utils/safeJsonParse');
 const messageUtil = require('./utils/message');
@@ -63,11 +63,10 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
     /**
      * Get bucket name from bucket attributes
      *
-     * @param {Object} value - log entry object
+     * @param {Object} attributes - bucket attributes from log entry
      * @return {String|undefined} - bucket name if available
      */
-    _getBucketNameFromAttributes(value) {
-        const attributes = this._getBucketAttributes(value);
+    _getBucketNameFromAttributes(attributes) {
         if (attributes && attributes.name) {
             return attributes.name;
         }
@@ -77,11 +76,10 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
     /**
      * Get notification configuration from bucket attributes
      *
-     * @param {Object} value - log entry object
+     * @param {Object} attributes - bucket attributes from log entry
      * @return {Object|undefined} - notification configuration if available
      */
-    _getBucketNotificationConfiguration(value) {
-        const attributes = this._getBucketAttributes(value);
+    _getBucketNotificationConfiguration(attributes) {
         if (attributes && attributes.notificationConfiguration) {
             return attributes.notificationConfiguration;
         }
@@ -96,9 +94,10 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
      * @return {undefined}
      */
     _processBucketEntry(bucket, value) {
-        const bucketName = this._getBucketNameFromAttributes(value);
+        const attributes = this._getBucketAttributes(value);
+        const bucketName = this._getBucketNameFromAttributes(attributes);
         const notificationConfiguration
-            = this._getBucketNotificationConfiguration(value);
+            = this._getBucketNotificationConfiguration(attributes);
         if (notificationConfiguration &&
             Object.keys(notificationConfiguration).length > 0) {
             const bnConfig = {
@@ -110,7 +109,8 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
             return undefined;
         }
         // bucket was deleter or notification conf has been removed, so remove zk node
-        return this.bnConfigManager.removeConfig(bucketName || bucket);
+        this.bnConfigManager.removeConfig(bucketName || bucket);
+        return undefined;
     }
 
     /**
@@ -184,7 +184,7 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
      * @return {String} - versioned base key
      */
     _extractVersionedBaseKey(key) {
-        return key.split(VID_SEP)[0];
+        return key.split(VID_SEPERATOR)[0];
     }
 
     /**

--- a/extensions/notification/NotificationQueuePopulator.js
+++ b/extensions/notification/NotificationQueuePopulator.js
@@ -3,6 +3,7 @@ const util = require('util');
 
 const { isMasterKey } = require('arsenal').versioning;
 const { usersBucket, mpuBucketPrefix, supportedNotificationEvents } = require('arsenal').constants;
+const VID_SEP = require('arsenal').versioning.VersioningConstants.VersionId.Separator;
 const configUtil = require('./utils/config');
 const safeJsonParse = require('./utils/safeJsonParse');
 const messageUtil = require('./utils/message');
@@ -116,18 +117,21 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
      * to display according to the
      * versioning state of the object
      * @param {Object} value log entry object
+     * @param {Object} overheadFields - extra fields
+     * @param {Object} overheadFields.versionId - object versionId
      * @return {String} versionId
      */
-    _getVersionId(value) {
+    _getVersionId(value, overheadFields) {
+        const versionId = value.versionId || (overheadFields && overheadFields.versionId);
         const isNullVersion = value.isNull;
-        const isVersioned = !!value.versionId;
+        const isVersioned = !!versionId;
         // Versioning suspended objects have
         // a versionId, however it is internal
         // and should not be used to get the object
         if (isNullVersion || !isVersioned) {
             return null;
         } else {
-            return value.versionId;
+            return versionId;
         }
     }
 
@@ -173,33 +177,68 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
     }
 
     /**
+     * Extract base key from versioned key
+     *
+     * @param {String} key - object key
+     * @return {String} - versioned base key
+     */
+    _extractVersionedBaseKey(key) {
+        return key.split(VID_SEP)[0];
+    }
+
+    /**
+     * Returns the dateTime of the event
+     * based on the event message property if existent
+     * or overhead fields
+     * @param {ObjectMD} value object metadata
+     * @param {Object} overheadFields overhead fields
+     * @param {Object} overheadFields.commitTimestamp - Kafka commit timestamp
+     * @param {Object} overheadFields.opTimestamp - MongoDB operation timestamp
+     * @returns {string} dateTime of the event
+     */
+    _getEventDateTime(value, overheadFields) {
+        if (overheadFields) {
+            return overheadFields.opTimestamp || overheadFields.commitTimestamp || null;
+        }
+        return (value && value[notifConstants.eventMessageProperty.dateTime]) || null;
+    }
+
+    /**
      * Process object entry from the log
      *
      * @param {String} bucket - bucket
      * @param {String} key - object key
      * @param {Object} value - log entry object
-     * @param {String} timestamp - operation timestamp
+     * @param {String} type - log entry type
+     * @param {Object} overheadFields - extra fields
+     * @param {Object} overheadFields.commitTimestamp - Kafka commit timestamp
+     * @param {Object} overheadFields.opTimestamp - MongoDB operation timestamp
      * @return {undefined}
      */
-    async _processObjectEntry(bucket, key, value, timestamp) {
+    async _processObjectEntry(bucket, key, value, type, overheadFields) {
         this._metricsStore.notifEvent();
         if (!this._shouldProcessEntry(key, value)) {
             return undefined;
         }
-        const { eventMessageProperty } = notifConstants;
-        const eventType = value[eventMessageProperty.eventType];
+        const { eventMessageProperty, deleteEvent } = notifConstants;
+        let eventType = value[eventMessageProperty.eventType];
+        if (eventType === undefined && type === 'del') {
+            eventType = deleteEvent;
+        }
         if (!this._isNotificationEventSupported(eventType)) {
             return undefined;
         }
-        const versionId = this._getVersionId(value);
+        const baseKey = this._extractVersionedBaseKey(key);
+        const versionId = this._getVersionId(value, overheadFields);
+        const dateTime = this._getEventDateTime(value, overheadFields);
         const config = await this.bnConfigManager.getConfig(bucket);
         if (config && Object.keys(config).length > 0) {
             const ent = {
                 bucket,
-                key: value.key,
+                key: baseKey,
                 eventType,
                 versionId,
-                dateTime: timestamp,
+                dateTime,
             };
             this.log.debug('validating entry', {
                 method: 'NotificationQueuePopulator._processObjectEntry',
@@ -272,7 +311,7 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
      * @return {undefined} Promise|undefined
      */
     filterAsync(entry, cb) {
-        const { bucket, key, overheadFields } = entry;
+        const { bucket, key, type, overheadFields } = entry;
         const value = entry.value || '{}';
         const { error, result } = safeJsonParse(value);
         // ignore if entry's value is not valid
@@ -291,7 +330,7 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
         }
         // object entry processing - filter and publish
         if (key && result) {
-            return this._processObjectEntryCb(bucket, key, result, overheadFields.opTimestamp, cb);
+            return this._processObjectEntryCb(bucket, key, result, type, overheadFields, cb);
         }
         return cb();
     }

--- a/extensions/notification/NotificationQueuePopulator.js
+++ b/extensions/notification/NotificationQueuePopulator.js
@@ -91,10 +91,11 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
     /**
      * Process bucket entry from the log
      *
+     * @param {string} bucket - bucket name from log entry
      * @param {Object} value - log entry object
      * @return {undefined}
      */
-    _processBucketEntry(value) {
+    _processBucketEntry(bucket, value) {
         const bucketName = this._getBucketNameFromAttributes(value);
         const notificationConfiguration
             = this._getBucketNotificationConfiguration(value);
@@ -108,8 +109,8 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
             this.bnConfigManager.setConfig(bucketName, bnConfig);
             return undefined;
         }
-        // bucket notification conf has been removed, so remove zk node
-        return this.bnConfigManager.removeConfig(bucketName);
+        // bucket was deleter or notification conf has been removed, so remove zk node
+        return this.bnConfigManager.removeConfig(bucketName || bucket);
     }
 
     /**
@@ -325,7 +326,7 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
         }
         // bucket notification configuration updates
         if (bucket && result && this._isBucketEntry(bucket, key)) {
-            this._processBucketEntry(result);
+            this._processBucketEntry(key, result);
             return cb();
         }
         // object entry processing - filter and publish

--- a/extensions/notification/configManager/BaseConfigManager.js
+++ b/extensions/notification/configManager/BaseConfigManager.js
@@ -1,0 +1,40 @@
+const { errors } = require('arsenal');
+
+class BaseConfigManager {
+
+    /**
+     * Setup the config manager
+     * @param {Function} cb callback
+     * @return {undefined}
+     */
+    setup(cb) {
+        return cb(errors.NotImplemented);
+    }
+
+    /**
+     * Get bucket notification configuration
+     * @param {String} bucket - bucket
+     * @return {Object|undefined} - configuration if available or undefined
+     */
+    getConfig(bucket) { // eslint-disable-line no-unused-vars
+        throw new errors.NotImplemented('Method not implemented');
+    }
+
+    /**
+     * Set bucket notification configuration
+     * @return {boolean} - false
+     */
+    setConfig() {
+        throw new errors.NotImplemented('Method not implemented');
+    }
+
+    /**
+     * Remove bucket notification configuration
+     * @return {boolean} - false
+     */
+    removeConfig() {
+        throw new errors.NotImplemented('Method not implemented');
+    }
+}
+
+module.exports = BaseConfigManager;

--- a/extensions/notification/configManager/MongoConfigManager.js
+++ b/extensions/notification/configManager/MongoConfigManager.js
@@ -4,6 +4,7 @@ const semver = require('semver');
 const { ZenkoMetrics } = require('arsenal').metrics;
 const LRUCache = require('arsenal').algorithms
     .cache.LRUCache;
+const { errors } = require('arsenal');
 
 const MongoClient = require('mongodb').MongoClient;
 
@@ -287,7 +288,7 @@ class MongoConfigManager extends BaseConfigManager {
                 bucket,
                 error: err.message,
             });
-            return undefined;
+            throw errors.InternalError.customizeDescription(err.message);
         }
     }
 

--- a/extensions/notification/configManager/MongoConfigManager.js
+++ b/extensions/notification/configManager/MongoConfigManager.js
@@ -1,0 +1,316 @@
+const joi = require('joi');
+const semver = require('semver');
+
+const { ZenkoMetrics } = require('arsenal').metrics;
+const LRUCache = require('arsenal').algorithms
+    .cache.LRUCache;
+
+const MongoClient = require('mongodb').MongoClient;
+
+const ChangeStream = require('../../../lib/wrappers/ChangeStream');
+const constants = require('../constants');
+const { constructConnectionString, getMongoVersion } = require('../../utils/MongoUtils');
+const BaseConfigManager = require('./BaseConfigManager');
+
+const paramsJoi = joi.object({
+    mongoConfig: joi.object().required(),
+    logger: joi.object().required(),
+}).required();
+
+const MAX_CACHED_ENTRIES = Number(process.env.MAX_CACHED_BUCKET_NOTIFICATION_CONFIGS)
+    || 1000;
+
+// should equal true if config manager's cache was hit during a get operation
+const CONFIG_MANAGER_CACHE_HIT = 'cache_hit';
+// Type of operation performed on the cache
+const CONFIG_MANAGER_OPERATION_TYPE = 'op';
+
+const cacheUpdates = ZenkoMetrics.createCounter({
+    name: 's3_notification_config_manager_cache_updates_total',
+    help: 'Total number of cache updates',
+    labelNames: [
+        CONFIG_MANAGER_OPERATION_TYPE,
+    ],
+});
+
+const configGetLag = ZenkoMetrics.createHistogram({
+    name: 's3_notification_config_manager_config_get_seconds',
+    help: 'Time it takes in seconds to get a bucket notification config from MongoDB',
+    labelNames: [
+        CONFIG_MANAGER_CACHE_HIT,
+    ],
+    buckets: [0.001, 0.01, 1, 10, 100, 1000],
+});
+
+const cachedBuckets = ZenkoMetrics.createGauge({
+    name: 's3_notification_config_manager_cached_buckets_count',
+    help: 'Total number of cached buckets in the notification config manager',
+});
+
+function onConfigManagerCacheUpdate(op) {
+    cacheUpdates.inc({
+        [CONFIG_MANAGER_OPERATION_TYPE]: op,
+    });
+    if (op === 'add') {
+        cachedBuckets.inc({});
+    } else if (op === 'delete') {
+        cachedBuckets.dec({});
+    }
+}
+
+function onConfigManagerConfigGet(cacheHit, delay) {
+    configGetLag.observe({
+        [CONFIG_MANAGER_CACHE_HIT]: cacheHit,
+    }, delay);
+}
+
+/**
+ * @class MongoConfigManager
+ *
+ * @classdesc Manages bucket notification configurations, the configurations
+ * are directly retrieved from the metastore, and are locally cached. Cache
+ * is invalidated using MongoDB change streams.
+ */
+class MongoConfigManager extends BaseConfigManager {
+    /**
+     * @constructor
+     * @param {Object} params - constructor params
+     * @param {Object} params.mongoConfig - mongoDB config
+     * @param {Logger} params.logger - logger object
+     */
+    constructor(params) {
+        super();
+        joi.attempt(params, paramsJoi);
+        this._logger = params.logger;
+        this._mongoConfig = params.mongoConfig;
+        this._cachedConfigs = new LRUCache(MAX_CACHED_ENTRIES);
+        this._mongoClient = null;
+        this._metastore = null;
+        this._metastoreChangeStream = null;
+    }
+
+    /**
+     * Connects to MongoDB using the MongoClientInterface
+     * and retreives the metastore collection
+     * @param {Function} cb callback
+     * @returns {undefined}
+     */
+    _setupMongoClient(cb) {
+        const mongoUrl = constructConnectionString(this._mongoConfig);
+        MongoClient.connect(mongoUrl, {
+            replicaSet: this._mongoConfig.replicaSet,
+            useNewUrlParser: true,
+        },
+        (err, client) => {
+            if (err) {
+                this._logger.error('Could not connect to MongoDB', {
+                    method: 'MongoConfigManager._setupMongoClient',
+                    error: err.message,
+                });
+                return cb(err);
+            }
+            this._logger.debug('Connected to MongoDB', {
+                method: 'MongoConfigManager._setupMongoClient',
+            });
+            try {
+                this._mongoClient = client.db(this._mongoConfig.database, {
+                    ignoreUndefined: true,
+                });
+                this._metastore = this._mongoClient.collection(constants.bucketMetastore);
+                // get mongodb version
+                getMongoVersion(this._mongoClient, (err, version) => {
+                    if (err) {
+                        this._logger.error('Could not get MongoDB version', {
+                            method: 'MongoConfigManager._setupMongoClient',
+                            error: err.message,
+                        });
+                        return cb(err);
+                    }
+                    this._mongoVersion = version;
+                    return cb();
+                });
+                return undefined;
+            } catch (error) {
+                return cb(error);
+            }
+        });
+    }
+
+    /**
+     * Handler for the change stream "change" event.
+     * Invalidates cached bucket configs based on the change.
+     * @param {ChangeStreamDocument} change Change stream change object
+     * @returns {undefined}
+     */
+    _handleChangeStreamChangeEvent(change) {
+        // invalidating cached notification configs
+        const cachedConfig = this._cachedConfigs.get(change.documentKey._id);
+        const bucketNotificationConfiguration = change.fullDocument ? change.fullDocument.value.
+            notificationConfiguration : null;
+        switch (change.operationType) {
+            case 'delete':
+                if (cachedConfig) {
+                    this._cachedConfigs.remove(change.documentKey._id);
+                    onConfigManagerCacheUpdate('delete');
+                }
+                break;
+            case 'replace':
+            case 'update':
+                if (cachedConfig) {
+                    // add() replaces the value of an entry if it exists in cache
+                    this._cachedConfigs.add(change.documentKey._id, bucketNotificationConfiguration);
+                    onConfigManagerCacheUpdate('update');
+                }
+                break;
+            default:
+                this._logger.debug('Skipping unsupported change stream event', {
+                    method: 'MongoConfigManager._handleChangeStreamChange',
+                });
+                break;
+        }
+        this._logger.debug('Change stream event processed', {
+            method: 'MongoConfigManager._handleChangeStreamChange',
+        });
+    }
+
+    /**
+     * Initializes a change stream on the metastore collection
+     * Only document delete and update/replace operations are
+     * taken into consideration to invalidate cache.
+     * Newly created buckets (insert operations) are not cached
+     * as queue populator instances read from different kafka
+     * partitions and so don't need the configs for all buckets
+     * @returns {undefined}
+     */
+    _setMetastoreChangeStream() {
+        /**
+         * To avoid processing irrelevant events
+         * we filter by the operation types and
+         * only project the fields needed
+         */
+        const changeStreamPipeline = [
+            {
+                $match: {
+                    $or: [
+                        { operationType: 'delete' },
+                        { operationType: 'replace' },
+                        { operationType: 'update' },
+                    ]
+                }
+            },
+            {
+                $project: {
+                    '_id': 1,
+                    'operationType': 1,
+                    'documentKey._id': 1,
+                    'fullDocument._id': 1,
+                    'fullDocument.value.notificationConfiguration': 1
+                },
+            },
+        ];
+        this._metastoreChangeStream = new ChangeStream({
+            logger: this._logger,
+            collection: this._metastore,
+            pipeline: changeStreamPipeline,
+            handler: this._handleChangeStreamChangeEvent.bind(this),
+            throwOnError: false,
+            useStartAfter: semver.gte(this._mongoVersion, '4.2.0'),
+        });
+        // start watching metastore
+        this._metastoreChangeStream.start();
+    }
+
+    /**
+     * Sets up the MongoConfigManager by
+     * connecting to mongo and initializing the
+     * change stream
+     * @param {Function} cb callback
+     * @returns {undefined}
+     */
+    setup(cb) {
+        this._setupMongoClient(err => {
+            if (err) {
+                this._logger.error('An error occured while setting up mongo client', {
+                    method: 'MongoConfigManager.setup',
+                });
+                return cb(err);
+            }
+            try {
+                this._setMetastoreChangeStream();
+            } catch (error) {
+                this._logger.error('An error occured while establishing the change stream', {
+                    method: 'MongoConfigManager._setMetastoreChangeStream',
+                });
+                return cb(error);
+            }
+            return cb();
+        });
+    }
+
+    /**
+     * Get bucket notification configuration
+     *
+     * @param {String} bucket - bucket
+     * @return {Object|undefined} - configuration if available or undefined
+     */
+    async getConfig(bucket) {
+        const startTime = Date.now();
+        // return cached config for bucket if it exists
+        const cachedConfig = this._cachedConfigs.get(bucket);
+        if (cachedConfig) {
+            const delay = (Date.now() - startTime) / 1000;
+            onConfigManagerConfigGet(true, delay);
+            return {
+                bucket,
+                notificationConfiguration: cachedConfig,
+            };
+        }
+        try {
+            // retreiving bucket metadata from the metastore
+            const bucketMetadata = await this._metastore.findOne({ _id: bucket });
+            const notificationConfiguration = bucketMetadata?.value?.notificationConfiguration;
+            const delay = (Date.now() - startTime) / 1000;
+            onConfigManagerConfigGet(false, delay);
+            if (!notificationConfiguration) {
+                return undefined;
+            }
+            // caching the bucket configuration
+            this._cachedConfigs.add(bucket, notificationConfiguration);
+            onConfigManagerCacheUpdate('add');
+            return {
+                bucket,
+                notificationConfiguration
+            };
+        } catch (err) {
+            this._logger.error('An error occured when getting notification ' +
+                'configuration of bucket', {
+                method: 'MongoConfigManager.getConfig',
+                bucket,
+                error: err.message,
+            });
+            return undefined;
+        }
+    }
+
+    /**
+     * Set bucket notification configuration
+     * Not needed for the MongoDB backend, as we
+     * use change streams to watch for config changes
+     * @return {boolean} - false
+     */
+    setConfig() {
+        return false;
+    }
+
+    /**
+     * Remove bucket notification configuration
+     * Not needed for the MongoDB backend, as we
+     * use change streams to watch for config changes
+     * @return {boolean} - false
+     */
+    removeConfig() {
+        return false;
+    }
+}
+
+module.exports = MongoConfigManager;

--- a/extensions/notification/configManager/MongoConfigManager.js
+++ b/extensions/notification/configManager/MongoConfigManager.js
@@ -8,12 +8,12 @@ const LRUCache = require('arsenal').algorithms
 const MongoClient = require('mongodb').MongoClient;
 
 const ChangeStream = require('../../../lib/wrappers/ChangeStream');
-const constants = require('../constants');
 const { constructConnectionString, getMongoVersion } = require('../../utils/MongoUtils');
 const BaseConfigManager = require('./BaseConfigManager');
 
 const paramsJoi = joi.object({
     mongoConfig: joi.object().required(),
+    bucketMetastore: joi.string().required(),
     logger: joi.object().required(),
 }).required();
 
@@ -84,6 +84,7 @@ class MongoConfigManager extends BaseConfigManager {
         this._logger = params.logger;
         this._mongoConfig = params.mongoConfig;
         this._cachedConfigs = new LRUCache(MAX_CACHED_ENTRIES);
+        this._bucketMetastore = params.bucketMetastore;
         this._mongoClient = null;
         this._metastore = null;
         this._metastoreChangeStream = null;
@@ -116,7 +117,7 @@ class MongoConfigManager extends BaseConfigManager {
                 this._mongoClient = client.db(this._mongoConfig.database, {
                     ignoreUndefined: true,
                 });
-                this._metastore = this._mongoClient.collection(constants.bucketMetastore);
+                this._metastore = this._mongoClient.collection(this._bucketMetastore);
                 // get mongodb version
                 getMongoVersion(this._mongoClient, (err, version) => {
                     if (err) {

--- a/extensions/notification/configManager/MongoConfigManager.js
+++ b/extensions/notification/configManager/MongoConfigManager.js
@@ -14,11 +14,9 @@ const BaseConfigManager = require('./BaseConfigManager');
 const paramsJoi = joi.object({
     mongoConfig: joi.object().required(),
     bucketMetastore: joi.string().required(),
+    maxCachedConfigs: joi.number().required(),
     logger: joi.object().required(),
 }).required();
-
-const MAX_CACHED_ENTRIES = Number(process.env.MAX_CACHED_BUCKET_NOTIFICATION_CONFIGS)
-    || 1000;
 
 // should equal true if config manager's cache was hit during a get operation
 const CONFIG_MANAGER_CACHE_HIT = 'cache_hit';
@@ -83,7 +81,7 @@ class MongoConfigManager extends BaseConfigManager {
         joi.attempt(params, paramsJoi);
         this._logger = params.logger;
         this._mongoConfig = params.mongoConfig;
-        this._cachedConfigs = new LRUCache(MAX_CACHED_ENTRIES);
+        this._cachedConfigs = new LRUCache(params.maxCachedConfigs);
         this._bucketMetastore = params.bucketMetastore;
         this._mongoClient = null;
         this._metastore = null;

--- a/extensions/notification/configManager/ZookeeperConfigManager.js
+++ b/extensions/notification/configManager/ZookeeperConfigManager.js
@@ -21,6 +21,7 @@ const paramsJoi = joi.object({
         then: joi.optional(),
         otherwise: joi.required(),
     }),
+    zkConcurrency: joi.number().required(),
     logger: joi.object().required(),
 }).required();
 
@@ -42,9 +43,9 @@ class ZookeeperConfigManager extends BaseConfigManager  {
         this._zkClient = params.zkClient;
         this._zkPath = params.zkPath;
         this._zkConfig = params.zkConfig;
+        this._zkConcurrency = params.zkConcurrency;
         this.log = params.logger;
         this._configs = new Map();
-        this._concurrency = constants.configManager.concurrency;
         this._emitter = new EventEmitter();
         this._setupEventListeners();
     }
@@ -324,7 +325,7 @@ class ZookeeperConfigManager extends BaseConfigManager  {
     }
 
     _updateLocalStore(buckets, cb) {
-        async.eachSeries(buckets, (bucket, next) => {
+        async.eachLimit(buckets, this._zkConcurrency, (bucket, next) => {
             this._getBucketNotifConfig(bucket, (err, data) => {
                 if (err) {
                     return next(err);

--- a/extensions/notification/configManager/ZookeeperConfigManager.js
+++ b/extensions/notification/configManager/ZookeeperConfigManager.js
@@ -420,6 +420,7 @@ class ZookeeperConfigManager extends BaseConfigManager  {
             });
         this._zkClient = new ZookeeperManager(zookeeperUrl, {
             autoCreateNamespace: this._zkConfig.autoCreateNamespace,
+            retries: this._zkConfig.retries,
         }, this.log);
 
         this._zkClient.once('error', done);

--- a/extensions/notification/configManager/ZookeeperConfigManager.js
+++ b/extensions/notification/configManager/ZookeeperConfigManager.js
@@ -145,6 +145,11 @@ class ZookeeperConfigManager extends BaseConfigManager  {
         const method
             = 'ZookeeperConfigManager._getBucketNotifConfig';
         const zkPath = this._getBucketNodeZkPath(bucket);
+        this.log.debug('fetching bucket notification configuration', {
+            method,
+            bucket,
+            zkPath,
+        });
         return this._zkClient.getData(zkPath, event => {
             this.log.debug('zookeeper getData watcher triggered', {
                 zkPath,
@@ -198,6 +203,11 @@ class ZookeeperConfigManager extends BaseConfigManager  {
         const method
             = 'ZookeeperConfigManager._setBucketNotifConfig';
         const zkPath = this._getBucketNodeZkPath(bucket);
+        this.log.debug('setting bucket notification configuration', {
+            method,
+            bucket,
+            zkPath,
+        });
         return async.waterfall([
             next => this._checkNodeExists(zkPath, next),
             (exists, next) => {
@@ -249,6 +259,11 @@ class ZookeeperConfigManager extends BaseConfigManager  {
         const method
             = 'ZookeeperConfigManager._createBucketNotifConfigNode';
         const zkPath = this._getBucketNodeZkPath(bucket);
+        this.log.debug('creating bucket notification configuration node', {
+            method,
+            bucket,
+            zkPath,
+        });
         return this._zkClient.mkdirp(zkPath, err => {
             if (err) {
                 this.log.error('Could not pre-create path in zookeeper', {
@@ -266,6 +281,11 @@ class ZookeeperConfigManager extends BaseConfigManager  {
         const method
             = 'ZookeeperConfigManager._removeBucketNotifConfigNode';
         const zkPath = this._getBucketNodeZkPath(bucket);
+        this.log.debug('removing bucket notification configuration node', {
+            method,
+            bucket,
+            zkPath,
+        });
         return this._zkClient.remove(zkPath, error => {
             if (error && error.name !== 'NO_NODE') {
                 this.log.error('Could not remove zookeeper node', {

--- a/extensions/notification/configManager/ZookeeperConfigManager.js
+++ b/extensions/notification/configManager/ZookeeperConfigManager.js
@@ -1,0 +1,449 @@
+const async = require('async');
+const joi = require('joi');
+const { EventEmitter } = require('events');
+const zookeeper = require('node-zookeeper-client');
+
+const ZookeeperManager = require('../../../lib/clients/ZookeeperManager');
+const BaseConfigManager = require('./BaseConfigManager');
+
+const safeJsonParse = require('../utils/safeJsonParse');
+const constants = require('../constants');
+
+const paramsJoi = joi.object({
+    zkClient: joi.object().optional(),
+    zkConfig: joi.object().when('zkClient', {
+        is: joi.exist(),
+        then: joi.optional(),
+        otherwise: joi.required(),
+    }),
+    zkPath: joi.string().when('zkClient', {
+        is: joi.exist(),
+        then: joi.optional(),
+        otherwise: joi.required(),
+    }),
+    logger: joi.object().required(),
+}).required();
+
+/**
+ * @class ZookeeperConfigManager
+ *
+ * @classdesc Manages bucket notification configurations in zookeeper
+ */
+class ZookeeperConfigManager extends BaseConfigManager  {
+    /**
+     * @constructor
+     * @param {Object} params - constructor params
+     * @param {Object} params.zkClient - zookeeper client
+     * @param {Logger} params.logger - logger object
+     */
+    constructor(params) {
+        super();
+        joi.attempt(params, paramsJoi);
+        this._zkClient = params.zkClient;
+        this._zkPath = params.zkPath;
+        this._zkConfig = params.zkConfig;
+        this.log = params.logger;
+        this._configs = new Map();
+        this._concurrency = constants.configManager.concurrency;
+        this._emitter = new EventEmitter();
+        this._setupEventListeners();
+    }
+
+    _errorListener(error, listener) {
+        this.log.error('ZookeeperConfigManager.emitter.error', {
+            listener,
+            error,
+        });
+        return undefined;
+    }
+
+    _setConfigListener(bucket, config) {
+        this.log.debug('ZookeeperConfigManager.emitter.setConfig', {
+            event: 'setConfig',
+            bucket,
+            config,
+        });
+        this._setBucketNotifConfig(bucket, JSON.stringify(config), err => {
+            if (err) {
+                this._emitter.emit('error', err, 'setConfigListener');
+            }
+            return undefined;
+        });
+    }
+
+    _getConfigListener(updatedBucket = '') {
+        this.log.debug('ZookeeperConfigManager.emitter.getConfig', {
+            event: 'getConfig',
+        });
+        this._listBucketsWithConfig((err, buckets) => {
+            if (err) {
+                this._emitter.emit('error', err, 'getConfigListener');
+                return undefined;
+            }
+            this.log.debug('bucket config to be updated in map', {
+                bucket: updatedBucket,
+            });
+            const newBuckets = this._getNewBucketNodes(buckets);
+            this.log.debug('new bucket configs to be added to map', {
+                buckets: newBuckets,
+            });
+            const bucketsToMap = updatedBucket ? [updatedBucket, ...newBuckets] : newBuckets;
+            this.log.debug('bucket configs to be added/updated to map', {
+                buckets: bucketsToMap,
+            });
+            if (bucketsToMap.length > 0) {
+                this._updateLocalStore(bucketsToMap);
+            }
+            return undefined;
+        });
+    }
+
+    _removeConfigListener(bucket) {
+        this.log.debug('ZookeeperConfigManager.emitter.removeConfig', {
+            event: 'removeConfig',
+            bucket,
+        });
+        this._removeBucketNotifConfigNode(bucket, err => {
+            if (err) {
+                this._emitter.emit('error', err, 'removeConfigListener');
+            }
+            return undefined;
+        });
+    }
+
+    _setupEventListeners() {
+        this._emitter.setMaxListeners(constants.configManager.maxListeners);
+        this._emitter
+            .on('error', error => this._errorListener(error))
+            .on('setConfig',
+                (bucket, config) => this._setConfigListener(bucket, config))
+            .on('getConfig', bucket => this._getConfigListener(bucket))
+            .on('removeConfig', bucket => this._removeConfigListener(bucket));
+    }
+
+    _callbackHandler(cb, err, result) {
+        if (cb && typeof cb === 'function') {
+            return cb(err, result);
+        }
+        return undefined;
+    }
+
+    _getBucketNodeZkPath(bucket) {
+        return `/${constants.zkConfigParentNode}/${bucket}`;
+    }
+
+    _getConfigDataFromBuffer(data) {
+        const { error, result } = safeJsonParse(data);
+        if (error) {
+            this.log.error('invalid config', { error, config: data });
+            return undefined;
+        }
+        return result;
+    }
+
+    _getBucketNotifConfig(bucket, cb) {
+        const method
+            = 'ZookeeperConfigManager._getBucketNotifConfig';
+        const zkPath = this._getBucketNodeZkPath(bucket);
+        return this._zkClient.getData(zkPath, event => {
+            this.log.debug('zookeeper getData watcher triggered', {
+                zkPath,
+                method,
+                event,
+                bucket,
+            });
+            if (event.type === zookeeper.Event.NODE_DATA_CHANGED) {
+                this._emitter.emit('getConfig', bucket);
+            }
+            if (event.type === zookeeper.Event.NODE_DELETED) {
+                this.removeConfig(bucket, false);
+            }
+        }, (error, data) => {
+            if (error && error.name !== 'NO_NODE') {
+                const errMsg
+                    = 'error fetching bucket notification configuration';
+                this.log.error(errMsg, {
+                    method,
+                    error,
+                });
+                return this._callbackHandler(cb, error);
+            }
+            if (data) {
+                return this._callbackHandler(cb, null, data);
+            }
+            // no configuration
+            return this._callbackHandler(cb);
+        });
+    }
+
+    _checkNodeExists(zkPath, cb) {
+        const method
+            = 'ZookeeperConfigManager._checkNodeExists';
+        return this._zkClient.exists(zkPath, (err, stat) => {
+            if (err) {
+                this.log.error('error checking node existence',
+                    { method, zkPath });
+                return this._callbackHandler(cb, err);
+            }
+            if (stat) {
+                this.log.debug('node exists', { method, zkPath });
+                return this._callbackHandler(cb, null, true);
+            }
+            this.log.debug('node does not exist', { method, zkPath });
+            return this._callbackHandler(cb, null, false);
+        });
+    }
+
+    _setBucketNotifConfig(bucket, data, cb) {
+        const method
+            = 'ZookeeperConfigManager._setBucketNotifConfig';
+        const zkPath = this._getBucketNodeZkPath(bucket);
+        return async.waterfall([
+            next => this._checkNodeExists(zkPath, next),
+            (exists, next) => {
+                if (!exists) {
+                    return this._createBucketNotifConfigNode(bucket,
+                        err => next(err));
+                }
+                return next();
+            },
+            next => this._zkClient.setData(zkPath, Buffer.from(data), -1, next),
+        ], err => {
+            if (err) {
+                this.log.error('error saving config', { method, zkPath, data });
+            }
+            return this._callbackHandler(cb, err);
+        });
+    }
+
+    _checkConfigurationParentNode(cb) {
+        const method
+            = 'ZookeeperConfigManager._checkConfigurationParentNode';
+        const zkPath = `/${constants.zkConfigParentNode}`;
+        return async.waterfall([
+            next => this._checkNodeExists(zkPath, next),
+            (exists, next) => {
+                if (!exists) {
+                    this.log.debug('parent configuration zookeeper node does ' +
+                        'not exist', { method, zkPath });
+                    return this._zkClient.mkdirp(zkPath, err => next(err));
+                }
+                this.log.debug('parent configuration zookeeper node exists',
+                    { method, zkPath });
+                return next();
+            },
+        ], err => {
+            if (err) {
+                const errMsg
+                    = 'error checking configuration zookeeper parent node';
+                this.log.error(errMsg, { method, zkPath, error: err.message });
+                return this._callbackHandler(cb, err);
+            }
+            this.log.debug('parent configuration zookeeper checked/added',
+                { method, zkPath });
+            return this._callbackHandler(cb);
+        });
+    }
+
+    _createBucketNotifConfigNode(bucket, cb) {
+        const method
+            = 'ZookeeperConfigManager._createBucketNotifConfigNode';
+        const zkPath = this._getBucketNodeZkPath(bucket);
+        return this._zkClient.mkdirp(zkPath, err => {
+            if (err) {
+                this.log.error('Could not pre-create path in zookeeper', {
+                    method,
+                    zkPath,
+                    error: err,
+                });
+                return this._callbackHandler(cb, err);
+            }
+            return this._callbackHandler(cb);
+        });
+    }
+
+    _removeBucketNotifConfigNode(bucket, cb) {
+        const method
+            = 'ZookeeperConfigManager._removeBucketNotifConfigNode';
+        const zkPath = this._getBucketNodeZkPath(bucket);
+        return this._zkClient.remove(zkPath, error => {
+            if (error && error.name !== 'NO_NODE') {
+                this.log.error('Could not remove zookeeper node', {
+                    method,
+                    zkPath,
+                    error,
+                });
+                return this._callbackHandler(cb, error);
+            }
+            if (!error) {
+                const msg
+                    = 'removed notification configuration zookeeper node';
+                this.log.debug(msg, {
+                    method,
+                    bucket,
+                });
+            }
+            return this._callbackHandler(cb);
+        });
+    }
+
+    _getNewBucketNodes(bucketsNodeList) {
+        if (Array.isArray(bucketsNodeList)) {
+            const bucketsFromMap = [...this._configs.keys()];
+            return bucketsNodeList.filter(b => !bucketsFromMap.includes(b));
+        }
+        return [];
+    }
+
+    _listBucketsWithConfig(cb) {
+        const method
+            = 'ZookeeperConfigManager._listBucketsWithConfig';
+        const zkPath = `/${constants.zkConfigParentNode}`;
+        this._zkClient.getChildren(zkPath, event => {
+            this.log.debug('zookeeper getChildren watcher triggered', {
+                zkPath,
+                method,
+                event,
+            });
+            if (event.type === zookeeper.Event.NODE_CHILDREN_CHANGED) {
+                this._emitter.emit('getConfig');
+            }
+        }, (error, buckets) => {
+            if (error) {
+                const errMsg
+                    = 'error listing buckets with configuration';
+                this.log.error(errMsg, {
+                    zkPath,
+                    method,
+                    error,
+                });
+                this._callbackHandler(cb, error);
+            }
+            this._callbackHandler(cb, null, buckets);
+        });
+    }
+
+    _updateLocalStore(buckets, cb) {
+        async.eachSeries(buckets, (bucket, next) => {
+            this._getBucketNotifConfig(bucket, (err, data) => {
+                if (err) {
+                    return next(err);
+                }
+                const configObject = this._getConfigDataFromBuffer(data);
+                if (configObject) {
+                    this._configs.set(bucket, configObject);
+                }
+                return next();
+            });
+        }, err => this._callbackHandler(cb, err));
+    }
+
+    /**
+     * Get bucket notification configuration
+     *
+     * @param {String} bucket - bucket
+     * @return {Object|undefined} - configuration if available or undefined
+     */
+    getConfig(bucket) {
+        return this._configs.get(bucket);
+    }
+
+    /**
+     * Add/update bucket notification configuration
+     *
+     * @param {String} bucket - bucket
+     * @param {Object} config - bucket notification configuration
+     * @return {boolean} - true if set
+     */
+    setConfig(bucket, config) {
+        try {
+            this.log.debug('set config', {
+                method: 'ZookeeperConfigManager.setConfig',
+                bucket,
+                config,
+            });
+            this._configs.set(bucket, config);
+            this._emitter.emit('setConfig', bucket, config);
+            return true;
+        } catch (err) {
+            const errMsg
+                = 'error setting bucket notification configuration';
+            this.log.error(errMsg, {
+                method: 'ZookeeperConfigManager.setConfig',
+                error: err.message,
+                bucket,
+                config,
+            });
+            return false;
+        }
+    }
+
+    /**
+     * Remove bucket notification configuration
+     *
+     * @param {String} bucket - bucket
+     * @return {boolean} - true if removed
+     */
+    removeConfig(bucket) {
+        try {
+            this.log.debug('remove config', {
+                method: 'ZookeeperConfigManager.removeConfig',
+                bucket,
+            });
+            this._configs.delete(bucket);
+            this._emitter.emit('removeConfig', bucket);
+            return true;
+        } catch (err) {
+            const errMsg
+                = 'error removing bucket notification configuration';
+            this.log.error(errMsg, {
+                method: 'ZookeeperConfigManager.removeConfig',
+                error: err,
+                bucket,
+            });
+            return false;
+        }
+    }
+
+    _setupZookeeper(done) {
+        if (this._zkClient) {
+            done();
+            return;
+        }
+
+        const zookeeperUrl =
+            `${this._zkConfig.connectionString}${this._zkPath}`;
+        this.log.info('opening zookeeper connection for reading ' +
+            'bucket notification configuration', {
+                zookeeperUrl,
+                method: 'ZookeeperConfigManager._setupZookeeper',
+            });
+        this._zkClient = new ZookeeperManager(zookeeperUrl, {
+            autoCreateNamespace: this._zkConfig.autoCreateNamespace,
+        }, this.log);
+
+        this._zkClient.once('error', done);
+        this._zkClient.once('ready', () => {
+            // just in case there would be more 'error' events emitted
+            this._zkClient.removeAllListeners('error');
+            done();
+        });
+    }
+
+    /**
+     * Setup bucket notification configuration manager
+     *
+     * @param {function} [cb] - callback
+     * @return {undefined}
+     */
+    setup(cb) {
+        async.waterfall([
+            next => this._setupZookeeper(next),
+            next => this._checkConfigurationParentNode(next),
+            (_, next) => this._listBucketsWithConfig(next),
+            (buckets, next) => this._updateLocalStore(buckets, next),
+        ], cb);
+    }
+}
+
+module.exports = ZookeeperConfigManager;

--- a/extensions/notification/configManager/ZookeeperConfigManager.js
+++ b/extensions/notification/configManager/ZookeeperConfigManager.js
@@ -113,7 +113,6 @@ class ZookeeperConfigManager extends BaseConfigManager  {
     }
 
     _setupEventListeners() {
-        this._emitter.setMaxListeners(constants.configManager.maxListeners);
         this._emitter
             .on('error', error => this._errorListener(error))
             .on('setConfig',

--- a/extensions/notification/constants.js
+++ b/extensions/notification/constants.js
@@ -14,6 +14,7 @@ const constants = {
     supportedAuthTypes: ['kerberos'],
     deleteEvent: 's3:ObjectRemoved:Delete',
     eventMessageProperty: {
+        dateTime: 'last-modified',
         eventType: 'originOp',
         region: 'dataStoreName',
         schemaVersion: 'md-model-version',

--- a/extensions/notification/constants.js
+++ b/extensions/notification/constants.js
@@ -5,6 +5,7 @@ const constants = {
         suffix: 'Suffix',
     },
     bucketNotifConfigPropName: 'notificationConfiguration',
+    zkConfigParentNode: 'config',
     arn: {
         partition: 'scality',
         service: 'bucketnotif',
@@ -22,6 +23,10 @@ const constants = {
     eventVersion: '1.0',
     eventSource: 'scality:s3',
     eventS3SchemaVersion: '1.0',
+    configManager: {
+        concurrency: 50,
+        maxListeners: 0,
+    },
     bucketMetastore: '__metastore',
 };
 

--- a/extensions/notification/constants.js
+++ b/extensions/notification/constants.js
@@ -28,7 +28,6 @@ const constants = {
         concurrency: 50,
         maxListeners: 0,
     },
-    bucketMetastore: '__metastore',
 };
 
 module.exports = constants;

--- a/extensions/notification/constants.js
+++ b/extensions/notification/constants.js
@@ -24,10 +24,6 @@ const constants = {
     eventVersion: '1.0',
     eventSource: 'scality:s3',
     eventS3SchemaVersion: '1.0',
-    configManager: {
-        concurrency: 50,
-        maxListeners: 0,
-    },
 };
 
 module.exports = constants;

--- a/extensions/notification/destination/KafkaNotificationDestination.js
+++ b/extensions/notification/destination/KafkaNotificationDestination.js
@@ -47,8 +47,12 @@ class KafkaNotificationDestination extends NotificationDestination {
 
     _setupProducer(done) {
         const { host, port, topic, pollIntervalMs, auth } = this._destinationConfig;
+        let kafkaHost = host;
+        if (port) {
+            kafkaHost = `${host}:${port}`;
+        }
         const producer = new KafkaProducer({
-            kafka: { hosts: `${host}:${port}` },
+            kafka: { hosts: kafkaHost },
             topic,
             pollIntervalMs,
             auth,

--- a/extensions/notification/queueProcessor/QueueProcessor.js
+++ b/extensions/notification/queueProcessor/QueueProcessor.js
@@ -99,7 +99,7 @@ class QueueProcessor extends EventEmitter {
             this.bnConfigManager = new NotificationConfigManager({
                 mongoConfig: this.mongoConfig,
                 bucketMetastore: this.notifConfig.bucketMetastore,
-                zkClient: this.zkClient,
+                maxCachedConfigs: this.notifConfig.maxCachedConfigs,
                 zkConfig: this.zkConfig,
                 zkPath: this.notifConfig.zookeeperPath,
                 logger: this.logger,

--- a/extensions/notification/queueProcessor/QueueProcessor.js
+++ b/extensions/notification/queueProcessor/QueueProcessor.js
@@ -102,6 +102,7 @@ class QueueProcessor extends EventEmitter {
                 maxCachedConfigs: this.notifConfig.maxCachedConfigs,
                 zkConfig: this.zkConfig,
                 zkPath: this.notifConfig.zookeeperPath,
+                zkConcurrency: this.notifConfig.zookeeperOpConcurrency,
                 logger: this.logger,
             });
             return this.bnConfigManager.setup(done);

--- a/extensions/notification/queueProcessor/QueueProcessor.js
+++ b/extensions/notification/queueProcessor/QueueProcessor.js
@@ -4,7 +4,6 @@ const { EventEmitter } = require('events');
 const Logger = require('werelogs').Logger;
 const async = require('async');
 const assert = require('assert');
-const util = require('util');
 const { ZenkoMetrics } = require('arsenal').metrics;
 const errors = require('arsenal').errors;
 
@@ -34,6 +33,7 @@ class QueueProcessor extends EventEmitter {
      *
      * @constructor
      * @param {Object} mongoConfig - mongodb connnection configuration object
+     * @param {Object} zkConfig - zookeeper configuration object
      * @param {Object} kafkaConfig - kafka configuration object
      * @param {string} kafkaConfig.hosts - list of kafka brokers
      *   as "host:port[,host:port...]"
@@ -65,10 +65,11 @@ class QueueProcessor extends EventEmitter {
      * @param {String} destinationId - resource name/id of destination
      * @param {Object} destinationAuth - destination authentication config
      */
-    constructor(mongoConfig, kafkaConfig, notifConfig, destinationId,
+    constructor(mongoConfig, zkConfig, kafkaConfig, notifConfig, destinationId,
         destinationAuth) {
         super();
         this.mongoConfig = mongoConfig;
+        this.zkConfig = zkConfig;
         this.kafkaConfig = kafkaConfig;
         this.notifConfig = notifConfig;
         this.destinationId = destinationId;
@@ -84,10 +85,6 @@ class QueueProcessor extends EventEmitter {
         this.bnConfigManager = null;
         this._consumer = null;
         this._destination = null;
-        // Once the notification manager is initialized
-        // this will hold the callback version of the getConfig
-        // function of the notification config manager
-        this._getConfig = null;
 
         this.logger = new Logger('Backbeat:Notification:QueueProcessor');
     }
@@ -101,6 +98,10 @@ class QueueProcessor extends EventEmitter {
         try {
             this.bnConfigManager = new NotificationConfigManager({
                 mongoConfig: this.mongoConfig,
+                bucketMetastore: this.notifConfig.bucketMetastore,
+                zkClient: this.zkClient,
+                zkConfig: this.zkConfig,
+                zkPath: this.notifConfig.zookeeperPath,
                 logger: this.logger,
             });
             return this.bnConfigManager.setup(done);
@@ -181,9 +182,6 @@ class QueueProcessor extends EventEmitter {
                     this.emit('ready');
                     return next();
                 });
-                // callbackify getConfig from notification config manager
-                this._getConfig = util.callbackify(this.bnConfigManager
-                    .getConfig.bind(this.bnConfigManager));
                 return undefined;
             },
         ], err => {
@@ -231,7 +229,7 @@ class QueueProcessor extends EventEmitter {
         }
         const { bucket, key, eventType } = sourceEntry;
         try {
-            return this._getConfig(bucket, (err, notifConfig) => {
+            return this.bnConfigManager.getConfig(bucket, (err, notifConfig) => {
                 if (err) {
                     this.logger.error('Error while getting notification configuration', {
                         bucket,

--- a/extensions/notification/queueProcessor/QueueProcessor.js
+++ b/extensions/notification/queueProcessor/QueueProcessor.js
@@ -240,19 +240,15 @@ class QueueProcessor extends EventEmitter {
                     return done(err);
                 }
                 if (notifConfig && Object.keys(notifConfig).length > 0) {
-                    const destBnConf = notifConfig.queueConfig.filter(
-                        c => c.queueArn.split(':').pop()
-                            === this.destinationId);
-                    if (!destBnConf.length) {
+                    // get destination specific notification config
+                    const queueConfig = notifConfig.notificationConfiguration.queueConfig.filter(
+                            c => c.queueArn.split(':').pop() === this.destinationId
+                    );
+                    if (!queueConfig.length) {
                         // skip, if there is no config for the current
                         // destination resource
-                        return done();
+                        return undefined;
                     }
-                    // pass only destination resource specific config to
-                    // validate entry
-                    const bnConfig = {
-                        queueConfig: destBnConf,
-                    };
                     this.logger.debug('validating entry', {
                         method: 'QueueProcessor.processKafkaEntry',
                         bucket,
@@ -261,7 +257,13 @@ class QueueProcessor extends EventEmitter {
                         eventType,
                         destination: this.destinationId,
                     });
-                    const { isValid, matchingConfig } = configUtil.validateEntry(bnConfig, sourceEntry);
+                    const destConfig = {
+                        bucket,
+                        notificationConfiguration: {
+                            queueConfig,
+                        },
+                    };
+                    const { isValid, matchingConfig } = configUtil.validateEntry(destConfig, sourceEntry);
                     if (isValid) {
                         // add notification configuration id to the message
                         sourceEntry.configurationId = matchingConfig.id;

--- a/extensions/notification/queueProcessor/task.js
+++ b/extensions/notification/queueProcessor/task.js
@@ -16,6 +16,7 @@ const config = require('../../../lib/Config');
 const kafkaConfig = config.kafka;
 const notifConfig = config.extensions.notification;
 const mongoConfig = config.queuePopulator.mongo;
+const zkConfig = config.zookeeper;
 
 const log = new werelogs.Logger('Backbeat:NotificationProcessor:task');
 werelogs.configure({
@@ -44,7 +45,7 @@ if (isDestinationAuthEmpty) {
     destinationAuth = null;
 }
 const queueProcessor = new QueueProcessor(
-    mongoConfig, kafkaConfig, notifConfig, destination, destinationAuth);
+    mongoConfig, zkConfig, kafkaConfig, notifConfig, destination, destinationAuth);
 
 /**
  * Handle ProbeServer liveness check

--- a/extensions/notification/utils/config.js
+++ b/extensions/notification/utils/config.js
@@ -76,7 +76,7 @@ function filterConfigsByEvent(queueConfig, eventType) {
  * @return {Object} Result with validity boolean and matching configuration rule.
  */
 function validateEntry(bnConfig, entry) {
-    const eventType = entry.eventType;
+    const { bucket, eventType } = entry;
 
     /**
      * if the event type is unavailable, it is an entry that is a
@@ -87,9 +87,14 @@ function validateEntry(bnConfig, entry) {
         return { isValid: false, matchingConfig: null };
     }
 
+    if (bucket !== bnConfig.bucket) {
+        return { isValid: false, matchingConfig: null };
+    }
+
     // check if the event type matches at least one supported event from
     // one of the queue configurations
-    const qConfigs = filterConfigsByEvent(bnConfig.queueConfig, eventType);
+    const notifConf = bnConfig.notificationConfiguration;
+    const qConfigs = filterConfigsByEvent(notifConf.queueConfig, eventType);
 
     if (qConfigs.length > 0) {
         const matchingConfig = qConfigs.find(c => {

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -20,7 +20,7 @@ const redisConfig = config.redis;
 const httpsConfig = config.https;
 const internalHttpsConfig = config.internalHttps;
 const mConfig = config.metrics;
-const { connectionString, autoCreateNamespace } = zkConfig;
+const { connectionString, autoCreateNamespace, retries } = zkConfig;
 const RESUME_NODE = 'scheduledResume';
 const { startProbeServer, getReplicationProbeConfig } = require('../../../lib/util/probe');
 const { DEFAULT_LIVE_ROUTE, DEFAULT_METRICS_ROUTE, DEFAULT_READY_ROUTE } =
@@ -288,6 +288,7 @@ function initAndStart(zkClient) {
 
 const zkClient = new ZookeeperManager(connectionString, {
     autoCreateNamespace,
+    retries,
 }, log);
 
 zkClient.once('error', err => {

--- a/lib/api/BackbeatAPI.js
+++ b/lib/api/BackbeatAPI.js
@@ -1305,9 +1305,10 @@ class BackbeatAPI {
     }
 
     _setZookeeper(cb) {
-        const { connectionString, autoCreateNamespace } = this._zkConfig;
+        const { connectionString, autoCreateNamespace, retries } = this._zkConfig;
         const zkClient = new ZookeeperManager(connectionString, {
             autoCreateNamespace,
+            retries,
         }, this._logger);
 
         zkClient.once('error', cb);

--- a/lib/config.joi.js
+++ b/lib/config.joi.js
@@ -23,6 +23,7 @@ const joiSchema = joi.object({
     zookeeper: {
         connectionString: joi.string().required(),
         autoCreateNamespace: joi.boolean().default(false),
+        retries: joi.number().default(3),
     },
     kafka: {
         hosts: joi.string().required(),

--- a/lib/queuePopulator/KafkaLogConsumer/ListRecordStream.js
+++ b/lib/queuePopulator/KafkaLogConsumer/ListRecordStream.js
@@ -118,6 +118,10 @@ class ListRecordStream extends stream.Transform {
             return callback(null, null);
         }
         const objectMd = this._getObjectMd(changeStreamDocument);
+        if (!objectMd) {
+            // skipping empty events
+            return callback(null, null);
+        }
         const opType = this._getType(changeStreamDocument.operationType, objectMd);
         const streamObject = {
             // timestamp of the kafka message

--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -516,9 +516,6 @@ class LogReader {
             }
         }
         async.eachSeries(this._extensions, (ext, next) => {
-            if (entry.value === undefined) {
-                return next();
-            }
             const overheadFields = {
                 commitTimestamp: record.timestamp,
                 opTimestamp: entry.timestamp,

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -400,6 +400,7 @@ class QueuePopulator {
 
         this.zkClient = new ZookeeperManager(zookeeperUrl, {
             autoCreateNamespace: this.zkConfig.autoCreateNamespace,
+            retries: this.zkConfig.retries,
         }, this.log);
 
         this.zkClient.once('error', done);

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -421,6 +421,7 @@ class QueuePopulator {
                     bucketMetastore: this.extConfigs.notification.bucketMetastore,
                     maxCachedConfigs: this.extConfigs.notification.maxCachedConfigs,
                     zkClient: this.zkClient,
+                    zkConcurrency: this.extConfigs.notification.zookeeperOpConcurrency,
                     logger: this.log,
                 });
                 return this.bnConfigManager.setup(done);

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -419,6 +419,7 @@ class QueuePopulator {
                 this.bnConfigManager = new NotificationConfigManager({
                     mongoConfig: this.qpConfig.mongo,
                     bucketMetastore: this.extConfigs.notification.bucketMetastore,
+                    maxCachedConfigs: this.extConfigs.notification.maxCachedConfigs,
                     zkClient: this.zkClient,
                     logger: this.log,
                 });

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -199,8 +199,8 @@ class QueuePopulator {
                 return next(err);
             }),
             next => this._setupFailedCRRClients(next),
-            next => this._setupNotificationConfigManager(next),
-            next => this._setupZookeeper(err => {
+            next => this._setupZookeeper(next),
+            next => this._setupNotificationConfigManager(err => {
                 if (err) {
                     return next(err);
                 }
@@ -417,6 +417,8 @@ class QueuePopulator {
             try {
                 this.bnConfigManager = new NotificationConfigManager({
                     mongoConfig: this.qpConfig.mongo,
+                    bucketMetastore: this.extConfigs.notification.bucketMetastore,
+                    zkClient: this.zkClient,
                     logger: this.log,
                 });
                 return this.bnConfigManager.setup(done);

--- a/lib/queuePopulator/QueuePopulatorExtension.js
+++ b/lib/queuePopulator/QueuePopulatorExtension.js
@@ -36,12 +36,13 @@ class QueuePopulatorExtension {
      * @return {undefined}
      */
     setupZookeeper(cb) {
-        const { connectionString, autoCreateNamespace } = this.zkConfig;
+        const { connectionString, autoCreateNamespace, retries } = this.zkConfig;
         this.log.info('opening zookeeper connection for populator extensions', {
             zookeeperUrl: connectionString,
         });
         this.zkClient = new ZookeeperManager(connectionString, {
             autoCreateNamespace,
+            retries,
         }, this.log);
         this.zkClient.once('error', cb);
         this.zkClient.once('ready', () => {

--- a/tests/config.notification.json
+++ b/tests/config.notification.json
@@ -28,6 +28,7 @@
     },
     "extensions": {
         "notification": {
+            "bucketMetastore": "__metastore",
             "topic": "backbeat-bucket-notification",
             "monitorNotificationFailures": true,
             "queueProcessor": {

--- a/tests/functional/notification/NotificationConfigManager.js
+++ b/tests/functional/notification/NotificationConfigManager.js
@@ -35,6 +35,7 @@ describe('NotificationConfigManager ::', () => {
     const params = {
         mongoConfig,
         bucketMetastore: '__metastore',
+        maxCachedConfigs: 1000,
         logger,
     };
     let manager;

--- a/tests/unit/lib/queuePopulator/kafkaLogConsumer/ListRecordStream.js
+++ b/tests/unit/lib/queuePopulator/kafkaLogConsumer/ListRecordStream.js
@@ -111,7 +111,7 @@ describe('ListRecordStream', () => {
     });
 
     describe('_transform', () => {
-        it('should correct format entry', done => {
+        it('should return correct format entry', done => {
             const kafkaMessage = getKafkaMessage(JSON.stringify(changeStreamDocument));
             listRecordStream.write(kafkaMessage);
             listRecordStream.once('data', data => {
@@ -130,10 +130,39 @@ describe('ListRecordStream', () => {
                 return done();
             });
         });
+
         it('should skip record if format is invalid', done => {
             const kafkaMessage = getKafkaMessage(JSON.stringify(changeStreamDocument));
-            const InvalidKafkaMessage = getKafkaMessage('');
+            const InvalidKafkaMessage = getKafkaMessage('}{');
             listRecordStream.write(InvalidKafkaMessage);
+            listRecordStream.write(kafkaMessage);
+            listRecordStream.once('data', data => {
+                // Streams guarantee that data is kept in the
+                // same order when writing and reading it.
+                // This means that if the function doesn't work
+                // as intended and processed the invalid
+                // event it should be read in first by this event
+                // handler which'll fail the test
+                assert.deepEqual(data, {
+                    timestamp: new Date(kafkaMessage.timestamp),
+                    db: 'example-bucket',
+                    entries: [{
+                        key: 'example-key',
+                        type: 'put',
+                        value: JSON.stringify({
+                            field: 'value'
+                        }),
+                        timestamp: '2023-11-29T15:05:57.000Z',
+                    }],
+                });
+                return done();
+            });
+        });
+
+        it('should skip empty record', done => {
+            const kafkaMessage = getKafkaMessage(JSON.stringify(changeStreamDocument));
+            const EmptyKafkaMessage = getKafkaMessage('{}');
+            listRecordStream.write(EmptyKafkaMessage);
             listRecordStream.write(kafkaMessage);
             listRecordStream.once('data', data => {
                 // Streams guarantee that data is kept in the

--- a/tests/unit/lifecycle/LifecycleQueuePopulator.spec.js
+++ b/tests/unit/lifecycle/LifecycleQueuePopulator.spec.js
@@ -375,7 +375,10 @@ describe('LifecycleQueuePopulator', () => {
             lcqp = new LifecycleQueuePopulator(params);
             lcqp.locationConfigs = Object.assign({}, coldLocationConfigs, locationConfigs);
         });
-        it('it should call _handleDeleteOp on delete message', () => {
+        afterEach(() => {
+            sinon.restore();
+        });
+        it('should call _handleDeleteOp on delete message', () => {
             const handleDeleteStub = sinon.stub(lcqp, '_handleDeleteOp').returns();
             lcqp.filter({
                 type: 'delete',

--- a/tests/unit/notification/NotificationConfigManager.js
+++ b/tests/unit/notification/NotificationConfigManager.js
@@ -1,355 +1,178 @@
 const assert = require('assert');
 const werelogs = require('werelogs');
 const sinon = require('sinon');
-const events = require('events');
-const MongoClient = require('mongodb').MongoClient;
 
-const ChangeStream = require('../../../lib/wrappers/ChangeStream');
-const NotificationConfigManager
-    = require('../../../extensions/notification/NotificationConfigManager');
-const { errors } = require('arsenal');
-const mongoConfig
-    = require('../../config.json').queuePopulator.mongo;
+const NotificationConfigManager = require('../../../extensions/notification/NotificationConfigManager');
+const MongoConfigManager = require('../../../extensions/notification/configManager/MongoConfigManager');
+const ZookeeperConfigManager = require('../../../extensions/notification/configManager/ZookeeperConfigManager');
 
 const logger = new werelogs.Logger('NotificationConfigManager:test');
 
-const notificationConfiguration = {
-    queueConfig: [
-        {
-            events: ['s3:ObjectCreated:Put'],
-            queueArn: 'arn:scality:bucketnotif:::destination1',
-            filterRules: [],
-        },
-    ],
+const bucketConfig = {
+    bucket: 'bucket1',
+    notificationConfiguration: {
+        queueConfig: [
+            {
+                events: ['s3:ObjectCreated:Put'],
+                queueArn: 'arn:scality:bucketnotif:::destination1',
+                filterRules: [],
+            },
+        ],
+    },
 };
 
-const notificationConfigurationVariant = {
-    queueConfig: [
-        {
-            events: ['s3:ObjectCreated:*'],
-            queueArn: 'arn:scality:bucketnotif:::destination2',
-            filterRules: [],
-        },
-    ],
-};
+describe('NotificationConfigManager', () => {
+    describe('constructor', () => {
+        it('should use the mongodb backend', () => {
+            const params = {
+                mongoConfig: {
+                    database: 'eb1e786d-da1e-3fc5-83d2-46f083ab9764',
+                    readPreference: 'primary',
+                    replicaSetHosts: 'localhost:27017',
+                    shardCollections: true,
+                    writeConcern: 'majority'
+                },
+                bucketMetastore: '__metastore',
+                logger,
+            };
 
-describe('NotificationConfigManager ::', () => {
-    const params = {
-        mongoConfig,
-        logger,
-    };
-
-    afterEach(() => {
-        sinon.restore();
-    });
-
-    describe('Constructor & setup ::', () => {
-        it('Constructor should validate params', done => {
-            assert.throws(() => new NotificationConfigManager());
-            assert.throws(() => new NotificationConfigManager({}));
-            assert.throws(() => new NotificationConfigManager({
-                mongoConfig: null,
-                logger: null,
-            }));
             const manager = new NotificationConfigManager(params);
-            assert(manager instanceof NotificationConfigManager);
-            return done();
+            assert(manager._configManagerBackend instanceof MongoConfigManager);
         });
 
-        it('Setup should initialize the mongoClient and the change stream', done => {
+        it('should use the zookeeper backend', () => {
+            const params = {
+                zkClient: {},
+                logger,
+            };
+
             const manager = new NotificationConfigManager(params);
-            const setMongoStub = sinon.stub(manager, '_setupMongoClient').callsArg(0);
-            const setChangeStreamStub = sinon.stub(manager, '_setMetastoreChangeStream').returns();
+            assert(manager._configManagerBackend instanceof ZookeeperConfigManager);
+            assert.strictEqual(manager._usesZookeeperBackend, true);
+        });
+    });
+
+    describe('getConfig', () => {
+        it('should return the configuration', () => {
+            const params = {
+                zkClient: {},
+                logger,
+            };
+            const manager = new NotificationConfigManager(params);
+
+            sinon.stub(manager._configManagerBackend, 'getConfig').returns(bucketConfig);
+
+            const result = manager.getConfig('bucket1');
+            assert.strictEqual(result, bucketConfig);
+        });
+
+        it('should return the configuration with a callback', done => {
+            const params = {
+                zkClient: {},
+                logger,
+            };
+            const manager = new NotificationConfigManager(params);
+
+            sinon.stub(manager._configManagerBackend, 'getConfig').returns(bucketConfig);
+
+            manager.getConfig('bucket1', (err, result) => {
+                assert.ifError(err);
+                assert.strictEqual(result, bucketConfig);
+                done();
+            });
+        });
+
+        it('should return the configuration in a promise', done => {
+            const params = {
+                zkClient: {},
+                logger,
+            };
+            const manager = new NotificationConfigManager(params);
+
+            sinon.stub(manager._configManagerBackend, 'getConfig').resolves(bucketConfig);
+
+            manager.getConfig('bucket1')
+                .then(result => {
+                    assert.strictEqual(result, bucketConfig);
+                    done();
+                })
+                .catch(err => assert.ifError(err));
+        });
+
+        it('should call callback when the promise resolves', done => {
+            const params = {
+                zkClient: {},
+                logger,
+            };
+            const manager = new NotificationConfigManager(params);
+
+            sinon.stub(manager._configManagerBackend, 'getConfig').resolves(bucketConfig);
+
+            manager.getConfig('bucket1', (err, result) => {
+                assert.ifError(err);
+                assert.strictEqual(result, bucketConfig);
+                done();
+            });
+        });
+    });
+
+    describe('setConfig', () => {
+        it('should call setConfig of the backend', () => {
+            const params = {
+                mongoConfig: {
+                    database: 'eb1e786d-da1e-3fc5-83d2-46f083ab9764',
+                    readPreference: 'primary',
+                    replicaSetHosts: 'localhost:27017',
+                    shardCollections: true,
+                    writeConcern: 'majority'
+                },
+                bucketMetastore: '__metastore',
+                logger,
+            };
+
+            const manager = new NotificationConfigManager(params);
+            manager._configManagerBackend.setConfig = sinon.stub().returns(false);
+            manager.setConfig('bucket1', bucketConfig);
+            assert(manager._configManagerBackend.setConfig.calledOnce);
+        });
+    });
+
+    describe('removeConfig', () => {
+        it('should call removeConfig of the backend', () => {
+            const params = {
+                mongoConfig: {
+                    database: 'eb1e786d-da1e-3fc5-83d2-46f083ab9764',
+                    readPreference: 'primary',
+                    replicaSetHosts: 'localhost:27017',
+                    shardCollections: true,
+                    writeConcern: 'majority'
+                },
+                bucketMetastore: '__metastore',
+                logger,
+            };
+
+            const manager = new NotificationConfigManager(params);
+            manager._configManagerBackend.removeConfig = sinon.stub().returns(false);
+            manager.removeConfig('bucket1');
+            assert(manager._configManagerBackend.removeConfig.calledOnce);
+        });
+    });
+
+    describe('setup', () => {
+        it('should call the setup method of the backend', done => {
+            const params = {
+                zkClient: {},
+                logger,
+            };
+
+            const manager = new NotificationConfigManager(params);
+            const stub = sinon.stub(manager._configManagerBackend, 'setup').yields();
+
             manager.setup(err => {
                 assert.ifError(err);
-                assert(setMongoStub.calledOnce);
-                assert(setChangeStreamStub.calledOnce);
-                // cache should initially be empty
-                assert.strictEqual(manager._cachedConfigs.count(), 0);
-                return done();
+                assert(stub.calledOnce);
+                done();
             });
-        });
-
-        it('Setup should fail when mongo setup fails', done => {
-            const manager = new NotificationConfigManager(params);
-            const setMongoStub = sinon.stub(manager, '_setupMongoClient').callsArgWith(0,
-                errors.InternalError);
-            const setChangeStreamStub = sinon.stub(manager, '_setMetastoreChangeStream');
-            manager.setup(err => {
-                assert.deepEqual(err, errors.InternalError);
-                assert(setMongoStub.calledOnce);
-                assert(setChangeStreamStub.notCalled);
-                return done();
-            });
-        });
-
-        it('Setup should fail when changeStream setup fails', done => {
-            const manager = new NotificationConfigManager(params);
-            const setMongoStub = sinon.stub(manager, '_setupMongoClient').callsArg(0);
-            const setChangeStreamStub = sinon.stub(manager, '_setMetastoreChangeStream').throws(
-                errors.InternalError);
-            manager.setup(err => {
-                assert.deepEqual(err, errors.InternalError);
-                assert(setMongoStub.calledOnce);
-                assert(setChangeStreamStub.calledOnce);
-                return done();
-            });
-        });
-    });
-
-    describe('_setupMongoClient ::', () => {
-        it('should setup the mongo client and get metastore collection', () => {
-            const manager = new NotificationConfigManager(params);
-            const getCollectionStub = sinon.stub();
-            const mongoCommandStub = sinon.stub().returns({
-                version: '4.3.17',
-            });
-            const getDbStub = sinon.stub().returns({
-                collection: getCollectionStub,
-                command: mongoCommandStub,
-            });
-            const mongoConnectStub = sinon.stub(MongoClient, 'connect').callsArgWith(2, null, {
-                db: getDbStub,
-            });
-            manager._setupMongoClient(err => {
-                assert.ifError(err);
-                assert(mongoConnectStub.calledOnce);
-                assert(getDbStub.calledOnce);
-                assert(getCollectionStub.calledOnce);
-                assert(mongoCommandStub.calledOnceWith({
-                    buildInfo: 1,
-                }));
-                assert.equal(manager._mongoVersion, '4.3.17');
-            });
-        });
-
-        it('should fail when mongo client setup fails', () => {
-            const manager = new NotificationConfigManager(params);
-            sinon.stub(MongoClient, 'connect').callsArgWith(2,
-                errors.InternalError, null);
-            manager._setupMongoClient(err => {
-                assert.deepEqual(err, errors.InternalError);
-            });
-        });
-
-        it('should fail when when getting the metadata db', () => {
-            const manager = new NotificationConfigManager(params);
-            const getDbStub = sinon.stub().throws(errors.InternalError);
-            sinon.stub(MongoClient, 'connect').callsArgWith(2, null, {
-                db: getDbStub,
-            });
-            manager._setupMongoClient(err => {
-                assert.deepEqual(err, errors.InternalError);
-            });
-        });
-
-        it('should fail when mongo client fails to get metastore', () => {
-            const manager = new NotificationConfigManager(params);
-            const getCollectionStub = sinon.stub().throws(errors.InternalError);
-            const getDbStub = sinon.stub().returns({
-                collection: getCollectionStub,
-                });
-            sinon.stub(MongoClient, 'connect').callsArgWith(2, null, {
-                db: getDbStub,
-            });
-            manager._setupMongoClient(err => {
-                assert.deepEqual(err, errors.InternalError);
-            });
-        });
-    });
-
-    describe('_handleChangeStreamChangeEvent ::', () => {
-        it('should remove entry from cache', () => {
-            const changeStreamEvent = {
-                _id: 'resumeToken',
-                operationType: 'delete',
-                documentKey: {
-                    _id: 'example-bucket-1',
-                },
-                fullDocument: {
-                    _id: 'example-bucket-1',
-                    value: {
-                        notificationConfiguration,
-                    }
-                }
-            };
-            const manager = new NotificationConfigManager(params);
-            // populating cache
-            manager._cachedConfigs.add('example-bucket-1', notificationConfiguration);
-            assert.strictEqual(manager._cachedConfigs.count(), 1);
-            // handling change stream event
-            manager._handleChangeStreamChangeEvent(changeStreamEvent);
-            // should delete bucket config from cache
-            assert.strictEqual(manager._cachedConfigs.get('example-bucket-1'),
-                undefined);
-            assert.strictEqual(manager._cachedConfigs.count(), 0);
-        });
-
-        it('should replace entry from cache', () => {
-            const changeStreamEvent = {
-                _id: 'resumeToken',
-                operationType: 'replace',
-                documentKey: {
-                    _id: 'example-bucket-1',
-                },
-                fullDocument: {
-                    _id: 'example-bucket-1',
-                    value: {
-                        notificationConfiguration:
-                            notificationConfigurationVariant,
-                    }
-                }
-            };
-            const manager = new NotificationConfigManager(params);
-            // populating cache
-            manager._cachedConfigs.add('example-bucket-1', notificationConfiguration);
-            assert.strictEqual(manager._cachedConfigs.count(), 1);
-            // handling change stream event
-            manager._handleChangeStreamChangeEvent(changeStreamEvent);
-            // should update bucket config in cache
-            assert.deepEqual(manager._cachedConfigs.get('example-bucket-1'),
-                notificationConfigurationVariant);
-            assert.strictEqual(manager._cachedConfigs.count(), 1);
-            // same thing should happen with "update" event
-            changeStreamEvent.operationType = 'update';
-            // reseting config to default one
-            changeStreamEvent.fullDocument.value.notificationConfiguration =
-                notificationConfiguration;
-            // emiting the new "update" event
-            manager._handleChangeStreamChangeEvent(changeStreamEvent);
-            // cached config must be updated
-            assert.deepEqual(manager._cachedConfigs.get('example-bucket-1'),
-                notificationConfiguration);
-            assert.strictEqual(manager._cachedConfigs.count(), 1);
-        });
-
-        it('should do nothing when config not in cache', () => {
-            const changeStreamEvent = {
-                _id: 'resumeToken',
-                operationType: 'delete',
-                documentKey: {
-                    _id: 'example-bucket-2',
-                },
-                fullDocument: {
-                    _id: 'example-bucket-2',
-                    value: {
-                        notificationConfiguration:
-                            notificationConfigurationVariant,
-                    }
-                }
-            };
-            const manager = new NotificationConfigManager(params);
-            // populating cache
-            manager._cachedConfigs.add('example-bucket-1', notificationConfiguration);
-            assert.strictEqual(manager._cachedConfigs.count(), 1);
-            // handling change stream event
-            manager._handleChangeStreamChangeEvent(changeStreamEvent);
-            // cache should not change
-            assert.deepEqual(manager._cachedConfigs.get('example-bucket-1'),
-                notificationConfiguration);
-            assert.strictEqual(manager._cachedConfigs.count(), 1);
-        });
-
-        it('should do nothing when operation is not supported', () => {
-            const changeStreamEvent = {
-                _id: 'resumeToken',
-                operationType: 'insert',
-                documentKey: {
-                    _id: 'example-bucket-1',
-                },
-                fullDocument: {
-                    _id: 'example-bucket-2',
-                    value: {
-                        notificationConfiguration:
-                            notificationConfigurationVariant,
-                    }
-                }
-            };
-            const manager = new NotificationConfigManager(params);
-            // populating cache
-            manager._cachedConfigs.add('example-bucket-1', notificationConfiguration);
-            assert.strictEqual(manager._cachedConfigs.count(), 1);
-            assert(manager._cachedConfigs.get('example-bucket-1'));
-            // handling change stream event
-            manager._handleChangeStreamChangeEvent(changeStreamEvent);
-            // cache should not change
-            assert.deepEqual(manager._cachedConfigs.get('example-bucket-1'),
-                notificationConfiguration);
-            assert.strictEqual(manager._cachedConfigs.count(), 1);
-        });
-    });
-
-    describe('_setMetastoreChangeStream ::', () =>  {
-         it('should use resumeAfter with mongo 3.6', () => {
-            const manager = new NotificationConfigManager(params);
-            manager._mongoVersion = '3.6.2';
-            manager._metastore = {
-                watch: sinon.stub().returns(new events.EventEmitter()),
-            };
-            manager._setMetastoreChangeStream();
-            assert(manager._metastoreChangeStream instanceof ChangeStream);
-            assert.equal(manager._metastoreChangeStream._resumeField, 'resumeAfter');
-        });
-
-        it('should use resumeAfter with mongo 4.0', () => {
-            const manager = new NotificationConfigManager(params);
-            manager._mongoVersion = '4.0.7';
-            manager._metastore = {
-                watch: sinon.stub().returns(new events.EventEmitter()),
-            };
-            manager._setMetastoreChangeStream();
-            assert(manager._metastoreChangeStream instanceof ChangeStream);
-            assert.equal(manager._metastoreChangeStream._resumeField, 'resumeAfter');
-        });
-
-        it('should use startAfter with mongo 4.2', () => {
-            const manager = new NotificationConfigManager(params);
-            manager._mongoVersion = '4.2.3';
-            manager._metastore = {
-                watch: sinon.stub().returns(new events.EventEmitter()),
-            };
-            manager._setMetastoreChangeStream();
-            assert(manager._metastoreChangeStream instanceof ChangeStream);
-            assert.equal(manager._metastoreChangeStream._resumeField, 'startAfter');
-        });
-    });
-
-    describe('getConfig ::', () =>  {
-        it('should return notification configuration of bucket', async () => {
-            const manager = new NotificationConfigManager(params);
-            manager._metastore = {
-                findOne: () => (
-                    {
-                        value: {
-                            notificationConfiguration,
-                        }
-                    }),
-            };
-            assert.strictEqual(manager._cachedConfigs.count(), 0);
-            const config = await manager.getConfig('example-bucket-1');
-            assert.deepEqual(config, notificationConfiguration);
-            // should also cache config
-            assert.strictEqual(manager._cachedConfigs.count(), 1);
-            assert.deepEqual(manager._cachedConfigs.get('example-bucket-1'),
-                notificationConfiguration);
-        });
-
-        it('should return undefined when bucket doesn\'t have notification configuration', async () => {
-            const manager = new NotificationConfigManager(params);
-            manager._metastore = {
-                findOne: () => ({ value: {} }),
-            };
-            const config = await manager.getConfig('example-bucket-1');
-            assert.strictEqual(config, undefined);
-        });
-
-        it('should return undefined when mongo findOne fails', async () => {
-            const manager = new NotificationConfigManager(params);
-            manager._metastore = {
-                findOne: sinon.stub().throws(errors.InternalError),
-            };
-            const config = await manager.getConfig('example-bucket-1');
-            assert.strictEqual(config, undefined);
         });
     });
 });

--- a/tests/unit/notification/NotificationConfigManager.js
+++ b/tests/unit/notification/NotificationConfigManager.js
@@ -44,6 +44,7 @@ describe('NotificationConfigManager', () => {
         it('should use the zookeeper backend', () => {
             const params = {
                 zkClient: {},
+                zkConcurrency: 10,
                 logger,
             };
 
@@ -57,6 +58,7 @@ describe('NotificationConfigManager', () => {
         it('should return the configuration', () => {
             const params = {
                 zkClient: {},
+                zkConcurrency: 10,
                 logger,
             };
             const manager = new NotificationConfigManager(params);
@@ -70,6 +72,7 @@ describe('NotificationConfigManager', () => {
         it('should return the configuration with a callback', done => {
             const params = {
                 zkClient: {},
+                zkConcurrency: 10,
                 logger,
             };
             const manager = new NotificationConfigManager(params);
@@ -86,6 +89,7 @@ describe('NotificationConfigManager', () => {
         it('should return the configuration in a promise', done => {
             const params = {
                 zkClient: {},
+                zkConcurrency: 10,
                 logger,
             };
             const manager = new NotificationConfigManager(params);
@@ -103,6 +107,7 @@ describe('NotificationConfigManager', () => {
         it('should call callback when the promise resolves', done => {
             const params = {
                 zkClient: {},
+                zkConcurrency: 10,
                 logger,
             };
             const manager = new NotificationConfigManager(params);
@@ -165,6 +170,7 @@ describe('NotificationConfigManager', () => {
         it('should call the setup method of the backend', done => {
             const params = {
                 zkClient: {},
+                zkConcurrency: 10,
                 logger,
             };
 

--- a/tests/unit/notification/NotificationConfigManager.js
+++ b/tests/unit/notification/NotificationConfigManager.js
@@ -33,6 +33,7 @@ describe('NotificationConfigManager', () => {
                     writeConcern: 'majority'
                 },
                 bucketMetastore: '__metastore',
+                maxCachedConfigs: 1000,
                 logger,
             };
 
@@ -127,6 +128,7 @@ describe('NotificationConfigManager', () => {
                     writeConcern: 'majority'
                 },
                 bucketMetastore: '__metastore',
+                maxCachedConfigs: 1000,
                 logger,
             };
 
@@ -148,6 +150,7 @@ describe('NotificationConfigManager', () => {
                     writeConcern: 'majority'
                 },
                 bucketMetastore: '__metastore',
+                maxCachedConfigs: 1000,
                 logger,
             };
 

--- a/tests/unit/notification/NotificationQueuePopulator.js
+++ b/tests/unit/notification/NotificationQueuePopulator.js
@@ -13,19 +13,22 @@ const notificationConfig
 
 const logger = new werelogs.Logger('NotificationConfigManager:test');
 
-const notificationConfiguration = {
-    queueConfig: [
-        {
-            events: ['s3:ObjectCreated:Put'],
-            queueArn: 'arn:scality:bucketnotif:::destination1',
-            filterRules: [],
-        },
-        {
-            events: ['s3:ObjectRemoved:Delete'],
-            queueArn: 'arn:scality:bucketnotif:::destination2',
-            filterRules: [],
-        },
-    ],
+const config = {
+    bucket: 'example-bucket',
+    notificationConfiguration: {
+        queueConfig: [
+            {
+                events: ['s3:ObjectCreated:Put'],
+                queueArn: 'arn:scality:bucketnotif:::destination1',
+                filterRules: [],
+            },
+            {
+                events: ['s3:ObjectRemoved:Delete'],
+                queueArn: 'arn:scality:bucketnotif:::destination2',
+                filterRules: [],
+            },
+        ],
+    },
 };
 
 describe('NotificationQueuePopulator ::', () => {
@@ -35,6 +38,7 @@ describe('NotificationQueuePopulator ::', () => {
     beforeEach(() => {
         bnConfigManager = new NotificationConfigManager({
             mongoConfig,
+            bucketMetastore: '__metastore',
             logger,
         });
         notificationQueuePopulator = new NotificationQueuePopulator({
@@ -64,7 +68,7 @@ describe('NotificationQueuePopulator ::', () => {
 
     describe('_processObjectEntry ::', () => {
         it('should publish object entry in notification topic of destination1', async () => {
-            sinon.stub(bnConfigManager, 'getConfig').returns(notificationConfiguration);
+            sinon.stub(bnConfigManager, 'getConfig').returns(config);
             const publishStub = sinon.stub(notificationQueuePopulator, 'publish');
             await notificationQueuePopulator._processObjectEntry(
                 'example-bucket',
@@ -80,7 +84,7 @@ describe('NotificationQueuePopulator ::', () => {
         });
 
         it('should publish object entry in notification topic of destination2', async () => {
-            sinon.stub(bnConfigManager, 'getConfig').returns(notificationConfiguration);
+            sinon.stub(bnConfigManager, 'getConfig').returns(config);
             const publishStub = sinon.stub(notificationQueuePopulator, 'publish');
             await notificationQueuePopulator._processObjectEntry(
                 'example-bucket',
@@ -97,7 +101,7 @@ describe('NotificationQueuePopulator ::', () => {
 
         it('should not publish object entry in notification topic if ' +
             'config validation failed', async () => {
-            sinon.stub(bnConfigManager, 'getConfig').returns(notificationConfiguration);
+            sinon.stub(bnConfigManager, 'getConfig').returns(config);
             const publishStub = sinon.stub(notificationQueuePopulator, 'publish');
             await notificationQueuePopulator._processObjectEntry(
                 'example-bucket',
@@ -124,18 +128,21 @@ describe('NotificationQueuePopulator ::', () => {
                 })),
             };
             sinon.stub(bnConfigManager, 'getConfig').returns({
-                queueConfig: [
-                    {
-                        events: ['s3:ObjectCreated:Put'],
-                        queueArn: 'arn:scality:bucketnotif:::destination1',
-                        filterRules: [],
-                    },
-                    {
-                        events: ['s3:ObjectCreated:Put'],
-                        queueArn: 'arn:scality:bucketnotif:::destination2',
-                        filterRules: [],
-                    }
-                ],
+                bucket: 'example-bucket',
+                notificationConfiguration: {
+                    queueConfig: [
+                        {
+                            events: ['s3:ObjectCreated:Put'],
+                            queueArn: 'arn:scality:bucketnotif:::destination1',
+                            filterRules: [],
+                        },
+                        {
+                            events: ['s3:ObjectCreated:Put'],
+                            queueArn: 'arn:scality:bucketnotif:::destination2',
+                            filterRules: [],
+                        }
+                    ],
+                },
             });
             const publishStub = sinon.stub(notificationQueuePopulator, 'publish');
             await notificationQueuePopulator._processObjectEntry(
@@ -163,18 +170,21 @@ describe('NotificationQueuePopulator ::', () => {
                 })),
             };
             sinon.stub(bnConfigManager, 'getConfig').returns({
-                queueConfig: [
-                    {
-                        events: ['s3:ObjectCreated:Put'],
-                        queueArn: 'arn:scality:bucketnotif:::destination1',
-                        filterRules: [],
-                    },
-                    {
-                        events: ['s3:ObjectCreated:Put'],
-                        queueArn: 'arn:scality:bucketnotif:::destination2',
-                        filterRules: [],
-                    }
-                ],
+                bucket: 'example-bucket',
+                notificationConfiguration: {
+                    queueConfig: [
+                        {
+                            events: ['s3:ObjectCreated:Put'],
+                            queueArn: 'arn:scality:bucketnotif:::destination1',
+                            filterRules: [],
+                        },
+                        {
+                            events: ['s3:ObjectCreated:Put'],
+                            queueArn: 'arn:scality:bucketnotif:::destination2',
+                            filterRules: [],
+                        }
+                    ],
+                },
             });
             const publishStub = sinon.stub(notificationQueuePopulator, 'publish');
             await notificationQueuePopulator._processObjectEntry(
@@ -194,28 +204,31 @@ describe('NotificationQueuePopulator ::', () => {
         it('should publish object entry to each entry\'s destination topic when multiple ' +
             'destinations are valid for an event', async () => {
             sinon.stub(bnConfigManager, 'getConfig').returns({
-                queueConfig: [
-                    {
-                        events: ['s3:ObjectCreated:Put'],
-                        queueArn: 'arn:scality:bucketnotif:::destination1',
-                        filterRules: [],
-                    },
-                    {
-                        events: ['s3:ObjectCreated:Put'],
-                        queueArn: 'arn:scality:bucketnotif:::destination2',
-                        filterRules: [],
-                    },
-                    {
-                        events: ['s3:ObjectCreated:Put'],
-                        queueArn: 'arn:scality:bucketnotif:::destination3',
-                        filterRules: [],
-                    },
-                    {
-                        events: ['s3:ObjectCreated:Put'],
-                        queueArn: 'arn:scality:bucketnotif:::destination4',
-                        filterRules: [],
-                    },
-                ],
+                bucket: 'example-bucket',
+                notificationConfiguration: {
+                    queueConfig: [
+                        {
+                            events: ['s3:ObjectCreated:Put'],
+                            queueArn: 'arn:scality:bucketnotif:::destination1',
+                            filterRules: [],
+                        },
+                        {
+                            events: ['s3:ObjectCreated:Put'],
+                            queueArn: 'arn:scality:bucketnotif:::destination2',
+                            filterRules: [],
+                        },
+                        {
+                            events: ['s3:ObjectCreated:Put'],
+                            queueArn: 'arn:scality:bucketnotif:::destination3',
+                            filterRules: [],
+                        },
+                        {
+                            events: ['s3:ObjectCreated:Put'],
+                            queueArn: 'arn:scality:bucketnotif:::destination4',
+                            filterRules: [],
+                        },
+                    ],
+                },
             });
             // override the destinations' config to add two new destinations that use
             // the default shared internal topic
@@ -253,13 +266,16 @@ describe('NotificationQueuePopulator ::', () => {
         it('should not publish object entry in notification topic if ' +
             'notification is non standard', async () => {
             sinon.stub(bnConfigManager, 'getConfig').returns({
-                queueConfig: [
-                    {
-                        events: ['s3:ObjectCreated:*'],
-                        queueArn: 'arn:scality:bucketnotif:::destination1',
-                        filterRules: [],
-                    },
-                ],
+                bucket: 'example-bucket',
+                notificationConfiguration: {
+                    queueConfig: [
+                        {
+                            events: ['s3:ObjectCreated:*'],
+                            queueArn: 'arn:scality:bucketnotif:::destination1',
+                            filterRules: [],
+                        },
+                    ],
+                },
             });
             const publishStub = sinon.stub(notificationQueuePopulator, 'publish');
             await notificationQueuePopulator._processObjectEntry(
@@ -273,6 +289,36 @@ describe('NotificationQueuePopulator ::', () => {
                     'md-model-version': '1',
                 });
             assert(publishStub.notCalled);
+        });
+
+        it('should use proper fields or S3C delete notification', async () => {
+            sinon.stub(bnConfigManager, 'getConfig').returns(config);
+            const publishStub = sinon.stub(notificationQueuePopulator, 'publish').returns();
+            const timestamp = new Date().toISOString();
+            await notificationQueuePopulator._processObjectEntry(
+                'example-bucket',
+                'example-key\x0098500086134471999999RG001  0',
+                {},
+                'del',
+                {
+                    versionId: '123456',
+                    commitTimestamp: timestamp,
+                }
+            );
+            const expectedMessage = {
+                bucket: 'example-bucket',
+                key: 'example-key',
+                versionId: '123456',
+                dateTime: timestamp,
+                eventType: 's3:ObjectRemoved:Delete',
+                region: null,
+                schemaVersion: null,
+                size: null,
+            };
+            assert(publishStub.calledOnce);
+            assert.strictEqual(publishStub.getCall(0).args.at(0), 'internal-notification-topic-destination2');
+            assert.strictEqual(publishStub.getCall(0).args.at(1), 'example-bucket/example-key');
+            assert.deepEqual(JSON.parse(publishStub.getCall(0).args.at(2)), expectedMessage);
         });
     });
 
@@ -295,11 +341,12 @@ describe('NotificationQueuePopulator ::', () => {
             });
         });
 
-        it('should fail if entry is a bucket entry', done => {
-            const processEntryStub = sinon.stub(notificationQueuePopulator, '_processObjectEntry');
+        it('should ignore bucket operations', done => {
+            const processObjectEntryStub = sinon.stub(notificationQueuePopulator, '_processObjectEntry');
+            const processBucketEntryStub = sinon.stub(notificationQueuePopulator, '_processBucketEntry');
             const entry = {
-                bucket: '__metastore',
-                key: 'example-bucket',
+                bucket: 'users..bucket',
+                key: 'example-key',
                 type: 'put',
                 value: '{}',
                 overheadFields: {
@@ -308,12 +355,110 @@ describe('NotificationQueuePopulator ::', () => {
             };
             notificationQueuePopulator.filterAsync(entry, err => {
                 assert.ifError(err);
-                assert(processEntryStub.notCalled);
+                assert(processObjectEntryStub.notCalled);
+                assert(processBucketEntryStub.notCalled);
                 return done();
             });
         });
 
-        it('should process the entry', done => {
+        it('should ignore mpu bucket operations', done => {
+            const processObjectEntryStub = sinon.stub(notificationQueuePopulator, '_processObjectEntry');
+            const processBucketEntryStub = sinon.stub(notificationQueuePopulator, '_processBucketEntry');
+            const entry = {
+                bucket: '__metastore',
+                key: 'mpuShadowBucketexample-bucket',
+                type: 'put',
+                value: '{}',
+                overheadFields: {
+                    opTimestamp: new Date().toISOString(),
+                },
+            };
+            notificationQueuePopulator.filterAsync(entry, err => {
+                assert.ifError(err);
+                assert(processObjectEntryStub.notCalled);
+                assert(processBucketEntryStub.notCalled);
+                return done();
+            });
+        });
+
+        it('should updated config when a bucket entry contains notification configuration', done => {
+            const processEntryStub = sinon.stub(notificationQueuePopulator, '_processObjectEntry').yields();
+            const setConfigStub = sinon.stub(notificationQueuePopulator.bnConfigManager, 'setConfig').returns(true);
+            const entry = {
+                bucket: '__metastore',
+                key: 'example-bucket',
+                type: 'put',
+                value: '{"attributes":"{\\"name\\":\\"example-bucket\\",\\"notificationConfiguration\\":' +
+                    '{\\"queueConfig\\":[{\\"events\\":[\\"s3:ObjectCreated:*\\"],\\"queueArn\\":' +
+                    '\\"arn:scality:bucketnotif:::notification-target\\"}]}}"}',
+                overheadFields: {
+                    opTimestamp: new Date().toISOString(),
+                },
+            };
+            notificationQueuePopulator.filterAsync(entry, err => {
+                assert.ifError(err);
+                assert(processEntryStub.notCalled);
+                assert(setConfigStub.calledWithMatch(
+                    'example-bucket',
+                    {
+                        bucket: 'example-bucket',
+                        notificationConfiguration: {
+                            queueConfig: [
+                                {
+                                    events: ['s3:ObjectCreated:*'],
+                                    queueArn: 'arn:scality:bucketnotif:::notification-target',
+                                },
+                            ],
+                        },
+                    },
+                ));
+                return done();
+            });
+        });
+
+        it('remove config when bucket no longer has notification configured', done => {
+            const processEntryStub = sinon.stub(notificationQueuePopulator, '_processObjectEntry').yields();
+            const removeConfigStub = sinon.stub(notificationQueuePopulator.bnConfigManager, 'removeConfig')
+                .returns(true);
+            const entry = {
+                bucket: '__metastore',
+                key: 'example-bucket',
+                type: 'put',
+                value: '{"attributes":"{\\"name\\":\\"example-bucket\\"}"}',
+                overheadFields: {
+                    opTimestamp: new Date().toISOString(),
+                },
+            };
+            notificationQueuePopulator.filterAsync(entry, err => {
+                assert.ifError(err);
+                assert(processEntryStub.notCalled);
+                assert(removeConfigStub.calledWithMatch('example-bucket'));
+                return done();
+            });
+        });
+
+        it('should remove config whe bucket is deleted', done => {
+            const processEntryStub = sinon.stub(notificationQueuePopulator, '_processObjectEntry').yields();
+            const removeConfigStub = sinon.stub(notificationQueuePopulator.bnConfigManager, 'removeConfig')
+                .returns(true);
+            const entry = {
+                bucket: '__metastore',
+                key: 'example-bucket',
+                type: 'del',
+                value: undefined,
+                overheadFields: {
+                    opTimestamp: new Date().toISOString(),
+                },
+            };
+            notificationQueuePopulator.filterAsync(entry, err => {
+                assert.ifError(err);
+                assert(processEntryStub.notCalled);
+                assert(removeConfigStub.calledWithMatch('example-bucket'));
+                return done();
+            });
+        });
+
+        it('should process an object entry', done => {
             const processEntryCbStub = sinon.stub(notificationQueuePopulator, '_processObjectEntryCb')
                 .yields();
             const entry = {
@@ -338,22 +483,31 @@ describe('NotificationQueuePopulator ::', () => {
             {
                 desc: 'non versioned',
                 input: {},
+                overhead: null,
                 out: null
             },
             {
                 desc: 'versioned',
                 input: { versionId: '1234' },
+                overhead: null,
+                out: '1234'
+            },
+            {
+                desc: 'versioned (S3C delete case)',
+                input: {},
+                overhead: { versionId: '1234' },
                 out: '1234'
             },
             {
                 desc: 'a null version',
                 input: { isNull: true, versionId: '1234' },
+                overhead: null,
                 out: null
             },
         ].forEach(tests => {
-            const { desc, input, out } = tests;
+            const { desc, input, overhead, out } = tests;
             it(`Should return ${out} when object is ${desc}`, () => {
-                const versionId = notificationQueuePopulator._getVersionId(input);
+                const versionId = notificationQueuePopulator._getVersionId(input, overhead);
                 assert.strictEqual(versionId, out);
             });
         });
@@ -418,32 +572,36 @@ describe('NotificationQueuePopulator with multiple rules ::', () => {
     beforeEach(() => {
         bnConfigManager = new NotificationConfigManager({
             mongoConfig,
+            bucketMetastore: '__metastore',
             logger,
         });
         sinon.stub(bnConfigManager, 'getConfig').returns({
-            queueConfig: [
-                {
-                    events: ['s3:ObjectCreated:*'],
-                    queueArn: 'arn:scality:bucketnotif:::destination1',
-                    id: '0',
-                    filterRules: [
-                        {
-                            name: 'Prefix',
-                            value: 'toto/',
-                        },
-                    ],
-                }, {
-                    events: ['s3:ObjectCreated:*'],
-                    queueArn: 'arn:scality:bucketnotif:::destination1',
-                    id: '1',
-                    filterRules: [
-                        {
-                            name: 'Prefix',
-                            value: 'tata/',
-                        },
-                    ],
-                },
-            ],
+            bucket: 'example-bucket',
+            notificationConfiguration: {
+                queueConfig: [
+                    {
+                        events: ['s3:ObjectCreated:*'],
+                        queueArn: 'arn:scality:bucketnotif:::destination1',
+                        id: '0',
+                        filterRules: [
+                            {
+                                name: 'Prefix',
+                                value: 'toto/',
+                            },
+                        ],
+                    }, {
+                        events: ['s3:ObjectCreated:*'],
+                        queueArn: 'arn:scality:bucketnotif:::destination1',
+                        id: '1',
+                        filterRules: [
+                            {
+                                name: 'Prefix',
+                                value: 'tata/',
+                            },
+                        ],
+                    },
+                ],
+            },
         });
         notificationQueuePopulator = new NotificationQueuePopulator({
             config: notificationConfig,

--- a/tests/unit/notification/NotificationQueuePopulator.js
+++ b/tests/unit/notification/NotificationQueuePopulator.js
@@ -39,6 +39,7 @@ describe('NotificationQueuePopulator ::', () => {
         bnConfigManager = new NotificationConfigManager({
             mongoConfig,
             bucketMetastore: '__metastore',
+            maxCachedConfigs: 1000,
             logger,
         });
         notificationQueuePopulator = new NotificationQueuePopulator({
@@ -573,6 +574,7 @@ describe('NotificationQueuePopulator with multiple rules ::', () => {
         bnConfigManager = new NotificationConfigManager({
             mongoConfig,
             bucketMetastore: '__metastore',
+            maxCachedConfigs: 1000,
             logger,
         });
         sinon.stub(bnConfigManager, 'getConfig').returns({

--- a/tests/unit/notification/NotificationQueueProcessor.js
+++ b/tests/unit/notification/NotificationQueueProcessor.js
@@ -11,17 +11,22 @@ const kafkaConfig
     = require('../../config.notification.json').queuePopulator.kafka;
 const notificationConfig
     = require('../../config.notification.json').extensions.notification;
+const zookeeperConfig
+    = require('../../config.notification.json').zookeeper;
 
 const logger = new werelogs.Logger('NotificationQueueProcessor:test');
 
-const notificationConfiguration = {
-    queueConfig: [
-        {
-            events: ['s3:ObjectCreated:*'],
-            queueArn: 'arn:scality:bucketnotif:::destination1',
-            filterRules: [],
-        },
-    ],
+const config = {
+    bucket: 'example-bucket',
+    notificationConfiguration: {
+        queueConfig: [
+            {
+                events: ['s3:ObjectCreated:*'],
+                queueArn: 'arn:scality:bucketnotif:::destination1',
+                filterRules: [],
+            },
+        ],
+    },
 };
 
 const kafkaEntry = {
@@ -80,7 +85,7 @@ describe('NotificationQueueProcessor:: ', () => {
     let notificationQueueProcessor;
 
     beforeEach(() => {
-        notificationQueueProcessor = new NotificationQueueProcessor(mongoConfig, kafkaConfig,
+        notificationQueueProcessor = new NotificationQueueProcessor(mongoConfig, zookeeperConfig, kafkaConfig,
             notificationConfig, notificationConfig.destinations[0].resource, null);
         notificationQueueProcessor.logger = logger;
     });
@@ -91,7 +96,9 @@ describe('NotificationQueueProcessor:: ', () => {
 
     describe('processKafkaEntry ::', () => {
         it('should publish notification in correct format', async () => {
-            notificationQueueProcessor._getConfig = sinon.stub().yields(null, notificationConfiguration);
+            notificationQueueProcessor.bnConfigManager = {
+                getConfig: sinon.stub().yields(null, config),
+            };
             const sendStub = sinon.stub().yields(null);
             notificationQueueProcessor._destination = {
                 send: sendStub,

--- a/tests/unit/notification/QueueProcessor.spec.js
+++ b/tests/unit/notification/QueueProcessor.spec.js
@@ -9,7 +9,7 @@ describe('notification QueueProcessor', () => {
     let qp;
 
     before(done => {
-        qp = new QueueProcessor(null, null, {
+        qp = new QueueProcessor(null, null, null, {
             destinations: [
                 {
                     resource: 'destId',
@@ -17,22 +17,22 @@ describe('notification QueueProcessor', () => {
                 },
             ],
         }, 'destId', null);
-        qp._getConfig = (bucket, cb) => cb(null, {
-            queueConfig: [
-                {
-                    queueArn: 'arn:scality:bucketnotif:::destId',
-                    events: [
-                        's3:ObjectCreated:*',
-                    ],
-                },
-            ],
-        });
         qp.bnConfigManager = {
             setConfig: () => {},
+            getConfig: (bucket, cb) => cb(null, {
+                bucket: 'mybucket',
+                notificationConfiguration: {
+                    queueConfig: [
+                        {
+                            queueArn: 'arn:scality:bucketnotif:::destId',
+                            events: [
+                                's3:ObjectCreated:*',
+                            ],
+                        },
+                    ],
+                },
+            })
         };
-        qp.bnConfigManager.setConfig('mybucket', {
-            host: 'foo',
-        });
         qp._setupDestination('kafka', done);
     });
 
@@ -175,7 +175,7 @@ describe('notification QueueProcessor with multiple rules', () => {
     let sendStub;
 
     before(done => {
-        qp = new QueueProcessor(null, null, {
+        qp = new QueueProcessor(null, null, null, {
             destinations: [
                 {
                     resource: 'destId',
@@ -184,34 +184,36 @@ describe('notification QueueProcessor with multiple rules', () => {
             ],
         }, 'destId', null);
 
-        qp._getConfig = (bucket, cb) => cb(null, {
-            queueConfig: [
-                {
-                    events: ['s3:ObjectCreated:*'],
-                    queueArn: 'arn:scality:bucketnotif:::destId',
-                    id: '0',
-                    filterRules: [
+        qp.bnConfigManager = {
+            setConfig: () => {},
+            getConfig: (bucket, cb) => cb(null, {
+                bucket: 'mybucket',
+                notificationConfiguration: {
+                    queueConfig: [
                         {
-                            name: 'Prefix',
-                            value: 'toto/',
-                        },
-                    ],
-                }, {
-                    events: ['s3:ObjectCreated:*'],
-                    queueArn: 'arn:scality:bucketnotif:::destId',
-                    id: '1',
-                    filterRules: [
-                        {
-                            name: 'Prefix',
-                            value: 'tata/',
+                            events: ['s3:ObjectCreated:*'],
+                            queueArn: 'arn:scality:bucketnotif:::destId',
+                            id: '0',
+                            filterRules: [
+                                {
+                                    name: 'Prefix',
+                                    value: 'toto/',
+                                },
+                            ],
+                        }, {
+                            events: ['s3:ObjectCreated:*'],
+                            queueArn: 'arn:scality:bucketnotif:::destId',
+                            id: '1',
+                            filterRules: [
+                                {
+                                    name: 'Prefix',
+                                    value: 'tata/',
+                                },
+                            ],
                         },
                     ],
                 },
-            ],
-        });
-
-        qp.bnConfigManager = {
-            setConfig: () => {},
+            }),
         };
 
         qp._setupDestination('kafka', done);
@@ -360,7 +362,7 @@ describe('notification QueueProcessor with one rule filtering by prefix and suff
     let sendStub;
 
     before(done => {
-        qp = new QueueProcessor(null, null, {
+        qp = new QueueProcessor(null, null, null, {
             destinations: [
                 {
                     resource: 'destId',
@@ -369,28 +371,30 @@ describe('notification QueueProcessor with one rule filtering by prefix and suff
             ],
         }, 'destId', null);
 
-        qp._getConfig = (bucket, cb) => cb(null, {
-            queueConfig: [
-                {
-                    events: ['s3:ObjectCreated:*'],
-                    queueArn: 'arn:scality:bucketnotif:::destId',
-                    id: '0',
-                    filterRules: [
+        qp.bnConfigManager = {
+            setConfig: () => {},
+            getConfig: (bucket, cb) => cb(null, {
+                bucket: 'mybucket',
+                notificationConfiguration: {
+                    queueConfig: [
                         {
-                            name: 'Prefix',
-                            value: 'toto/',
-                        },
-                        {
-                            name: 'Suffix',
-                            value: '.png',
+                            events: ['s3:ObjectCreated:*'],
+                            queueArn: 'arn:scality:bucketnotif:::destId',
+                            id: '0',
+                            filterRules: [
+                                {
+                                    name: 'Prefix',
+                                    value: 'toto/',
+                                },
+                                {
+                                    name: 'Suffix',
+                                    value: '.png',
+                                },
+                            ],
                         },
                     ],
                 },
-            ],
-        });
-
-        qp.bnConfigManager = {
-            setConfig: () => {},
+            }),
         };
 
         qp._setupDestination('kafka', done);
@@ -505,7 +509,7 @@ describe('notification QueueProcessor with multiple rules and object matching al
     let sendStub;
 
     before(done => {
-        qp = new QueueProcessor(null, null, {
+        qp = new QueueProcessor(null, null, null, {
             destinations: [
                 {
                     resource: 'destId',
@@ -514,34 +518,36 @@ describe('notification QueueProcessor with multiple rules and object matching al
             ],
         }, 'destId', null);
 
-        qp._getConfig = (bucket, cb) => cb(null, {
-            queueConfig: [
-                {
-                    events: ['s3:ObjectCreated:*'],
-                    queueArn: 'arn:scality:bucketnotif:::destId',
-                    id: '0',
-                    filterRules: [
+        qp.bnConfigManager = {
+            setConfig: () => {},
+            getConfig: (bucket, cb) => cb(null, {
+                bucket: 'mybucket',
+                notificationConfiguration: {
+                    queueConfig: [
                         {
-                            name: 'Prefix',
-                            value: 'toto/',
-                        },
-                    ],
-                }, {
-                    events: ['s3:ObjectCreated:*'],
-                    queueArn: 'arn:scality:bucketnotif:::destId',
-                    id: '1',
-                    filterRules: [
-                        {
-                            name: 'Suffix',
-                            value: '.png',
+                            events: ['s3:ObjectCreated:*'],
+                            queueArn: 'arn:scality:bucketnotif:::destId',
+                            id: '0',
+                            filterRules: [
+                                {
+                                    name: 'Prefix',
+                                    value: 'toto/',
+                                },
+                            ],
+                        }, {
+                            events: ['s3:ObjectCreated:*'],
+                            queueArn: 'arn:scality:bucketnotif:::destId',
+                            id: '1',
+                            filterRules: [
+                                {
+                                    name: 'Suffix',
+                                    value: '.png',
+                                },
+                            ],
                         },
                     ],
                 },
-            ],
-        });
-
-        qp.bnConfigManager = {
-            setConfig: () => {},
+            }),
         };
 
         qp._setupDestination('kafka', done);
@@ -616,7 +622,7 @@ describe('notification QueueProcessor destination id not matching the rule desti
     let sendStub;
 
     before(done => {
-        qp = new QueueProcessor(null, null, {
+        qp = new QueueProcessor(null, null, null, {
             destinations: [
                 {
                     resource: 'destId',
@@ -642,18 +648,24 @@ describe('notification QueueProcessor destination id not matching the rule desti
         ];
 
         mismatchedARN.forEach(arn => {
-            qp._getConfig = (bucket, cb) => cb(null, {
-                queueConfig: [
-                    {
-                        events: ['s3:ObjectCreated:*'],
-                        queueArn: arn,
-                        id: '0',
-                        filterRules: [
-                            { name: 'Prefix', value: 'toto/' },
+            qp.bnConfigManager = {
+                setConfig: () => {},
+                getConfig: (bucket, cb) => cb(null, {
+                    bucket: 'mybucket',
+                    notificationConfiguration: {
+                        queueConfig: [
+                            {
+                                events: ['s3:ObjectCreated:*'],
+                                queueArn: arn,
+                                id: '0',
+                                filterRules: [
+                                    { name: 'Prefix', value: 'toto/' },
+                                ],
+                            },
                         ],
                     },
-                ],
-            });
+                }),
+            };
 
             const kafkaEntry = {
                 value: JSON.stringify({

--- a/tests/unit/notification/configManager/MongoConfigManager.spec.js
+++ b/tests/unit/notification/configManager/MongoConfigManager.spec.js
@@ -1,0 +1,373 @@
+const assert = require('assert');
+const werelogs = require('werelogs');
+const sinon = require('sinon');
+const events = require('events');
+const MongoClient = require('mongodb').MongoClient;
+
+const ChangeStream = require('../../../../lib/wrappers/ChangeStream');
+const MongoConfigManager
+    = require('../../../../extensions/notification/configManager/MongoConfigManager');
+const { errors } = require('arsenal');
+const mongoConfig
+    = require('../../../config.json').queuePopulator.mongo;
+
+const logger = new werelogs.Logger('MongoConfigManager:test');
+
+const notificationConfiguration = {
+    queueConfig: [
+        {
+            events: ['s3:ObjectCreated:Put'],
+            queueArn: 'arn:scality:bucketnotif:::destination1',
+            filterRules: [],
+        },
+    ],
+};
+
+const notificationConfigurationVariant = {
+    queueConfig: [
+        {
+            events: ['s3:ObjectCreated:*'],
+            queueArn: 'arn:scality:bucketnotif:::destination2',
+            filterRules: [],
+        },
+    ],
+};
+
+describe('MongoConfigManager ::', () => {
+    const params = {
+        mongoConfig,
+        bucketMetastore: '__metastore',
+        logger,
+    };
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    describe('Constructor & setup ::', () => {
+        it('Constructor should validate params', done => {
+            assert.throws(() => new MongoConfigManager());
+            assert.throws(() => new MongoConfigManager({}));
+            assert.throws(() => new MongoConfigManager({
+                mongoConfig: null,
+                logger: null,
+            }));
+            const manager = new MongoConfigManager(params);
+            assert(manager instanceof MongoConfigManager);
+            return done();
+        });
+
+        it('Setup should initialize the mongoClient and the change stream', done => {
+            const manager = new MongoConfigManager(params);
+            const setMongoStub = sinon.stub(manager, '_setupMongoClient').callsArg(0);
+            const setChangeStreamStub = sinon.stub(manager, '_setMetastoreChangeStream').returns();
+            manager.setup(err => {
+                assert.ifError(err);
+                assert(setMongoStub.calledOnce);
+                assert(setChangeStreamStub.calledOnce);
+                // cache should initially be empty
+                assert.strictEqual(manager._cachedConfigs.count(), 0);
+                return done();
+            });
+        });
+
+        it('Setup should fail when mongo setup fails', done => {
+            const manager = new MongoConfigManager(params);
+            const setMongoStub = sinon.stub(manager, '_setupMongoClient').callsArgWith(0,
+                errors.InternalError);
+            const setChangeStreamStub = sinon.stub(manager, '_setMetastoreChangeStream');
+            manager.setup(err => {
+                assert.deepEqual(err, errors.InternalError);
+                assert(setMongoStub.calledOnce);
+                assert(setChangeStreamStub.notCalled);
+                return done();
+            });
+        });
+
+        it('Setup should fail when changeStream setup fails', done => {
+            const manager = new MongoConfigManager(params);
+            const setMongoStub = sinon.stub(manager, '_setupMongoClient').callsArg(0);
+            const setChangeStreamStub = sinon.stub(manager, '_setMetastoreChangeStream').throws(
+                errors.InternalError);
+            manager.setup(err => {
+                assert.deepEqual(err, errors.InternalError);
+                assert(setMongoStub.calledOnce);
+                assert(setChangeStreamStub.calledOnce);
+                return done();
+            });
+        });
+    });
+
+    describe('_setupMongoClient ::', () => {
+        it('should setup the mongo client and get metastore collection', () => {
+            const manager = new MongoConfigManager(params);
+            const getCollectionStub = sinon.stub();
+            const mongoCommandStub = sinon.stub().returns({
+                version: '4.3.17',
+            });
+            const getDbStub = sinon.stub().returns({
+                collection: getCollectionStub,
+                command: mongoCommandStub,
+            });
+            const mongoConnectStub = sinon.stub(MongoClient, 'connect').callsArgWith(2, null, {
+                db: getDbStub,
+            });
+            manager._setupMongoClient(err => {
+                assert.ifError(err);
+                assert(mongoConnectStub.calledOnce);
+                assert(getDbStub.calledOnce);
+                assert(getCollectionStub.calledOnce);
+                assert(mongoCommandStub.calledOnceWith({
+                    buildInfo: 1,
+                }));
+                assert.equal(manager._mongoVersion, '4.3.17');
+            });
+        });
+
+        it('should fail when mongo client setup fails', () => {
+            const manager = new MongoConfigManager(params);
+            sinon.stub(MongoClient, 'connect').callsArgWith(2,
+                errors.InternalError, null);
+            manager._setupMongoClient(err => {
+                assert.deepEqual(err, errors.InternalError);
+            });
+        });
+
+        it('should fail when when getting the metadata db', () => {
+            const manager = new MongoConfigManager(params);
+            const getDbStub = sinon.stub().throws(errors.InternalError);
+            sinon.stub(MongoClient, 'connect').callsArgWith(2, null, {
+                db: getDbStub,
+            });
+            manager._setupMongoClient(err => {
+                assert.deepEqual(err, errors.InternalError);
+            });
+        });
+
+        it('should fail when mongo client fails to get metastore', () => {
+            const manager = new MongoConfigManager(params);
+            const getCollectionStub = sinon.stub().throws(errors.InternalError);
+            const getDbStub = sinon.stub().returns({
+                collection: getCollectionStub,
+                });
+            sinon.stub(MongoClient, 'connect').callsArgWith(2, null, {
+                db: getDbStub,
+            });
+            manager._setupMongoClient(err => {
+                assert.deepEqual(err, errors.InternalError);
+            });
+        });
+    });
+
+    describe('_handleChangeStreamChangeEvent ::', () => {
+        it('should remove entry from cache', () => {
+            const changeStreamEvent = {
+                _id: 'resumeToken',
+                operationType: 'delete',
+                documentKey: {
+                    _id: 'example-bucket-1',
+                },
+                fullDocument: {
+                    _id: 'example-bucket-1',
+                    value: {
+                        notificationConfiguration,
+                    }
+                }
+            };
+            const manager = new MongoConfigManager(params);
+            // populating cache
+            manager._cachedConfigs.add('example-bucket-1', notificationConfiguration);
+            assert.strictEqual(manager._cachedConfigs.count(), 1);
+            // handling change stream event
+            manager._handleChangeStreamChangeEvent(changeStreamEvent);
+            // should delete bucket config from cache
+            assert.strictEqual(manager._cachedConfigs.get('example-bucket-1'),
+                undefined);
+            assert.strictEqual(manager._cachedConfigs.count(), 0);
+        });
+
+        it('should replace entry from cache', () => {
+            const changeStreamEvent = {
+                _id: 'resumeToken',
+                operationType: 'replace',
+                documentKey: {
+                    _id: 'example-bucket-1',
+                },
+                fullDocument: {
+                    _id: 'example-bucket-1',
+                    value: {
+                        notificationConfiguration:
+                            notificationConfigurationVariant,
+                    }
+                }
+            };
+            const manager = new MongoConfigManager(params);
+            // populating cache
+            manager._cachedConfigs.add('example-bucket-1', notificationConfiguration);
+            assert.strictEqual(manager._cachedConfigs.count(), 1);
+            // handling change stream event
+            manager._handleChangeStreamChangeEvent(changeStreamEvent);
+            // should update bucket config in cache
+            assert.deepEqual(manager._cachedConfigs.get('example-bucket-1'),
+                notificationConfigurationVariant);
+            assert.strictEqual(manager._cachedConfigs.count(), 1);
+            // same thing should happen with "update" event
+            changeStreamEvent.operationType = 'update';
+            // reseting config to default one
+            changeStreamEvent.fullDocument.value.notificationConfiguration =
+                notificationConfiguration;
+            // emiting the new "update" event
+            manager._handleChangeStreamChangeEvent(changeStreamEvent);
+            // cached config must be updated
+            assert.deepEqual(manager._cachedConfigs.get('example-bucket-1'),
+                notificationConfiguration);
+            assert.strictEqual(manager._cachedConfigs.count(), 1);
+        });
+
+        it('should do nothing when config not in cache', () => {
+            const changeStreamEvent = {
+                _id: 'resumeToken',
+                operationType: 'delete',
+                documentKey: {
+                    _id: 'example-bucket-2',
+                },
+                fullDocument: {
+                    _id: 'example-bucket-2',
+                    value: {
+                        notificationConfiguration:
+                            notificationConfigurationVariant,
+                    }
+                }
+            };
+            const manager = new MongoConfigManager(params);
+            // populating cache
+            manager._cachedConfigs.add('example-bucket-1', notificationConfiguration);
+            assert.strictEqual(manager._cachedConfigs.count(), 1);
+            // handling change stream event
+            manager._handleChangeStreamChangeEvent(changeStreamEvent);
+            // cache should not change
+            assert.deepEqual(manager._cachedConfigs.get('example-bucket-1'),
+                notificationConfiguration);
+            assert.strictEqual(manager._cachedConfigs.count(), 1);
+        });
+
+        it('should do nothing when operation is not supported', () => {
+            const changeStreamEvent = {
+                _id: 'resumeToken',
+                operationType: 'insert',
+                documentKey: {
+                    _id: 'example-bucket-1',
+                },
+                fullDocument: {
+                    _id: 'example-bucket-2',
+                    value: {
+                        notificationConfiguration:
+                            notificationConfigurationVariant,
+                    }
+                }
+            };
+            const manager = new MongoConfigManager(params);
+            // populating cache
+            manager._cachedConfigs.add('example-bucket-1', notificationConfiguration);
+            assert.strictEqual(manager._cachedConfigs.count(), 1);
+            assert(manager._cachedConfigs.get('example-bucket-1'));
+            // handling change stream event
+            manager._handleChangeStreamChangeEvent(changeStreamEvent);
+            // cache should not change
+            assert.deepEqual(manager._cachedConfigs.get('example-bucket-1'),
+                notificationConfiguration);
+            assert.strictEqual(manager._cachedConfigs.count(), 1);
+        });
+    });
+
+    describe('_setMetastoreChangeStream ::', () =>  {
+         it('should use resumeAfter with mongo 3.6', () => {
+            const manager = new MongoConfigManager(params);
+            manager._mongoVersion = '3.6.2';
+            manager._metastore = {
+                watch: sinon.stub().returns(new events.EventEmitter()),
+            };
+            manager._setMetastoreChangeStream();
+            assert(manager._metastoreChangeStream instanceof ChangeStream);
+            assert.equal(manager._metastoreChangeStream._resumeField, 'resumeAfter');
+        });
+
+        it('should use resumeAfter with mongo 4.0', () => {
+            const manager = new MongoConfigManager(params);
+            manager._mongoVersion = '4.0.7';
+            manager._metastore = {
+                watch: sinon.stub().returns(new events.EventEmitter()),
+            };
+            manager._setMetastoreChangeStream();
+            assert(manager._metastoreChangeStream instanceof ChangeStream);
+            assert.equal(manager._metastoreChangeStream._resumeField, 'resumeAfter');
+        });
+
+        it('should use startAfter with mongo 4.2', () => {
+            const manager = new MongoConfigManager(params);
+            manager._mongoVersion = '4.2.3';
+            manager._metastore = {
+                watch: sinon.stub().returns(new events.EventEmitter()),
+            };
+            manager._setMetastoreChangeStream();
+            assert(manager._metastoreChangeStream instanceof ChangeStream);
+            assert.equal(manager._metastoreChangeStream._resumeField, 'startAfter');
+        });
+    });
+
+    describe('getConfig ::', () =>  {
+        it('should return notification configuration of bucket', async () => {
+            const manager = new MongoConfigManager(params);
+            manager._metastore = {
+                findOne: () => (
+                    {
+                        value: {
+                            notificationConfiguration,
+                        }
+                    }),
+            };
+            const expectedConfig = {
+                bucket: 'example-bucket-1',
+                notificationConfiguration,
+            };
+            assert.strictEqual(manager._cachedConfigs.count(), 0);
+            const config = await manager.getConfig('example-bucket-1');
+            assert.deepEqual(config, expectedConfig);
+            // should also cache config
+            assert.strictEqual(manager._cachedConfigs.count(), 1);
+            assert.deepEqual(manager._cachedConfigs.get('example-bucket-1'), notificationConfiguration);
+        });
+
+        it('should return undefined when bucket doesn\'t have notification configuration', async () => {
+            const manager = new MongoConfigManager(params);
+            manager._metastore = {
+                findOne: () => ({ value: {} }),
+            };
+            const config = await manager.getConfig('example-bucket-1');
+            assert.deepEqual(config, undefined);
+        });
+
+        it('should return undefined when mongo findOne fails', async () => {
+            const manager = new MongoConfigManager(params);
+            manager._metastore = {
+                findOne: sinon.stub().throws(errors.InternalError),
+            };
+            const config = await manager.getConfig('example-bucket-1');
+            assert.strictEqual(config, undefined);
+        });
+    });
+
+    describe('setConfig ::', () =>  {
+        it('should always return false', async () => {
+            const manager = new MongoConfigManager(params);
+            assert.strictEqual(manager.setConfig('example-bucket-1', {}), false);
+        });
+    });
+
+    describe('removeConfig ::', () =>  {
+        it('should always return false', async () => {
+            const manager = new MongoConfigManager(params);
+            assert.strictEqual(manager.removeConfig('example-bucket-1'), false);
+        });
+    });
+});

--- a/tests/unit/notification/configManager/MongoConfigManager.spec.js
+++ b/tests/unit/notification/configManager/MongoConfigManager.spec.js
@@ -37,6 +37,7 @@ describe('MongoConfigManager ::', () => {
     const params = {
         mongoConfig,
         bucketMetastore: '__metastore',
+        maxCachedConfigs: 100,
         logger,
     };
 
@@ -347,13 +348,19 @@ describe('MongoConfigManager ::', () => {
             assert.deepEqual(config, undefined);
         });
 
-        it('should return undefined when mongo findOne fails', async () => {
+        it('should throw when mongo findOne fails', done => {
             const manager = new MongoConfigManager(params);
             manager._metastore = {
                 findOne: sinon.stub().throws(errors.InternalError),
             };
-            const config = await manager.getConfig('example-bucket-1');
-            assert.strictEqual(config, undefined);
+            manager.getConfig('example-bucket-1')
+            .then(() => {
+                assert.fail('should have thrown');
+            })
+            .catch(err => {
+                assert.deepEqual(err, errors.InternalError);
+                done();
+            });
         });
     });
 

--- a/tests/unit/notification/configManager/ZookeeperConfigManager.spec.js
+++ b/tests/unit/notification/configManager/ZookeeperConfigManager.spec.js
@@ -1,0 +1,256 @@
+const assert = require('assert');
+const async = require('async');
+const werelogs = require('werelogs');
+const ZookeeperMock = require('zookeeper-mock');
+const ZookeeperManager = require('../../../../lib/clients/ZookeeperManager');
+const sinon = require('sinon');
+
+const ZookeeperConfigManager
+    = require('../../../../extensions/notification/configManager/ZookeeperConfigManager');
+const constants
+    = require('../../../../extensions/notification/constants');
+
+const logger = new werelogs.Logger('ZookeeperConfigManager:test');
+const { zkConfigParentNode } = constants;
+const concurrency = 10;
+const bucketPrefix = 'bucket';
+const timeoutMs = 100;
+
+function getTestConfigValue(bucket) {
+    const data = {
+        bucket,
+        notificationConfiguration: {
+            queueConfig: [
+                {
+                    events: ['s3:ObjectCreated:Put'],
+                    queueArn: 'arn:scality:bucketnotif:::destination1',
+                    filterRules: [],
+                    id: `${zkConfigParentNode}-${bucket}`,
+                },
+            ],
+        },
+    };
+    return data;
+}
+
+function populateTestConfigs(zkClient, numberOfConfigs, cb) {
+    async.timesLimit(numberOfConfigs, concurrency, (n, done) => {
+        const bucket = `${bucketPrefix}${n + 1}`;
+        const val = getTestConfigValue(bucket);
+        const strVal = JSON.stringify(val);
+        const node = `/${zkConfigParentNode}/${bucket}`;
+        async.series([
+            next => zkClient.mkdirp(node, next),
+            next => zkClient.setData(node, strVal, next),
+        ], done);
+    }, cb);
+}
+
+function listBuckets(zkClient, cb) {
+    const node = `/${zkConfigParentNode}`;
+    zkClient.getChildren(node, cb);
+}
+
+function deleteTestConfigs(zkClient, cb) {
+    const node = `/${zkConfigParentNode}`;
+    listBuckets(zkClient, (error, children) => {
+        if (error) {
+            assert.ifError(error);
+            cb(error);
+        } else {
+            async.eachLimit(children, concurrency, (child, next) => {
+                const childNode = `${node}/${child}`;
+                zkClient.remove(childNode, next);
+            }, cb);
+        }
+    });
+}
+
+function checkCount(zkClient, manager, cb) {
+    listBuckets(zkClient, (err, buckets) => {
+        assert.ifError(err);
+        const zkConfigCount = buckets.length;
+        const managerConfigs = [...manager._configs.keys()];
+        assert.strictEqual(zkConfigCount, managerConfigs.length);
+        cb();
+    });
+}
+
+function managerInit(manager, cb) {
+    manager.setup(err => {
+        assert.ifError(err);
+        cb();
+    });
+}
+
+function checkParentConfigZkNode(manager, cb) {
+    const zkPath = `/${zkConfigParentNode}`;
+    manager._checkNodeExists(zkPath, (err, exists) => {
+        assert.ifError(err);
+        assert(exists);
+        cb();
+    });
+}
+
+describe('ZookeeperConfigManager', () => {
+    const zk = new ZookeeperMock({ doLog: false });
+    const zkClient = zk.createClient();
+    const params = {
+        zkClient,
+        logger,
+    };
+
+    describe('Constructor', () => {
+        function checkConfigParentNodeStub(cb) {
+            return cb(new Error('error checking config parent node'));
+        }
+
+        after(() => {
+            sinon.restore();
+            zk._resetState();
+        });
+
+        it('constructor and setup checks', done => {
+            assert.throws(() => new ZookeeperConfigManager());
+            assert.throws(() => new ZookeeperConfigManager({}));
+            assert.throws(() => new ZookeeperConfigManager({
+                zkClient: null,
+                logger: null,
+            }));
+            const manager = new ZookeeperConfigManager(params);
+            assert(manager instanceof ZookeeperConfigManager);
+            async.series([
+                next => managerInit(manager, next),
+                next => checkParentConfigZkNode(manager, next),
+            ], done);
+        });
+
+        it('should return error if checkConfigParentNode fails', done => {
+            const manager = new ZookeeperConfigManager(params);
+            sinon.stub(manager, '_checkConfigurationParentNode')
+                .callsFake(checkConfigParentNodeStub);
+            manager.setup(err => {
+                assert(err);
+                return done();
+            });
+        });
+    });
+
+    describe('Operations', () => {
+        beforeEach(done => populateTestConfigs(zkClient, 5, done));
+
+        afterEach(() => {
+            zk._resetState();
+        });
+
+        it('should get bucket notification configuration', () => {
+            const manager = new ZookeeperConfigManager(params);
+            managerInit(manager, () => {
+                const bucket = 'bucket1';
+                const result = manager.getConfig(bucket);
+                assert.strictEqual(result.bucket, bucket);
+            });
+        });
+
+        it('should return undefined for a non-existing bucket', () => {
+            const manager = new ZookeeperConfigManager(params);
+            managerInit(manager, () => {
+                const bucket = 'bucket100';
+                const result = manager.getConfig(bucket);
+                assert.strictEqual(result, undefined);
+            });
+        });
+
+        it('should add bucket notification configuration', done => {
+            const manager = new ZookeeperConfigManager(params);
+            managerInit(manager, () => {
+                const bucket = 'bucket100';
+                const config = getTestConfigValue(bucket);
+                const result = manager.setConfig(bucket, config);
+                assert(result);
+                setTimeout(() => {
+                    checkCount(zkClient, manager, done);
+                }, timeoutMs);
+            });
+        });
+
+        it('should update bucket notification configuration', done => {
+            const manager = new ZookeeperConfigManager(params);
+            managerInit(manager, () => {
+                const bucket = 'bucket1';
+                const config = getTestConfigValue(`${bucket}-updated`);
+                const result = manager.setConfig(bucket, config);
+                assert(result);
+                setTimeout(() => {
+                    const updatedConfig = manager.getConfig(bucket);
+                    assert.strictEqual(updatedConfig.bucket,
+                        `${bucket}-updated`);
+                    checkCount(zkClient, manager, done);
+                }, timeoutMs);
+            });
+        });
+
+        it('should remove bucket notification configuration', done => {
+            const manager = new ZookeeperConfigManager(params);
+            managerInit(manager, () => {
+                const bucket = 'bucket1';
+                let result = manager.removeConfig(bucket);
+                assert(result);
+                setTimeout(() => {
+                    result = manager.getConfig(bucket);
+                    assert.strictEqual(result, undefined);
+                    checkCount(zkClient, manager, done);
+                }, timeoutMs);
+            });
+        });
+
+        it('config count should be zero when all configs are removed', done => {
+            const manager = new ZookeeperConfigManager(params);
+            async.series([
+                next => managerInit(manager, next),
+                next => deleteTestConfigs(zkClient, next),
+                next => setTimeout(next, timeoutMs),
+                next => checkCount(zkClient, manager, next),
+            ], done);
+        });
+    });
+
+    describe('setup', () => {
+        it('should setup zookeeper client when it\'s not provided', done => {
+            const manager = new ZookeeperConfigManager({
+                zkPath: '/notification',
+                zkConfig: {
+                    connectionString: '127.0.0.1:2181',
+                    autoCreateNamespace: false,
+                },
+                logger,
+            });
+            sinon.stub(manager, '_checkConfigurationParentNode').yields(null, null);
+            sinon.stub(manager, '_listBucketsWithConfig').yields(null, null);
+            sinon.stub(manager, '_updateLocalStore').yields(null);
+            const interval = setInterval(() => {
+                if (manager._zkClient) {
+                    manager._zkClient.emit('ready');
+                    clearInterval(interval);
+                }
+            }, 30);
+            manager.setup(err => {
+                assert.ifError(err);
+                assert(manager._zkClient instanceof ZookeeperManager);
+                done();
+            });
+        });
+
+        it('should not create zookeeper client when it\'s provided', done => {
+            const manager = new ZookeeperConfigManager(params);
+            sinon.stub(manager, '_checkConfigurationParentNode').yields(null, null);
+            sinon.stub(manager, '_listBucketsWithConfig').yields(null, null);
+            sinon.stub(manager, '_updateLocalStore').yields(null);
+            manager.setup(err => {
+                assert.ifError(err);
+                assert(!(manager._zkClient instanceof ZookeeperManager));
+                done();
+            });
+        });
+    });
+});

--- a/tests/unit/notification/configManager/ZookeeperConfigManager.spec.js
+++ b/tests/unit/notification/configManager/ZookeeperConfigManager.spec.js
@@ -97,6 +97,7 @@ describe('ZookeeperConfigManager', () => {
     const zkClient = zk.createClient();
     const params = {
         zkClient,
+        zkConcurrency: 10,
         logger,
     };
 
@@ -223,6 +224,7 @@ describe('ZookeeperConfigManager', () => {
                     connectionString: '127.0.0.1:2181',
                     autoCreateNamespace: false,
                 },
+                zkConcurrency: 10,
                 logger,
             });
             sinon.stub(manager, '_checkConfigurationParentNode').yields(null, null);

--- a/tests/unit/notification/utils/config.js
+++ b/tests/unit/notification/utils/config.js
@@ -518,7 +518,7 @@ describe('Notification configuration util', () => {
                 const bnConfig
                     = getBucketNotifConfig(test.entry.bucket, configMap);
                 const result
-                    = notifConfUtil.validateEntry(bnConfig.notificationConfiguration, test.entry);
+                    = notifConfUtil.validateEntry(bnConfig, test.entry);
                 assert.strictEqual(test.pass, result.isValid);
                 if (test.pass) {
                     assert.deepStrictEqual(test.expectedMatchingConfig, result.matchingConfig);

--- a/tests/unit/notification/utils/config.js
+++ b/tests/unit/notification/utils/config.js
@@ -527,5 +527,29 @@ describe('Notification configuration util', () => {
                 }
             });
         });
+
+        it('should fail if the configuration is for another bucket', () => {
+            const config =  {
+                bucket: 'bucket1',
+                notificationConfiguration: {
+                    queueConfig: [
+                        {
+                            events: ['s3:ObjectCreated:Put'],
+                            queueArn: 'q1',
+                            filterRules: [],
+                            id: 'config1',
+                        },
+                    ],
+                },
+            };
+            const entry = {
+                eventType: 's3:ObjectCreated:Put',
+                bucket: 'bucket10',
+                key: 'test.png',
+            };
+            const result = notifConfUtil.validateEntry(config, entry);
+            assert.strictEqual(false, result.isValid);
+            assert(!result.matchingConfig);
+        });
     });
 });


### PR DESCRIPTION
- Added support for specifying multiple destination kafka hosts in bucket notification (ported logic from 7.x)
- Ported NotificationConfigManager from 7.x with tests
- Added an abstract NotificationConfigManager class to support both MongoDB and Zookeeper backends
- Ported code from 7.x that handles updating notification configs in the Zookeeper backend
- NotificationConfigManager now returns 7.x config structure, this was changed to keep the code functional with previously stored configs in Zookeeper on S3C.
- Support S3C delete notifications. 
- Made metastore collection name configurable as the name is different between S3c and Zenko.
- Fixed config not getting removed from zookeeper when a bucket is deleted.

**Note:** To ease reviews, please review commit by commit.

Issue: BB-497