### PR TITLE
S3C supports having different queueProcessor probeserver configuratio…

### DIFF
--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -71,7 +71,10 @@ const joiSchema = joi.object({
         concurrency: joi.number().greater(0).default(10),
         mpuPartsConcurrency: joi.number().greater(0).default(10),
         minMPUSizeMB: joi.number().greater(0).default(20),
-        probeServer: probeServerJoi.default(),
+        probeServer: probeServerJoi.alternatives().try(
+            probeServerJoi,
+            probeServerPerSite
+        ).default(),
         circuitBreaker: joi.object().optional(),
     }).required(),
     replicationStatusProcessor: {

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -71,7 +71,7 @@ const joiSchema = joi.object({
         concurrency: joi.number().greater(0).default(10),
         mpuPartsConcurrency: joi.number().greater(0).default(10),
         minMPUSizeMB: joi.number().greater(0).default(20),
-        probeServer: probeServerJoi.alternatives().try(
+        probeServer: joi.alternatives().try(
             probeServerJoi,
             probeServerPerSite
         ).default(),

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const joi = require('joi');
 const { hostPortJoi, transportJoi, bootstrapListJoi, adminCredsJoi,
-        retryParamsJoi, probeServerJoi } =
+        retryParamsJoi, probeServerJoi, probeServerPerSite } =
     require('../../lib/config/configItems.joi');
 
 const qpRetryJoi = joi.object({

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -74,7 +74,7 @@ const joiSchema = joi.object({
         probeServer: joi.alternatives().try(
             probeServerJoi,
             probeServerPerSite
-        ).default({bindAddress: 'localhost', port: ""}),
+        ).default({ bindAddress: 'localhost', port: '' }),
         circuitBreaker: joi.object().optional(),
     }).required(),
     replicationStatusProcessor: {

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -73,7 +73,7 @@ const joiSchema = joi.object({
         minMPUSizeMB: joi.number().greater(0).default(20),
         probeServer: joi.alternatives().try(
             probeServerJoi,
-            probeServerPerSite
+            probeServerPerSite,
         ).default({ bindAddress: 'localhost', port: 4042 }),
         circuitBreaker: joi.object().optional(),
     }).required(),

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -74,7 +74,7 @@ const joiSchema = joi.object({
         probeServer: joi.alternatives().try(
             probeServerJoi,
             probeServerPerSite
-        ).default({ bindAddress: 'localhost', port: '' }),
+        ).default({ bindAddress: 'localhost', port: 4042 }),
         circuitBreaker: joi.object().optional(),
     }).required(),
     replicationStatusProcessor: {

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -74,7 +74,7 @@ const joiSchema = joi.object({
         probeServer: joi.alternatives().try(
             probeServerJoi,
             probeServerPerSite
-        ).default(),
+        ).default({bindAddress: 'localhost', port: ""}),
         circuitBreaker: joi.object().optional(),
     }).required(),
     replicationStatusProcessor: {

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -243,23 +243,24 @@ function initAndStart(zkClient) {
          * Get probe config will pull the configuration for the probe server based on
          * the provided site key, and if the probe server config is not an array, it will
          * return the global probe server config.
+         * 
+         *  Get the probe server config for the first site in the site names list,
+         *  as if the probeConfig is an array there is only one element in site names
          *
          * @param {Object} queueProcessorConfig - Configuration of the queue processor that
          *      holds the probe server configs for all sites
-         * @param {string} site - Name of the site we are processing
+         * @param {Array<String>} siteNames - List of site names
          * @returns {ProbeServerConfig} Config for site or global config
          */
-        function getProbeConfig(queueProcessorConfig, site) {
-            if (Array.isArray(queueProcessorConfig.probeServer) && site) {
-                return queueProcessorConfig.probeServer.filter(probe => probe.site === site)[0];
+        function getProbeConfig(queueProcessorConfig, siteNames) {
+            if (Array.isArray(queueProcessorConfig.probeServer) && siteNames[0]) {
+                return queueProcessorConfig.probeServer.filter(probe => probe.site === siteNames[0])[0];
             }
             return queueProcessorConfig.probeServer;
         }
 
         startProbeServer(
-            // get the probe server config for the first site in the bootstrap list,
-            // as if the probeConfig is an array there is only one element in bootstrap list
-            getProbeConfig(repConfig.queueProcessor, bootstrapList[0].site),
+            getProbeConfig(repConfig.queueProcessor, siteNames),
             (err, probeServer) => {
                 if (err) {
                     log.fatal('error creating probe server', {

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -243,7 +243,7 @@ function initAndStart(zkClient) {
          * Get probe config will pull the configuration for the probe server based on
          * the provided site key, and if the probe server config is not an array, it will
          * return the global probe server config.
-         * 
+         *
          *  Get the probe server config for the first site in the site names list,
          *  as if the probeConfig is an array there is only one element in site names
          *

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -155,6 +155,28 @@ function setupZkSiteNode(qp, zkClient, site, done) {
     });
 }
 
+/**
+ * Get probe config will pull the configuration for the probe server based on
+ * the provided site key, and if the probe server config is not an array, it will
+ * return the global probe server config.
+ *
+ *  Get the probe server config for the first site in the site names list,
+ *  as if the probeConfig is an array there is only one element in site names
+ *
+ * @param {Object} queueProcessorConfig - Configuration of the queue processor that
+ *      holds the probe server configs for all sites
+ * @param {Array<String>} siteNames - List of site names
+ * @returns {ProbeServerConfig} Config for site or global config
+ */
+function getProbeConfig(queueProcessorConfig, siteNames) {
+    if (Array.isArray(queueProcessorConfig.probeServer) &&
+    queueProcessorConfig.probeServer.length > 0 &&
+    siteNames.length > 0) {
+        return queueProcessorConfig.probeServer.filter(probe => probe.site === siteNames[0])[0];
+    }
+    return queueProcessorConfig.probeServer;
+}
+
 function initAndStart(zkClient) {
     initManagement({
         serviceName: 'replication',
@@ -238,26 +260,6 @@ function initAndStart(zkClient) {
                 process.exit(1);
             }
         });
-
-        /**
-         * Get probe config will pull the configuration for the probe server based on
-         * the provided site key, and if the probe server config is not an array, it will
-         * return the global probe server config.
-         *
-         *  Get the probe server config for the first site in the site names list,
-         *  as if the probeConfig is an array there is only one element in site names
-         *
-         * @param {Object} queueProcessorConfig - Configuration of the queue processor that
-         *      holds the probe server configs for all sites
-         * @param {Array<String>} siteNames - List of site names
-         * @returns {ProbeServerConfig} Config for site or global config
-         */
-        function getProbeConfig(queueProcessorConfig, siteNames) {
-            if (Array.isArray(queueProcessorConfig.probeServer) && siteNames[0]) {
-                return queueProcessorConfig.probeServer.filter(probe => probe.site === siteNames[0])[0];
-            }
-            return queueProcessorConfig.probeServer;
-        }
 
         startProbeServer(
             getProbeConfig(repConfig.queueProcessor, siteNames),

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -243,7 +243,7 @@ function initAndStart(zkClient) {
          * Get probe config will pull the configuration for the probe server based on
          * the provided site key, and if the probe server config is not an array, it will
          * return the global probe server config.
-         * 
+         *
          * @param {Object} queueProcessorConfig - Configuration of the queue processor that
          *      holds the probe server configs for all sites
          * @param {string} site - Name of the site we are processing

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -22,7 +22,7 @@ const internalHttpsConfig = config.internalHttps;
 const mConfig = config.metrics;
 const { connectionString, autoCreateNamespace } = zkConfig;
 const RESUME_NODE = 'scheduledResume';
-const { startProbeServer } = require('../../../lib/util/probe');
+const { startProbeServer, getProbeConfig } = require('../../../lib/util/probe');
 const { DEFAULT_LIVE_ROUTE, DEFAULT_METRICS_ROUTE, DEFAULT_READY_ROUTE } =
     require('arsenal').network.probe.ProbeServer;
 const { sendSuccess } = require('arsenal').network.probe.Utils;
@@ -153,28 +153,6 @@ function setupZkSiteNode(qp, zkClient, site, done) {
         }
         return done(null, { paused: false });
     });
-}
-
-/**
- * Get probe config will pull the configuration for the probe server based on
- * the provided site key, and if the probe server config is not an array, it will
- * return the global probe server config.
- *
- *  Get the probe server config for the first site in the site names list,
- *  as if the probeConfig is an array there is only one element in site names
- *
- * @param {Object} queueProcessorConfig - Configuration of the queue processor that
- *      holds the probe server configs for all sites
- * @param {Array<String>} siteNames - List of site names
- * @returns {ProbeServerConfig} Config for site or global config
- */
-function getProbeConfig(queueProcessorConfig, siteNames) {
-    if (Array.isArray(queueProcessorConfig.probeServer) &&
-    queueProcessorConfig.probeServer.length > 0 &&
-    siteNames.length > 0) {
-        return queueProcessorConfig.probeServer.filter(probe => probe.site === siteNames[0])[0];
-    }
-    return queueProcessorConfig.probeServer;
 }
 
 function initAndStart(zkClient) {

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -239,8 +239,27 @@ function initAndStart(zkClient) {
             }
         });
 
+        /**
+         * Get probe config will pull the configuration for the probe server based on
+         * the provided site key, and if the probe server config is not an array, it will
+         * return the global probe server config.
+         * 
+         * @param {Object} queueProcessorConfig - Configuration of the queue processor that
+         *      holds the probe server configs for all sites
+         * @param {string} site - Name of the site we are processing
+         * @returns {ProbeServerConfig} Config for site or global config
+         */
+        function getProbeConfig(queueProcessorConfig, site) {
+            if (Array.isArray(queueProcessorConfig.probeServer) && site) {
+                return queueProcessorConfig.probeServer.filter(probe => probe.site === site)[0];
+            }
+            return queueProcessorConfig.probeServer;
+        }
+
         startProbeServer(
-            repConfig.queueProcessor.probeServer,
+            // get the probe server config for the first site in the bootstrap list,
+            // as if the probeConfig is an array there is only one element in bootstrap list
+            getProbeConfig(repConfig.queueProcessor, bootstrapList[0].site),
             (err, probeServer) => {
                 if (err) {
                     log.fatal('error creating probe server', {

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -240,7 +240,7 @@ function initAndStart(zkClient) {
         });
 
         startProbeServer(
-            getProbeConfig(repConfig.queueProcessor, siteNames),
+            getProbeConfig(repConfig.queueProcessor, siteNames, log),
             (err, probeServer) => {
                 if (err) {
                     log.fatal('error creating probe server', {

--- a/lib/config/configItems.joi.js
+++ b/lib/config/configItems.joi.js
@@ -112,6 +112,14 @@ const probeServerJoi = joi.object({
     port: joi.number().required(),
 });
 
+const probeServerPerSite = joi.array().items(
+    joi.object({
+        bindAddress: joi.string().default('localhost'),
+        port: joi.number().required(),
+        site: joi.string().required()
+    })
+)
+
 const mongoJoi = joi.object({
     replicaSetHosts: joi.string().default('localhost:27017'),
     logName: joi.string().default('s3-recordlog'),

--- a/lib/config/configItems.joi.js
+++ b/lib/config/configItems.joi.js
@@ -112,7 +112,7 @@ const probeServerJoi = joi.object({
     port: joi.number().required(),
 });
 
-const probeServerPerSite = joi.array().items(
+const probeServerPerSite = joi.array().min(1).items(
     joi.object({
         bindAddress: joi.string().default('localhost'),
         port: joi.number().required(),

--- a/lib/config/configItems.joi.js
+++ b/lib/config/configItems.joi.js
@@ -118,7 +118,7 @@ const probeServerPerSite = joi.array().items(
         port: joi.number().required(),
         site: joi.string().required()
     })
-)
+);
 
 const mongoJoi = joi.object({
     replicaSetHosts: joi.string().default('localhost:27017'),
@@ -169,6 +169,7 @@ module.exports = {
     retryParamsJoi,
     certFilePathsJoi,
     probeServerJoi,
+    probeServerPerSite,
     stsConfigJoi,
     mongoJoi,
     qpKafkaJoi,

--- a/lib/util/probe.js
+++ b/lib/util/probe.js
@@ -2,6 +2,10 @@ const util = require('util');
 const { ProbeServer } = require('arsenal').network.probe.ProbeServer;
 const { ZenkoMetrics } = require('arsenal').metrics;
 const RdkafkaStats = require('node-rdkafka-prometheus');
+const werelogs = require('werelogs');
+
+const Logger = werelogs.Logger;
+
 
 /**
  * Configure probe servers
@@ -75,11 +79,20 @@ function getProbeConfig(queueProcessorConfig, siteNames) {
         if (!Array.isArray(queueProcessorConfig.probeServer)) {
             return queueProcessorConfig.probeServer;
         }
+
+        Logger.error('Configuration set for specific sites, but no site provided to the process', {
+            siteNames,
+            queueProcessorConfig,
+        });
         return undefined;
     }
 
     if (Array.isArray(queueProcessorConfig.probeServer)) {
         if (siteNames.length !== 1) {
+            Logger.error('Process configured for more than one site', {
+                siteNames,
+                queueProcessorConfig,
+            });
             return undefined;
         }
 

--- a/lib/util/probe.js
+++ b/lib/util/probe.js
@@ -72,40 +72,26 @@ function observeKafkaStats(msg) {
  * @returns {Object|undefined} Config for site or global config, undefined if no match found or invalid config
  */
 function getProbeConfig(queueProcessorConfig, siteNames, logger) {
-    if (siteNames.length === 0) {
-        if (!Array.isArray(queueProcessorConfig.probeServer)) {
-            return queueProcessorConfig.probeServer;
+        if (Array.isArray(queueProcessorConfig.probeServer)) {
+            if (siteNames.length !== 1) {
+                logger.error('Process configured for more than one site or no site provided', {
+                    siteNames,
+                    queueProcessorConfig,
+                });
+                return undefined;
+            }
+            const siteConfig = queueProcessorConfig.probeServer.find(config => config.site === siteNames[0]);
+            if (siteConfig === undefined) {
+                logger.warn('Probe server configuration for site not found', {
+                    siteName: siteNames[0],
+                    queueProcessorConfig,
+                });
+            }
+            return siteConfig;
         }
 
-        logger.error('Configuration set for specific sites, but no site provided to the process', {
-            siteNames,
-            queueProcessorConfig,
-        });
-        return undefined;
+        return queueProcessorConfig.probeServer;
     }
-
-    if (Array.isArray(queueProcessorConfig.probeServer)) {
-        if (siteNames.length !== 1) {
-            logger.error('Process configured for more than one site', {
-                siteNames,
-                queueProcessorConfig,
-            });
-            return undefined;
-        }
-
-        const siteConfig = queueProcessorConfig.probeServer.find(config => config.site === siteNames[0]);
-        if (siteConfig === undefined) {
-            logger.warn('Probe server configuration for site not found', {
-                siteName: siteNames[0],
-                queueProcessorConfig,
-            });
-        }
-
-        return siteConfig;
-    }
-
-    return queueProcessorConfig.probeServer;
-}
 
 module.exports = {
     startProbeServer,

--- a/lib/util/probe.js
+++ b/lib/util/probe.js
@@ -2,10 +2,6 @@ const util = require('util');
 const { ProbeServer } = require('arsenal').network.probe.ProbeServer;
 const { ZenkoMetrics } = require('arsenal').metrics;
 const RdkafkaStats = require('node-rdkafka-prometheus');
-const werelogs = require('werelogs');
-
-const Logger = werelogs.Logger;
-
 
 /**
  * Configure probe servers
@@ -72,10 +68,10 @@ function observeKafkaStats(msg) {
  * @param {Object} queueProcessorConfig - Configuration of the queue processor that
  *      holds the probe server configs for all sites
  * @param {Array<String>} siteNames - List of site names (should contain at most one element)
+ * @param {Logger} logger - Logger instance
  * @returns {Object|undefined} Config for site or global config, undefined if no match found or invalid config
  */
-function getProbeConfig(queueProcessorConfig, siteNames) {
-    const logger = new Logger('Backbeat:Probe:getProbeConfig');
+function getProbeConfig(queueProcessorConfig, siteNames, logger) {
 
     if (siteNames.length === 0) {
         if (!Array.isArray(queueProcessorConfig.probeServer)) {
@@ -102,7 +98,7 @@ function getProbeConfig(queueProcessorConfig, siteNames) {
         return siteConfig || undefined;
     }
 
-    return undefined;
+    return queueProcessorConfig.probeServer;
 }
 
 module.exports = {

--- a/lib/util/probe.js
+++ b/lib/util/probe.js
@@ -60,8 +60,39 @@ function observeKafkaStats(msg) {
     kafkaMetrics.observe(JSON.parse(msg.message));
 }
 
+/**
+ * Get probe config will pull the configuration for the probe server based on
+ * the provided site name. If siteNames is empty, it returns the global probe server config
+ * only if it's a single object.
+ *
+ * @param {Object} queueProcessorConfig - Configuration of the queue processor that
+ *      holds the probe server configs for all sites
+ * @param {Array<String>} siteNames - List of site names (should contain at most one element)
+ * @returns {Object|undefined} Config for site or global config, undefined if no match found or invalid config
+ */
+function getProbeConfig(queueProcessorConfig, siteNames) {
+    if (siteNames.length === 0) {
+        if (!Array.isArray(queueProcessorConfig.probeServer)) {
+            return queueProcessorConfig.probeServer;
+        }
+        return undefined;
+    }
+
+    if (Array.isArray(queueProcessorConfig.probeServer)) {
+        if (siteNames.length !== 1) {
+            return undefined;
+        }
+
+        const siteConfig = queueProcessorConfig.probeServer.find(config => config.site === siteNames[0]);
+        return siteConfig || undefined;
+    }
+
+    return undefined;
+}
+
 module.exports = {
     startProbeServer,
     startProbeServerPromise,
     observeKafkaStats,
+    getProbeConfig,
 };

--- a/lib/util/probe.js
+++ b/lib/util/probe.js
@@ -72,7 +72,6 @@ function observeKafkaStats(msg) {
  * @returns {Object|undefined} Config for site or global config, undefined if no match found or invalid config
  */
 function getProbeConfig(queueProcessorConfig, siteNames, logger) {
-
     if (siteNames.length === 0) {
         if (!Array.isArray(queueProcessorConfig.probeServer)) {
             return queueProcessorConfig.probeServer;
@@ -95,7 +94,14 @@ function getProbeConfig(queueProcessorConfig, siteNames, logger) {
         }
 
         const siteConfig = queueProcessorConfig.probeServer.find(config => config.site === siteNames[0]);
-        return siteConfig || undefined;
+        if (siteConfig === undefined) {
+            logger.warn('Probe server configuration for site not found', {
+                siteName: siteNames[0],
+                queueProcessorConfig,
+            });
+        }
+
+        return siteConfig;
     }
 
     return queueProcessorConfig.probeServer;

--- a/lib/util/probe.js
+++ b/lib/util/probe.js
@@ -75,12 +75,14 @@ function observeKafkaStats(msg) {
  * @returns {Object|undefined} Config for site or global config, undefined if no match found or invalid config
  */
 function getProbeConfig(queueProcessorConfig, siteNames) {
+    const logger = new Logger('Backbeat:Probe:getProbeConfig');
+
     if (siteNames.length === 0) {
         if (!Array.isArray(queueProcessorConfig.probeServer)) {
             return queueProcessorConfig.probeServer;
         }
 
-        Logger.error('Configuration set for specific sites, but no site provided to the process', {
+        logger.error('Configuration set for specific sites, but no site provided to the process', {
             siteNames,
             queueProcessorConfig,
         });
@@ -89,7 +91,7 @@ function getProbeConfig(queueProcessorConfig, siteNames) {
 
     if (Array.isArray(queueProcessorConfig.probeServer)) {
         if (siteNames.length !== 1) {
-            Logger.error('Process configured for more than one site', {
+            logger.error('Process configured for more than one site', {
                 siteNames,
                 queueProcessorConfig,
             });

--- a/tests/unit/lib/util/probe.spec.js
+++ b/tests/unit/lib/util/probe.spec.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const { startProbeServer } =
+const { startProbeServer, getProbeConfig } =
     require('../../../../lib/util/probe');
 
 describe('Probe server', () => {
@@ -25,3 +25,50 @@ describe('Probe server', () => {
         });
     });
 });
+
+describe.only('getProbeConfig', function() {
+    it('returns the probeServer config when siteNames is empty and probeServer is a single object', function() {
+      const queueProcessorConfig = {
+        probeServer: { bindAddress: '127.0.0.1', port: '8080' }
+      };
+      const siteNames = [];
+  
+      const result = getProbeConfig(queueProcessorConfig, siteNames);
+      assert.deepStrictEqual(result, { bindAddress: '127.0.0.1', port: '8080' });
+    });
+  
+    it('returns undefined when siteNames is empty and probeServer is not a single object', function() {
+      const queueProcessorConfig = {
+        probeServer: [{ site: 'site1', bindAddress: '127.0.0.1', port: '8080' }]
+      };
+      const siteNames = [];
+  
+      const result = getProbeConfig(queueProcessorConfig, siteNames);
+      assert.strictEqual(result, undefined);
+    });
+  
+    it('returns the correct site config when probeServer is an array and siteNames has one matching element', function() {
+      const queueProcessorConfig = {
+        probeServer: [
+          { site: 'site1', bindAddress: '127.0.0.1', port: '8080' },
+          { site: 'site2', bindAddress: '127.0.0.2', port: '8081' }
+        ]
+      };
+      const siteNames = ['site2'];
+  
+      const result = getProbeConfig(queueProcessorConfig, siteNames);
+      assert.deepStrictEqual(result, { site: 'site2', bindAddress: '127.0.0.2', port: '8081' });
+    });
+  
+    it('returns undefined when probeServer is an array and siteNames has no matching element', function() {
+      const queueProcessorConfig = {
+        probeServer: [
+          { site: 'site1', bindAddress: '127.0.0.1', port: '8080' }
+        ]
+      };
+      const siteNames = ['site2'];
+  
+      const result = getProbeConfig(queueProcessorConfig, siteNames);
+      assert.strictEqual(result, undefined);
+    });
+  });

--- a/tests/unit/lib/util/probe.spec.js
+++ b/tests/unit/lib/util/probe.spec.js
@@ -1,6 +1,7 @@
 const assert = require('assert');
 const { startProbeServer, getProbeConfig } =
     require('../../../../lib/util/probe');
+const Logger = require('werelogs').Logger;
 
 describe('Probe server', () => {
     it('is not created with no config', done => {
@@ -27,13 +28,14 @@ describe('Probe server', () => {
 });
 
 describe('getProbeConfig', () => {
+  const log = new Logger('getProbeConfig');
     it('returns the probeServer config when siteNames is empty and probeServer is a single object', () => {
       const queueProcessorConfig = {
         probeServer: { bindAddress: '127.0.0.1', port: '8080' }
       };
       const siteNames = [];
 
-      const result = getProbeConfig(queueProcessorConfig, siteNames);
+      const result = getProbeConfig(queueProcessorConfig, siteNames, log);
       assert.deepStrictEqual(result, { bindAddress: '127.0.0.1', port: '8080' });
     });
 
@@ -43,7 +45,7 @@ describe('getProbeConfig', () => {
       };
       const siteNames = [];
 
-      const result = getProbeConfig(queueProcessorConfig, siteNames);
+      const result = getProbeConfig(queueProcessorConfig, siteNames, log);
       assert.strictEqual(result, undefined);
     });
 
@@ -56,7 +58,7 @@ describe('getProbeConfig', () => {
       };
       const siteNames = ['site2'];
 
-      const result = getProbeConfig(queueProcessorConfig, siteNames);
+      const result = getProbeConfig(queueProcessorConfig, siteNames, log);
       assert.deepStrictEqual(result, { site: 'site2', bindAddress: '127.0.0.2', port: '8081' });
     });
 
@@ -68,7 +70,7 @@ describe('getProbeConfig', () => {
       };
       const siteNames = ['site2'];
 
-      const result = getProbeConfig(queueProcessorConfig, siteNames);
+      const result = getProbeConfig(queueProcessorConfig, siteNames, log);
       assert.strictEqual(result, undefined);
     });
 
@@ -81,17 +83,17 @@ describe('getProbeConfig', () => {
         };
         const siteNames = ['site1', 'site2']; // More than one element in siteNames
 
-        const result = getProbeConfig(queueProcessorConfig, siteNames);
+        const result = getProbeConfig(queueProcessorConfig, siteNames, log);
         assert.strictEqual(result, undefined);
     });
 
-    it('returns undefined when probeServer is not an array and siteNames is not empty', () => {
+    it('returns probeserver when probeServer is not an array and siteNames is not empty', () => {
         const queueProcessorConfig = {
             probeServer: { bindAddress: '127.0.0.1', port: '8080' } // probeServer is a single object
         };
         const siteNames = ['site1']; // siteNames is not empty
 
-        const result = getProbeConfig(queueProcessorConfig, siteNames);
-        assert.strictEqual(result, undefined);
+        const result = getProbeConfig(queueProcessorConfig, siteNames, log);
+        assert.deepStrictEqual(result, queueProcessorConfig.probeServer);
     });
   });

--- a/tests/unit/lib/util/probe.spec.js
+++ b/tests/unit/lib/util/probe.spec.js
@@ -26,28 +26,28 @@ describe('Probe server', () => {
     });
 });
 
-describe.only('getProbeConfig', function() {
-    it('returns the probeServer config when siteNames is empty and probeServer is a single object', function() {
+describe('getProbeConfig', () => {
+    it('returns the probeServer config when siteNames is empty and probeServer is a single object', () => {
       const queueProcessorConfig = {
         probeServer: { bindAddress: '127.0.0.1', port: '8080' }
       };
       const siteNames = [];
-  
+
       const result = getProbeConfig(queueProcessorConfig, siteNames);
       assert.deepStrictEqual(result, { bindAddress: '127.0.0.1', port: '8080' });
     });
-  
-    it('returns undefined when siteNames is empty and probeServer is not a single object', function() {
+
+    it('returns undefined when siteNames is empty and probeServer is not a single object', () => {
       const queueProcessorConfig = {
         probeServer: [{ site: 'site1', bindAddress: '127.0.0.1', port: '8080' }]
       };
       const siteNames = [];
-  
+
       const result = getProbeConfig(queueProcessorConfig, siteNames);
       assert.strictEqual(result, undefined);
     });
-  
-    it('returns the correct site config when probeServer is an array and siteNames has one matching element', function() {
+
+    it('returns the correct site config when probeServer is an array and siteNames has one matching element', () => {
       const queueProcessorConfig = {
         probeServer: [
           { site: 'site1', bindAddress: '127.0.0.1', port: '8080' },
@@ -55,19 +55,19 @@ describe.only('getProbeConfig', function() {
         ]
       };
       const siteNames = ['site2'];
-  
+
       const result = getProbeConfig(queueProcessorConfig, siteNames);
       assert.deepStrictEqual(result, { site: 'site2', bindAddress: '127.0.0.2', port: '8081' });
     });
-  
-    it('returns undefined when probeServer is an array and siteNames has no matching element', function() {
+
+    it('returns undefined when probeServer is an array and siteNames has no matching element', () => {
       const queueProcessorConfig = {
         probeServer: [
           { site: 'site1', bindAddress: '127.0.0.1', port: '8080' }
         ]
       };
       const siteNames = ['site2'];
-  
+
       const result = getProbeConfig(queueProcessorConfig, siteNames);
       assert.strictEqual(result, undefined);
     });

--- a/tests/unit/lib/util/probe.spec.js
+++ b/tests/unit/lib/util/probe.spec.js
@@ -71,4 +71,27 @@ describe('getProbeConfig', () => {
       const result = getProbeConfig(queueProcessorConfig, siteNames);
       assert.strictEqual(result, undefined);
     });
+
+    it('returns undefined when siteNames contains more than one element', () => {
+        const queueProcessorConfig = {
+            probeServer: [
+                { site: 'site1', bindAddress: '127.0.0.1', port: '8080' },
+                { site: 'site2', bindAddress: '127.0.0.2', port: '8081' }
+            ]
+        };
+        const siteNames = ['site1', 'site2']; // More than one element in siteNames
+
+        const result = getProbeConfig(queueProcessorConfig, siteNames);
+        assert.strictEqual(result, undefined);
+    });
+
+    it('returns undefined when probeServer is not an array and siteNames is not empty', () => {
+        const queueProcessorConfig = {
+            probeServer: { bindAddress: '127.0.0.1', port: '8080' } // probeServer is a single object
+        };
+        const siteNames = ['site1']; // siteNames is not empty
+
+        const result = getProbeConfig(queueProcessorConfig, siteNames);
+        assert.strictEqual(result, undefined);
+    });
   });


### PR DESCRIPTION
S3C supports having different queueProcessor probeserver configuration per site.

Joi configuration supports having multiple types for a single config parameter, this will allow supporting passing both an array or a single object containing the probeserver config.