### PR TITLE
allow consuming log records without wait when more logs are available

### DIFF
--- a/lib/config.joi.js
+++ b/lib/config.joi.js
@@ -42,6 +42,7 @@ const joiSchema = joi.object({
         zookeeperPath: joi.string().required(),
 
         logSource: joi.alternatives().try(logSourcesJoi).required(),
+        exhaustLogSource: joi.bool().default(false),
         bucketd: hostPortJoi
             .keys({ transport: transportJoi })
             .when('logSource', { is: 'bucketd', then: joi.required() }),

--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -423,6 +423,7 @@ class LogReader {
             // continuously send 'data' events as they come.
             if (logRes.tailable &&
                 logStats.nbLogRecordsRead >= batchState.maxRead) {
+                logStats.hasMoreLog = true;
                 logger.debug('ending batch', {
                     method: 'LogReader._processPrepareEntries',
                     reason: 'limit on number of read records reached',
@@ -440,6 +441,9 @@ class LogReader {
             return shipBatchCb(err);
         };
         const endEventHandler = () => {
+            if (logStats.nbLogRecordsRead >= batchState.maxRead) {
+                logStats.hasMoreLog = true;
+            }
             logger.debug('ending record stream', {
                 method: 'LogReader._processPrepareEntries',
             });

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -524,7 +524,24 @@ class QueuePopulator {
     _processLogEntries(params, done) {
         return async.map(
             this.logReaders,
-            (logReader, cb) => logReader.processLogEntries(params, cb),
+            (logReader, readerDone) => {
+                async.doWhilst(
+                    next => {
+                        logReader.processLogEntries(params, (err, hasMoreLog) => {
+                            if (err) {
+                                this.log.error('error processing log entries', {
+                                    method: 'QueuePopulator._processLogEntries',
+                                    error: err,
+                                });
+                                return next(err);
+                            }
+                            return next(null, hasMoreLog);
+                        });
+                    },
+                    hasMoreLog => this.qpConfig.exhaustLogSource && hasMoreLog && !this.logReadersUpdate,
+                    readerDone,
+                );
+            },
             done);
     }
 


### PR DESCRIPTION
The cooldown between batches is removed when more logs are available to consume.

This is mostly needed for S3C to keep good replication rates.

Issue: BB-532