### PR TITLE
use deleteObject to expire objects in S3c

### DIFF
--- a/tests/unit/mocks.js
+++ b/tests/unit/mocks.js
@@ -61,13 +61,16 @@ class MockRequestAPI extends EventEmitter {
 }
 
 class BackbeatClientMock {
-    constructor() {
+    constructor(params) {
         this.response = null;
         this.batchDeleteResponse = {};
         this.times = {
             batchDeleteResponse: 0,
             deleteObjectFromExpiration: 0,
         };
+        if (params?.isS3c) {
+            this.deleteObjectFromExpiration = undefined;
+        }
     }
 
     deleteObjectFromExpiration() {
@@ -186,6 +189,7 @@ class S3ClientMock {
             headObject: 0,
             deleteObject: 0,
             deleteMultipartObject: 0,
+            abortMultipartUpload: 0,
         };
     }
 
@@ -215,6 +219,12 @@ class S3ClientMock {
 
     deleteMultipartObject() {
         this.calls.deleteMultipartObject += 1;
+        this.assertRespIsSet();
+        return new S3RequestMock(this.response.error, this.response.data);
+    }
+
+    abortMultipartUpload() {
+        this.calls.abortMultipartUpload += 1;
         this.assertRespIsSet();
         return new S3RequestMock(this.response.error, this.response.data);
     }


### PR DESCRIPTION
Zenko supports the "deleteObjectFromExpiration" API, which sets the proper originOp in the metadata to trigger a nortification when an object gets expired. S3C doesn't support that API, so we switch to the standard deleteObject API in this case.

Issue: BB-556