### PR TITLE
Fix the dataMoverTopic config param always being required

### DIFF
--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -53,11 +53,7 @@ const joiSchema = joi.object({
         bootstrapList: bootstrapListJoi,
     },
     topic: joi.string().required(),
-    dataMoverTopic: joi.string().when('..lifecycle.supportedLifecycleRules', {
-        is: joi.array().has(joi.string().valid('transition')),
-        then: joi.required(),
-        otherwise: joi.forbidden(),
-    }),
+    dataMoverTopic: joi.string().optional(),
     replicationStatusTopic: joi.string().required(),
     monitorReplicationFailures: joi.boolean().default(true),
     replicationFailedTopic: joi.string().required(),

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -82,6 +82,13 @@ class Config extends EventEmitter {
             });
         }
 
+        const lifecycleConfig = parsedConfig.extensions?.lifecycle;
+        const backbeatSupportsTransition = lifecycleConfig?.supportedLifecycleRules?.includes('transitions');
+        const replicationConfig = parsedConfig.extensions?.replication;
+        if (backbeatSupportsTransition && !replicationConfig.dataMoverTopic) {
+            throw new Error('dataMoverTopic is required when lifecycle transitions is supported');
+        }
+
         if (parsedConfig.extensions && parsedConfig.extensions.replication
             && parsedConfig.extensions.replication.destination
             && parsedConfig.extensions.replication.destination.bootstrapList) {

--- a/tests/unit/lib/config/Config.spec.js
+++ b/tests/unit/lib/config/Config.spec.js
@@ -6,20 +6,47 @@ const { Config } = require('../../../../lib/Config');
 const backbeatConfig = require('./config.json');
 
 describe('Config', () => {
+    let config;
+    let testConfig;
+
+    beforeEach(() => {
+        config = new Config();
+        // deep copy the config to avoid modifying the original
+        testConfig = JSON.parse(JSON.stringify(backbeatConfig));
+    });
+
     it('should make the probeserver config in the queuePoulator' +
         'required when multiple extensions are configured', () => {
-        const config = new Config();
-        const testConfig = { ...backbeatConfig };
         delete testConfig.queuePopulator.probeServer;
         assert.throws(() => config._parseConfig(testConfig));
     });
 
     it('should make the probeserver config in the queuePoulator' +
         'optional when only notification config is specified', () => {
-        const config = new Config();
-        const testConfig = { ...backbeatConfig };
         delete testConfig.queuePopulator.probeServer;
         testConfig.extensions = { notification: testConfig.extensions.notification };
+        assert.doesNotThrow(() => config._parseConfig(testConfig));
+    });
+
+    it('should throw an error when dataMoverTopic is not provided and transition is supported', () => {
+        delete testConfig.extensions.replication.dataMoverTopic;
+        testConfig.extensions.lifecycle.supportedLifecycleRules = [
+            'transitions',
+            'noncurrentVersionTransition',
+            'expiration',
+            'noncurrentVersionExpiration',
+            'abortIncompleteMultipartUpload',
+        ];
+        assert.throws(() => config._parseConfig(testConfig));
+    });
+
+    it('should make dataMoverTopic optional when transitions are not supported', () => {
+        delete testConfig.extensions.replication.dataMoverTopic;
+        testConfig.extensions.lifecycle.supportedLifecycleRules = [
+            'expiration',
+            'noncurrentVersionExpiration',
+            'abortIncompleteMultipartUpload',
+        ];
         assert.doesNotThrow(() => config._parseConfig(testConfig));
     });
 });


### PR DESCRIPTION
Extension configs are validated independently of each other, so validating the dataMoverTopic based on the supportedLifecycleRules param is not currently possible.

Issue: BB-619