### PR TITLE
use the same queue populator zookeeper path as in 7.x

### DIFF
--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -39,8 +39,7 @@ class LogReader {
         this.zkClient = params.zkClient;
         this.kafkaConfig = params.kafkaConfig;
         this.logConsumer = params.logConsumer;
-        this.pathToLogOffset = `${config.queuePopulator.zookeeperPath}/` +
-            `logState/${params.logId}/logOffset`;
+        this.pathToLogOffset = `/logState/${params.logId}/logOffset`;
         this.logOffset = null;
         this.log = params.logger;
         this._producers = {};


### PR DESCRIPTION
This change would not affect Zenko. Offsets are no longer stored in Zookeeper as they are managed directly by Kafka when using the Kafka log consumer.

Issue: BB-533