### PR TITLE
Default oplogPopulatorChangeStreamLimit to 10

### DIFF
--- a/monitoring/oplog-populator/alerts.yaml
+++ b/monitoring/oplog-populator/alerts.yaml
@@ -10,7 +10,7 @@ x-inputs:
   value: 10
 - name: oplogPopulatorChangeStreamLimit
   type: config
-  value: 0
+  value: 10
 
 groups:
 - name: Oplog Populator

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "8.6.50",
+  "version": "8.6.51",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Should not trigger an alert by default.

Issue: BB-627
