### PR TITLE
Support lifecycle transitions on OOB bucket

### DIFF
--- a/.github/actions/ft-test/action.yaml
+++ b/.github/actions/ft-test/action.yaml
@@ -27,7 +27,7 @@ runs:
       env:
         BACKBEAT_CONFIG_FILE: ${{ inputs.config }}
 
-    - uses: codecov/codecov-action@v4
+    - uses: codecov/codecov-action@v5
       with:
         token: ${{ inputs.token }}
         directory: ./coverage/ft_test:${{ inputs.testsuite }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -90,7 +90,7 @@ jobs:
                -nodes 1 -stream -timeout 5m -slowSpecThreshold 60
       working-directory: bucket-scanner
 
-    - uses: codecov/codecov-action@v4
+    - uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: bucket-scanner
@@ -143,7 +143,7 @@ jobs:
       run: yarn run cover:test
       env:
         BACKBEAT_CONFIG_FILE: tests/config.json
-    - uses: codecov/codecov-action@v4
+    - uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: ./coverage/test

--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -227,16 +227,9 @@ class MongoQueueProcessor {
             params.versionId = versionId;
         }
 
+        log.debug('getting zenko object metadata', { bucket, key, versionId, params });
+
         return this._mongoClient.getObject(bucket, key, params, log, (err, data) => {
-            if (err && err.NoSuchKey) {
-                // TODO: this may happen if the object was created from artesca side (e.g. on restore)
-                //       --> in that case, the versionId does not match, and we cannot find the object
-                //       --> yet we have the 'ring' versionId in the (zenko) entry's `location`
-                //           field, so we may try to look it up (get all versions, check the one with
-                //           where location is indeed in the RING and with the 'target' versionId)
-                // ....or we introduce a way to store the RING object with the target metadata
-                return done();
-            }
             if (err) {
                 log.error('error getting zenko object metadata', {
                     method: 'MongoQueueProcessor._getZenkoObjectMetadata',
@@ -245,18 +238,6 @@ class MongoQueueProcessor {
                 });
                 return done(err);
             }
-
-            // Sanity check (esp. for restored objects case): verify that the object in the data
-            // location matches the object we ingested
-            // if (data.location[0].dataStoreVersionId !== entry.getVersionId()) {
-            //     const err = new Error('version id mismatch');
-            //     log.error('error getting zenko object metadata', {
-            //         method: 'MongoQueueProcessor._getZenkoObjectMetadata',
-            //         err,
-            //         entry: entry.getLogInfo(),
-            //     });
-            //     return done(err); // TODO: should we return an error here, or just consider a mismatch?
-            // }
 
             return done(null, data);
         });
@@ -672,6 +653,9 @@ class MongoQueueProcessor {
         MongoProcessorMetrics.onProcessKafkaEntry();
         const log = this.logger.newRequestLogger();
         const sourceEntry = QueueEntry.createFromKafkaEntry(kafkaEntry);
+
+        this.logger.info('processing kafka entry', { sourceEntry });
+
         if (sourceEntry.error) {
             log.end().error('error processing source entry',
                               { error: sourceEntry.error });

--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -432,9 +432,9 @@ class MongoQueueProcessor {
                     return done();
                 }
 
-                return cb();
+                return cb(null, zenkoObjMd);
             },
-            cb => {
+            (zenkoObjMd, cb) => {
                 const options = {};
 
                 // Calling deleteObject with empty options to use deleteObjectNoVer which is used
@@ -449,9 +449,9 @@ class MongoQueueProcessor {
                     options.versionId = versionId;
                 }
 
-                // If the bucket has no lifecycle or notification configuration, we don't need the
-                // oplog update, and can skip it to lower the load on mongo
-                if (!bucketInfo.lifecycleConfiguration && !bucketInfo.notificationConfiguration) {
+                // If the bucket has notification configuration and the object is not archived, we
+                // don't need the oplog update, and can skip it to lower the load on mongo
+                if (!zenkoObjMd.archive && !bucketInfo.notificationConfiguration) {
                     options.doesNotNeedOpogUpdate = true;
                 }
 

--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -625,19 +625,36 @@ class MongoQueueProcessor {
             const location = bucketInfo.getLocationConstraint();
 
             if (sourceEntry instanceof DeleteOpQueueEntry) {
-                return this._processDeleteOpQueueEntry(log, sourceEntry,
-                    location, err => {
+                return this._getZenkoObjectMetadata(log, sourceEntry, bucketInfo, (err, zenkoObjMd) => {
+                    if (err) {
+                        this._normalizePendingMetric(location);
+                        return done(err);
+                    }
+
+                    if (zenkoObjMd.dataStoreName !== location) {
+                        log.end().info('skipping delete entry with location mismatch', {
+                            entry: sourceEntry.getLogInfo(),
+                            location,
+                            zenkoLocation: zenkoObjMd.location,
+                        });
+                        this._normalizePendingMetric(location);
+                        return done();
+                    }
+
+                    return this._processDeleteOpQueueEntry(log, sourceEntry, location, err => {
                         this._handleMetrics(sourceEntry, !!err);
                         return done(err);
                     });
+                });
             }
+
             if (sourceEntry instanceof ObjectQueueEntry) {
-                return this._processObjectQueueEntry(log, sourceEntry, location,
-                    bucketInfo, err => {
-                        this._handleMetrics(sourceEntry, !!err);
-                        return done(err);
-                    });
+                return this._processObjectQueueEntry(log, sourceEntry, location, bucketInfo, err => {
+                    this._handleMetrics(sourceEntry, !!err);
+                    return done(err);
+                });
             }
+
             log.end().warn('skipping unknown source entry', {
                 entry: sourceEntry.getLogInfo(),
                 entryType: sourceEntry.constructor.name,

--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -235,7 +235,7 @@ class MongoQueueProcessor {
 
     /**
      * get dataStoreVersionId, if exists
-     * @param {Object} objMd - object md fetched from mongo
+     * @param {ObjectMDData} objMd - object md fetched from mongo
      * @param {String} site - storage location name
      * @return {String} dataStoreVersionId
      */
@@ -510,46 +510,6 @@ class MongoQueueProcessor {
                 return done(err);
             }
 
-            // If the object has `x-amz-meta-scal-version-id`, we need to use it instead of the id.
-            // This should only happen for objects restored onto the OOB location, and the location
-            // should match in that case
-            if (scalVersionId) {
-                if (!zenkoObjMd) {
-                    this.logger.warn('missing source entry, ignoring x-amz-meta-scal-version-id', {
-                        method: 'MongoQueueProcessor._processObjectQueueEntry',
-                        location,
-                    });
-                    // This may happen if the object has been deleted from Zenko, but we processed
-                    // the create/update event from oplog after the object was deleted. We can
-                    // proceed normally and create the entry, as we will get a followup "delete"
-                    // operation and will thus eventually be consistent.
-                } else if (zenkoObjMd.location?.length !== 1 ||
-                    zenkoObjMd.location[0].dataStoreName !== location ||
-                    zenkoObjMd.location[0].dataStoreVersionId !== sourceEntry.getVersionId()) {
-                    this.logger.warn('mismatched source entry, skipping entry', {
-                        method: 'MongoQueueProcessor._processObjectQueueEntry',
-                        location,
-                    });
-
-                    // If the versionId does not match, it mean the object metadata has been updated
-                    // in Zenko already, and we are thus processing an outdated oplog entry: which
-                    // should be ignored. Not much of an issue though, as we have retrieved Zenko
-                    // object, so `getContentType()` will pickup tag changes only.
-                } else {
-                    this.logger.info('restored oob object', {
-                        bucket, key, scalVersionId, zenkoObjMd, sourceEntry
-                    });
-
-                    sourceEntry.setVersionId(scalVersionId);
-
-                    // TODO: do we need to update the (mongo) metadata in that case???
-                    // - This may happen if object is re-tagged while restored?
-                    // - Need to cleanup scal version id: delete objVal['x-amz-meta-scal-version-id'];
-                    // - Need to keep the archive & restore fields in the metadata
-                    return done();
-                }
-            }
-
             const content = getContentType(sourceEntry, zenkoObjMd);
             if (content.length === 0) {
                 this._normalizePendingMetric(location);
@@ -562,11 +522,20 @@ class MongoQueueProcessor {
                 return done();
             }
 
-            // update necessary metadata fields before saving to Zenko MongoDB
-            this._updateOwnerMD(sourceEntry, bucketInfo);
-            this._updateObjectDataStoreName(sourceEntry, location);
-            this._updateLocations(sourceEntry, location);
-            this._updateAcl(sourceEntry);
+            if (zenkoObjMd) {
+                // Keep existing metadata fields, only need to update the tags
+                const tags = sourceEntry.getTags();
+                sourceEntry._data = { ...zenkoObjMd }; // eslint-disable-line no-param-reassign
+                sourceEntry.setTags(tags);
+            } else {
+                // Update necessary metadata fields before saving to Zenko MongoDB
+                this._updateOwnerMD(sourceEntry, bucketInfo);
+                this._updateObjectDataStoreName(sourceEntry, location);
+                this._updateLocations(sourceEntry, location);
+                this._updateAcl(sourceEntry);
+            }
+
+            // Try to update replication info, if applicable
             this._updateReplicationInfo(sourceEntry, bucketInfo, content,
                 zenkoObjMd);
 

--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -400,7 +400,14 @@ class MongoQueueProcessor {
     _processDeleteOpQueueEntry(log, sourceEntry, location, bucketInfo, done) {
         const bucket = sourceEntry.getBucket();
         const key = sourceEntry.getObjectKey();
-        const versionId = extractVersionId(sourceEntry.getObjectVersionedKey());
+        const entryVersionId = extractVersionId(sourceEntry.getObjectVersionedKey());
+
+        // Use x-amz-meta-scal-version-id if provided, instead of the actual versionId of the object.
+        // This should happen only for restored objects : in all other situations, both the source
+        // and ingested objects should have the same version id (and no x-amz-meta-scal-version-id
+        // metadata).
+        const scalVersionId = sourceEntry.getOverheadField('x-amz-meta-scal-version-id');
+        const versionId = scalVersionId ? VersionID.decode(scalVersionId) : entryVersionId;
 
         this.logger.debug('processing object delete', { bucket, key, versionId });
 
@@ -416,7 +423,7 @@ class MongoQueueProcessor {
                     zenkoObjMd.location?.length !== 1 ||
                     zenkoObjMd.location[0].dataStoreName !== location ||
                     zenkoObjMd.location[0].key !== key ||
-                    (zenkoObjMd.location[0].dataStoreVersionId || 'null') !== encode(versionId)
+                    (zenkoObjMd.location[0].dataStoreVersionId || 'null') !== encode(entryVersionId)
                 ) {
                     log.end().info('ignore delete entry, transitioned to another location', {
                         entry: sourceEntry.getLogInfo(),

--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -393,10 +393,11 @@ class MongoQueueProcessor {
      * @param {Logger.newRequestLogger} log - request logger object
      * @param {DeleteOpQueueEntry} sourceEntry - delete object entry
      * @param {string} location - zenko storage location name
+     * @param {BucketInfo} bucketInfo - bucket info object
      * @param {function} done - callback(error)
      * @return {undefined}
      */
-    _processDeleteOpQueueEntry(log, sourceEntry, location, done) {
+    _processDeleteOpQueueEntry(log, sourceEntry, location, bucketInfo, done) {
         const bucket = sourceEntry.getBucket();
         const key = sourceEntry.getObjectKey();
         const versionId = extractVersionId(sourceEntry.getObjectVersionedKey());
@@ -427,14 +428,25 @@ class MongoQueueProcessor {
                 return cb();
             },
             cb => {
-                // Calling deleteObject with undefined options to use deleteObjectNoVer which is used for
-                // deleting non versioned objects that only have master keys.
-                // When deleting a versioned object however we supply the version id in the options, which
-                // causes the function to call the deleteObjectVer function that is used to handle objects that
-                // have both a master and version keys. This handles the deletion of both the version and the master
-                // keys in the case where no other version is available, or deleting the version and updating the
-                // master key otherwise.
-                const options = versionId ? { versionId } : undefined;
+                const options = {};
+
+                // Calling deleteObject with empty options to use deleteObjectNoVer which is used
+                // for deleting non versioned objects that only have master keys.
+                // When deleting a versioned object however we supply the version id in the options,
+                // which causes the function to call the deleteObjectVer function that is used to
+                // handle objects that have both a master and version keys. This handles the
+                // deletion of both the version and the master keys in the case where no other
+                // version is available, or deleting the version and updating the master key
+                // otherwise.
+                if (versionId) {
+                    options.versionId = versionId;
+                }
+
+                // If the bucket has no lifecycle or notification configuration, we don't need the
+                // oplog update, and can skip it to lower the load on mongo
+                if (!bucketInfo.lifecycleConfiguration && !bucketInfo.notificationConfiguration) {
+                    options.doesNotNeedOpogUpdate = true;
+                }
 
                 return this._mongoClient.deleteObject(bucket, key, options, log, cb);
             },

--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -197,33 +197,23 @@ class MongoQueueProcessor {
         ], done);
     }
 
-    _getZenkoObjectMetadata(log, entry, bucketInfo, done) {
-        // NOTE: This is used for updating replication info, as well as validating the
-        // `x-amz-meta-scal-version-id` header. If the Zenko bucket does not have repInfo set and
-        // the header is not set, then we can ignore fetching
-        const bucketRepInfo = bucketInfo.getReplicationConfiguration();
-        // KO for DeleteOpQueueEntry : no such field (and no metadata...)
-        const scalVersionId = entry.getValue ? entry.getValue()['x-amz-meta-scal-version-id'] : undefined;
-        if (!(entry instanceof DeleteOpQueueEntry) &&
-            !scalVersionId &&
-            (!bucketRepInfo || !bucketRepInfo.rules || !bucketRepInfo.rules[0].enabled)) {
-            return done();
-        }
-
+    /**
+     * Retrieve Zenko object metadata from MongoDB
+     * @param {Logger} log The logger object
+     * @param {ObjectQueueEntry|DeleteOpQueueEntry} entry The entry to being processed
+     * @param {string} versionId The version id of the object
+     * @param {function} done The callback function
+     * @returns {undefined}
+     */
+    _getZenkoObjectMetadata(log, entry, versionId, done) {
         const bucket = entry.getBucket();
         const key = entry.getObjectKey();
         const params = {};
 
-        // Use x-amz-meta-scal-version-id if provided, instead of the actual versionId of the object.
-        // This should happen only for restored objects : in all other situations, both the source
-        // and ingested objects should have the same version id (and not x-amz-meta-scal-version-id
-        // metadata).
-        const versionId = VersionID.decode(scalVersionId) || entry.getVersionId();
-
         // master keys with a 'null' version id comming from
         // a versioning suspended bucket are considered a version
         // we should not specify the version id in this case
-        if (versionId && !entry.getIsNull()) {
+        if (versionId && !(entry.getIsNull && entry.getIsNull())) {
             params.versionId = versionId;
         }
 
@@ -411,35 +401,69 @@ class MongoQueueProcessor {
         const key = sourceEntry.getObjectKey();
         const versionId = extractVersionId(sourceEntry.getObjectVersionedKey());
 
-        const options = versionId ? { versionId } : undefined;
+        this.logger.debug('processing object delete', { bucket, key, versionId });
 
-        // Calling deleteObject with undefined options to use deleteObjectNoVer which is used for
-        // deleting non versioned objects that only have master keys.
-        // When deleting a versioned object however we supply the version id in the options, which
-        // causes the function to call the deleteObjectVer function that is used to handle objects that
-        // have both a master and version keys. This handles the deletion of both the version and the master
-        // keys in the case where no other version is available, or deleting the version and updating the
-        // master key otherwise.
-        return this._mongoClient.deleteObject(bucket, key, options, log,
-            err => {
-                if (err) {
-                    this._normalizePendingMetric(location);
-                    log.end().error('error deleting object metadata ' +
-                    'from mongo', {
-                        bucket,
-                        key,
-                        error: err.message,
+        async.waterfall([
+            cb => this._getZenkoObjectMetadata(log, sourceEntry, versionId, cb),
+            (zenkoObjMd, cb) => {
+                // Skip if the object is in a different location, i.e. when the delete was caused
+                // by restored-object expiration or transition. It works because the dataStoreName
+                // is updated before actually sending the object to GC to effectively delete the
+                // data.
+                const encode = versionId => (versionId ? VersionID.encode(versionId) : 'null');
+                if (zenkoObjMd.dataStoreName !== location ||
+                    zenkoObjMd.location?.length !== 1 ||
+                    zenkoObjMd.location[0].dataStoreName !== location ||
+                    zenkoObjMd.location[0].key !== key ||
+                    (zenkoObjMd.location[0].dataStoreVersionId || 'null') !== encode(versionId)
+                ) {
+                    log.end().info('ignore delete entry, transitioned to another location', {
+                        entry: sourceEntry.getLogInfo(),
                         location,
                     });
-                    return done(err);
+                    return done();
                 }
-                this._produceMetricCompletionEntry(location);
-                log.end().info('object metadata deleted from mongo', {
+
+                return cb();
+            },
+            cb => {
+                // Calling deleteObject with undefined options to use deleteObjectNoVer which is used for
+                // deleting non versioned objects that only have master keys.
+                // When deleting a versioned object however we supply the version id in the options, which
+                // causes the function to call the deleteObjectVer function that is used to handle objects that
+                // have both a master and version keys. This handles the deletion of both the version and the master
+                // keys in the case where no other version is available, or deleting the version and updating the
+                // master key otherwise.
+                const options = versionId ? { versionId } : undefined;
+
+                return this._mongoClient.deleteObject(bucket, key, options, log, cb);
+            },
+        ], err => {
+            if (err?.is.NoSuchKey) {
+                log.end().info('skipping delete entry', {
                     entry: sourceEntry.getLogInfo(),
                     location,
                 });
                 return done();
+            }
+            if (err) {
+                this._normalizePendingMetric(location);
+                log.end().error('error deleting object metadata ' +
+                    'from mongo', {
+                    bucket,
+                    key,
+                    error: err.message,
+                    location,
+                });
+                return done(err);
+            }
+            this._produceMetricCompletionEntry(location);
+            log.end().info('object metadata deleted from mongo', {
+                entry: sourceEntry.getLogInfo(),
+                location,
             });
+            return done();
+        });
     }
 
     /**
@@ -454,14 +478,29 @@ class MongoQueueProcessor {
     _processObjectQueueEntry(log, sourceEntry, location, bucketInfo, done) {
         const bucket = sourceEntry.getBucket();
         const key = sourceEntry.getObjectKey();
+        const scalVersionId = sourceEntry.getValue()['x-amz-meta-scal-version-id'];
 
-        this.logger.info('processing object metadata', {
-            bucket, key, scalVersionId: sourceEntry.getValue()['x-amz-meta-scal-version-id'],
-        });
+        this.logger.debug('processing object metadata', { bucket, key, scalVersionId });
 
-        this._getZenkoObjectMetadata(log, sourceEntry, bucketInfo,
-        (err, zenkoObjMd) => {
-            if (err) {
+        const maybeGetZenkoObjectMetadata = cb => {
+            // NOTE: ZenkoObjMD is used for updating replication info, as well as validating the
+            // `x-amz-meta-scal-version-id` header of restored objects. If the Zenko bucket does
+            // not have repInfo set and the header is not set, then we can skip fetching.
+            const bucketRepInfo = bucketInfo.getReplicationConfiguration();
+            if (!scalVersionId && !bucketRepInfo?.rules?.some(r => r.enabled)) {
+                return cb();
+            }
+
+            // Use x-amz-meta-scal-version-id if provided, instead of the actual versionId of the object.
+            // This should happen only for restored objects : in all other situations, both the source
+            // and ingested objects should have the same version id (and not x-amz-meta-scal-version-id
+            // metadata).
+            const versionId = scalVersionId ? VersionID.decode(scalVersionId) : sourceEntry.getVersionId();
+            return this._getZenkoObjectMetadata(log, sourceEntry, versionId, cb);
+        };
+
+        maybeGetZenkoObjectMetadata((err, zenkoObjMd) => {
+            if (err && !err.NoSuchKey) {
                 this._normalizePendingMetric(location);
                 log.end().error('error processing object queue entry', {
                     method: 'MongoQueueProcessor._processObjectQueueEntry',
@@ -469,6 +508,46 @@ class MongoQueueProcessor {
                     location,
                 });
                 return done(err);
+            }
+
+            // If the object has `x-amz-meta-scal-version-id`, we need to use it instead of the id.
+            // This should only happen for objects restored onto the OOB location, and the location
+            // should match in that case
+            if (scalVersionId) {
+                if (!zenkoObjMd) {
+                    this.logger.warn('missing source entry, ignoring x-amz-meta-scal-version-id', {
+                        method: 'MongoQueueProcessor._processObjectQueueEntry',
+                        location,
+                    });
+                    // This may happen if the object has been deleted from Zenko, but we processed
+                    // the create/update event from oplog after the object was deleted. We can
+                    // proceed normally and create the entry, as we will get a followup "delete"
+                    // operation and will thus eventually be consistent.
+                } else if (zenkoObjMd.location?.length !== 1 ||
+                    zenkoObjMd.location[0].dataStoreName !== location ||
+                    zenkoObjMd.location[0].dataStoreVersionId !== sourceEntry.getVersionId()) {
+                    this.logger.warn('mismatched source entry, skipping entry', {
+                        method: 'MongoQueueProcessor._processObjectQueueEntry',
+                        location,
+                    });
+
+                    // If the versionId does not match, it mean the object metadata has been updated
+                    // in Zenko already, and we are thus processing an outdated oplog entry: which
+                    // should be ignored. Not much of an issue though, as we have retrieved Zenko
+                    // object, so `getContentType()` will pickup tag changes only.
+                } else {
+                    this.logger.info('restored oob object', {
+                        bucket, key, scalVersionId, zenkoObjMd, sourceEntry
+                    });
+
+                    sourceEntry.setVersionId(scalVersionId);
+
+                    // TODO: do we need to update the (mongo) metadata in that case???
+                    // - This may happen if object is re-tagged while restored?
+                    // - Need to cleanup scal version id: delete objVal['x-amz-meta-scal-version-id'];
+                    // - Need to keep the archive & restore fields in the metadata
+                    return done();
+                }
             }
 
             const content = getContentType(sourceEntry, zenkoObjMd);
@@ -497,33 +576,6 @@ class MongoQueueProcessor {
 
             const objVal = sourceEntry.getValue();
             const params = {};
-
-            // If the object has `x-amz-meta-scal-version-id`, we need to use it instead of the id.
-            // This should only happen for objects restored onto the OOB location, and the location
-            // should match in that case
-            const scalVersionId = objVal['x-amz-meta-scal-version-id'];
-            if (scalVersionId) {
-
-                this.logger.info('restored oob object', {
-                    bucket, key, scalVersionId, zenkoObjMd, sourceEntry
-                });
-
-                if (!zenkoObjMd) {
-                    this.logger.warn('missing source entry, ignoring x-amz-meta-scal-version-id', {
-                        method: 'MongoQueueProcessor._processObjectQueueEntry',
-                        location,
-                    });
-                } else if (zenkoObjMd.location[0]?.dataStoreVersionId !== sourceEntry.getVersionId()) {
-                    this.logger.warn('mismatched source entry, ignoring x-amz-meta-scal-version-id', {
-                        method: 'MongoQueueProcessor._processObjectQueueEntry',
-                        location,
-                    });
-                } else {
-                    sourceEntry.setVersionId(zenkoObjMd.versionId);
-                    delete objVal['x-amz-meta-scal-version-id'];
-                    delete objVal['x-amz-meta-scal-restore-info'];
-                }
-            }
 
             // Versioning suspended entries will have a version id but also a isNull tag.
             // These master keys are considered a version and do not have a duplicate version,
@@ -654,7 +706,7 @@ class MongoQueueProcessor {
         const log = this.logger.newRequestLogger();
         const sourceEntry = QueueEntry.createFromKafkaEntry(kafkaEntry);
 
-        this.logger.info('processing kafka entry', { sourceEntry });
+        this.logger.trace('processing kafka entry', { sourceEntry });
 
         if (sourceEntry.error) {
             log.end().error('error processing source entry',
@@ -671,38 +723,11 @@ class MongoQueueProcessor {
             const location = bucketInfo.getLocationConstraint();
 
             if (sourceEntry instanceof DeleteOpQueueEntry) {
-                return this._getZenkoObjectMetadata(log, sourceEntry, bucketInfo, (err, zenkoObjMd) => {
-                    if (err) {
-                        this._normalizePendingMetric(location);
-                        return done(err);
-                    }
-
-                    // TODO: use getReducedLocation() ? or x-amz-storage-class ? or dataStoreName ?
-                    // * x-amz-storage-class --> will always indicate the "cold" location
-                    // * dataStoreName will be cold when archived, and "oob" when restored
-                    // ==> we update the data store name (and x-amz-storage-class) before actually
-                    //   removing the data so we should look at this: so we can ignore when there is
-                    //   a match (e.g. lifecycle gc) and process when the event when user deletes
-                    //   the (restored) object
-                    //
-                    // TODO: two cases for restored object to test
-                    // - expiring restored object from Sorbet --> delete from Zenko, should work fine...
-                    // - delete made on the ring (user deletes the object) --> need to be propagated to Zenko!
-                    if (zenkoObjMd?.dataStoreName !== location) {
-                        log.end().info('skipping delete entry with location mismatch', {
-                            entry: sourceEntry.getLogInfo(),
-                            location,
-                            zenkoLocation: zenkoObjMd.location,
-                        });
-                        this._normalizePendingMetric(location);
-                        return done();
-                    }
-
-                    return this._processDeleteOpQueueEntry(log, sourceEntry, location, err => {
+                return this._processDeleteOpQueueEntry(log, sourceEntry,
+                    location, bucketInfo, err => {
                         this._handleMetrics(sourceEntry, !!err);
                         return done(err);
                     });
-                });
             }
 
             if (sourceEntry instanceof ObjectQueueEntry) {

--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -7,7 +7,8 @@ const errors = require('arsenal').errors;
 const { replicationBackends, emptyFileMd5 } = require('arsenal').constants;
 const MongoClient = require('arsenal').storage
     .metadata.mongoclient.MongoClientInterface;
-const ObjectMD = require('arsenal').models.ObjectMD;
+const { ObjectMD } = require('arsenal').models;
+const { VersionID } = require('arsenal').versioning;
 const { extractVersionId } = require('../../lib/util/versioning');
 
 const Config = require('../../lib/Config');
@@ -197,27 +198,43 @@ class MongoQueueProcessor {
     }
 
     _getZenkoObjectMetadata(log, entry, bucketInfo, done) {
-        // NOTE: This is only used for updating replication info. If the Zenko
-        //   bucket does not have repInfo set, then we can ignore fetching
+        // NOTE: This is used for updating replication info, as well as validating the
+        // `x-amz-meta-scal-version-id` header. If the Zenko bucket does not have repInfo set and
+        // the header is not set, then we can ignore fetching
         const bucketRepInfo = bucketInfo.getReplicationConfiguration();
-        if (!bucketRepInfo || !bucketRepInfo.rules ||
-            !bucketRepInfo.rules[0].enabled) {
+        // KO for DeleteOpQueueEntry : no such field (and no metadata...)
+        const scalVersionId = entry.getValue ? entry.getValue()['x-amz-meta-scal-version-id'] : undefined;
+        if (!(entry instanceof DeleteOpQueueEntry) &&
+            !scalVersionId &&
+            (!bucketRepInfo || !bucketRepInfo.rules || !bucketRepInfo.rules[0].enabled)) {
             return done();
         }
 
         const bucket = entry.getBucket();
         const key = entry.getObjectKey();
         const params = {};
+
+        // Use x-amz-meta-scal-version-id if provided, instead of the actual versionId of the object.
+        // This should happen only for restored objects : in all other situations, both the source
+        // and ingested objects should have the same version id (and not x-amz-meta-scal-version-id
+        // metadata).
+        const versionId = VersionID.decode(scalVersionId) || entry.getVersionId();
+
         // master keys with a 'null' version id comming from
         // a versioning suspended bucket are considered a version
         // we should not specify the version id in this case
-        if (entry.getVersionId() && !entry.getIsNull()) {
-            params.versionId = entry.getVersionId();
+        if (versionId && !entry.getIsNull()) {
+            params.versionId = versionId;
         }
 
-        return this._mongoClient.getObject(bucket, key, params, log,
-        (err, data) => {
+        return this._mongoClient.getObject(bucket, key, params, log, (err, data) => {
             if (err && err.NoSuchKey) {
+                // TODO: this may happen if the object was created from artesca side (e.g. on restore)
+                //       --> in that case, the versionId does not match, and we cannot find the object
+                //       --> yet we have the 'ring' versionId in the (zenko) entry's `location`
+                //           field, so we may try to look it up (get all versions, check the one with
+                //           where location is indeed in the RING and with the 'target' versionId)
+                // ....or we introduce a way to store the RING object with the target metadata
                 return done();
             }
             if (err) {
@@ -228,6 +245,19 @@ class MongoQueueProcessor {
                 });
                 return done(err);
             }
+
+            // Sanity check (esp. for restored objects case): verify that the object in the data
+            // location matches the object we ingested
+            // if (data.location[0].dataStoreVersionId !== entry.getVersionId()) {
+            //     const err = new Error('version id mismatch');
+            //     log.error('error getting zenko object metadata', {
+            //         method: 'MongoQueueProcessor._getZenkoObjectMetadata',
+            //         err,
+            //         entry: entry.getLogInfo(),
+            //     });
+            //     return done(err); // TODO: should we return an error here, or just consider a mismatch?
+            // }
+
             return done(null, data);
         });
     }
@@ -444,6 +474,10 @@ class MongoQueueProcessor {
         const bucket = sourceEntry.getBucket();
         const key = sourceEntry.getObjectKey();
 
+        this.logger.info('processing object metadata', {
+            bucket, key, scalVersionId: sourceEntry.getValue()['x-amz-meta-scal-version-id'],
+        });
+
         this._getZenkoObjectMetadata(log, sourceEntry, bucketInfo,
         (err, zenkoObjMd) => {
             if (err) {
@@ -482,6 +516,34 @@ class MongoQueueProcessor {
 
             const objVal = sourceEntry.getValue();
             const params = {};
+
+            // If the object has `x-amz-meta-scal-version-id`, we need to use it instead of the id.
+            // This should only happen for objects restored onto the OOB location, and the location
+            // should match in that case
+            const scalVersionId = objVal['x-amz-meta-scal-version-id'];
+            if (scalVersionId) {
+
+                this.logger.info('restored oob object', {
+                    bucket, key, scalVersionId, zenkoObjMd, sourceEntry
+                });
+
+                if (!zenkoObjMd) {
+                    this.logger.warn('missing source entry, ignoring x-amz-meta-scal-version-id', {
+                        method: 'MongoQueueProcessor._processObjectQueueEntry',
+                        location,
+                    });
+                } else if (zenkoObjMd.location[0]?.dataStoreVersionId !== sourceEntry.getVersionId()) {
+                    this.logger.warn('mismatched source entry, ignoring x-amz-meta-scal-version-id', {
+                        method: 'MongoQueueProcessor._processObjectQueueEntry',
+                        location,
+                    });
+                } else {
+                    sourceEntry.setVersionId(zenkoObjMd.versionId);
+                    delete objVal['x-amz-meta-scal-version-id'];
+                    delete objVal['x-amz-meta-scal-restore-info'];
+                }
+            }
+
             // Versioning suspended entries will have a version id but also a isNull tag.
             // These master keys are considered a version and do not have a duplicate version,
             // we don't specify the version id and repairMaster in this case
@@ -631,7 +693,18 @@ class MongoQueueProcessor {
                         return done(err);
                     }
 
-                    if (zenkoObjMd.dataStoreName !== location) {
+                    // TODO: use getReducedLocation() ? or x-amz-storage-class ? or dataStoreName ?
+                    // * x-amz-storage-class --> will always indicate the "cold" location
+                    // * dataStoreName will be cold when archived, and "oob" when restored
+                    // ==> we update the data store name (and x-amz-storage-class) before actually
+                    //   removing the data so we should look at this: so we can ignore when there is
+                    //   a match (e.g. lifecycle gc) and process when the event when user deletes
+                    //   the (restored) object
+                    //
+                    // TODO: two cases for restored object to test
+                    // - expiring restored object from Sorbet --> delete from Zenko, should work fine...
+                    // - delete made on the ring (user deletes the object) --> need to be propagated to Zenko!
+                    if (zenkoObjMd?.dataStoreName !== location) {
                         log.end().info('skipping delete entry with location mismatch', {
                             entry: sourceEntry.getLogInfo(),
                             location,
@@ -649,10 +722,11 @@ class MongoQueueProcessor {
             }
 
             if (sourceEntry instanceof ObjectQueueEntry) {
-                return this._processObjectQueueEntry(log, sourceEntry, location, bucketInfo, err => {
-                    this._handleMetrics(sourceEntry, !!err);
-                    return done(err);
-                });
+                return this._processObjectQueueEntry(log, sourceEntry, location,
+                    bucketInfo, err => {
+                        this._handleMetrics(sourceEntry, !!err);
+                        return done(err);
+                    });
             }
 
             log.end().warn('skipping unknown source entry', {

--- a/lib/models/DeleteOpQueueEntry.js
+++ b/lib/models/DeleteOpQueueEntry.js
@@ -12,13 +12,16 @@ class DeleteOpQueueEntry {
      * @param {string} bucket - entry bucket
      * @param {string} key - entry key (a versioned key if the entry
      * was for a versioned object or a regular key if no versioning)
+     * @param {object} overheadFields - overhead fields associated with
+     * the operation (e.g. previous object's metadata)
      */
-    constructor(bucket, key) {
+    constructor(bucket, key, overheadFields) {
         this._bucket = bucket;
         this._key = key;
         this._objectVersionedKey = key;
         this._objectKey = _extractVersionedBaseKey(key);
         this._startProcessing = Date.now();
+        this._overheadFields = overheadFields || {};
     }
 
     getStartProcessing() {
@@ -31,6 +34,9 @@ class DeleteOpQueueEntry {
         }
         if (typeof this.getObjectKey() !== 'string') {
             return { message: 'missing key name' };
+        }
+        if (typeof this._overheadFields !== 'object') {
+            return { message: 'invalid overhead fields' };
         }
         return undefined;
     }
@@ -49,6 +55,10 @@ class DeleteOpQueueEntry {
 
     getObjectVersionedKey() {
         return this._objectVersionedKey;
+    }
+
+    getOverheadField(field) {
+        return this._overheadFields[field];
     }
 
     isVersion() {

--- a/lib/models/QueueEntry.js
+++ b/lib/models/QueueEntry.js
@@ -27,7 +27,8 @@ class QueueEntry {
             }
             let entry;
             if (record.type === 'del') {
-                entry = new DeleteOpQueueEntry(record.bucket, record.key);
+                const overheadFields = JSON.parse(record.overheadFields);
+                entry = new DeleteOpQueueEntry(record.bucket, record.key, overheadFields);
             } else if (record.bucket === usersBucket) {
                 // BucketQueueEntry class just handles puts of keys
                 // to usersBucket

--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -516,9 +516,9 @@ class LogReader {
         }
         async.eachSeries(this._extensions, (ext, next) => {
             const overheadFields = {
+                ...entry.overhead,
                 commitTimestamp: record.timestamp,
                 opTimestamp: entry.timestamp,
-                versionId: entry.overhead?.versionId,
             };
             const entryToFilter = {
                 type: entry.type,

--- a/tests/functional/ingestion/MongoQueueProcessor.js
+++ b/tests/functional/ingestion/MongoQueueProcessor.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert');
 const async = require('async');
+const sinon = require('sinon');
 const { ObjectMD, BucketInfo } = require('arsenal').models;
 const { decode, encode } = require('arsenal').versioning.VersionID;
 const errors = require('arsenal').errors;
@@ -13,6 +14,7 @@ const MongoQueueProcessor =
     require('../../../extensions/mongoProcessor/MongoQueueProcessor');
 const authdata = require('../../../conf/authdata.json');
 const ObjectQueueEntry = require('../../../lib/models/ObjectQueueEntry');
+const DeleteOpQueueEntry = require('../../../lib/models/DeleteOpQueueEntry');
 const fakeLogger = require('../../utils/fakeLogger');
 
 const kafkaConfig = config.kafka;
@@ -119,8 +121,14 @@ class MongoClientMock {
         // we get object from mongo to determine replicationInfo.Content types.
         // use "tags" and "versionId" for determining this.
         const obj = new ObjectMD()
-                            .setVersionId(VERSION_ID)
-                            .setTags({ mytag: 'mytags-value' });
+            .setVersionId(VERSION_ID)
+            .setTags({ mytag: 'mytags-value' })
+            .setDataStoreName(LOCATION)
+            .setLocation([{
+                key: KEY,
+                dataStoreName: LOCATION,
+                dataStoreVersionId: encode(VERSION_ID),
+            }]);
         return cb(null, obj._data);
     }
 
@@ -204,74 +212,86 @@ describe('MongoQueueProcessor', function mqp() {
 
     afterEach(() => {
         mqp.reset();
+        sinon.restore();
     });
 
     describe('::_getZenkoObjectMetadata', () => {
-        function testGetZenkoObjectMetadata(entry, cb) {
-            mongoClient.getBucketAttributes(BUCKET, fakeLogger,
-            (error, bucketInfo) => {
-                assert.ifError(error);
-
-                mqp._getZenkoObjectMetadata(fakeLogger, entry, bucketInfo, cb);
-            });
-        }
-
-        it('should return empty if key does not exist in mongo', done => {
+        it('should return an error if key does not exist in mongo', done => {
             const key = 'nonexistant';
             const objmd = new ObjectMD().setKey(key);
             const entry = new ObjectQueueEntry(BUCKET, key, objmd);
-            testGetZenkoObjectMetadata(entry, (err, res) => {
-                assert.ifError(err);
+            mqp._getZenkoObjectMetadata(fakeLogger, entry, VERSION_ID, (err, res) => {
+                assert.ok(err?.is?.NoSuchKey);
 
                 assert.strictEqual(res, undefined);
                 return done();
             });
         });
 
-        it('should return empty if version id of object does not exist in ' +
-        'mongo', done => {
+        it('should return an error if version id of object does not exist in mongo', done => {
             const versionKey = `${KEY}${VID_SEP}${NEW_VERSION_ID}`;
             const objmd = new ObjectMD()
-                                .setKey(KEY)
-                                .setVersionId(NEW_VERSION_ID);
+                .setKey(KEY)
+                .setVersionId(NEW_VERSION_ID);
             const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd);
-            testGetZenkoObjectMetadata(entry, (err, res) => {
-                assert.ifError(err);
+            mqp._getZenkoObjectMetadata(fakeLogger, entry, NEW_VERSION_ID, (err, res) => {
+                assert.ok(err?.is?.NoSuchKey);
 
                 assert.strictEqual(res, undefined);
                 return done();
             });
-        });
-
-        it('should return empty if bucket replication info is disabled',
-        done => {
-            const disabledRepInfo = Object.assign({}, mockReplicationInfo, {
-                rules: [{ enabled: false }],
-            });
-            const disabledMockBucketInfo = {
-                getReplicationConfiguration: () => disabledRepInfo,
-            };
-            const versionKey = `${KEY}${VID_SEP}${NEW_VERSION_ID}`;
-            const objmd = new ObjectMD()
-                                .setKey(KEY)
-                                .setVersionId(NEW_VERSION_ID);
-            const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd);
-            mqp._getZenkoObjectMetadata(fakeLogger, entry,
-                disabledMockBucketInfo, (err, res) => {
-                    assert.ifError(err);
-
-                    assert.strictEqual(res, undefined);
-                    return done();
-                });
         });
 
         it('should return object metadata for existing version', done => {
             const versionKey = `${KEY}${VID_SEP}${VERSION_ID}`;
             const objmd = new ObjectMD()
-                                .setKey(KEY)
-                                .setVersionId(VERSION_ID);
+                .setKey(KEY)
+                .setVersionId(VERSION_ID);
             const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd);
-            testGetZenkoObjectMetadata(entry, (err, res) => {
+            mqp._getZenkoObjectMetadata(fakeLogger, entry, VERSION_ID, (err, res) => {
+                assert.ifError(err);
+
+                assert(res);
+                assert.strictEqual(res.versionId, VERSION_ID);
+                return done();
+            });
+        });
+
+        it('should return object metadata for existing version from DeleteOpQueueEntry', done => {
+            const versionKey = `${KEY}${VID_SEP}${VERSION_ID}`;
+            const entry = new DeleteOpQueueEntry(BUCKET, versionKey);
+            mqp._getZenkoObjectMetadata(fakeLogger, entry, VERSION_ID, (err, res) => {
+                assert.ifError(err);
+
+                assert(res);
+                assert.strictEqual(res.versionId, VERSION_ID);
+                return done();
+            });
+        });
+
+        it('should return object metadata for null "master" version', done => {
+            const versionKey = `${KEY}`;
+            const objmd = new ObjectMD()
+                .setKey(KEY);
+            const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd);
+            mqp._getZenkoObjectMetadata(fakeLogger, entry, null, (err, res) => {
+                assert.ifError(err);
+
+                assert(res);
+                assert.strictEqual(res.versionId, VERSION_ID);
+                return done();
+            });
+        });
+
+        it('should return object metadata for null "suspended" version', done => {
+            const versionKey = `${KEY}${VID_SEP}${NEW_VERSION_ID}`;
+            const objmd = new ObjectMD()
+                .setKey(KEY)
+                .setVersionId(NEW_VERSION_ID)
+                .setNullVersionId(NEW_VERSION_ID)
+                .setIsNull(true);
+            const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd);
+            mqp._getZenkoObjectMetadata(fakeLogger, entry, NEW_VERSION_ID, (err, res) => {
                 assert.ifError(err);
 
                 assert(res);
@@ -306,6 +326,7 @@ describe('MongoQueueProcessor', function mqp() {
 
         afterEach(() => {
             mqp.resetMetricsStore();
+            sinon.restore();
         });
 
         it('should save to mongo a new version entry and update fields',
@@ -544,6 +565,256 @@ describe('MongoQueueProcessor', function mqp() {
                 validateMetricReport('completed', done);
             });
         });
+
+        it('should fail when mongo is not available', done => {
+            const versionKey = `${KEY}${VID_SEP}${VERSION_ID}`;
+            const objmd = new ObjectMD()
+                .setAcl()
+                .setKey(KEY)
+                .setVersionId(VERSION_ID);
+            const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd);
+            const getObject = sinon.stub(mongoClient, 'getObject').yields(errors.InternalError);
+            async.waterfall([
+                next => mongoClient.getBucketAttributes(BUCKET, fakeLogger,
+                    next),
+                (bucketInfo, next) => mqp._processObjectQueueEntry(fakeLogger,
+                    entry, LOCATION, bucketInfo, next),
+            ], err => {
+                assert.ok(err?.is?.InternalError);
+
+                sinon.assert.calledOnce(getObject);
+                assert.strictEqual(getObject.getCall(0).args[0], BUCKET);
+                assert.strictEqual(getObject.getCall(0).args[1], KEY);
+                assert.strictEqual(getObject.getCall(0).args[2].versionId, VERSION_ID);
+
+                validateMetricReport('pendingOnly', done);
+            });
+        });
+
+        it('should save to mongo a new version entry when no replication', done => {
+            const versionKey = `${KEY}${VID_SEP}${NEW_VERSION_ID}`;
+            const objmd = new ObjectMD()
+                .setAcl()
+                .setKey(KEY)
+                .setVersionId(NEW_VERSION_ID);
+            const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd);
+            const getObject = sinon.stub(mongoClient, 'getObject').yields(errors.InternalError);
+            async.waterfall([
+                next => mongoClient.getBucketAttributes(BUCKET, fakeLogger,
+                    next),
+                (bucketInfo, next) => next(null,
+                    bucketInfo.setReplicationConfiguration(null)),
+                (bucketInfo, next) => mqp._processObjectQueueEntry(fakeLogger,
+                    entry, LOCATION, bucketInfo, next),
+            ], err => {
+                assert.ifError(err);
+                sinon.assert.notCalled(getObject);
+
+                const added = mqp.getAdded();
+                assert.strictEqual(added.length, 1);
+                const objVal = added[0].objVal;
+                assert.strictEqual(added[0].key, versionKey);
+                // key shall now be always populated
+                assert.deepStrictEqual(objVal.key, KEY);
+                // acl should reset
+                assert.deepStrictEqual(objVal.acl, new ObjectMD().getAcl());
+                // owner md should update
+                assert.strictEqual(objVal['owner-display-name'],
+                    authdata.accounts[0].name);
+                assert.strictEqual(objVal['owner-id'],
+                    authdata.accounts[0].canonicalID);
+                // dataStoreName should update
+                assert.strictEqual(objVal.dataStoreName, LOCATION);
+                // locations should update, no data in object
+                assert.strictEqual(objVal.location.length, 1);
+                const loc = objVal.location[0];
+                assert.strictEqual(loc.key, KEY);
+                assert.strictEqual(loc.size, 0);
+                assert.strictEqual(loc.start, 0);
+                assert.strictEqual(loc.dataStoreName, LOCATION);
+                assert.strictEqual(loc.dataStoreType, 'aws_s3');
+                assert.strictEqual(decode(loc.dataStoreVersionId),
+                    NEW_VERSION_ID);
+
+                // replication info should be empty
+                const repInfo = objVal.replicationInfo;
+                assert.strictEqual(repInfo.status, '');
+                assert.deepStrictEqual(repInfo.backends, []);
+                assert.deepStrictEqual(repInfo.content, []);
+                assert.strictEqual(repInfo.storageClass, '');
+                assert.strictEqual(repInfo.storageType, '');
+                assert.strictEqual(repInfo.dataStoreVersionId, '');
+
+                done();
+            });
+        });
+
+        it('should save to mongo a new version entry when scal-version-id not found', done => {
+            const versionKey = `${KEY}${VID_SEP}${NEW_VERSION_ID}`;
+            const objmd = new ObjectMD()
+                .setAcl()
+                .setKey(KEY)
+                .setVersionId(NEW_VERSION_ID);
+            const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd)
+                .setUserMetadata({ 'x-amz-meta-scal-version-id': encode(VERSION_ID) });
+            const getObject = sinon.stub(mongoClient, 'getObject').yields(errors.NoSuchKey);
+            async.waterfall([
+                next => mongoClient.getBucketAttributes(BUCKET, fakeLogger,
+                    next),
+                (bucketInfo, next) => next(null,
+                    bucketInfo.setReplicationConfiguration(null)),
+                (bucketInfo, next) => mqp._processObjectQueueEntry(fakeLogger,
+                    entry, LOCATION, bucketInfo, next),
+            ], err => {
+                assert.ifError(err);
+
+                sinon.assert.calledOnce(getObject);
+                assert.strictEqual(getObject.getCall(0).args[0], BUCKET);
+                assert.strictEqual(getObject.getCall(0).args[1], KEY);
+                assert.strictEqual(getObject.getCall(0).args[2].versionId, VERSION_ID);
+
+                const added = mqp.getAdded();
+                assert.strictEqual(added.length, 1);
+                const objVal = added[0].objVal;
+                assert.strictEqual(added[0].key, versionKey);
+                // key shall now be always populated
+                assert.deepStrictEqual(objVal.key, KEY);
+                // acl should reset
+                assert.deepStrictEqual(objVal.acl, new ObjectMD().getAcl());
+                // owner md should update
+                assert.strictEqual(objVal['owner-display-name'],
+                    authdata.accounts[0].name);
+                assert.strictEqual(objVal['owner-id'],
+                    authdata.accounts[0].canonicalID);
+                // dataStoreName should update
+                assert.strictEqual(objVal.dataStoreName, LOCATION);
+                // locations should update, no data in object
+                assert.strictEqual(objVal.location.length, 1);
+                const loc = objVal.location[0];
+                assert.strictEqual(loc.key, KEY);
+                assert.strictEqual(loc.size, 0);
+                assert.strictEqual(loc.start, 0);
+                assert.strictEqual(loc.dataStoreName, LOCATION);
+                assert.strictEqual(loc.dataStoreType, 'aws_s3');
+                assert.strictEqual(decode(loc.dataStoreVersionId),
+                    NEW_VERSION_ID);
+
+                // replication info should be empty
+                const repInfo = objVal.replicationInfo;
+                assert.strictEqual(repInfo.status, '');
+                assert.deepStrictEqual(repInfo.backends, []);
+                assert.deepStrictEqual(repInfo.content, []);
+                assert.strictEqual(repInfo.storageClass, '');
+                assert.strictEqual(repInfo.storageType, '');
+                assert.strictEqual(repInfo.dataStoreVersionId, '');
+
+                done();
+            });
+        });
+
+        it('should save to mongo a new version entry when scal-version-id does not match the data location', done => {
+            const versionKey = `${KEY}${VID_SEP}${NEW_VERSION_ID}`;
+            const objmd = new ObjectMD()
+                .setAcl()
+                .setKey(KEY)
+                .setVersionId(NEW_VERSION_ID);
+            const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd)
+                .setUserMetadata({ 'x-amz-meta-scal-version-id': encode(VERSION_ID) });
+            const getObject = sinon.stub(mongoClient, 'getObject').callThrough();
+            async.waterfall([
+                next => mongoClient.getBucketAttributes(BUCKET, fakeLogger,
+                    next),
+                (bucketInfo, next) => next(null,
+                    bucketInfo.setReplicationConfiguration(null)),
+                (bucketInfo, next) => mqp._processObjectQueueEntry(fakeLogger,
+                    entry, LOCATION, bucketInfo, next),
+            ], err => {
+                assert.ifError(err);
+
+                sinon.assert.calledOnce(getObject);
+
+                const added = mqp.getAdded();
+                assert.strictEqual(added.length, 1);
+                const objVal = added[0].objVal;
+                assert.strictEqual(added[0].key, versionKey);
+                // key shall now be always populated
+                assert.deepStrictEqual(objVal.key, KEY);
+                // acl should reset
+                assert.deepStrictEqual(objVal.acl, new ObjectMD().getAcl());
+                // owner md should update
+                assert.strictEqual(objVal['owner-display-name'],
+                    authdata.accounts[0].name);
+                assert.strictEqual(objVal['owner-id'],
+                    authdata.accounts[0].canonicalID);
+                // dataStoreName should update
+                assert.strictEqual(objVal.dataStoreName, LOCATION);
+                // locations should update, no data in object
+                assert.strictEqual(objVal.location.length, 1);
+                const loc = objVal.location[0];
+                assert.strictEqual(loc.key, KEY);
+                assert.strictEqual(loc.size, 0);
+                assert.strictEqual(loc.start, 0);
+                assert.strictEqual(loc.dataStoreName, LOCATION);
+                assert.strictEqual(loc.dataStoreType, 'aws_s3');
+                assert.strictEqual(decode(loc.dataStoreVersionId),
+                    NEW_VERSION_ID);
+
+                // replication info should be empty
+                const repInfo = objVal.replicationInfo;
+                assert.strictEqual(repInfo.status, '');
+                assert.deepStrictEqual(repInfo.backends, []);
+                assert.deepStrictEqual(repInfo.content, []);
+                assert.strictEqual(repInfo.storageClass, '');
+                assert.strictEqual(repInfo.storageType, '');
+                assert.strictEqual(repInfo.dataStoreVersionId, '');
+
+                done();
+            });
+        });
+
+        it('should skip restored entry scal-version-id', done => {
+            const versionKey = `${KEY}${VID_SEP}${NEW_VERSION_ID}`;
+            const objmd = new ObjectMD()
+                .setAcl()
+                .setKey(KEY)
+                .setVersionId(NEW_VERSION_ID);
+            const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd)
+                .setUserMetadata({ 'x-amz-meta-scal-version-id': encode(VERSION_ID) });
+            const getObject = sinon.stub(mongoClient, 'getObject').yields(null,
+                new ObjectMD()
+                    .setVersionId(VERSION_ID)
+                    .setTags({ mytag: 'mytags-value' })
+                    .setDataStoreName(LOCATION)
+                    .setAmzStorageClass('cold')
+                    .setLocation([{
+                        key: KEY,
+                        start: 0,
+                        size: 50,
+                        dataStoreName: LOCATION,
+                        dataStoreVersionId: NEW_VERSION_ID,
+                    }])._data
+            );
+            async.waterfall([
+                next => mongoClient.getBucketAttributes(BUCKET, fakeLogger,
+                    next),
+                (bucketInfo, next) => next(null,
+                    bucketInfo.setReplicationConfiguration(null)),
+                (bucketInfo, next) => mqp._processObjectQueueEntry(fakeLogger,
+                    entry, LOCATION, bucketInfo, next),
+            ], err => {
+                assert.ifError(err);
+
+                sinon.assert.calledOnce(getObject);
+                assert.strictEqual(getObject.getCall(0).args[0], BUCKET);
+                assert.strictEqual(getObject.getCall(0).args[1], KEY);
+                assert.strictEqual(getObject.getCall(0).args[2].versionId, VERSION_ID);
+
+                const added = mqp.getAdded();
+                assert.strictEqual(added.length, 0);
+
+                done();
+            });
+        });
     });
 
     describe('::_processDeleteOpQueueEntry', () => {
@@ -551,8 +822,9 @@ describe('MongoQueueProcessor', function mqp() {
             // use existing version id
             const versionKey = `${KEY}${VID_SEP}${VERSION_ID}`;
             const objmd = new ObjectMD()
-                                .setKey(KEY)
-                                .setVersionId(VERSION_ID);
+                .setKey(KEY)
+                .setVersionId(VERSION_ID)
+                .setDataStoreName(LOCATION);
             const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd);
             async.waterfall([
                 next => mongoClient.getBucketAttributes(BUCKET, fakeLogger,
@@ -571,8 +843,17 @@ describe('MongoQueueProcessor', function mqp() {
         });
 
         it('should delete an existing non versioned object from mongo', done => {
-            const objmd = new ObjectMD().setKey(KEY);
-            const entry = new ObjectQueueEntry(BUCKET, KEY, objmd);
+            const objmd = new ObjectMD()
+                .setKey(KEY)
+                .setDataStoreName(LOCATION);
+            const entry = new DeleteOpQueueEntry(BUCKET, KEY);
+            sinon.stub(mqp._mongoClient, 'getObject').yields(null, objmd
+                .setLocation([{
+                    key: KEY,
+                    dataStoreVersionId: '',
+                    dataStoreName: LOCATION,
+                }])
+                .getValue());
             async.waterfall([
                 next => mongoClient.getBucketAttributes(BUCKET, fakeLogger,
                     next),
@@ -585,6 +866,76 @@ describe('MongoQueueProcessor', function mqp() {
                 assert.strictEqual(deleted.length, 1);
                 assert.strictEqual(deleted[0].key, KEY);
                 assert.strictEqual(deleted[0].versionId, undefined);
+                done();
+            });
+        });
+
+        it('should not delete object from mongo when object is in another location', done => {
+            // use existing version id
+            const versionKey = `${KEY}${VID_SEP}${VERSION_ID}`;
+            const entry = new DeleteOpQueueEntry(BUCKET, versionKey);
+            sinon.stub(mqp._mongoClient, 'getObject').yields(null, new ObjectMD()
+                .setKey(KEY)
+                .setVersionId(VERSION_ID)
+                .setDataStoreName('cold')
+                .setLocation([{
+                    key: KEY,
+                    dataStoreVersionId: encode(VERSION_ID),
+                    dataStoreName: LOCATION,
+                }])
+                .getValue());
+            async.waterfall([
+                next => mongoClient.getBucketAttributes(BUCKET, fakeLogger,
+                    next),
+                (bucketInfo, next) => mqp._processDeleteOpQueueEntry(fakeLogger,
+                    entry, LOCATION, next),
+            ], err => {
+                assert.ifError(err);
+
+                const deleted = mqp.getDeleted();
+                assert.strictEqual(deleted.length, 0);
+                done();
+            });
+        });
+
+        it('should not fail if object to delete does not exist anymore in mongo', done => {
+            // use existing version id
+            const versionKey = `${KEY}${VID_SEP}${VERSION_ID}`;
+            const entry = new DeleteOpQueueEntry(BUCKET, versionKey);
+            const deleteObject = sinon.stub(mongoClient, 'deleteObject').yields(errors.NoSuchKey);
+            async.waterfall([
+                next => mongoClient.getBucketAttributes(BUCKET, fakeLogger, next),
+                (bucketInfo, next) => mqp._processDeleteOpQueueEntry(fakeLogger,
+                    entry, LOCATION, next),
+            ], err => {
+                assert.ifError(err);
+
+                assert.ok(deleteObject.calledOnce);
+                assert.strictEqual(deleteObject.getCall(0).args[0], BUCKET);
+                assert.strictEqual(deleteObject.getCall(0).args[1], KEY);
+                assert.strictEqual(deleteObject.getCall(0).args[2].versionId, VERSION_ID);
+
+                done();
+            });
+        });
+
+        it('should fail if deleteObject fails', done => {
+            // use existing version id
+            const versionKey = `${KEY}${VID_SEP}${VERSION_ID}`;
+            const entry = new DeleteOpQueueEntry(BUCKET, versionKey);
+            const deleteObject = sinon.stub(mongoClient, 'deleteObject').yields(errors.InternalError);
+            async.waterfall([
+                next => mongoClient.getBucketAttributes(BUCKET, fakeLogger, next),
+                (bucketInfo, next) => mqp._processDeleteOpQueueEntry(fakeLogger,
+                    entry, LOCATION, next),
+            ], err => {
+                assert.ok(err?.is?.InternalError);
+
+                assert.ok(deleteObject.calledOnce);
+                assert.strictEqual(deleteObject.getCall(0).args[0], BUCKET);
+                assert.strictEqual(deleteObject.getCall(0).args[1], KEY);
+                assert.strictEqual(deleteObject.getCall(0).args[2].versionId, VERSION_ID);
+
                 done();
             });
         });

--- a/tests/functional/ingestion/MongoQueueProcessor.js
+++ b/tests/functional/ingestion/MongoQueueProcessor.js
@@ -849,7 +849,7 @@ describe('MongoQueueProcessor', function mqp() {
                     ...bucketInfo,
                     lifecycleConfiguration: new LifecycleConfiguration(null, { replicationEndpoints: [] }),
                 }),
-                options: { versionId: VERSION_ID },
+                options: { doesNotNeedOpogUpdate: true, versionId: VERSION_ID },
             },
         ].forEach(({
             title, patchBucketInfo, options,
@@ -922,6 +922,8 @@ describe('MongoQueueProcessor', function mqp() {
                     dataStoreVersionId: encode(NEW_VERSION_ID),
                     dataStoreName: LOCATION,
                 }])
+                .setAmzStorageClass('cold')
+                .setArchive(mockArchive)
                 .getValue());
             const deleteObject = sinon.stub(mongoClient, 'deleteObject').callThrough();
             async.waterfall([
@@ -943,10 +945,35 @@ describe('MongoQueueProcessor', function mqp() {
                 assert.deepStrictEqual(deleteObject.getCall(0).args[0], BUCKET);
                 assert.deepStrictEqual(deleteObject.getCall(0).args[1], KEY);
                 assert.deepStrictEqual(deleteObject.getCall(0).args[2], {
-                    doesNotNeedOpogUpdate: true,
                     versionId: VERSION_ID
                 });
 
+                done();
+            });
+        });
+
+        it('should not delete object from mongo when object is archived', done => {
+            // use existing version id
+            const versionKey = `${KEY}${VID_SEP}${VERSION_ID}`;
+            const entry = new DeleteOpQueueEntry(BUCKET, versionKey);
+            sinon.stub(mqp._mongoClient, 'getObject').yields(null, new ObjectMD()
+                .setKey(KEY)
+                .setVersionId(VERSION_ID)
+                .setDataStoreName('cold')
+                .setAmzStorageClass('cold')
+                .setArchive(mockArchive)
+                .setLocation([])
+                .getValue());
+            async.waterfall([
+                next => mongoClient.getBucketAttributes(BUCKET, fakeLogger,
+                    next),
+                (bucketInfo, next) => mqp._processDeleteOpQueueEntry(fakeLogger,
+                    entry, LOCATION, bucketInfo, next),
+            ], err => {
+                assert.ifError(err);
+
+                const deleted = mqp.getDeleted();
+                assert.strictEqual(deleted.length, 0);
                 done();
             });
         });
@@ -964,6 +991,8 @@ describe('MongoQueueProcessor', function mqp() {
                     dataStoreVersionId: encode(VERSION_ID),
                     dataStoreName: LOCATION,
                 }])
+                .setAmzStorageClass('cold')
+                .setArchive(mockArchive)
                 .getValue());
             async.waterfall([
                 next => mongoClient.getBucketAttributes(BUCKET, fakeLogger,

--- a/tests/functional/ingestion/MongoQueueProcessor.js
+++ b/tests/functional/ingestion/MongoQueueProcessor.js
@@ -16,6 +16,7 @@ const authdata = require('../../../conf/authdata.json');
 const ObjectQueueEntry = require('../../../lib/models/ObjectQueueEntry');
 const DeleteOpQueueEntry = require('../../../lib/models/DeleteOpQueueEntry');
 const fakeLogger = require('../../utils/fakeLogger');
+const { ObjectMDArchive } = require('arsenal/build/lib/models');
 
 const kafkaConfig = config.kafka;
 const mongoProcessorConfig = config.extensions.mongoProcessor;
@@ -30,6 +31,12 @@ const LOCATION = 'us-east-1';
 const VERSION_ID = '98445230573829999999RG001  15.144.0';
 // new version id > existing version id
 const NEW_VERSION_ID = '98445235075994999999RG001  14.90.2';
+
+const mockArchive = new ObjectMDArchive(
+    { archiveId: '123456789' },
+    Date.now() - 3600 * 1000, 1,
+    Date.now(), Date.now() + 23 * 3600 * 1000,
+);
 
 const mockReplicationInfo = {
     role: 'arn:aws:iam::root:role/s3-replication-role',
@@ -712,80 +719,21 @@ describe('MongoQueueProcessor', function mqp() {
             });
         });
 
-        it('should save to mongo a new version entry when scal-version-id does not match the data location', done => {
+        it('should not update restored entry', done => {
             const versionKey = `${KEY}${VID_SEP}${NEW_VERSION_ID}`;
             const objmd = new ObjectMD()
                 .setAcl()
                 .setKey(KEY)
-                .setVersionId(NEW_VERSION_ID);
-            const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd)
+                .setVersionId(NEW_VERSION_ID)
                 .setUserMetadata({ 'x-amz-meta-scal-version-id': encode(VERSION_ID) });
-            const getObject = sinon.stub(mongoClient, 'getObject').callThrough();
-            async.waterfall([
-                next => mongoClient.getBucketAttributes(BUCKET, fakeLogger,
-                    next),
-                (bucketInfo, next) => next(null,
-                    bucketInfo.setReplicationConfiguration(null)),
-                (bucketInfo, next) => mqp._processObjectQueueEntry(fakeLogger,
-                    entry, LOCATION, bucketInfo, next),
-            ], err => {
-                assert.ifError(err);
-
-                sinon.assert.calledOnce(getObject);
-
-                const added = mqp.getAdded();
-                assert.strictEqual(added.length, 1);
-                const objVal = added[0].objVal;
-                assert.strictEqual(added[0].key, versionKey);
-                // key shall now be always populated
-                assert.deepStrictEqual(objVal.key, KEY);
-                // acl should reset
-                assert.deepStrictEqual(objVal.acl, new ObjectMD().getAcl());
-                // owner md should update
-                assert.strictEqual(objVal['owner-display-name'],
-                    authdata.accounts[0].name);
-                assert.strictEqual(objVal['owner-id'],
-                    authdata.accounts[0].canonicalID);
-                // dataStoreName should update
-                assert.strictEqual(objVal.dataStoreName, LOCATION);
-                // locations should update, no data in object
-                assert.strictEqual(objVal.location.length, 1);
-                const loc = objVal.location[0];
-                assert.strictEqual(loc.key, KEY);
-                assert.strictEqual(loc.size, 0);
-                assert.strictEqual(loc.start, 0);
-                assert.strictEqual(loc.dataStoreName, LOCATION);
-                assert.strictEqual(loc.dataStoreType, 'aws_s3');
-                assert.strictEqual(decode(loc.dataStoreVersionId),
-                    NEW_VERSION_ID);
-
-                // replication info should be empty
-                const repInfo = objVal.replicationInfo;
-                assert.strictEqual(repInfo.status, '');
-                assert.deepStrictEqual(repInfo.backends, []);
-                assert.deepStrictEqual(repInfo.content, []);
-                assert.strictEqual(repInfo.storageClass, '');
-                assert.strictEqual(repInfo.storageType, '');
-                assert.strictEqual(repInfo.dataStoreVersionId, '');
-
-                done();
-            });
-        });
-
-        it('should skip restored entry scal-version-id', done => {
-            const versionKey = `${KEY}${VID_SEP}${NEW_VERSION_ID}`;
-            const objmd = new ObjectMD()
-                .setAcl()
-                .setKey(KEY)
-                .setVersionId(NEW_VERSION_ID);
-            const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd)
-                .setUserMetadata({ 'x-amz-meta-scal-version-id': encode(VERSION_ID) });
+            const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd);
             const getObject = sinon.stub(mongoClient, 'getObject').yields(null,
                 new ObjectMD()
+                    .setKey(KEY)
                     .setVersionId(VERSION_ID)
-                    .setTags({ mytag: 'mytags-value' })
                     .setDataStoreName(LOCATION)
                     .setAmzStorageClass('cold')
+                    .setArchive(mockArchive)
                     .setLocation([{
                         key: KEY,
                         start: 0,
@@ -811,6 +759,69 @@ describe('MongoQueueProcessor', function mqp() {
 
                 const added = mqp.getAdded();
                 assert.strictEqual(added.length, 0);
+
+                done();
+            });
+        });
+
+        it('should update tags on restored entry', done => {
+            const versionKey = `${KEY}${VID_SEP}${NEW_VERSION_ID}`;
+            const entry = new ObjectQueueEntry(BUCKET, versionKey, new ObjectMD()
+                .setAcl()
+                .setKey(KEY)
+                .setTags({ mytag: 'mytags-value' })
+                .setVersionId(NEW_VERSION_ID)
+                .setUserMetadata({ 'x-amz-meta-scal-version-id': encode(VERSION_ID) }));
+            const objmd = new ObjectMD()
+                .setKey(KEY)
+                .setVersionId(VERSION_ID)
+                .setDataStoreName(LOCATION)
+                .setAmzStorageClass('cold')
+                .setArchive(mockArchive)
+                .setLocation([{
+                    key: KEY,
+                    start: 0,
+                    size: 50,
+                    dataStoreName: LOCATION,
+                    dataStoreVersionId: NEW_VERSION_ID,
+                }]);
+            const getObject = sinon.stub(mongoClient, 'getObject').yields(null, objmd.getValue());
+            async.waterfall([
+                next => mongoClient.getBucketAttributes(BUCKET, fakeLogger,
+                    next),
+                (bucketInfo, next) => mqp._processObjectQueueEntry(fakeLogger,
+                    entry, LOCATION, bucketInfo, next),
+            ], err => {
+                assert.ifError(err);
+
+                sinon.assert.calledOnce(getObject);
+                assert.strictEqual(getObject.getCall(0).args[0], BUCKET);
+                assert.strictEqual(getObject.getCall(0).args[1], KEY);
+                assert.strictEqual(getObject.getCall(0).args[2].versionId, VERSION_ID);
+
+                const added = mqp.getAdded();
+                assert.strictEqual(added.length, 1);
+
+                // Expect tags and replicationInfo to have been updated
+                const objVal = added[0].objVal;
+                assert.deepStrictEqual(objVal, objmd
+                    .setTags({ mytag: 'mytags-value' })
+                    .setReplicationInfo({
+                        backends: [{
+                            dataStoreVersionId: '',
+                            site: 'test-site-2',
+                            status: 'PENDING'
+                        }],
+                        content: ['METADATA', 'PUT_TAGGING'],
+                        dataStoreVersionId: '',
+                        destination: 'arn:aws:s3:::mqp-test-bucket',
+                        isNFS: null,
+                        role: 'arn:aws:iam::root:role/s3-replication-role',
+                        status: 'PENDING',
+                        storageClass: 'test-site-2',
+                        storageType: 'aws_s3'
+                    })
+                    .getValue());
 
                 done();
             });

--- a/tests/functional/ingestion/MongoQueueProcessor.js
+++ b/tests/functional/ingestion/MongoQueueProcessor.js
@@ -907,6 +907,50 @@ describe('MongoQueueProcessor', function mqp() {
             });
         });
 
+        it('should use scal-version-id overhead field', done => {
+            // use existing version id
+            const versionKey = `${KEY}${VID_SEP}${NEW_VERSION_ID}`;
+            const entry = new DeleteOpQueueEntry(BUCKET, versionKey, {
+                'x-amz-meta-scal-version-id': encode(VERSION_ID),
+            });
+            const getObject = sinon.stub(mongoClient, 'getObject').yields(null, new ObjectMD()
+                .setKey(KEY)
+                .setVersionId(VERSION_ID)
+                .setDataStoreName(LOCATION)
+                .setLocation([{
+                    key: KEY,
+                    dataStoreVersionId: encode(NEW_VERSION_ID),
+                    dataStoreName: LOCATION,
+                }])
+                .getValue());
+            const deleteObject = sinon.stub(mongoClient, 'deleteObject').callThrough();
+            async.waterfall([
+                next => mongoClient.getBucketAttributes(BUCKET, fakeLogger,
+                    next),
+                (bucketInfo, next) => mqp._processDeleteOpQueueEntry(fakeLogger,
+                    entry, LOCATION, bucketInfo, next),
+            ], err => {
+                assert.ifError(err);
+
+                sinon.assert.calledOnce(getObject);
+                assert.deepStrictEqual(deleteObject.getCall(0).args[0], BUCKET);
+                assert.deepStrictEqual(deleteObject.getCall(0).args[1], KEY);
+                assert.deepStrictEqual(deleteObject.getCall(0).args[2], {
+                    versionId: VERSION_ID
+                });
+
+                sinon.assert.calledOnce(deleteObject);
+                assert.deepStrictEqual(deleteObject.getCall(0).args[0], BUCKET);
+                assert.deepStrictEqual(deleteObject.getCall(0).args[1], KEY);
+                assert.deepStrictEqual(deleteObject.getCall(0).args[2], {
+                    doesNotNeedOpogUpdate: true,
+                    versionId: VERSION_ID
+                });
+
+                done();
+            });
+        });
+
         it('should not delete object from mongo when object is in another location', done => {
             // use existing version id
             const versionKey = `${KEY}${VID_SEP}${VERSION_ID}`;

--- a/tests/functional/ingestion/MongoQueueProcessor.js
+++ b/tests/functional/ingestion/MongoQueueProcessor.js
@@ -16,7 +16,7 @@ const authdata = require('../../../conf/authdata.json');
 const ObjectQueueEntry = require('../../../lib/models/ObjectQueueEntry');
 const DeleteOpQueueEntry = require('../../../lib/models/DeleteOpQueueEntry');
 const fakeLogger = require('../../utils/fakeLogger');
-const { ObjectMDArchive } = require('arsenal/build/lib/models');
+const { ObjectMDArchive, LifecycleConfiguration, NotificationConfiguration } = require('arsenal/build/lib/models');
 
 const kafkaConfig = config.kafka;
 const mongoProcessorConfig = config.extensions.mongoProcessor;
@@ -829,19 +829,41 @@ describe('MongoQueueProcessor', function mqp() {
     });
 
     describe('::_processDeleteOpQueueEntry', () => {
-        it('should delete an existing versioned object from mongo', done => {
+        [
+            {
+                title: '',
+                patchBucketInfo: (bucketInfo, next) => next(null, bucketInfo),
+                options: { doesNotNeedOpogUpdate: true, versionId: VERSION_ID },
+            },
+            {
+                title: ' with bucket notification',
+                patchBucketInfo: (bucketInfo, next) => next(null, {
+                    ...bucketInfo,
+                    notificationConfiguration: new NotificationConfiguration(),
+                }),
+                options: { versionId: VERSION_ID },
+            },
+            {
+                title: ' with lifecycle configuration',
+                patchBucketInfo: (bucketInfo, next) => next(null, {
+                    ...bucketInfo,
+                    lifecycleConfiguration: new LifecycleConfiguration(null, { replicationEndpoints: [] }),
+                }),
+                options: { versionId: VERSION_ID },
+            },
+        ].forEach(({
+            title, patchBucketInfo, options,
+        }) => it(`should delete an existing versioned object from mongo${title}`, done => {
             // use existing version id
             const versionKey = `${KEY}${VID_SEP}${VERSION_ID}`;
-            const objmd = new ObjectMD()
-                .setKey(KEY)
-                .setVersionId(VERSION_ID)
-                .setDataStoreName(LOCATION);
-            const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd);
+            const entry = new DeleteOpQueueEntry(BUCKET, versionKey);
+            const deleteObject = sinon.stub(mongoClient, 'deleteObject').callThrough();
             async.waterfall([
                 next => mongoClient.getBucketAttributes(BUCKET, fakeLogger,
                     next),
+                patchBucketInfo,
                 (bucketInfo, next) => mqp._processDeleteOpQueueEntry(fakeLogger,
-                    entry, LOCATION, next),
+                    entry, LOCATION, bucketInfo, next),
             ], err => {
                 assert.ifError(err);
 
@@ -849,9 +871,13 @@ describe('MongoQueueProcessor', function mqp() {
                 assert.strictEqual(deleted.length, 1);
                 assert.strictEqual(deleted[0].key, KEY);
                 assert.strictEqual(deleted[0].versionId, VERSION_ID);
+
+                sinon.assert.calledOnce(deleteObject);
+                assert.deepStrictEqual(deleteObject.getCall(0).args[2], options);
+
                 done();
             });
-        });
+        }));
 
         it('should delete an existing non versioned object from mongo', done => {
             const objmd = new ObjectMD()
@@ -869,7 +895,7 @@ describe('MongoQueueProcessor', function mqp() {
                 next => mongoClient.getBucketAttributes(BUCKET, fakeLogger,
                     next),
                 (bucketInfo, next) => mqp._processDeleteOpQueueEntry(fakeLogger,
-                    entry, LOCATION, next),
+                    entry, LOCATION, bucketInfo, next),
             ], err => {
                 assert.ifError(err);
 
@@ -899,7 +925,7 @@ describe('MongoQueueProcessor', function mqp() {
                 next => mongoClient.getBucketAttributes(BUCKET, fakeLogger,
                     next),
                 (bucketInfo, next) => mqp._processDeleteOpQueueEntry(fakeLogger,
-                    entry, LOCATION, next),
+                    entry, LOCATION, bucketInfo, next),
             ], err => {
                 assert.ifError(err);
 
@@ -917,14 +943,17 @@ describe('MongoQueueProcessor', function mqp() {
             async.waterfall([
                 next => mongoClient.getBucketAttributes(BUCKET, fakeLogger, next),
                 (bucketInfo, next) => mqp._processDeleteOpQueueEntry(fakeLogger,
-                    entry, LOCATION, next),
+                    entry, LOCATION, bucketInfo, next),
             ], err => {
                 assert.ifError(err);
 
                 assert.ok(deleteObject.calledOnce);
                 assert.strictEqual(deleteObject.getCall(0).args[0], BUCKET);
                 assert.strictEqual(deleteObject.getCall(0).args[1], KEY);
-                assert.strictEqual(deleteObject.getCall(0).args[2].versionId, VERSION_ID);
+                assert.deepStrictEqual(deleteObject.getCall(0).args[2], {
+                    doesNotNeedOpogUpdate: true,
+                    versionId: VERSION_ID
+                });
 
                 done();
             });
@@ -938,14 +967,17 @@ describe('MongoQueueProcessor', function mqp() {
             async.waterfall([
                 next => mongoClient.getBucketAttributes(BUCKET, fakeLogger, next),
                 (bucketInfo, next) => mqp._processDeleteOpQueueEntry(fakeLogger,
-                    entry, LOCATION, next),
+                    entry, LOCATION, bucketInfo, next),
             ], err => {
                 assert.ok(err?.is?.InternalError);
 
                 assert.ok(deleteObject.calledOnce);
                 assert.strictEqual(deleteObject.getCall(0).args[0], BUCKET);
                 assert.strictEqual(deleteObject.getCall(0).args[1], KEY);
-                assert.strictEqual(deleteObject.getCall(0).args[2].versionId, VERSION_ID);
+                assert.deepStrictEqual(deleteObject.getCall(0).args[2], {
+                    doesNotNeedOpogUpdate: true,
+                    versionId: VERSION_ID,
+                });
 
                 done();
             });

--- a/tests/unit/lib/queuePopulator/LogReader.spec.js
+++ b/tests/unit/lib/queuePopulator/LogReader.spec.js
@@ -117,7 +117,6 @@ describe('LogReader', () => {
             overheadFields: {
                 commitTimestamp: record.timestamp,
                 opTimestamp: '2023-11-29T15:05:57.065Z',
-                versionId: undefined,
             },
         };
         assert(mockExtension.filter.firstCall.calledWith(expectedArgs));
@@ -163,7 +162,6 @@ describe('LogReader', () => {
             overheadFields: {
                 commitTimestamp: record.timestamp,
                 opTimestamp: '2023-11-29T15:05:57.065Z',
-                versionId: undefined,
             },
         };
         assert(mockExtension.filter.firstCall.calledWith(expectedArgs));
@@ -295,7 +293,6 @@ describe('LogReader', () => {
                         overheadFields: {
                             commitTimestamp: date,
                             opTimestamp: date,
-                            versionId: undefined,
                             ...params.overhead,
                         },
                     }));


### PR DESCRIPTION
Core idea is to consider that OOB does not sync the whole bucket, but only the objects which are indeed in the OOB location : there may be objects in Zenko which are not in Metadata, as long as they are not marked as present in that location.

This requires just a few changes:
* Delete operations ignore objects whose dataStoreLocation is not the OOB location itself. This fixes most of the issues, and allows transitioning objects from S3C to cold stoage (they get removed from S3C completely at the end of the transition).
* When object is restored, cloudserver will now add an extra user metadata (`x-amz-meta-scal-version-id`): this is used to ensure we do not duplicate the object when it is restored.
* Finally, need to tweak the way _updates_ (not actual ingestions) from S3C are processed, to ensure we keep the extra Zenko fields (esp. transition or cold storage fields), while updating only what is expected: i.e. only tags.

Issue: BB-590
