### PR TITLE
BB-649 Lifecycle should expire CRR REPLICA objects

### DIFF
--- a/extensions/lifecycle/tasks/LifecycleDeleteObjectTask.js
+++ b/extensions/lifecycle/tasks/LifecycleDeleteObjectTask.js
@@ -201,8 +201,9 @@ class LifecycleDeleteObjectTask extends BackbeatTask {
                 return done(err);
             }
             const replicationStatus = objMD.getReplicationStatus();
-            if (replicationStatus && replicationStatus !== 'COMPLETED') {
-                const error = new PendingReplicationError('object has a pending replication status');
+            if (['PENDING', 'PROCESSING', 'FAILED'].includes(replicationStatus)) {
+                const error = new PendingReplicationError(
+                    `object has a pending replication status: ${replicationStatus}`);
                 return done(error);
             }
             return done();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "7.10.19",
+  "version": "7.10.20",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/lifecycle/LifecycleDeleteObjectTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleDeleteObjectTask.spec.js
@@ -111,6 +111,7 @@ describe('LifecycleDeleteObjectTask', () => {
 
     [
         'COMPLETED',
+        'REPLICA',
         undefined,
     ].forEach(status => {
         it(`should delete replicating object with status: ${status}`, done => {


### PR DESCRIPTION
**Context:**
In replication, multiple statuses can indicate the replication state. These statuses are stored in an object's metadata under the property `replicationStatus`:

- `PENDING`: Assigned to the source object's metadata. When a CRR (Cross-Region Replication) configuration is enabled on a bucket, any S3 PUT or metadata operations on matching objects set their status to PENDING.
- `PROCESSING`: Assigned to the source object's metadata if there are multiple CRR destinations and some replication tasks are still pending.
- `FAILED`: Assigned to the source object's metadata if replication to any CRR destination has failed.
- `COMPLETED`: Assigned to the source object's metadata when replication to all CRR destinations has successfully finished.
- `REPLICA`: Assigned to the destination object's metadata once the data has been successfully copied.
- `undefined`: Indicates that no replication configuration has been set up for the object.

**Issue**
We introduced a whitelist of object statuses for lifecycle rules, but only included undefined and `COMPLETED`. We accidentally left out `REPLICA`.

**Impact**
Because `REPLICA` wasn’t included, lifecycle rules don’t clean up objects in CRR target buckets. This can cause major issues like running out of disk space and slower listings due to too many delete markers.

**Fix**
We’re reverting back to the old approach of using a blacklist for specific replication statuses (`PENDING`, `PROCESSING`, and `FAILED`).