### PR TITLE
EnsureServiceUser: global command options not accessible after bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,8 @@ COPY . /usr/src/app
 COPY --from=builder /usr/src/app/node_modules ./node_modules/
 COPY --from=builder /usr/local/bin/dockerize /usr/local/bin/
 
+ENV AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE=1
+
 ENTRYPOINT ["tini", "--", "/usr/src/app/docker-entrypoint.sh"]
 
 EXPOSE 8900

--- a/bin/ensureServiceUser
+++ b/bin/ensureServiceUser
@@ -369,15 +369,17 @@ function apply(iamClient, stsClient, serviceName, policyFile, log, cb) {
     ], cb);
 }
 
-function wrapAction(actionFunc, serviceName, options) {
+function wrapAction(actionFunc, serviceName, _, cmd) {
+    const options = cmd.optsWithGlobals();
+
     werelogs.configure({
-        level: options.parent.logLevel,
-        dump: options.parent.logDumpLevel,
+        level: options.logLevel,
+        dump: options.logDumpLevel,
     });
 
     const log = new werelogs.Logger(process.argv[1]).newRequestLogger();
-    const iamClient = createIAMClient(options.parent);
-    const stsClient = createSTSClient(options.parent);
+    const iamClient = createIAMClient(options);
+    const stsClient = createSTSClient(options);
 
     actionFunc(iamClient, stsClient, serviceName, options.policy, log, (err, data) => {
         if (err) {

--- a/lib/models/QueueEntry.js
+++ b/lib/models/QueueEntry.js
@@ -27,7 +27,7 @@ class QueueEntry {
             }
             let entry;
             if (record.type === 'del') {
-                const overheadFields = JSON.parse(record.overheadFields);
+                const overheadFields = record.overheadFields && JSON.parse(record.overheadFields);
                 entry = new DeleteOpQueueEntry(record.bucket, record.key, overheadFields);
             } else if (record.bucket === usersBucket) {
                 // BucketQueueEntry class just handles puts of keys

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.0.1",
+  "version": "9.0.2",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/lib/models/ObjectQueueEntry.spec.js
+++ b/tests/unit/lib/models/ObjectQueueEntry.spec.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 
 const QueueEntry = require('../../../../lib/models/QueueEntry');
 const { replicationEntry } = require('../../../utils/kafkaEntries');
+const DeleteOpQueueEntry = require('../../../../lib/models/DeleteOpQueueEntry');
 
 describe('ObjectQueueEntry', () => {
     describe('toRetryEntry', () => {
@@ -17,6 +18,34 @@ describe('ObjectQueueEntry', () => {
             const retryEntry = entry.toRetryEntry('sf');
             assert.strictEqual(retryEntry.getReplicationBackends().length, 1);
             assert.strictEqual(retryEntry.getReplicationBackends()[0].site, 'sf');
+        });
+    });
+    describe('createFromKafkaEntry', () => {
+        it('should create a DeleteOpQueueEntry without overhead fields', () => {
+            const entry = QueueEntry.createFromKafkaEntry({
+                value: JSON.stringify({
+                    type: 'del',
+                    bucket: 'bucket',
+                    key: 'key',
+                }),
+            });
+            assert(entry instanceof DeleteOpQueueEntry);
+            assert.strictEqual(entry.getBucket(), 'bucket');
+            assert.strictEqual(entry.getKey(), 'key');
+        });
+        it('should create a DeleteOpQueueEntry with overhead fields', () => {
+            const entry = QueueEntry.createFromKafkaEntry({
+                value: JSON.stringify({
+                    type: 'del',
+                    bucket: 'bucket',
+                    key: 'key',
+                    overheadFields: JSON.stringify({ foo: 'bar' }),
+                }),
+            });
+            assert(entry instanceof DeleteOpQueueEntry);
+            assert.strictEqual(entry.getBucket(), 'bucket');
+            assert.strictEqual(entry.getKey(), 'key');
+            assert.deepStrictEqual(entry.getOverheadField('foo'), 'bar');
         });
     });
 });


### PR DESCRIPTION
- ensureServiceUser: fix global options not accessible in action function after bump of commander
- Suppress AWS SDK maintenance warnings (breaks the operator logic for getting service user credentials in the logs)
- Fix OOB delete events always expected to contain overhead fields (only supported in recent versions of S3C)

Issue: BB-656