### PR TITLE
Support AssumeRole in CRR

### DIFF
--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -15,7 +15,7 @@ const CRR_FAILURE_EXPIRY = 24 * 60 * 60; // Expire Redis keys after 24 hours.
 const OBJECT_SIZE_METRICS = [66560, 8388608, 68157440];
 
 const destinationAuthJoi = joi.object({
-    type: joi.alternatives().try('account', 'role', 'service')
+    type: joi.alternatives().try('account', 'role', 'service', 'assumeRole')
         .required(),
     account: joi.string()
         .when('type', { is: 'account', then: joi.required() }),
@@ -25,6 +25,8 @@ const destinationAuthJoi = joi.object({
         adminPort: joi.number().greater(0).optional(),
         adminCredentialsFile: joi.string().optional(),
     }).when('type', { is: 'role', then: joi.required() }),
+    sts: hostPortJoi
+        .when('type', { is: 'assumeRole', then: joi.required() }),
 });
 
 const joiSchema = joi.object({

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -14,6 +14,19 @@ const qpRetryJoi = joi.object({
 const CRR_FAILURE_EXPIRY = 24 * 60 * 60; // Expire Redis keys after 24 hours.
 const OBJECT_SIZE_METRICS = [66560, 8388608, 68157440];
 
+const destinationAuthJoi = joi.object({
+    type: joi.alternatives().try('account', 'role', 'service')
+        .required(),
+    account: joi.string()
+        .when('type', { is: 'account', then: joi.required() }),
+    vault: joi.object({
+        host: joi.string().optional(),
+        port: joi.number().greater(0).optional(),
+        adminPort: joi.number().greater(0).optional(),
+        adminCredentialsFile: joi.string().optional(),
+    }).when('type', { is: 'role', then: joi.required() }),
+});
+
 const joiSchema = joi.object({
     source: {
         transport: transportJoi,
@@ -36,22 +49,22 @@ const joiSchema = joi.object({
             }).when('type', { is: 'role', then: joi.required() }),
         }).required(),
     },
-    destination: {
+    destination: joi.object({
         transport: transportJoi,
-        auth: joi.object({
-            type: joi.alternatives().try('account', 'role', 'service')
-                .required(),
-            account: joi.string()
-                .when('type', { is: 'account', then: joi.required() }),
-            vault: joi.object({
-                host: joi.string().optional(),
-                port: joi.number().greater(0).optional(),
-                adminPort: joi.number().greater(0).optional(),
-                adminCredentialsFile: joi.string().optional(),
-            }),
-        }).required(),
+        auth: destinationAuthJoi.optional(),
+        sites: joi.object().pattern(
+            joi.string(), // site name
+            joi.object({
+                transport: transportJoi,
+                auth: destinationAuthJoi,
+            }).required()
+        ).when('auth', {
+            is: joi.exist(),
+            then: joi.optional(),
+            otherwise: joi.required(),
+        }),
         bootstrapList: bootstrapListJoi,
-    },
+    }).required().custom(_validatePerSiteDestinationConfig),
     topic: joi.string().required(),
     dataMoverTopic: joi.string().optional(),
     replicationStatusTopic: joi.string().required(),
@@ -90,6 +103,33 @@ const joiSchema = joi.object({
     objectSizeMetrics: joi.array().items(joi.number()).default(OBJECT_SIZE_METRICS),
 });
 
+/**
+ * When using per site configuration, validate that there is an auth
+ * and transport configuration for each site in the bootstrap list.
+ * @param {Object} authConfig - auth config
+ * @param {joi.CustomHelpers} helpers  - joi helpers
+ * @returns {Object|joi.ErrorReport} - auth config when validated or a joi error
+ */
+function _validatePerSiteDestinationConfig(destination, helpers) {
+    // destination.auth and destination.transport is used as a default for all sites
+    // no need to check destination.transport as it has a default value and is always set.
+    if (destination.auth) {
+        return destination;
+    }
+    const missingConfigs = [];
+    destination.bootstrapList.forEach(b => {
+        if (!destination.sites?.[b.site]?.auth) {
+            missingConfigs.push(b.site);
+        }
+    });
+    if (missingConfigs.length > 0) {
+        return helpers.message({
+            custom: `missing destination configuration for sites: ${missingConfigs.join(',')}`
+        });
+    }
+    return destination;
+}
+
 function _loadAdminCredentialsFromFile(filePath) {
     const adminCredsJSON = fs.readFileSync(filePath);
     const adminCredsObj = JSON.parse(adminCredsJSON);
@@ -103,7 +143,6 @@ function _loadAdminCredentialsFromFile(filePath) {
 function configValidator(backbeatConfig, extConfig) {
     const validatedConfig = joi.attempt(extConfig, joiSchema);
     const { source, destination } = validatedConfig;
-
     if (source.auth.vault) {
         const { adminCredentialsFile } = source.auth.vault;
         if (adminCredentialsFile) {
@@ -111,12 +150,24 @@ function configValidator(backbeatConfig, extConfig) {
                 _loadAdminCredentialsFromFile(adminCredentialsFile);
         }
     }
-    if (destination.auth.vault) {
+    if (destination.auth?.vault) {
         const { adminCredentialsFile } = destination.auth.vault;
         if (adminCredentialsFile) {
             destination.auth.vault.adminCredentials =
                 _loadAdminCredentialsFromFile(adminCredentialsFile);
         }
+    }
+    if (destination.sites) {
+        Object.values(destination.sites).forEach(site => {
+            if (site.auth?.vault) {
+                const { adminCredentialsFile } = site.auth.vault;
+                if (adminCredentialsFile) {
+                    // eslint-disable-next-line no-param-reassign
+                    site.auth.vault.adminCredentials =
+                        _loadAdminCredentialsFromFile(adminCredentialsFile);
+                }
+            }
+        });
     }
     return validatedConfig;
 }

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -169,23 +169,31 @@ function initAndStart(zkClient) {
         log.info('management init done');
 
         const bootstrapList = config.getBootstrapList();
+        const siteNames = bootstrapList.map(i => i.site);
 
-        const destConfig = Object.assign({}, repConfig.destination);
-        destConfig.bootstrapList = bootstrapList;
+        // initialize per site destination configs
+        const destConfig = {};
+        siteNames.forEach(site => {
+            destConfig[site] = config.getReplicationSiteDestConfig(site);
+        });
 
         config.on('bootstrap-list-update', () => {
-            destConfig.bootstrapList = config.getBootstrapList();
-
+            const updatedBootstrapList = config.getBootstrapList();
             const activeSites = Object.keys(activeQProcessors);
-            const updatedSites = destConfig.bootstrapList.map(i => i.site);
+            const updatedSites = updatedBootstrapList.map(i => i.site);
             const allSites = [...new Set(activeSites.concat(updatedSites))];
 
             async.each(allSites, (site, next) => {
                 if (updatedSites.includes(site)) {
+                    if (!destConfig[site]) {
+                        destConfig[site] = config.getReplicationSiteDestConfig(site);
+                    } else {
+                        destConfig[site].bootstrapList = updatedBootstrapList;
+                    }
                     if (!activeSites.includes(site)) {
                         const qp = new QueueProcessor(
                             topic, zkConfig, zkClient, kafkaConfig,
-                            sourceConfig, destConfig,
+                            sourceConfig, destConfig[site],
                             repConfig, redisConfig, mConfig,
                             httpsConfig, internalHttpsConfig,
                             site, repConfig.queueProcessor.circuitBreaker);
@@ -206,6 +214,7 @@ function initAndStart(zkClient) {
                         }
                         activeQProcessors[site].stop(() => { });
                         delete activeQProcessors[site];
+                        delete destConfig[site];
                         return next();
                     });
                 }
@@ -217,11 +226,10 @@ function initAndStart(zkClient) {
         });
 
         // Start QueueProcessor for each site
-        const siteNames = bootstrapList.map(i => i.site);
         async.each(siteNames, (site, next) => {
             const qp = new QueueProcessor(
                 topic, zkConfig, zkClient, kafkaConfig,
-                sourceConfig, destConfig, repConfig, redisConfig,
+                sourceConfig, destConfig[site], repConfig, redisConfig,
                 mConfig, httpsConfig, internalHttpsConfig,
                 site, repConfig.queueProcessor.circuitBreaker);
             activeQProcessors[site] = qp;

--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -5,6 +5,7 @@ const errors = require('arsenal').errors;
 const jsutil = require('arsenal').jsutil;
 const ObjectMDLocation = require('arsenal').models.ObjectMDLocation;
 
+const ClientManager = require('../../../lib/clients/ClientManager');
 const BackbeatClient = require('../../../lib/clients/BackbeatClient');
 const BackbeatMetadataProxy = require('../../../lib/BackbeatMetadataProxy');
 
@@ -17,11 +18,17 @@ const RoleCredentials = require('../../../lib/credentials/RoleCredentials');
 const { metricsExtension, metricsTypeQueued, metricsTypeCompleted, replicationStages } = require('../constants');
 
 const ObjectQueueEntry = require('../../../lib/models/ObjectQueueEntry');
+const { authTypeAssumeRole } = require('../../../lib/constants');
+const locations = require('../../../conf/locationConfig.json');
 
 const errorAlreadyCompleted = {};
 
 function _extractAccountIdFromRole(role) {
     return role.split(':')[4];
+}
+
+function _extractRoleNameFromRole(role) {
+    return role.split(':role/')[1];
 }
 
 // BACKBEAT_INJECT_REPLICATION_ERROR_RATE variable can be set to randomly introduce errors.
@@ -716,11 +723,38 @@ class ReplicateObject extends BackbeatTask {
     }
 
     _setupDestClients(targetRole, log) {
+        this.destBackbeatHost = this.destHosts.pickHost();
+
+        if (this.destConfig.auth.type === authTypeAssumeRole) {
+            const accountId = _extractAccountIdFromRole(targetRole);
+            const roleName = _extractRoleNameFromRole(targetRole);
+            this.clientManager = new ClientManager({
+                id: accountId,
+                authConfig: {
+                    type: authTypeAssumeRole,
+                    roleName,
+                    sts: {
+                        ...this.destConfig.auth.sts,
+                        accessKey: locations[this.site].details.credentials.accessKey,
+                        secretKey: locations[this.site].details.credentials.secretKey,
+                    },
+                },
+                s3Config: {
+                    host: this.destBackbeatHost.host,
+                    port: this.destBackbeatHost.port,
+                },
+                transport: this.destConfig.transport,
+            }, this.logger);
+            this.clientManager.initSTSConfig();
+            this.clientManager.initCredentialsManager();
+            this.backbeatDest = this.clientManager.getBackbeatClient(accountId);
+            return;
+        }
+
         this.s3destCredentials =
             this._createCredentials('target', this.destConfig.auth,
                 targetRole, log);
 
-        this.destBackbeatHost = this.destHosts.pickHost();
         this.backbeatDest = new BackbeatClient({
             endpoint: `${this.destConfig.transport}://` +
                 `${this.destBackbeatHost.host}:${this.destBackbeatHost.port}`,

--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -103,6 +103,13 @@ class ReplicateObject extends BackbeatTask {
         }
         this._setupDestClients(this.targetRole, log);
 
+        // Destination Vault admin API is not accessible when
+        // using assumeRole i.e when targeting an Zenko
+        // We delegate this task to the destination's Cloudserver
+        if (this.destConfig.auth.type === authTypeAssumeRole) {
+            return process.nextTick(cb);
+        }
+
         return this.retry({
             actionDesc: 'lookup target account attributes',
             logFields: { entry: destEntry.getLogInfo() },
@@ -584,6 +591,14 @@ class ReplicateObject extends BackbeatTask {
         });
         const cbOnce = jsutil.once(cb);
 
+        // accountid is only needed when using assumeRole auth
+        // to delegate the task of updating metadata with
+        // the target account info to the destination's Cloudserver
+        let accountId = undefined;
+        if (this.destConfig.auth.type === authTypeAssumeRole) {
+            accountId = _extractAccountIdFromRole(this.targetRole);
+        }
+
         // sends extra header x-scal-replication-content to the target
         // if it's a metadata operation only
         const replicationContent = (mdOnly ? 'METADATA' : undefined);
@@ -592,6 +607,7 @@ class ReplicateObject extends BackbeatTask {
             Bucket: entry.getBucket(),
             Key: entry.getObjectKey(),
             VersionId: entry.getEncodedVersionId(),
+            AccountId: accountId,
             ContentLength: Buffer.byteLength(mdBlob),
             Body: mdBlob,
             ReplicationContent: replicationContent,

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -302,6 +302,20 @@ class Config extends EventEmitter {
                                 .update(instanceId)
                                 .digest('hex');
     }
+
+    /**
+     * returns the queue processor's site specific destination configuration
+     * @param {string} site - site name
+     * @returns {object} site specific destination configuration
+     */
+    getReplicationSiteDestConfig(site) {
+        const destConfig = this.extensions.replication.destination;
+        return {
+            transport: destConfig.sites?.[site]?.transport || destConfig.transport,
+            auth: destConfig.sites?.[site]?.auth || destConfig.auth,
+            bootstrapList: this.bootstrapList,
+        };
+    }
 }
 
 module.exports = new Config();

--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -727,6 +727,11 @@
                         "location": "querystring",
                         "locationName": "versionId"
                     },
+                    "AccountId": {
+                        "type": "string",
+                        "location": "querystring",
+                        "locationName": "accountId"
+                    },
                     "ContentLength": {
                         "location": "header",
                         "locationName": "Content-Length",

--- a/tests/unit/conf/Config.js
+++ b/tests/unit/conf/Config.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert');
 const joi = require('joi');
+const sinon = require('sinon');
 const config = require('../../../lib/Config');
 const { Config } = require('../../../lib/Config');
 const { authJoi, inheritedAuthJoi } = require('../../../lib/config/configItems.joi');
@@ -87,5 +88,69 @@ describe('Site name', () => {
         const expectedBootstrapList = conf.bootstrapList;
         const newConfig = new Config();
         assert.deepStrictEqual(newConfig.bootstrapList, expectedBootstrapList);
+    });
+});
+
+describe('Config', () => {
+    describe('getReplicationSiteDestConfig', () => {
+        let ogConfigFileEnv;
+        before(() => {
+            ogConfigFileEnv = process.env.BACKBEAT_CONFIG_FILE;
+        });
+        afterEach(() => {
+            sinon.restore();
+        });
+        after(() => {
+            if (ogConfigFileEnv) {
+                process.env.BACKBEAT_CONFIG_FILE = ogConfigFileEnv;
+            }
+        });
+        it('should return replication site destination config', () => {
+            process.env.BACKBEAT_CONFIG_FILE = `${__dirname}/configs/replicationMultiDestConfig.json`;
+            const conf = new Config();
+            const destConfig = conf.getReplicationSiteDestConfig('aws3');
+            assert.deepStrictEqual(destConfig, {
+                transport: 'https',
+                auth: {
+                    type: 'service',
+                    account: 'service-replication-3',
+                },
+                bootstrapList: [
+                    { site: 'aws1', type: 'aws_s3' },
+                    { site: 'aws2', type: 'aws_s3' },
+                    { site: 'aws3', type: 'aws_s3' }
+                ]
+            });
+        });
+
+        it('should return default replication destination config when site one is not available', () => {
+            process.env.BACKBEAT_CONFIG_FILE = `${__dirname}/configs/replicationMultiDestConfig.json`;
+            const conf = new Config();
+            sinon.stub(conf.extensions.replication, 'destination').value({
+                transport: 'https',
+                auth: {
+                    type: 'service',
+                    account: 'service-replication',
+                },
+                bootstrapList: [
+                    { site: 'aws1', type: 'aws_s3' },
+                    { site: 'aws2', type: 'aws_s3' },
+                    { site: 'aws3', type: 'aws_s3' }
+                ]
+            });
+            const destConfig = conf.getReplicationSiteDestConfig('aws3');
+            assert.deepStrictEqual(destConfig, {
+                transport: 'https',
+                auth: {
+                    type: 'service',
+                    account: 'service-replication',
+                },
+                bootstrapList: [
+                    { site: 'aws1', type: 'aws_s3' },
+                    { site: 'aws2', type: 'aws_s3' },
+                    { site: 'aws3', type: 'aws_s3' }
+                ]
+            });
+        });
     });
 });

--- a/tests/unit/conf/configs/replicationMultiDestConfig.json
+++ b/tests/unit/conf/configs/replicationMultiDestConfig.json
@@ -1,0 +1,214 @@
+{
+    "zookeeper": {
+        "connectionString": "127.0.0.1:2181/backbeat",
+        "autoCreateNamespace": false
+    },
+    "kafka": {
+        "hosts": "127.0.0.1:9092",
+        "backlogMetrics": {
+            "zkPath": "/backbeat/run/kafka-backlog-metrics",
+            "intervalS": 60
+        },
+        "maxRequestSize": 5000020
+    },
+    "s3": {
+        "host": "127.0.0.1",
+        "port": 8000
+    },
+    "vaultAdmin": {
+        "host": "127.0.0.1",
+        "port": 8500
+    },
+    "replicationGroupId": "RG001  ",
+    "queuePopulator": {
+        "cronRule": "*/5 * * * * *",
+        "batchMaxRead": 10000,
+        "batchTimeoutMs": 9000,
+        "zookeeperPath": "/queue-populator",
+        "logSource": "mongo",
+        "bucketd": {
+            "host": "127.0.0.1",
+            "port": 9000
+        },
+        "dmd": {
+            "host": "127.0.0.1",
+            "port": 9990
+        },
+        "mongo": {
+            "replicaSetHosts":
+                "localhost:27017,localhost:27018,localhost:27019",
+            "writeConcern": "majority",
+            "replicaSet": "rs0",
+            "readPreference": "primary",
+            "database": "metadata"
+        },
+        "kafka": {
+            "topic": "backbeat-oplog",
+            "consumerGroupId": "backbeat-qp-oplog-group"
+        },
+        "probeServer": {
+            "bindAddress": "0.0.0.0",
+            "port": 4042
+        }
+    },
+    "extensions": {
+        "replication": {
+            "source": {
+                "transport": "http",
+                "s3": {
+                    "host": "127.0.0.1",
+                    "port": 8000
+                },
+                "auth": {
+                    "type": "service",
+                    "account": "service-replication",
+                    "vault": {
+                        "host": "127.0.0.1",
+                        "port": 8500,
+                        "adminPort": 8600
+                    }
+                }
+            },
+            "destination": {
+                "transport": "http",
+                "sites": {
+                    "aws1": {
+                        "transport": "http",
+                        "auth": {
+                            "type": "service",
+                            "account": "service-replication-1"
+                        }
+                    },
+                    "aws2": {
+                        "transport": "http",
+                        "auth": {
+                            "type": "service",
+                            "account": "service-replication-2"
+                        }
+                    },
+                    "aws3": {
+                        "transport": "https",
+                        "auth": {
+                            "type": "service",
+                            "account": "service-replication-3"
+                        }
+                    }
+                },
+                "bootstrapList": [
+                    { "site": "aws1", "type": "aws_s3" },
+                    { "site": "aws2", "type": "aws_s3" },
+                    { "site": "aws3", "type": "aws_s3" }
+                ]
+            },
+            "topic": "backbeat-replication",
+            "dataMoverTopic": "backbeat-data-mover",
+            "replicationStatusTopic": "backbeat-replication-status",
+            "replicationFailedTopic": "backbeat-replication-failed",
+            "monitorReplicationFailures": true,
+            "monitorReplicationFailureExpiryTimeS": 86400,
+            "replayTopics": [
+                {
+                    "topicName": "backbeat-replication-replay-0",
+                    "retries": 5
+                }
+            ],
+            "queueProcessor": {
+                "groupId": "backbeat-replication-group",
+                "retry": {
+                    "aws_s3": {
+                        "maxRetries": 5,
+                        "timeoutS": 900,
+                        "backoff": {
+                            "min": 60000,
+                            "max": 900000,
+                            "jitter": 0.1,
+                            "factor": 1.5
+                        }
+                    },
+                    "azure": {
+                        "maxRetries": 5,
+                        "timeoutS": 900,
+                        "backoff": {
+                            "min": 60000,
+                            "max": 900000,
+                            "jitter": 0.1,
+                            "factor": 1.5
+                        }
+                    },
+                    "gcp": {
+                        "maxRetries": 5,
+                        "timeoutS": 900,
+                        "backoff": {
+                            "min": 60000,
+                            "max": 900000,
+                            "jitter": 0.1,
+                            "factor": 1.5
+                        }
+                    },
+                    "scality": {
+                        "maxRetries": 5,
+                        "timeoutS": 300,
+                        "backoff": {
+                            "min": 1000,
+                            "max": 300000,
+                            "jitter": 0.1,
+                            "factor": 1.5
+                        }
+                    }
+                },
+                "concurrency": 10,
+                "mpuPartsConcurrency": 10,
+                "probeServer": {
+                    "bindAddress": "localhost",
+                    "port": 4043
+                }
+            },
+            "replicationStatusProcessor": {
+                "groupId": "backbeat-replication-group",
+                "retry": {
+                    "maxRetries": 5,
+                    "timeoutS": 300,
+                    "backoff": {
+                        "min": 1000,
+                        "max": 300000,
+                        "jitter": 0.1,
+                        "factor": 1.5
+                    }
+                },
+                "concurrency": 10,
+                "probeServer": {
+                    "bindAddress": "localhost",
+                    "port": 4045
+                }
+            },
+            "objectSizeMetrics": [
+                66560,
+                8388608,
+                68157440
+            ]
+        }
+    },
+    "log": {
+        "logLevel": "info",
+        "dumpLevel": "error"
+    },
+    "metrics": {
+        "topic": "backbeat-metrics"
+    },
+    "server": {
+        "healthChecks": {
+            "allowFrom": ["127.0.0.1/8", "::1"]
+        },
+        "host": "127.0.0.1",
+        "port": 8900
+    },
+    "redis": {
+        "host": "localhost",
+        "port": 6379
+    },
+    "certFilePaths": {
+        "key": "",
+        "cert": "",
+        "ca": ""
+    }
+}

--- a/tests/unit/replication/ReplicateObject.spec.js
+++ b/tests/unit/replication/ReplicateObject.spec.js
@@ -1,0 +1,111 @@
+const assert = require('assert');
+const sinon = require('sinon');
+
+const QueueEntry = require('../../../lib/models/QueueEntry');
+const ReplicateObject = require('../../../extensions/replication/tasks/ReplicateObject');
+
+const { replicationEntry } = require('../../utils/kafkaEntries');
+const fakeLogger = require('../../utils/fakeLogger');
+
+describe('ReplicateObject', () => {
+    let task;
+
+    beforeEach(() => {
+        task = new ReplicateObject({
+            getStateVars: () => ({
+                site: 'site',
+                repConfig: {
+                    queueProcessor: {
+                        retry: {
+                            scality: {
+                                maxRetries: 3,
+                            }
+                        },
+                    },
+                },
+                destConfig: {
+                    auth: {
+                        site: 'zenko',
+                        type: 'assumeRole',
+                        sts: {
+                            host: 'sts.enpoint.com',
+                            port: 80
+                        },
+                    },
+                    bootstrapList: [{
+                        site: 'site',
+                        servers: ['localhost:9095'],
+                    }]
+                },
+                destHosts: {
+                    pickNextHost: () => 'localhost:9095',
+                }
+            }),
+        });
+    });
+
+    describe('_setTargetAccountMd', () => {
+        it('should skip gettin target account info when auth type is assumeRole', done => {
+            sinon.stub(task, '_setupDestClients').returns();
+            const setTargetAccountStub = sinon.stub(task, '_setTargetAccountMdOnce').yields();
+            task._setTargetAccountMd({}, '', fakeLogger, err => {
+                assert.ifError(err);
+                assert(setTargetAccountStub.notCalled);
+                done();
+            });
+        });
+
+        it('should get target account info', done => {
+            sinon.stub(task, '_setupDestClients').returns();
+            const setTargetAccountStub = sinon.stub(task, '_setTargetAccountMdOnce').yields();
+            task.destConfig.auth = {
+                type: 'service',
+                account: 'replication-service',
+            };
+            task._setTargetAccountMd({ getLogInfo: () => {} }, '', fakeLogger, err => {
+                assert.ifError(err);
+                assert(setTargetAccountStub.calledOnce);
+                done();
+            });
+        });
+    });
+
+    describe('_putMetadataOnce', () => {
+        it('should pass extract accountId from role and pass it when using AssumeRole auth', done => {
+            sinon.stub(task, '_publishMetadataWriteMetrics').returns();
+            const entry = QueueEntry.createFromKafkaEntry(replicationEntry);
+            task.backbeatDest = {
+                putMetadata: sinon.stub().returns({
+                    send: sinon.stub().yields(),
+                    on: sinon.stub(),
+                }),
+            };
+            task.targetRole = 'arn:aws:iam::123456789012:role/crr-role';
+            task._putMetadataOnce(entry, true, fakeLogger, err => {
+                assert.ifError(err);
+                assert(task.backbeatDest.putMetadata.calledOnce);
+                assert.deepStrictEqual(task.backbeatDest.putMetadata
+                    .firstCall.args[0].AccountId, '123456789012');
+                done();
+            });
+        });
+        it('should not pass accountId when not in assumeRole', done => {
+            sinon.stub(task, '_publishMetadataWriteMetrics').returns();
+            const entry = QueueEntry.createFromKafkaEntry(replicationEntry);
+            task.backbeatDest = {
+                putMetadata: sinon.stub().returns({
+                    send: sinon.stub().yields(),
+                    on: sinon.stub(),
+                }),
+            };
+            task.targetRole = 'arn:aws:iam::123456789012:role/crr-role';
+            sinon.stub(task.destConfig.auth, 'type').value('role');
+            task._putMetadataOnce(entry, true, fakeLogger, err => {
+                assert.ifError(err);
+                assert(task.backbeatDest.putMetadata.calledOnce);
+                assert.strictEqual(task.backbeatDest.putMetadata.firstCall.args[0].AccountId, undefined);
+                done();
+            });
+        });
+    });
+});

--- a/tests/unit/replication/ReplicateObject.spec.js
+++ b/tests/unit/replication/ReplicateObject.spec.js
@@ -3,6 +3,8 @@ const sinon = require('sinon');
 
 const QueueEntry = require('../../../lib/models/QueueEntry');
 const ReplicateObject = require('../../../extensions/replication/tasks/ReplicateObject');
+const ClientManager = require('../../../lib/clients/ClientManager');
+const locations = require('../../../conf/locationConfig.json');
 
 const { replicationEntry } = require('../../utils/kafkaEntries');
 const fakeLogger = require('../../utils/fakeLogger');
@@ -11,6 +13,21 @@ describe('ReplicateObject', () => {
     let task;
 
     beforeEach(() => {
+        locations.site = {
+            details: {
+                awsEndpoint: 'https://s3.amazonaws.com',
+                bucketMatch: true,
+                bucketName: 'ring-bucket-1',
+                credentials: {
+                    accessKey: 'accessKey1',
+                    secretKey: 'verySecretKey1',
+                },
+            },
+            isTransient: false,
+            legacyAwsBehavior: false,
+            objectId: '06a862b3-fee4-11eb-a6ba-26bd22419be2',
+            type: 'aws_s3'
+        };
         task = new ReplicateObject({
             getStateVars: () => ({
                 site: 'site',
@@ -35,13 +52,23 @@ describe('ReplicateObject', () => {
                     bootstrapList: [{
                         site: 'site',
                         servers: ['localhost:9095'],
-                    }]
+                    }],
+                    transport: 'http',
                 },
                 destHosts: {
                     pickNextHost: () => 'localhost:9095',
-                }
+                    pickHost: () => ({
+                        host: 'localhost',
+                        port: 9095,
+                    }),
+                },
+                logger: fakeLogger,
             }),
         });
+    });
+
+    afterEach(() => {
+        sinon.restore();
     });
 
     describe('_setTargetAccountMd', () => {
@@ -105,6 +132,52 @@ describe('ReplicateObject', () => {
                 assert(task.backbeatDest.putMetadata.calledOnce);
                 assert.strictEqual(task.backbeatDest.putMetadata.firstCall.args[0].AccountId, undefined);
                 done();
+            });
+        });
+    });
+
+    describe('_setupDestClients', () => {
+        it('should setup destination client with proper creds when using assumeRole', () => {
+            sinon.stub(ClientManager.prototype, 'initCredentialsManager').returns(null);
+            sinon.stub(ClientManager.prototype, 'getBackbeatClient').returns(null);
+            task._setupDestClients('arn:aws:iam::123456789012:role/crr-role', fakeLogger);
+            assert.deepStrictEqual(task.clientManager._id, '123456789012');
+            assert.deepStrictEqual(task.clientManager._authConfig, {
+                type: 'assumeRole',
+                roleName: 'crr-role',
+                sts: {
+                    host: 'sts.enpoint.com',
+                    port: 80,
+                    accessKey: 'accessKey1',
+                    secretKey: 'verySecretKey1',
+                },
+            });
+            assert.deepStrictEqual(task.clientManager._s3Config, {
+                host: 'localhost',
+                port: 9095,
+            });
+            assert.deepStrictEqual(task.clientManager._transport, 'http');
+            assert.deepStrictEqual(task.clientManager._stsConfig.endpoint, 'http://sts.enpoint.com:80');
+            assert.deepStrictEqual(task.clientManager._stsConfig.credentials, {
+                accessKeyId: 'accessKey1',
+                secretAccessKey: 'verySecretKey1',
+            });
+        });
+
+        it('should setup destination BackbeatClient with proper creds when not in assumeRole', () => {
+            task.destConfig.auth = {
+                type: 'service',
+                account: 'replication-service',
+            };
+            sinon.stub(task, '_createCredentials').returns({
+                accessKeyId: 'accessKeyNoAssumeRole',
+                secretAccessKey: 'secretKeyNoAssumeRole',
+            });
+            task._setupDestClients('arn:aws:iam::123456789012:role/crr-role', fakeLogger);
+            assert.strictEqual(task.backbeatDest.config.endpoint, 'http://localhost:9095');
+            assert.deepStrictEqual(task.backbeatDest.config.credentials, {
+                accessKeyId: 'accessKeyNoAssumeRole',
+                secretAccessKey: 'secretKeyNoAssumeRole',
             });
         });
     });

--- a/tests/unit/replication/ReplicationConfigValidator.spec.js
+++ b/tests/unit/replication/ReplicationConfigValidator.spec.js
@@ -1,0 +1,287 @@
+const assert = require('assert');
+
+const configValidator = require('../../../extensions/replication/ReplicationConfigValidator');
+
+const baseConfig = {
+    source: {
+        transport: 'http',
+        s3: {
+            host: '127.0.0.1',
+            port: 8000
+        },
+        auth: {
+            type: 'service',
+            account: 'service-replication',
+            vault: {
+                host: '127.0.0.1',
+                port: 8500,
+                adminPort: 8600
+            }
+        }
+    },
+    destination: {
+        transport: 'http',
+        bootstrapList: [
+            { site: 'aws1', type: 'aws_s3' },
+            { site: 'aws2', type: 'aws_s3' },
+            { site: 'aws3', type: 'aws_s3' },
+        ],
+        auth: {
+            type: 'service',
+            account: 'service-replication'
+        }
+    },
+    topic: 'backbeat-replication',
+    dataMoverTopic: 'backbeat-data-mover',
+    replicationStatusTopic: 'backbeat-replication-status',
+    replicationFailedTopic: 'backbeat-replication-failed',
+    monitorReplicationFailures: true,
+    monitorReplicationFailureExpiryTimeS: 86400,
+    replayTopics: [
+        {
+            topicName: 'backbeat-replication-replay-0',
+            retries: 5
+        }
+    ],
+    queueProcessor: {
+        groupId: 'backbeat-replication-group',
+        retry: {
+            scality: {
+                maxRetries: 5,
+                timeoutS: 300,
+                backoff: {
+                    min: 1000,
+                    max: 300000,
+                    jitter: 0.1,
+                    factor: 1.5
+                }
+            }
+        },
+        concurrency: 10,
+        mpuPartsConcurrency: 10,
+        probeServer: {
+            bindAddress: 'localhost',
+            port: 4043
+        }
+    },
+    replicationStatusProcessor: {
+        groupId: 'backbeat-replication-group',
+        retry: {
+            maxRetries: 5,
+            timeoutS: 300,
+            backoff: {
+                min: 1000,
+                max: 300000,
+                jitter: 0.1,
+                factor: 1.5
+            }
+        },
+        concurrency: 10,
+        probeServer: {
+            bindAddress: 'localhost',
+            port: 4045
+        }
+    },
+    objectSizeMetrics: [
+        66560,
+        8388608,
+        68157440
+    ]
+};
+
+describe('ReplicationConfigValidator', () => {
+   it('should require all sites to have a config when destination auth is per site', () => {
+        const config = {
+            ...baseConfig,
+            destination: {
+                ...baseConfig.destination,
+                sites: {
+                    aws1: {
+                        auth: { type: 'service', account: 'service-replication' },
+                    },
+                    aws4: {
+                        auth: { type: 'service', account: 'service-replication' },
+                    },
+                }
+            }
+        };
+        delete config.destination.auth;
+        assert.throws(() => configValidator({}, config),
+            err => err.message === 'missing destination configuration for sites: aws2,aws3');
+   });
+   it('should not require all sites to have a config when destination.auth is defined', () => {
+        const config = {
+            ...baseConfig,
+            destination: {
+                ...baseConfig.destination,
+                sites: {
+                    aws1: {
+                        auth: { type: 'service', account: 'service-replication' },
+                    },
+                    aws4: {
+                        auth: { type: 'service', account: 'service-replication' },
+                    },
+                }
+            }
+        };
+        assert.doesNotThrow(() => configValidator({}, config));
+   });
+   it('should allow specifying a custom transport for a site', () => {
+        const config = {
+            ...baseConfig,
+            destination: {
+                ...baseConfig.destination,
+                sites: {
+                    aws1: {
+                        transport: 'https',
+                    },
+                }
+            }
+        };
+        assert.doesNotThrow(() => configValidator({}, config));
+   });
+   it('should require destination auth to contain sts config when type is assumeRole', () => {
+        const config = {
+            ...baseConfig,
+            destination: {
+                ...baseConfig.destination,
+                sites: {
+                    aws1: {
+                        auth: {
+                            type: 'assumeRole',
+                            account: 'service-replication'
+                        },
+                    },
+                    aws2: {
+                        auth: {
+                            type: 'service',
+                            account: 'service-replication'
+                        },
+                    },
+                    aws3: {
+                        auth: {
+                            type: 'service',
+                            account: 'service-replication'
+                        },
+                    },
+                },
+            }
+        };
+        assert.throws(() => configValidator({}, config),
+            err => err.message === '"destination.sites.aws1.auth.sts" is required');
+   });
+   it('should validate new destination schema', () => {
+        const config = {
+            ...baseConfig,
+            destination: {
+                ...baseConfig.destination,
+                sites: {
+                    aws1: {
+                        transport: 'http',
+                        auth: {
+                            type: 'assumeRole',
+                            sts: {
+                                host: 'sts.enpoint.com',
+                                port: 80
+                            },
+                        },
+                    },
+                    aws2: {
+                        transport: 'http',
+                        auth: {
+                            type: 'service',
+                            account: 'service-replication',
+                        },
+                    },
+                    aws3: {
+                        transport: 'http',
+                        auth: {
+                            type: 'service',
+                            account: 'service-replication',
+                        },
+                    },
+                },
+            }
+        };
+        delete config.destination.auth;
+        delete config.destination.transport;
+        assert.doesNotThrow(() => configValidator({}, config));
+   });
+   it('should validate old destination schema', () => {
+        const config = {
+            ...baseConfig,
+            destination: {
+                ...baseConfig.destination,
+                transport: undefined,
+                auth: {
+                    type: 'service',
+                    account: 'service-replication'
+                }
+            }
+        };
+        assert.doesNotThrow(() => configValidator({}, config));
+   });
+   it('should load admin credentials from file when adminCredentialsFile is set', () => {
+        const config = {
+            ...baseConfig,
+            source: {
+                ...baseConfig.source,
+                auth: {
+                    type: 'role',
+                    vault: {
+                        host: 'localhost',
+                        port: 8200,
+                        adminPort: 8201,
+                        adminCredentialsFile: `${__dirname}/utils/admin-backbeat.json`,
+                    },
+                },
+            },
+            destination: {
+                ...baseConfig.destination,
+                auth: {
+                    type: 'role',
+                    vault: {
+                        host: 'localhost',
+                        port: 8200,
+                        adminPort: 8201,
+                        adminCredentialsFile: `${__dirname}/utils/admin-backbeat.json`,
+                    },
+                },
+                sites: {
+                    aws1: {
+                        auth: {
+                            type: 'role',
+                            vault: {
+                                host: 'localhost',
+                                port: 8200,
+                                adminPort: 8201,
+                                adminCredentialsFile: `${__dirname}/utils/admin-backbeat.json`,
+                            },
+                        },
+                    },
+                },
+            }
+        };
+        const conf = configValidator({}, config);
+        const adminCredentials = {
+            accessKey: 'HPZYD8TCLETBDZBPNTNQ',
+            secretKey: 'prMKjH3Epf2O7+pLA0iwW9OcZjiFVRpHT=7ir3w6',
+        };
+        assert.deepStrictEqual(
+            conf.source.auth.vault.adminCredentials,
+            adminCredentials,
+        );
+        assert.deepStrictEqual(
+            conf.destination.auth.vault.adminCredentials,
+            adminCredentials,
+        );
+        assert.deepStrictEqual(
+            conf.destination.auth.vault.adminCredentials,
+            adminCredentials,
+        );
+        assert.deepStrictEqual(
+            conf.destination.sites.aws1.auth.vault.adminCredentials,
+            adminCredentials,
+        );
+   });
+});

--- a/tests/unit/replication/utils/admin-backbeat.json
+++ b/tests/unit/replication/utils/admin-backbeat.json
@@ -1,0 +1,3 @@
+{
+    "HPZYD8TCLETBDZBPNTNQ": "prMKjH3Epf2O7+pLA0iwW9OcZjiFVRpHT=7ir3w6"
+}


### PR DESCRIPTION
- Support per site replication destination config to allow having a mix of CRR and Zenko Replication locations.
- Remove vault admin API call that get account details, this task will be delegated to the destination Cloudserver that will get the account details and place them into the objectMD.
- Support AssumeRole auth type in CRR.

Issue: BB-647