### PR TITLE
BackbeatConsumer : ensure ordered processing of messages with the same key

### DIFF
--- a/extensions/gc/GarbageCollector.js
+++ b/extensions/gc/GarbageCollector.js
@@ -138,6 +138,10 @@ class GarbageCollector extends EventEmitter {
             topic: this._gcConfig.topic,
             groupId: this._gcConfig.consumer.groupId,
             concurrency: this._gcConfig.consumer.concurrency,
+            // respecting the order of messages for the same object
+            // is not required in the garbage collector (messages
+            // sent to the gc don't have a key anyways)
+            orderByFunc: null,
             queueProcessor: this.processKafkaEntry.bind(this),
         });
         this._consumer.on('error', () => {

--- a/extensions/lifecycle/LifecycleConfigValidator.js
+++ b/extensions/lifecycle/LifecycleConfigValidator.js
@@ -8,7 +8,7 @@ const {
     retryParamsJoi,
 } = require('../../lib/config/configItems.joi');
 
-const { supportedLifecycleRules }  = require('../../lib/constants');
+const { supportedLifecycleRules, backbeatConsumer: { MAX_QUEUED_DEFAULT } } = require('../../lib/constants');
 
 const joiSchema = joi.object({
     zookeeperPath: joi.string().required(),
@@ -59,6 +59,7 @@ const joiSchema = joi.object({
         groupId: joi.string().required(),
         retry: retryParamsJoi,
         concurrency: joi.number().greater(0).default(10),
+        maxQueued: joi.number().greater(0).default(MAX_QUEUED_DEFAULT),
         probeServer: probeServerJoi.default(),
         circuitBreaker: joi.object().optional(),
     },
@@ -67,6 +68,7 @@ const joiSchema = joi.object({
         groupId: joi.string().required(),
         retry: retryParamsJoi,
         concurrency: joi.number().greater(0).default(10),
+        maxQueued: joi.number().greater(0).default(MAX_QUEUED_DEFAULT),
         probeServer: probeServerJoi.default(),
         circuitBreaker: joi.object().optional(),
     },

--- a/extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor.js
+++ b/extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor.js
@@ -427,6 +427,9 @@ class LifecycleBucketProcessor {
             topic: this._lcConfig.bucketTasksTopic,
             groupId: this._lcConfig.bucketProcessor.groupId,
             concurrency: this._lcConfig.bucketProcessor.concurrency,
+            // respecting the order of messages for the same bucket
+            // is not required in the bucket processor
+            orderByFunc: null,
             queueProcessor: this._processBucketEntry.bind(this),
             circuitBreaker: this._circuitBreakerConfig,
             circuitBreakerMetrics: {

--- a/extensions/lifecycle/objectProcessor/LifecycleObjectProcessor.js
+++ b/extensions/lifecycle/objectProcessor/LifecycleObjectProcessor.js
@@ -83,6 +83,7 @@ class LifecycleObjectProcessor extends EventEmitter {
             topic,
             groupId: this._processConfig.groupId,
             concurrency: this._processConfig.concurrency,
+            maxQueued: this._processConfig.maxQueued,
             queueProcessor: this.processObjectTaskEntry.bind(this),
             circuitBreaker: this._lcConfig.objectProcessor.circuitBreaker,
             circuitBreakerMetrics: {

--- a/extensions/lifecycle/objectProcessor/LifecycleObjectTransitionProcessor.js
+++ b/extensions/lifecycle/objectProcessor/LifecycleObjectTransitionProcessor.js
@@ -129,6 +129,7 @@ class LifecycleObjectTransitionProcessor extends LifecycleObjectProcessor {
                 topic,
                 groupId: this._processConfig.groupId,
                 concurrency: this._processConfig.concurrency,
+                maxQueued: this._processConfig.maxQueued,
                 queueProcessor: this.processColdStorageStatusEntry.bind(this),
                 circuitBreaker,
             };

--- a/extensions/mongoProcessor/MongoProcessorConfigValidator.js
+++ b/extensions/mongoProcessor/MongoProcessorConfigValidator.js
@@ -1,11 +1,14 @@
 const joi = require('joi');
 const { retryParamsJoi, probeServerJoi } = require('../../lib/config/configItems.joi');
 
+const { MAX_QUEUED_DEFAULT }  = require('../../lib/constants').backbeatConsumer;
+
 const joiSchema = joi.object({
     topic: joi.string().required(),
     groupId: joi.string().required(),
     retry: retryParamsJoi,
     concurrency: joi.number().greater(0).default(1),
+    maxQueued: joi.number().greater(0).default(MAX_QUEUED_DEFAULT),
     probeServer: probeServerJoi.default(),
     circuitBreaker: joi.object().optional(),
 });

--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -146,6 +146,7 @@ class MongoQueueProcessor {
                     type: 'mongo_queue_processor',
                 },
                 concurrency: this.mongoProcessorConfig.concurrency,
+                maxQueued: this.mongoProcessorConfig.maxQueued,
             });
             this._consumer.on('error', () => {
                 MongoProcessorMetrics.onIngestionKafkaConsume('error');

--- a/extensions/notification/NotificationConfigValidator.js
+++ b/extensions/notification/NotificationConfigValidator.js
@@ -1,6 +1,8 @@
 const joi = require('joi');
 const { probeServerJoi } = require('../../lib/config/configItems.joi');
 
+const { MAX_QUEUED_DEFAULT }  = require('../../lib/constants').backbeatConsumer;
+
 const authSchema = joi.object({
     type: joi.string(),
     ssl: joi.boolean(),
@@ -42,6 +44,7 @@ const joiSchema = joi.object({
     queueProcessor: {
         groupId: joi.string().required(),
         concurrency: joi.number().greater(0).default(1000),
+        maxQueued: joi.number().greater(0).default(MAX_QUEUED_DEFAULT),
     },
     destinations: joi.array().items(destinationSchema).default([]),
     // TODO: BB-625 reset to being required after supporting probeserver in S3C

--- a/extensions/notification/queueProcessor/QueueProcessor.js
+++ b/extensions/notification/queueProcessor/QueueProcessor.js
@@ -174,6 +174,7 @@ class QueueProcessor extends EventEmitter {
                     topic: internalTopic,
                     groupId: consumerGroupId,
                     concurrency,
+                    maxQueued: this.notifConfig.queueProcessor.maxQueued,
                     queueProcessor: this.processKafkaEntry.bind(this),
                 });
                 this._consumer.on('error', err => {

--- a/extensions/replication/ReplicationConfigValidator.js
+++ b/extensions/replication/ReplicationConfigValidator.js
@@ -4,6 +4,8 @@ const { hostPortJoi, transportJoi, bootstrapListJoi, adminCredsJoi,
         retryParamsJoi, probeServerJoi, probeServerPerSite } =
     require('../../lib/config/configItems.joi');
 
+const { MAX_QUEUED_DEFAULT }  = require('../../lib/constants').backbeatConsumer;
+
 const qpRetryJoi = joi.object({
     aws_s3: retryParamsJoi, // eslint-disable-line camelcase
     azure: retryParamsJoi,
@@ -85,6 +87,7 @@ const joiSchema = joi.object({
         retry: qpRetryJoi,
         concurrency: joi.number().greater(0).default(10),
         mpuPartsConcurrency: joi.number().greater(0).default(10),
+        maxQueued: joi.number().greater(0).default(MAX_QUEUED_DEFAULT),
         minMPUSizeMB: joi.number().greater(0).default(20),
         probeServer: joi.alternatives().try(
             probeServerJoi,
@@ -97,6 +100,7 @@ const joiSchema = joi.object({
         groupId: joi.string().required(),
         retry: retryParamsJoi,
         concurrency: joi.number().greater(0).default(10),
+        maxQueued: joi.number().greater(0).default(MAX_QUEUED_DEFAULT),
         probeServer: probeServerJoi.default(),
     },
     replayProcessor: joi.object({

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -404,6 +404,7 @@ class QueueProcessor extends EventEmitter {
             topic,
             groupId,
             concurrency: this.repConfig.queueProcessor.concurrency,
+            maxQueued: this.repConfig.queueProcessor.maxQueued,
             queueProcessor: queueProcessorFunc,
             canary: true,
             circuitBreaker: this.circuitBreakerConfig,

--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -395,8 +395,8 @@ class ReplicationStatusProcessor {
                     },
                     topic: this.repConfig.replicationStatusTopic,
                     groupId: this.repConfig.replicationStatusProcessor.groupId,
-                    concurrency:
-                    this.repConfig.replicationStatusProcessor.concurrency,
+                    concurrency: this.repConfig.replicationStatusProcessor.concurrency,
+                    maxQueued: this.repConfig.replicationStatusProcessor.maxQueued,
                     queueProcessor: this.processKafkaEntry.bind(this),
                     bootstrap: (options && options.bootstrap) || false,
                 });

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -9,14 +9,17 @@ const { BreakerState, CircuitBreaker } = require('breakbeat').CircuitBreaker;
 
 const BackbeatProducer = require('./BackbeatProducer');
 const OffsetLedger = require('./OffsetLedger');
+const TaskScheduler = require('./tasks/TaskScheduler');
 const KafkaBacklogMetrics = require('./KafkaBacklogMetrics');
 const {
     startCircuitBreakerMetricsExport,
 } = require('./CircuitBreaker');
 const { observeKafkaStats } = require('./util/probe');
+const {
+    CONCURRENCY_DEFAULT,
+    MAX_QUEUED_DEFAULT,
+} = require('./constants').backbeatConsumer;
 
-// controls the number of messages to process in parallel
-const CONCURRENCY_DEFAULT = 1;
 const CLIENT_ID = 'BackbeatConsumer';
 const { withTopicPrefix } = require('./util/topic');
 
@@ -107,13 +110,33 @@ class BackbeatConsumer extends EventEmitter {
             circuitBreakerMetrics: joi.object({
                 type: joi.string().required(),
             }).optional(),
+            // Function to determine what to order the processing queue by.
+            // Default function orders by the key of the message, if the message
+            // has a key. Messages with the same key are processed in order.
+            // Messages with different keys are processed in parallel.
+            // Setting this to null will disable ordering and will process messages
+            // in parallel.
+            orderByFunc: joi.function()
+                .default(ctx => ctx?.entry?.key?.toString())
+                .allow(null),
+            // When ordering is enabled, one message is processed at a time
+            // for a given key, other messages with the same key are queued.
+            // This parameter controls the maximum number of messages that can
+            // be queued for processing (not per key but globally).
+            // Avoid having a very high value for this parameter as it will increase
+            // the risk of re-processing previously processed messages in case of
+            // a crash or rebalance, as the queued messages will block offset commit
+            // for more recent messages with different keys that might have been processed.
+            maxQueued: joi.number()
+                .greater(0)
+                .default(MAX_QUEUED_DEFAULT),
         });
         const validConfig = joi.attempt(config, configJoi,
                                         'invalid config params');
 
         const { clientId, zookeeper, kafka, topic, groupId, queueProcessor,
-                fromOffset, concurrency, fetchMaxBytes,
-                canary, bootstrap, circuitBreaker, circuitBreakerMetrics } = validConfig;
+                fromOffset, concurrency, maxQueued, fetchMaxBytes,
+                canary, bootstrap, circuitBreaker, circuitBreakerMetrics, orderByFunc } = validConfig;
 
         this._zookeeperEndpoint = zookeeper && zookeeper.connectionString;
         this._kafkaHosts = kafka.hosts;
@@ -128,12 +151,18 @@ class BackbeatConsumer extends EventEmitter {
         this._groupId = groupId;
         this._queueProcessor = queueProcessor;
         this._concurrency = concurrency;
+        this._maxQueued = maxQueued;
         this._fetchMaxBytes = fetchMaxBytes;
         this._canary = canary;
         this._bootstrap = bootstrap;
         this._offsetLedger = new OffsetLedger();
+        this._processingQueue = new TaskScheduler(
+            (ctx, done) => this._processTask(ctx.entry, done),
+            orderByFunc,
+            null,
+            this._concurrency,
+        );
 
-        this._processingQueue = null;
         this._messagesConsumed = 0;
         // this variable represents how many kafka messages have been
         // requested without having been received yet, i.e. still
@@ -334,9 +363,6 @@ class BackbeatConsumer extends EventEmitter {
             });
         }
 
-        this._processingQueue = async.queue(
-            this._queueProcessor, this._concurrency);
-
         this._consumer.on('event.error', error => {
             // This is a bit hacky: the "broker transport failure"
             // error occurs when the kafka broker reaps the idle
@@ -361,19 +387,22 @@ class BackbeatConsumer extends EventEmitter {
 
     /**
      * Get how many messages we may attempt to consume at this time,
-     * considering the maximum concurrency, current processing queue
-     * length and message retrievals still pending.
+     * considering the maximum concurrency, queued messages, and message
+     * retrievals still pending.
      *
      * @return {integer} a strictly positive number representing the
      * number of new messages that the pipeline is ready to process,
      * or zero if the processing pipeline is 100% busy
      */
     _getAvailableSlotsInPipeline() {
-        const nSlots = this._concurrency
+        // do not exceed max queued tasks limit
+        const nQueuedSlots = this._maxQueued
+                - this._processingQueue.length();
+        // do not exceed max concurrency limit
+        const nRunningSlots = this._concurrency
               - this._processingQueue.running()
-              - this._processingQueue.length()
               - this._nConsumePendingRequests;
-        return nSlots > 0 ? nSlots : 0;
+        return Math.max(0, Math.min(nQueuedSlots, nRunningSlots));
     }
 
     _tryConsume() {
@@ -421,8 +450,7 @@ class BackbeatConsumer extends EventEmitter {
                         entry.topic, entry.partition, entry.offset);
                     this._messagesConsumed++;
 
-                    const finishProcessingTask = this._startProcessingTask(entry);
-                    this._processingQueue.push(entry, (err, completionArgs) => {
+                    this._processingQueue.push({ entry }, (err, completionArgs, finishProcessingTask) => {
                         this._onEntryProcessingDone(err, entry, completionArgs);
                         finishProcessingTask(err);
                     });
@@ -451,6 +479,19 @@ class BackbeatConsumer extends EventEmitter {
                 this._scheduleNextTryConsume();
             }
         });
+    }
+
+    /**
+     * wrapper around the queueProcessor function to track processing
+     * of a task
+     * @param {Object} entry - kafka entry being processed
+     * @param {number} queuedTime - timestamp of when the task was queued
+     * @param {function} done - callback to be called when task has been processed
+     * @return {undefined}
+     */
+    _processTask(entry, done) {
+        const finishProcessingTask = this._startProcessingTask(entry);
+        this._queueProcessor(entry, (err, completionArgs) => done(err, completionArgs, finishProcessingTask));
     }
 
     /**
@@ -645,22 +686,20 @@ class BackbeatConsumer extends EventEmitter {
         } else if (err.code === kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
             this._log.info('rdkafka.revoke', {
                 assignment,
-                queueLen: this._processingQueue?.length(),
-                running: this._processingQueue?.running(),
+                queueLen: this._processingQueue.length(),
+                running: this._processingQueue.running(),
             });
 
             const unassign = jsutil.once(status => {
                 this._log.info(`processing queue ${status}, un-assigning`, {
-                    queueLen: this._processingQueue?.length(),
-                    running: this._processingQueue?.running(),
+                    queueLen: this._processingQueue.length(),
+                    running: this._processingQueue.running(),
                 });
 
                 KafkaBacklogMetrics.onRebalance(this._topic, this._groupId, status);
 
                 // Reset the drain callback
-                if (this._processingQueue) {
-                    this._processingQueue.drain = () => { };
-                }
+                this._processingQueue.setDrain(() => {});
 
                 // Reset the timer
                 clearTimeout(this._drainProcessQueueTimeout);
@@ -698,12 +737,12 @@ class BackbeatConsumer extends EventEmitter {
                 }
             });
 
-            if (!this._processingQueue || this._processingQueue.idle()) {
+            if (this._processingQueue.idle()) {
                 unassign(UNASSIGN_STATUS.IDLE);
                 return;
             }
 
-            this._processingQueue.drain = () => unassign(UNASSIGN_STATUS.DRAINED);
+            this._processingQueue.setDrain(() => unassign(UNASSIGN_STATUS.DRAINED));
 
             // Set timeout of `max.poll.interval.ms`), to ensure we complete the rebalance
             // eventually (even if a task is really stuck), and don't get kicked out of the consumer

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -450,6 +450,8 @@ class BackbeatConsumer extends EventEmitter {
                         entry.topic, entry.partition, entry.offset);
                     this._messagesConsumed++;
 
+                    KafkaBacklogMetrics.onTaskQueued(topic, partition, this._groupId);
+
                     this._processingQueue.push({ entry }, (err, completionArgs, finishProcessingTask) => {
                         this._onEntryProcessingDone(err, entry, completionArgs);
                         finishProcessingTask(err);
@@ -485,12 +487,15 @@ class BackbeatConsumer extends EventEmitter {
      * wrapper around the queueProcessor function to track processing
      * of a task
      * @param {Object} entry - kafka entry being processed
-     * @param {number} queuedTime - timestamp of when the task was queued
      * @param {function} done - callback to be called when task has been processed
      * @return {undefined}
      */
     _processTask(entry, done) {
         const finishProcessingTask = this._startProcessingTask(entry);
+
+        const { topic, partition } = entry;
+        KafkaBacklogMetrics.onTaskStarted(topic, partition, this._groupId);
+
         this._queueProcessor(entry, (err, completionArgs) => done(err, completionArgs, finishProcessingTask));
     }
 

--- a/lib/KafkaBacklogMetrics.js
+++ b/lib/KafkaBacklogMetrics.js
@@ -56,6 +56,18 @@ const taskProcessingTime = metrics.ZenkoMetrics.createHistogram({
     buckets: [0.01, 0.1, 1, 10, 50, 100, 200, 300],
 });
 
+const queuedTasksCountGauge = metrics.ZenkoMetrics.createGauge({
+    name: promMetricNames.taskQueuedCount,
+    help: 'Number of tasks currently in the queue',
+    labelNames: ['topic', 'partition', 'group'],
+});
+
+const runningTasksCountGauge = metrics.ZenkoMetrics.createGauge({
+    name: promMetricNames.taskRunningCount,
+    help: 'Number of tasks currently running',
+    labelNames: ['topic', 'partition', 'group'],
+});
+
 // global error instances for private use
 const CheckConditionError = new Error();
 const NoNodeError = new Error();
@@ -175,6 +187,21 @@ class KafkaBacklogMetrics extends EventEmitter {
         });
     }
 
+    static onTaskQueued(topic, partition, consumerGroup) {
+        queuedTasksCountGauge.inc({
+            topic, partition, group: consumerGroup,
+        });
+    }
+
+    static onTaskStarted(topic, partition, consumerGroup,) {
+        queuedTasksCountGauge.dec({
+            topic, partition, group: consumerGroup,
+        });
+        runningTasksCountGauge.inc({
+            topic, partition, group: consumerGroup,
+        });
+    }
+
     /**
      * Updates the metrics when a task has been processed.
      * @param {string} topic - The Kafka topic.
@@ -191,6 +218,9 @@ class KafkaBacklogMetrics extends EventEmitter {
                 topic, partition, group: consumerGroup,
             });
         }
+        runningTasksCountGauge.dec({
+            topic, partition, group: consumerGroup,
+        });
         taskProcessingTime.observe({ topic, partition, group: consumerGroup, error },
             durationMs / 1000);
     }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -6,7 +6,7 @@ const constants = {
             latestConsumedMessageTimestamp: 's3_backbeat_queue_latest_consumed_message_timestamp',
             latestConsumeEventTimestamp: 's3_backbeat_queue_latest_consume_event_timestamp',
             rebalanceTotal: 's3_backbeat_queue_rebalance_total',
-            slowTasksCount: 's3_backbeat_queue_slowTasks_count',
+            slowTasksCount: 's3_backbeat_queue_slowtasks_count',
             taskProcessingTime: 's3_backbeat_queue_task_processing_time_seconds',
             taskQueuedCount: 's3_backbeat_queue_queuedtasks_count',
             taskRunningCount: 's3_backbeat_queue_runningtasks_count',

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -62,7 +62,13 @@ const constants = {
         'abortIncompleteMultipartUpload',
         'transitions',
         'noncurrentVersionTransition'
-    ]
+    ],
+    backbeatConsumer: {
+        // controls the number of messages to process in parallel
+        CONCURRENCY_DEFAULT: 1,
+        // controls the max number of messages to queue for processing.
+        MAX_QUEUED_DEFAULT: 1000,
+    },
 };
 
 module.exports = constants;

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -8,6 +8,8 @@ const constants = {
             rebalanceTotal: 's3_backbeat_queue_rebalance_total',
             slowTasksCount: 's3_backbeat_queue_slowTasks_count',
             taskProcessingTime: 's3_backbeat_queue_task_processing_time_seconds',
+            taskQueuedCount: 's3_backbeat_queue_queuedtasks_count',
+            taskRunningCount: 's3_backbeat_queue_runningtasks_count',
         },
     },
     statusReady: 'READY',

--- a/lib/tasks/TaskScheduler.js
+++ b/lib/tasks/TaskScheduler.js
@@ -1,6 +1,13 @@
 const async = require('async');
 
 /**
+ * Function that is called when all tasks have been processed
+ * @typedef {Function} DrainFunction
+ * @param {undefined}
+ * @returns {undefined}
+ */
+
+/**
  * Schedule tasks according to:
  *
  * - An optional queue key that guarantees all tasks sharing the same
@@ -27,12 +34,21 @@ class TaskScheduler {
         this._processingFunc = processingFunc;
         this._getQueueKeyFunc = getQueueKeyFunc;
         this._getDedupeKeyFunc = getDedupeKeyFunc;
+        this._drainFunc = null;
         this._taskQueues = {};
         this._dedupeCache = {};
+        this._inQueue = 0; // Number of tasks currently waiting in the queue
+        this._running = 0; // Number of tasks currently running
+    }
+    
+    _queueProcessingFunc(ctx, done) {
+        this._inQueue--;
+        this._running++;
+        this._processingFunc(ctx, done);
     }
 
     _getNewTaskQueue(ctx, queueKey) {
-        const queue = async.queue(this._processingFunc);
+        const queue = async.queue(this._queueProcessingFunc.bind(this));
         queue.drain = () => delete this._taskQueues[queueKey];
         this._taskQueues[queueKey] = queue;
         return queue;
@@ -56,11 +72,13 @@ class TaskScheduler {
     push(ctx, done) {
         let dedupeKey;
         let queueKey;
-        const onTaskEnd = () => {
+        const onTaskEnd = (...args) => {
             if (dedupeKey !== undefined) {
                 delete this._dedupeCache[dedupeKey];
             }
-            done();
+            this._running--;
+            this._tryDrain();
+            done(...args);
         };
         if (this._getDedupeKeyFunc) {
             dedupeKey = this._getDedupeKeyFunc(ctx);
@@ -81,10 +99,52 @@ class TaskScheduler {
             }
             if (queueKey !== undefined) {
                 const queue = this._getTaskQueue(ctx, queueKey);
+                this._inQueue++;
                 return queue.push(ctx, onTaskEnd);
             }
         }
+        this._running++;
         return process.nextTick(() => this._processingFunc(ctx, onTaskEnd));
+    }
+
+    /**
+     * @returns {Number} The number of tasks waiting to be processed
+     */
+    length() {
+        return this._inQueue;
+    }
+
+    /**
+     * @returns {Number} The number of tasks currently being processed
+     */
+    running() {
+        return this._running;
+    }
+
+    /**
+     * @returns {Boolean} True if there are no tasks running or waiting
+     */
+    idle() {
+        return this._running === 0 && this._inQueue === 0;
+    }
+
+    /**
+     * Set a function to be called after all tasks have been processed
+     * @param {DrainFunction} func drain function
+     * @returns {undefined}
+     */
+    setDrain(func) {
+        this._drainFunc = func;
+    }
+
+    /**
+     * Call the drain function if there are no tasks running
+     * @returns {undefined}
+     */
+    _tryDrain() {
+        if (this.idle()) {
+            this._drainFunc?.();
+        }
     }
 }
 

--- a/monitoring/lifecycle/alerts.test.yaml
+++ b/monitoring/lifecycle/alerts.test.yaml
@@ -517,9 +517,9 @@ tests:
   - name: KafkaConsumerSlowTask
     interval: 1m
     input_series:
-      - series: s3_backbeat_queue_slowTasks_count{namespace="zenko",job="artesca-data-backbeat-object-processor-headless"}
+      - series: s3_backbeat_queue_slowtasks_count{namespace="zenko",job="artesca-data-backbeat-object-processor-headless"}
         values: 0 0 0 0 1 0 0 0 0 0
-      - series: s3_backbeat_queue_slowTasks_count{namespace="zenko",job="artesca-data-backbeat-bucket-processor-headless"}
+      - series: s3_backbeat_queue_slowtasks_count{namespace="zenko",job="artesca-data-backbeat-bucket-processor-headless"}
         values: 0 0 1 1 1 1 1 1 1 0
     alert_rule_test:
       - alertname: KafkaConsumerSlowTask

--- a/monitoring/lifecycle/alerts.yaml
+++ b/monitoring/lifecycle/alerts.yaml
@@ -311,7 +311,7 @@ groups:
 
   - alert: KafkaConsumerSlowTask
     Expr: |
-      sum(s3_backbeat_queue_slowTasks_count{namespace="${namespace}"}) by(job) > 0
+      sum(s3_backbeat_queue_slowtasks_count{namespace="${namespace}"}) by(job) > 0
     For: "5m"
     Labels:
      severity: warning

--- a/monitoring/lifecycle/dashboard.json
+++ b/monitoring/lifecycle/dashboard.json
@@ -3203,7 +3203,7 @@
       "targets": [
         {
           "datasource": null,
-          "expr": "label_replace(\nlabel_replace(\n  sum(s3_backbeat_queue_slowTasks_count{job=~\"$jobs\", namespace=\"${namespace}\"}) by (job)\n, \"job\", \"$1\", \"job\", \"${zenkoName}-backbeat-(?:lifecycle-)?(.*?)-headless\")\n, \"job\", \"$1-processor\", \"job\", \"(gc|transition)\")",
+          "expr": "label_replace(\nlabel_replace(\n  sum(s3_backbeat_queue_slowtasks_count{job=~\"$jobs\", namespace=\"${namespace}\"}) by (job)\n, \"job\", \"$1\", \"job\", \"${zenkoName}-backbeat-(?:lifecycle-)?(.*?)-headless\")\n, \"job\", \"$1-processor\", \"job\", \"(gc|transition)\")",
           "format": "time_series",
           "hide": false,
           "instant": false,

--- a/monitoring/lifecycle/dashboard.py
+++ b/monitoring/lifecycle/dashboard.py
@@ -139,7 +139,7 @@ class BacklogMetrics:
     )
 
     SLOW_TASKS = metrics.Metric(
-        's3_backbeat_queue_slowTasks_count',
+        's3_backbeat_queue_slowtasks_count',
         'topic', 'partition', 'group', job=['$jobs'], namespace='${namespace}',
     )
 

--- a/tests/unit/backbeatConsumer.js
+++ b/tests/unit/backbeatConsumer.js
@@ -156,4 +156,79 @@ describe('pause/resume topic partitions on circuit breaker', () => {
             assert(pauseStub.notCalled);
         });
     });
+
+    describe('_getAvailableSlotsInPipeline', () => {
+        [
+            {
+                // should take into account pending requests
+                state: {
+                    maxQueued : 10,
+                    concurrency : 10,
+                    processingQueue: {
+                        length: () => 0,
+                        running: () => 0,
+                    },
+                    nConsumePendingRequests: 5,
+                },
+                expectedSlots: 5,
+            },{
+                // should not exceed max running tasks
+                state: {
+                    maxQueued : 10,
+                    concurrency : 10,
+                    processingQueue: {
+                        length: () => 0,
+                        running: () => 9,
+                    },
+                    nConsumePendingRequests: 0,
+                },
+                expectedSlots: 1,
+            },{
+                // should not exceed max queued
+                state: {
+                    maxQueued : 10,
+                    concurrency : 10,
+                    processingQueue: {
+                        length: () => 9,
+                        running: () => 1,
+                    },
+                    nConsumePendingRequests: 0,
+                },
+                expectedSlots: 1,
+            },{
+                // should return 0 when exceeding max queued tasks
+                state: {
+                    maxQueued : 10,
+                    concurrency : 10,
+                    processingQueue: {
+                        length: () => 12,
+                        running: () => 1,
+                    },
+                    nConsumePendingRequests: 0,
+                },
+                expectedSlots: 0,
+            },{
+                // should return 0 when exceeding max running tasks
+                state: {
+                    maxQueued : 10,
+                    concurrency : 10,
+                    processingQueue: {
+                        length: () => 3,
+                        running: () => 13,
+                    },
+                    nConsumePendingRequests: 0,
+                },
+                expectedSlots: 0,
+            },
+        ].forEach((params, i) => {
+            it(`should return available slots in pipeline (scenario ${i})`, () => {
+                consumer._maxQueued = params.state.maxQueued;
+                consumer._concurrency = params.state.concurrency;
+                consumer._processingQueue = params.state.processingQueue;
+                consumer._nConsumePendingRequests = params.state.nConsumePendingRequests;
+                const availableSlots = consumer._getAvailableSlotsInPipeline();
+                assert.strictEqual(availableSlots, params.expectedSlots);
+            });
+        });
+    });
 });

--- a/tests/unit/lib/tasks/TaskScheduler.spec.js
+++ b/tests/unit/lib/tasks/TaskScheduler.spec.js
@@ -1,8 +1,14 @@
 const assert = require('assert');
+const sinon = require('sinon');
+const async = require('async');
 
 const TaskScheduler = require('../../../../lib/tasks/TaskScheduler');
 
-describe('TaskScheduler', () => {
+describe('TaskScheduler', () => {    
+    afterEach(() => {
+        sinon.restore();
+    });
+
     it('should ensure serialization of updates with the same queue key',
     done => {
         const taskScheduler = new TaskScheduler(
@@ -114,5 +120,413 @@ describe('TaskScheduler', () => {
                 }, doneFunc);
             }
         }
+    });
+
+    it('should accurately report the number of queued and running tasks', async () => {
+        const taskStates = {
+            key1: { complete: false },
+            key1q: { complete: false },
+            key2: { complete: false },
+            key3: { complete: false },
+            key4: { complete: false },
+            nokey1: { complete: false },
+            nokey2: { complete: false },
+        };
+        
+        const startSignals = {};
+        const completeSignals = {};
+        
+        // Create promise-based signals for each task
+        Object.keys(taskStates).forEach(key => {
+            const signals = {};
+            startSignals[key] = new Promise(resolve => { signals.startResolve = resolve; });
+            completeSignals[key] = new Promise(resolve => { signals.completeResolve = resolve; });
+            taskStates[key].signals = signals;
+        });
+        
+        // Create a task processor that signals when it starts and waits for completion signal
+        const processTask = async (ctx, callback) => {
+            const key = ctx.key;
+            taskStates[key].signals.startResolve();
+            
+            // Wait until we're told to complete
+            await completeSignals[key];
+            taskStates[key].complete = true;
+            callback();
+        };
+        
+        const taskScheduler = new TaskScheduler(
+            (ctx, done) => processTask(ctx, done),
+            ctx => ctx.queueKey,
+            null,
+        );
+        
+        const drainStub = sinon.stub();
+        taskScheduler.setDrain(drainStub);
+
+        // Add tasks with keys - these should run in parallel (one per key)
+        taskScheduler.push({ key: 'key1', queueKey: 'key1' }, () => {});
+        taskScheduler.push({ key: 'key2', queueKey: 'key2' }, () => {});
+        taskScheduler.push({ key: 'key3', queueKey: 'key3' }, () => {});
+        
+        // Add another task with key1 - this should be queued
+        taskScheduler.push({ key: 'key1q', queueKey: 'key1' }, () => {});
+        
+        // Add tasks without keys - these should run in parallel
+        taskScheduler.push({ key: 'nokey1' }, () => {});
+        taskScheduler.push({ key: 'nokey2' }, () => {});
+        
+        await Promise.all([
+            startSignals['key1'],
+            startSignals['key2'], 
+            startSignals['key3'],
+            startSignals['nokey1'],
+            startSignals['nokey2']
+        ]);
+        
+        assert.strictEqual(taskScheduler.running(), 5);
+        assert.strictEqual(taskScheduler.length(), 1);
+        
+        taskStates['key1'].signals.completeResolve();
+        await new Promise(resolve => setTimeout(resolve, 10)); // Small delay for processing
+        
+        // After key1 completes, its queued task should start
+        assert.strictEqual(taskScheduler.running(), 5);
+        assert.strictEqual(taskScheduler.length(), 0);
+
+        assert(drainStub.notCalled);
+        
+        // Complete all remaining tasks
+        Object.keys(taskStates).forEach(key => {
+            if (!taskStates[key].complete) {
+                taskStates[key].signals.completeResolve();
+            }
+        });
+        
+        // Wait a moment for all tasks to complete processing
+        await new Promise(resolve => setTimeout(resolve, 10));
+
+        assert.strictEqual(taskScheduler.running(), 0);
+        assert.strictEqual(taskScheduler.length(), 0);
+        assert(drainStub.calledOnce);
+    });
+
+    describe('_tryDrain', () => {
+        it('should call the drain function if there are no tasks in the queue', () => {
+            const taskScheduler = new TaskScheduler(() => {});
+            const drainStub = sinon.stub();
+            taskScheduler.setDrain(drainStub);
+            sinon.stub(taskScheduler, 'idle').returns(true);
+            taskScheduler._tryDrain();
+            assert(drainStub.calledOnce);
+        });
+        it('should not call the drain function if there are tasks in the queue', () => {
+            const taskScheduler = new TaskScheduler(() => {});
+            const drainStub = sinon.stub();
+            taskScheduler.setDrain(drainStub);
+            sinon.stub(taskScheduler, 'idle').returns(false);
+            taskScheduler._tryDrain();
+            assert(drainStub.notCalled);
+        });
+        it('should not fail when drain function not defined', () => {
+            const taskScheduler = new TaskScheduler(() => {});
+            sinon.stub(taskScheduler, 'idle').returns(false);
+            assert.doesNotThrow(() => taskScheduler._tryDrain());
+        });
+    });
+
+    describe('setDrain', () => {
+        it('should set the drain function', () => {
+            const taskScheduler = new TaskScheduler(() => {});
+            const drainStub = sinon.stub();
+            taskScheduler.setDrain(drainStub);
+            assert.strictEqual(taskScheduler._drainFunc, drainStub);
+        });
+    });
+
+    describe('idle', () => {
+        it('should return true if there are no tasks running or waiting', () => {
+            const taskScheduler = new TaskScheduler(() => {});
+            taskScheduler._running = 0;
+            taskScheduler._inQueue = 0;
+            assert(taskScheduler.idle());
+        });
+        it('should return false if there are tasks running', () => {
+            const taskScheduler = new TaskScheduler(() => {});
+            taskScheduler._running = 1;
+            taskScheduler._inQueue = 0;
+            assert(!taskScheduler.idle());
+        });
+        it('should return false if there are tasks waiting', () => {
+            const taskScheduler = new TaskScheduler(() => {});
+            taskScheduler._running = 0;
+            taskScheduler._inQueue = 1;
+            assert(!taskScheduler.idle());
+        });
+        it('should return false if there are tasks running and waiting', () => {
+            const taskScheduler = new TaskScheduler(() => {});
+            taskScheduler._running = 1;
+            taskScheduler._inQueue = 1;
+            assert(!taskScheduler.idle());
+        });
+    });
+
+    describe('running', () => {
+        it('should return the number of tasks currently being processed', () => {
+            const taskScheduler = new TaskScheduler(() => {});
+            taskScheduler._running = 3;
+            assert.strictEqual(taskScheduler.running(), 3);
+        });
+    });
+
+    describe('length', () => {
+        it('should return the number of tasks waiting to be processed', () => {
+            const taskScheduler = new TaskScheduler(() => {});
+            taskScheduler._inQueue = 5;
+            assert.strictEqual(taskScheduler.length(), 5);
+        });
+    });
+
+    describe('push', () => {
+        it('should process a task immediately if there is no queue key and no dedup key', done => {
+            const processingFunc = sinon.stub().yields({ data: 'data' });
+            const taskScheduler = new TaskScheduler(processingFunc, null, null);
+            taskScheduler.push({}, res => {
+                assert.strictEqual(res.data, 'data');
+                assert(processingFunc.calledOnce);
+                assert.strictEqual(taskScheduler._running, 0);
+                assert.strictEqual(taskScheduler._inQueue, 0);
+                done();
+            });
+        });
+        it('should process a task immediately if there is a queue key and no dedup key', done => {
+            const processingFunc = sinon.stub().yields({ data: 'data' });
+            const taskScheduler = new TaskScheduler(processingFunc, ctx => ctx.queueKey, null);
+            taskScheduler.push({ queueKey: 'key' }, res => {
+                assert.strictEqual(res.data, 'data');
+                assert(processingFunc.calledOnce);
+                assert.strictEqual(taskScheduler._running, 0);
+                assert.strictEqual(taskScheduler._inQueue, 0);
+                done();
+            });
+        });
+        it('should skip task with existing dedup key', done => {
+            let blockedTaskResolve;
+            const blockedTaskPromise = new Promise(resolve => { blockedTaskResolve = resolve; });
+            const processingFunc = sinon.stub().callsFake((ctx, cb) => {
+                if (ctx.id === 'block') {
+                    return blockedTaskPromise.then(() => cb());
+                }
+                return cb();
+            });
+            const taskScheduler = new TaskScheduler(processingFunc, null, ctx => ctx.dedupeKey);
+
+            const firstTaskCb = sinon.spy();
+            taskScheduler.push({ id: 'block', dedupeKey: 'key' }, firstTaskCb);
+
+            const secondTaskCb = sinon.spy();
+            taskScheduler.push({ dedupeKey: 'key' }, secondTaskCb);
+
+            process.nextTick(() => {
+                assert(processingFunc.calledOnce);
+                assert(firstTaskCb.notCalled);
+                assert(secondTaskCb.calledOnce);
+
+                blockedTaskResolve();
+
+                setTimeout(() => {
+                    assert(firstTaskCb.calledOnce);
+                    assert(processingFunc.calledOnce);
+                    assert.strictEqual(taskScheduler._running, 0);
+                    assert.strictEqual(taskScheduler._inQueue, 0);
+                    done();
+                }, 10);
+            });
+        });
+        it('should remove dedup key after task completion', done => {
+            const processingFunc = sinon.stub().yields();
+            const taskScheduler = new TaskScheduler(processingFunc, ctx => ctx.queueKey, null);
+            async.series([
+                next => taskScheduler.push({ queueKey: 'key' }, next),
+                next => taskScheduler.push({ queueKey: 'key' }, next),
+            ], () => {
+                assert(processingFunc.calledTwice);
+                done();
+            });
+        });
+        it('should ignore non string dedup key', done => {
+            let blockedTaskResolve;
+            const blockedTaskPromise = new Promise(resolve => { blockedTaskResolve = resolve; });
+            const processingFunc = sinon.stub().callsFake((ctx, cb) => {
+                if (ctx.id === 'block') {
+                    return blockedTaskPromise.then(() => cb());
+                }
+                return cb();
+            });
+            const taskScheduler = new TaskScheduler(processingFunc, null, ctx => ctx.dedupeKey);
+
+            const firstTaskCb = sinon.spy();
+            taskScheduler.push({ id: 'block', dedupeKey: 1 }, firstTaskCb);
+
+            const secondTaskCb = sinon.spy();
+            taskScheduler.push({ dedupeKey: 1 }, secondTaskCb);
+
+            process.nextTick(() => {
+                assert(processingFunc.calledTwice);
+                assert(firstTaskCb.notCalled);
+                assert(secondTaskCb.calledOnce);
+
+                blockedTaskResolve();
+
+                setTimeout(() => {
+                    assert(firstTaskCb.calledOnce);
+                    assert(processingFunc.calledTwice);
+                    assert.strictEqual(taskScheduler._running, 0);
+                    assert.strictEqual(taskScheduler._inQueue, 0);
+                    done();
+                }, 10);
+            });
+        });
+        it('should queue task with the same queue key', done => {
+            let blockedTaskResolve;
+            const blockedTaskPromise = new Promise(resolve => { blockedTaskResolve = resolve; });
+            const processingFunc = sinon.stub().callsFake((ctx, cb) => {
+                if (ctx.id === 'block') {
+                    return blockedTaskPromise.then(() => cb());
+                }
+                return cb();
+            });
+            const taskScheduler = new TaskScheduler(processingFunc, ctx => ctx.key);
+
+            const firstTaskCb = sinon.spy();
+            taskScheduler.push({ id: 'block', key: 'key' }, firstTaskCb);
+
+            const secondTaskCb = sinon.spy();
+            taskScheduler.push({ key: 'key' }, secondTaskCb);
+
+            const thirdTaskCb = sinon.spy();
+            taskScheduler.push({ key: 'different-key' }, thirdTaskCb);
+
+            setTimeout(() => {
+                assert.strictEqual(taskScheduler._running, 1);
+                assert.strictEqual(taskScheduler._inQueue, 1);
+                assert(firstTaskCb.notCalled);
+                assert(secondTaskCb.notCalled);
+                assert(thirdTaskCb.calledOnce);
+
+                blockedTaskResolve();
+
+                setTimeout(() => {
+                    assert(firstTaskCb.calledOnce);
+                    assert(secondTaskCb.calledOnce);
+                    assert(processingFunc.calledThrice);
+                    assert.strictEqual(taskScheduler._running, 0);
+                    assert.strictEqual(taskScheduler._inQueue, 0);
+                    done();
+                }, 10);
+            }, 10);
+        });
+        it('should ignore non string queue key', done => {
+            let blockedTaskResolve;
+            const blockTaskPromise = new Promise(resolve => { blockedTaskResolve = resolve; });
+            const processingFunc = sinon.stub().callsFake((ctx, cb) => {
+                if (ctx.id === 'block') {
+                    return blockTaskPromise.then(() => cb());
+                }
+                return cb();
+            });
+            const taskScheduler = new TaskScheduler(processingFunc, ctx => ctx.key);
+
+            const firstTaskCb = sinon.spy();
+            taskScheduler.push({ id: 'block', key: 1 }, firstTaskCb);
+
+            const secondTaskCb = sinon.spy();
+            taskScheduler.push({ key: 1 }, secondTaskCb);
+
+            setTimeout(() => {
+                assert.strictEqual(taskScheduler._running, 1);
+                assert.strictEqual(taskScheduler._inQueue, 0);
+                assert(firstTaskCb.notCalled);
+                assert(secondTaskCb.calledOnce);
+
+                blockedTaskResolve();
+
+                setTimeout(() => {
+                    assert(firstTaskCb.calledOnce);
+                    assert(processingFunc.calledTwice);
+                    assert.strictEqual(taskScheduler._running, 0);
+                    assert.strictEqual(taskScheduler._inQueue, 0);
+                    done();
+                }, 10);
+            }, 10);
+        });
+        it('should call the drain function if there are no tasks in the queue', done => {
+            let blockedTaskResolve;
+            const blockTaskPromise = new Promise(resolve => { blockedTaskResolve = resolve; });
+            const processingFunc = sinon.stub().callsFake((ctx, cb) => {
+                if (ctx.id === 'block') {
+                    return blockTaskPromise.then(() => cb());
+                }
+                return cb();
+            });
+            const taskScheduler = new TaskScheduler(processingFunc);
+
+            const drain = sinon.stub();
+            taskScheduler.setDrain(drain);
+
+            const firstTaskCb = sinon.spy();
+            taskScheduler.push({ id: 'block' }, firstTaskCb);
+
+            const secondTaskCb = sinon.spy();
+            taskScheduler.push({ id: 'block' }, secondTaskCb);
+
+            const thirdTaskCb = sinon.spy();
+            taskScheduler.push({ }, thirdTaskCb);
+
+            setTimeout(() => {
+                assert.strictEqual(taskScheduler._running, 2);
+                assert.strictEqual(taskScheduler._inQueue, 0);
+                assert(firstTaskCb.notCalled);
+                assert(secondTaskCb.notCalled);
+                assert(thirdTaskCb.calledOnce);
+                assert(drain.notCalled);
+
+                blockedTaskResolve();
+
+                setTimeout(() => {
+                    assert(firstTaskCb.calledOnce);
+                    assert(secondTaskCb.calledOnce);
+                    assert(drain.calledOnce);
+                    assert.strictEqual(taskScheduler._running, 0);
+                    assert.strictEqual(taskScheduler._inQueue, 0);
+                    done();
+                }, 10);
+            }, 10);
+        });
+    });
+
+    describe('_getTaskQueue', () => {
+        it('should return an existing task queue', () => {
+            const taskScheduler = new TaskScheduler(() => {});
+            const queue = async.queue(() => {});
+            taskScheduler._taskQueues.key = queue;
+            assert.strictEqual(taskScheduler._getTaskQueue({}, 'key'), queue);
+        });
+        it('should create a new task queue if one does not exist', () => {
+            const taskScheduler = new TaskScheduler(() => {});
+            const queue = taskScheduler._getTaskQueue({}, 'key');
+            assert.strictEqual(taskScheduler._taskQueues.key, queue);
+        });
+    });
+
+    describe('_queueProcessingFunc', () => {
+        it('should decrement the number of tasks in the queue and increment the number of running tasks', () => {
+            const taskScheduler = new TaskScheduler(() => {});
+            taskScheduler._inQueue = 1;
+            taskScheduler._running = 0;
+            taskScheduler._queueProcessingFunc();
+            assert.strictEqual(taskScheduler._inQueue, 0);
+            assert.strictEqual(taskScheduler._running, 1);
+        });
     });
 });


### PR DESCRIPTION
Instead of processing all messages concurrently, we now queue messages with the same key and process them one after the other in order. Messages with no key are processed concurrently as before.

The `taskScheduler` was re-used for this task as it allows queuing and sequential processing of tasks based on a key. This class was enhanced to support limiting the concurrency of tasks without a key + helper function to allow flow control in `BackbeatConsumer`.

Issue: BB-645