### PR TITLE
Support having multiple crr locations configured in the queueProcessor

### DIFF
--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -257,17 +257,12 @@ class QueueProcessor extends EventEmitter {
             this._setupRedis(redisConfig);
         }
 
-        // FIXME support multiple scality destination sites
-        if (Array.isArray(destConfig.bootstrapList)) {
-            destConfig.bootstrapList.forEach(dest => {
-                if (Array.isArray(dest.servers)) {
-                    this.destHosts =
-                        new RoundRobin(dest.servers, { defaultPort: 80 });
-                    if (dest.echo) {
-                        this._setupEcho();
-                    }
-                }
-            });
+        if (Array.isArray(this.destConfig.replicationEndpoint.servers)) {
+            this.destHosts =
+                new RoundRobin(this.destConfig.replicationEndpoint.servers, { defaultPort: 80 });
+            if (this.destConfig.replicationEndpoint.echo) {
+                this._setupEcho();
+            }
         }
 
         this.taskScheduler = new TaskScheduler(
@@ -889,10 +884,8 @@ class QueueProcessor extends EventEmitter {
                 sourceEntry.getReplicationStorageClass();
             const sites = getLocationsFromStorageClass(replicationStorageClass);
             if (sites.includes(this.site)) {
-                const replicationEndpoint = this.destConfig.bootstrapList
-                    .find(endpoint => endpoint.site === this.site);
-                if (replicationEndpoint &&
-                replicationBackends.includes(replicationEndpoint.type)) {
+                if (this.destConfig.replicationEndpoint &&
+                    replicationBackends.includes(this.destConfig.replicationEndpoint.type)) {
                     task = new MultipleBackendTask(this);
                 } else {
                     task = new ReplicateObject(this);

--- a/extensions/replication/queueProcessor/task.js
+++ b/extensions/replication/queueProcessor/task.js
@@ -185,10 +185,13 @@ function initAndStart(zkClient) {
 
             async.each(allSites, (site, next) => {
                 if (updatedSites.includes(site)) {
+                    const siteConfig = config.getReplicationSiteDestConfig(site);
                     if (!destConfig[site]) {
-                        destConfig[site] = config.getReplicationSiteDestConfig(site);
+                        destConfig[site] = siteConfig;
                     } else {
-                        destConfig[site].bootstrapList = updatedBootstrapList;
+                        // Only updating replicationEndpoint to keep maintaining reference
+                        // in the queue processor instance
+                        destConfig[site].replicationEndpoint = siteConfig.replicationEndpoint;
                     }
                     if (!activeSites.includes(site)) {
                         const qp = new QueueProcessor(

--- a/extensions/replication/tasks/CopyLocationTask.js
+++ b/extensions/replication/tasks/CopyLocationTask.js
@@ -23,18 +23,15 @@ const MPU_GCP_MAX_PARTS = 1024;
 class CopyLocationTask extends BackbeatTask {
 
     _getReplicationEndpointType() {
-        const replicationEndpoint = this.destConfig.bootstrapList
-            .find(endpoint => endpoint.site === this.site);
-        return replicationEndpoint.type;
+        return this.destConfig?.replicationEndpoint?.type;
     }
 
     constructor(qp) {
         const qpState = qp.getStateVars();
         super();
         Object.assign(this, qpState);
-        this.destType = null;
-        if (this.destConfig && this.destConfig.bootstrapList) {
-            this.destType = this._getReplicationEndpointType();
+        this.destType = this._getReplicationEndpointType();
+        if (this.destConfig && this.destType) {
             const retryParams =
                   this.repConfig.queueProcessor.retry[this.destType];
             if (retryParams) {

--- a/extensions/replication/tasks/MultipleBackendTask.js
+++ b/extensions/replication/tasks/MultipleBackendTask.js
@@ -38,9 +38,7 @@ const BACKBEAT_INJECT_REPLICATION_ERROR_DELTAG =
 class MultipleBackendTask extends ReplicateObject {
 
     _getReplicationEndpointType() {
-        const replicationEndpoint = this.destConfig.bootstrapList
-            .find(endpoint => endpoint.site === this.site);
-        return replicationEndpoint.type;
+        return this.destConfig.replicationEndpoint.type;
     }
 
     _setupRolesOnce(entry, log, cb) {

--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -45,16 +45,13 @@ class ReplicateObject extends BackbeatTask {
      */
     constructor(qp) {
         const qpState = qp.getStateVars();
-        const { repConfig, destConfig, site } = qpState;
+        const { repConfig, destConfig } = qpState;
 
         let retryParams = repConfig.queueProcessor.retry.scality;
 
-        if (destConfig?.bootstrapList) {
-            const destination = destConfig.bootstrapList
-                .find(endpoint => endpoint.site === site) || {};
-            const { type: destType } = destination;
-            if (repConfig.queueProcessor.retry[destType]) {
-                retryParams = repConfig.queueProcessor.retry[destType];
+        if (destConfig?.replicationEndpoint) {
+            if (repConfig.queueProcessor.retry[destConfig.replicationEndpoint.type]) {
+                retryParams = repConfig.queueProcessor.retry[destConfig.replicationEndpoint.type];
             }
         }
 

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -313,7 +313,7 @@ class Config extends EventEmitter {
         return {
             transport: destConfig.sites?.[site]?.transport || destConfig.transport,
             auth: destConfig.sites?.[site]?.auth || destConfig.auth,
-            bootstrapList: this.bootstrapList,
+            replicationEndpoint: this.bootstrapList.find(endpoint => endpoint.site === site),
         };
     }
 }

--- a/tests/functional/replication/pauseResumeState.js
+++ b/tests/functional/replication/pauseResumeState.js
@@ -25,9 +25,15 @@ const repConfig = config.extensions.replication;
 const sourceConfig = {
     auth: { type: 'skip' },
 };
-const destConfig = {
+const firstSite = repConfig.destination.bootstrapList[0].site;
+const firstSiteConf = {
     auth: { type: 'skip', vault: 'skip' },
-    bootstrapList: repConfig.destination.bootstrapList,
+    replicationEndpoint: repConfig.destination.bootstrapList[0],
+};
+const secondSite = repConfig.destination.bootstrapList[1].site;
+const secondSiteConf = {
+    auth: { type: 'skip', vault: 'skip' },
+    replicationEndpoint: repConfig.destination.bootstrapList[1],
 };
 const mConfig = config.metrics;
 
@@ -48,8 +54,6 @@ describe('CRR Pause/Resume status updates', function d() {
     this.timeout(10000);
     let zkHelper;
     let mockAPI;
-    const firstSite = destConfig.bootstrapList[0].site;
-    const secondSite = destConfig.bootstrapList[1].site;
     let qpSite1;
     let qpSite2;
     let consumer1;
@@ -74,14 +78,14 @@ describe('CRR Pause/Resume status updates', function d() {
             // qpSite1 (first site) is not paused
             qpSite1 = new QueueProcessor(
                 'backbeat-func-test-dummy-topic', zkConfig, zkClient,
-                kafkaConfig, sourceConfig, destConfig, repConfig,
+                kafkaConfig, sourceConfig, firstSiteConf, repConfig,
                 redisConfig, mConfig, {}, {}, firstSite);
             qpSite1.start();
 
             // qpSite2 (second site) is paused and has a scheduled resume
             qpSite2 = new QueueProcessor(
                 'backbeat-func-test-dummy-topic', zkConfig, zkClient,
-               kafkaConfig, sourceConfig, destConfig, repConfig,
+               kafkaConfig, sourceConfig, secondSiteConf, repConfig,
                redisConfig, mConfig, {}, {}, secondSite);
             qpSite2.start({ paused: true });
             qpSite2.scheduleResume(futureDate);
@@ -112,14 +116,14 @@ describe('CRR Pause/Resume status updates', function d() {
             // replay processor
             replayProcessor1 = new QueueProcessor(
                 ZK_TEST_CRR_REPLAY_TOPIC, zkConfig, zkClient,
-                kafkaConfig, sourceConfig, destConfig, replayConfig,
+                kafkaConfig, sourceConfig, firstSiteConf, replayConfig,
                 redisConfig, mConfig, {}, {}, firstSite);
             replayProcessor1.start();
 
             // replay processor 2 (second site) is paused
             replayProcessor2 = new QueueProcessor(
                 ZK_TEST_CRR_REPLAY_TOPIC, zkConfig, zkClient,
-                kafkaConfig, sourceConfig, destConfig, replayConfig,
+                kafkaConfig, sourceConfig, secondSiteConf, replayConfig,
                 redisConfig, mConfig, {}, {}, secondSite);
             replayProcessor2.start({ paused: true });
             replayProcessor2.scheduleResume(futureDate);

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -756,6 +756,56 @@ function sendCopyLocationAction(s3mock, queueProcessor, resultsCb) {
 
 /* eslint-enable max-len */
 
+function getQueueProcessorSiteConfig(site) {
+    const replicationEndpoints = {
+        sf: {
+            site: 'sf',
+            servers: constants.target.hosts.map(h => `${h.host}:${h.port}`),
+        },
+        toazure: {
+            site: 'toazure',
+            type: 'azure',
+        },
+    };
+    return [
+        'backbeat-func-test-dummy-topic',
+        { connectionString: '127.0.0.1:2181/backbeat',
+          autoCreateNamespace: false },
+        null,
+        { hosts: 'localhost:9092' },
+        { auth: { type: 'role',
+            vault: { host: constants.source.vault,
+                port: 7777 } },
+            s3: { host: constants.source.s3,
+                port: 7777 },
+            transport: 'http',
+        },
+        {
+            auth: { type: 'role' },
+            replicationEndpoint: replicationEndpoints[site],
+            transport: 'http',
+        },
+        { topic: 'backbeat-func-test-dummy-topic',
+          replicationStatusTopic: 'backbeat-func-test-repstatus',
+          queueProcessor: {
+              retry: {
+                  scality: { timeoutS: 5 },
+                  azure: { timeoutS: 5 },
+              },
+              groupId: 'backbeat-func-test-group-id',
+              mpuPartsConcurrency: 10,
+              sourceCheckIfSizeGreaterThanMB: 10,
+          },
+        },
+        { host: '127.0.0.1',
+          port: 6379 },
+        { topic: 'metrics-test-topic' },
+        {},
+        {},
+        site,
+    ];
+}
+
 describe('queue processor functional tests with mocking', () => {
     let queueProcessorSF;
     let queueProcessorAzure;
@@ -768,58 +818,17 @@ describe('queue processor functional tests with mocking', () => {
 
     before(function before(done) {
         this.timeout(60000);
-        const serverList =
-                  constants.target.hosts.map(h => `${h.host}:${h.port}`);
-
-        const qpParams = [
-            'backbeat-func-test-dummy-topic',
-            { connectionString: '127.0.0.1:2181/backbeat',
-              autoCreateNamespace: false },
-            null,
-            { hosts: 'localhost:9092' },
-            { auth: { type: 'role',
-                vault: { host: constants.source.vault,
-                    port: 7777 } },
-                s3: { host: constants.source.s3,
-                    port: 7777 },
-                transport: 'http',
-            },
-            { auth: { type: 'role' },
-                bootstrapList: [{
-                    site: 'sf', servers: serverList,
-                }, {
-                    site: 'toazure', type: 'azure',
-                }],
-                transport: 'http' },
-            { topic: 'backbeat-func-test-dummy-topic',
-              replicationStatusTopic: 'backbeat-func-test-repstatus',
-              queueProcessor: {
-                  retry: {
-                      scality: { timeoutS: 5 },
-                      azure: { timeoutS: 5 },
-                  },
-                  groupId: 'backbeat-func-test-group-id',
-                  mpuPartsConcurrency: 10,
-                  sourceCheckIfSizeGreaterThanMB: 10,
-              },
-            },
-            { host: '127.0.0.1',
-              port: 6379 },
-            { topic: 'metrics-test-topic' },
-            {},
-            {},
-        ];
         async.series([
             done => async.parallel([
                 done => {
                     queueProcessorSF =
-                        new QueueProcessor(...qpParams.concat(['sf']));
+                        new QueueProcessor(...getQueueProcessorSiteConfig('sf'));
                     queueProcessorSF.start({ disableConsumer: true });
                     queueProcessorSF.on('ready', done);
                 },
                 done => {
                     queueProcessorAzure =
-                        new QueueProcessor(...qpParams.concat(['toazure']));
+                        new QueueProcessor(...getQueueProcessorSiteConfig('toazure'));
                     queueProcessorAzure.start({ disableConsumer: true });
                     queueProcessorAzure.on('ready', done);
                 },

--- a/tests/functional/replication/streamedCopy.spec.js
+++ b/tests/functional/replication/streamedCopy.spec.js
@@ -39,9 +39,9 @@ const qpParams = [
       transport: 'http',
     },
     { auth: { type: 'account', account: 'bart' },
-      bootstrapList: [{
+      replicationEndpoint: {
           site: 'sf', servers: ['127.0.0.2:7777'],
-      }],
+      },
       transport: 'http' },
     { topic: 'backbeat-func-test-dummy-topic',
       replicationStatusTopic: 'backbeat-func-test-repstatus',

--- a/tests/unit/conf/Config.js
+++ b/tests/unit/conf/Config.js
@@ -115,11 +115,10 @@ describe('Config', () => {
                     type: 'service',
                     account: 'service-replication-3',
                 },
-                bootstrapList: [
-                    { site: 'aws1', type: 'aws_s3' },
-                    { site: 'aws2', type: 'aws_s3' },
-                    { site: 'aws3', type: 'aws_s3' }
-                ]
+                replicationEndpoint: {
+                    site: 'aws3',
+                    type: 'aws_s3',
+                },
             });
         });
 
@@ -145,11 +144,10 @@ describe('Config', () => {
                     type: 'service',
                     account: 'service-replication',
                 },
-                bootstrapList: [
-                    { site: 'aws1', type: 'aws_s3' },
-                    { site: 'aws2', type: 'aws_s3' },
-                    { site: 'aws3', type: 'aws_s3' }
-                ]
+                replicationEndpoint: {
+                    site: 'aws3',
+                    type: 'aws_s3',
+                },
             });
         });
     });

--- a/tests/unit/replication/CopyLocationTask.spec.js
+++ b/tests/unit/replication/CopyLocationTask.spec.js
@@ -97,4 +97,212 @@ describe('CopyLocationTask', () => {
             assert(task.replicationStatusProducer.notCalled);
         });
     });
+
+    describe('_initiateMPU', () => {
+        let task;
+        beforeEach(() => {
+            task = new CopyLocationTask({
+                getStateVars: () => ({
+                    site: 'test-site',
+                    mProducer: {
+                        getProducer: () => {},
+                    },
+                }),
+            });
+        });
+        it('should init mpu when location type is not azure', done => {
+            const entry = new ActionQueueEntry({
+                target: {
+                    key: 'key',
+                    eTag: '"1234-9"',
+                },
+                toLocation: 'test-site',
+            });
+            task.backbeatClient = {
+                multipleBackendInitiateMPU: sinon.stub().returns({
+                    send: cb => cb(null, {}),
+                    on: () => {},
+                }),
+            };
+            task.destConfig = {
+                replicationEndpoint: {
+                    site: 'test-site',
+                    type: 'aws_s3',
+                },
+            };
+            task._initiateMPU(entry, new ObjectMD(), fakeLogger, err => {
+                assert.ifError(err);
+                assert(task.backbeatClient.multipleBackendInitiateMPU.calledOnce);
+                done();
+            });
+        });
+        it('should not init mpu when location type is azure', done => {
+            const entry = new ActionQueueEntry({
+                target: {
+                    key: 'key',
+                    eTag: '"1234-9"',
+                },
+                toLocation: 'test-site',
+            });
+            task.backbeatClient = {
+                multipleBackendInitiateMPU: sinon.stub().returns({
+                    send: cb => cb(null, {}),
+                    on: () => {},
+                }),
+            };
+            task.destConfig = {
+                replicationEndpoint: {
+                    site: 'test-site',
+                    type: 'azure',
+                },
+            };
+            task._initiateMPU(entry, new ObjectMD(), fakeLogger, err => {
+                assert.ifError(err);
+                assert(task.backbeatClient.multipleBackendInitiateMPU.notCalled);
+                done();
+            });
+        });
+    });
+
+    describe('_completeRangedMPU', () => {
+        let task;
+        beforeEach(() => {
+            task = new CopyLocationTask({
+                getStateVars: () => ({
+                    site: 'test-site',
+                    repConfig: {
+                        queueProcessor: {
+                            mpuPartsConcurrency: 2,
+                        },
+                    },
+                    mProducer: {
+                        getProducer: () => {},
+                    },
+                }),
+            });
+        });
+        it('should abort MPU on part upload error', done => {
+            const entry = new ActionQueueEntry({
+                target: {
+                    key: 'key',
+                    eTag: '"1234-9"',
+                },
+                toLocation: 'test-site',
+            });
+            const objectMD = new ObjectMD();
+            objectMD.setContentLength(200);
+            
+            sinon.stub(task, '_getRanges').returns([
+                { start: 0, end: 100 },
+                { start: 101, end: 199 }
+            ]);
+            
+            const putRangeFunc = sinon.stub(task, '_getRangeAndPutMPUPart');
+            putRangeFunc.onCall(0).yields(null, {
+                partNumber: 0,
+                ETag: 'etag1',
+            });
+            putRangeFunc.onCall(1).yields(new Error('Upload failed'));
+            
+            const abortMpuFunc = sinon.stub(task, '_multipleBackendAbortMPU').yields();
+            const completeMpuFunc = sinon.stub(task, '_completeMPU').yields();
+            
+            task.destConfig = {
+                replicationEndpoint: {
+                    site: 'test-site',
+                    type: 'aws_s3',
+                },
+            };
+            
+            const uploadId = 'test-upload-id';
+            task._completeRangedMPU(entry, objectMD, uploadId, fakeLogger, err => {
+                assert(err);
+                assert.strictEqual(err.message, 'Upload failed');
+                assert(abortMpuFunc.calledOnce);
+                assert(abortMpuFunc.calledWith(
+                    entry, objectMD, uploadId, fakeLogger, sinon.match.func
+                ));
+                assert(completeMpuFunc.notCalled);
+                done();
+            });
+        });
+            
+        it('should handle Azure special case for MPU parts', done => {
+            const entry = new ActionQueueEntry({
+                target: {
+                    key: 'key',
+                    eTag: '"1234-9"',
+                },
+                toLocation: 'test-site',
+            });
+            const objectMD = new ObjectMD();
+            objectMD.setContentLength(200);
+            
+            sinon.stub(task, '_getRanges').returns([
+                { start: 0, end: 100 },
+                { start: 101, end: 199 }
+            ]);
+            
+            const putRangeFunc = sinon.stub(task, '_getRangeAndPutMPUPart');
+            putRangeFunc.onCall(0).yields(null, {
+                partNumber: 0,
+                ETag: 'etag1',
+                numberSubParts: 2
+            });
+            putRangeFunc.onCall(1).yields(null, {
+                partNumber: 1,
+                ETag: 'etag2',
+                numberSubParts: 1
+            });
+            
+            const completeMpuFunc = sinon.stub(task, '_completeMPU').yields();
+            
+            task.destConfig = {
+                replicationEndpoint: {
+                    site: 'test-site',
+                    type: 'azure',
+                },
+            };
+            
+            task._completeRangedMPU(entry, objectMD, 'test-upload-id', fakeLogger, err => {
+                assert.ifError(err);
+                assert(completeMpuFunc.calledOnce);
+                const completionData = completeMpuFunc.firstCall.args[3];
+                assert(completionData[0].NumberSubParts);
+                assert(completionData[1].NumberSubParts);
+                done();
+            });
+        });
+    });
+
+    describe('constructor', () => {
+        it('should use retry config of the relevent type', () => {
+            const task = new CopyLocationTask({
+                getStateVars: () => ({
+                    mProducer: {
+                        getProducer: () => {},
+                    },
+                    repConfig: {
+                        queueProcessor: {
+                            retry: {
+                                scality: {
+                                    maxRetries: 13,
+                                },
+                                azure: {
+                                    maxRetries: 5,
+                                },
+                            },
+                        },
+                    },
+                    destConfig: {
+                        replicationEndpoint: {
+                            site: 'test-site',
+                            type: 'scality',
+                        }
+                    },
+                }),
+            });
+            assert.strictEqual(task.retryParams.maxRetries, 13);
+        });
+    });
 });

--- a/tests/unit/replication/MultipleBackendTask.js
+++ b/tests/unit/replication/MultipleBackendTask.js
@@ -51,10 +51,15 @@ describe('MultipleBackendTask', function test() {
                 repConfig: {
                     queueProcessor: {
                         retry: retryConfig,
+                        mpuPartsConcurrency: 2,
                     },
                 },
                 sourceConfig: config.extensions.replication.source,
-                destConfig: config.extensions.replication.destination,
+                destConfig: {
+                    ...config.extensions.replication.destination,
+                    replicationEndpoint: config.extensions.replication.destination.bootstrapList
+                        .find(e => e.site === 'test-site-2'),
+                },
                 site: 'test-site-2',
                 notificationConfigManager: {
                     getConfig: () => null
@@ -435,6 +440,119 @@ describe('MultipleBackendTask', function test() {
                 assert(putObjectHandler.calledOnce);
                 delete task.repConfig.queueProcessor.minMPUSizeMB;
                 return done();
+            });
+        });
+    });
+
+    describe('_initiateMPU', () => {
+        it('should init mpu when location type is not azure', done => {
+            task.backbeatSource = {
+                multipleBackendInitiateMPU: sinon.stub().returns({
+                    send: cb => cb(null, {}),
+                    on: () => {},
+                }),
+            };
+            task.destConfig = {
+                replicationEndpoint: {
+                    site: 'test-site',
+                    type: 'aws_s3',
+                },
+            };
+            task._initiateMPU(sourceEntry, fakeLogger, err => {
+                assert.ifError(err);
+                assert(task.backbeatSource.multipleBackendInitiateMPU.calledOnce);
+                done();
+            });
+        });
+        it('should not init mpu when location type is azure', done => {
+            task.backbeatSource = {
+                multipleBackendInitiateMPU: sinon.stub().returns({
+                    send: cb => cb(null, {}),
+                    on: () => {},
+                }),
+            };
+            task.destConfig = {
+                replicationEndpoint: {
+                    site: 'test-site',
+                    type: 'azure',
+                },
+            };
+            task._initiateMPU(sourceEntry, fakeLogger, err => {
+                assert.ifError(err);
+                assert(task.backbeatSource.multipleBackendInitiateMPU.notCalled);
+                done();
+            });
+        });
+    });
+
+    describe('_completeRangedMPU', () => {
+        it('should abort MPU on part upload error', done => {            
+            sinon.stub(task, '_getRanges').returns([
+                { start: 0, end: 100 },
+                { start: 101, end: 199 }
+            ]);
+            
+            const putRangeFunc = sinon.stub(task, '_getRangeAndPutMPUPart');
+            putRangeFunc.onCall(0).yields(null, {
+                partNumber: 0,
+                ETag: 'etag1',
+            });
+            putRangeFunc.onCall(1).yields(new Error('Upload failed'));
+            
+            const abortMpuFunc = sinon.stub(task, '_multipleBackendAbortMPU').yields();
+            const completeMpuFunc = sinon.stub(task, '_completeMPU').yields();
+            
+            task.destConfig = {
+                replicationEndpoint: {
+                    site: 'test-site',
+                    type: 'aws_s3',
+                },
+            };
+            
+            const uploadId = 'test-upload-id';
+            task._completeRangedMPU(sourceEntry, uploadId, fakeLogger, err => {
+                assert(err);
+                assert.strictEqual(err.message, 'Upload failed');
+                assert(abortMpuFunc.calledOnce);
+                assert(completeMpuFunc.notCalled);
+                done();
+            });
+        });
+            
+        it('should handle Azure special case for MPU parts', done => {
+            sinon.stub(task, '_getRanges').returns([
+                { start: 0, end: 100 },
+                { start: 101, end: 199 }
+            ]);
+            
+            const putRangeFunc = sinon.stub(task, '_getRangeAndPutMPUPart');
+            putRangeFunc.onCall(0).yields(null, {
+                partNumber: 0,
+                ETag: 'etag1',
+                numberSubParts: 2
+            });
+            putRangeFunc.onCall(1).yields(null, {
+                partNumber: 1,
+                ETag: 'etag2',
+                numberSubParts: 1
+            });
+            
+            const completeMpuFunc = sinon.stub(task, '_completeMPU').yields();
+            
+            task.destConfig = {
+                replicationEndpoint: {
+                    site: 'test-site',
+                    type: 'azure',
+                },
+            };
+            
+            task._completeRangedMPU(sourceEntry, 'test-upload-id', fakeLogger, err => {
+                assert.ifError(err);
+                assert(completeMpuFunc.calledOnce);
+                const completionData = completeMpuFunc.firstCall.args[2];
+                assert(completionData[0].NumberSubParts);
+                assert(completionData[1].NumberSubParts);
+                done();
             });
         });
     });

--- a/tests/unit/replication/QueueProcessor.spec.js
+++ b/tests/unit/replication/QueueProcessor.spec.js
@@ -5,47 +5,55 @@ const constants = require('../../../lib/constants');
 const QueueProcessor =
     require('../../../extensions/replication/queueProcessor/QueueProcessor');
 
+function getQueueProcessorConfig() {
+    return [
+        'backbeat-func-test-dummy-topic',
+        { connectionString: '127.0.0.1:2181/backbeat',
+          autoCreateNamespace: false },
+        null,
+        { hosts: 'localhost:9092' },
+        { auth: { type: 'role',
+            vault: { host: 'localhost:9093',
+                port: 7777 } },
+            s3: { host: 'localhost:9094',
+                port: 7777 },
+            transport: 'http',
+        },
+        {
+            transport: 'http',
+            auth: { type: 'role' },
+            replicationEndpoint: {
+                site: 'site-crr',
+                servers: ['site-crr:8000'],
+            },
+        },
+        { topic: 'backbeat-func-test-dummy-topic',
+          replicationStatusTopic: 'backbeat-func-test-repstatus',
+          queueProcessor: {
+              retry: {
+                  scality: { timeoutS: 5 },
+                  azure: { timeoutS: 5 },
+              },
+              groupId: 'backbeat-func-test-group-id',
+              mpuPartsConcurrency: 10,
+          },
+        },
+        null,
+        { topic: 'metrics-test-topic' },
+        {},
+        {},
+        'site-crr',
+    ];
+}
+
 describe('Queue Processor', () => {
     let qp;
     beforeEach(() => {
-        qp = new QueueProcessor(
-            'backbeat-func-test-dummy-topic',
-            { connectionString: '127.0.0.1:2181/backbeat',
-              autoCreateNamespace: false },
-            null,
-            { hosts: 'localhost:9092' },
-            { auth: { type: 'role',
-                vault: { host: 'localhost:9093',
-                    port: 7777 } },
-                s3: { host: 'localhost:9094',
-                    port: 7777 },
-                transport: 'http',
-            },
-            { auth: { type: 'role' },
-                bootstrapList: [{
-                    site: 'site', servers: ['localhost:9095'],
-                }, {
-                    site: 'toazure', type: 'azure',
-                }],
-                transport: 'http' },
-            { topic: 'backbeat-func-test-dummy-topic',
-              replicationStatusTopic: 'backbeat-func-test-repstatus',
-              queueProcessor: {
-                  retry: {
-                      scality: { timeoutS: 5 },
-                      azure: { timeoutS: 5 },
-                  },
-                  groupId: 'backbeat-func-test-group-id',
-                  mpuPartsConcurrency: 10,
-              },
-            },
-            { host: '127.0.0.1',
-              port: 6379 },
-            { topic: 'metrics-test-topic' },
-            {},
-            {},
-            'site',
-        );
+        qp = new QueueProcessor(...getQueueProcessorConfig());
+    });
+
+    afterEach(() => {
+        sinon.restore();
     });
 
     describe('handle liveness', () => {
@@ -81,11 +89,11 @@ describe('Queue Processor', () => {
                     {
                         component: 'Replication Status Producer',
                         status: constants.statusUndefined,
-                        site: 'site',
+                        site: 'site-crr',
                     }, {
                         component: 'Consumer',
                         status: constants.statusUndefined,
-                        site: 'site',
+                        site: 'site-crr',
                     },
                 ]
             );
@@ -117,14 +125,56 @@ describe('Queue Processor', () => {
                     {
                         component: 'Replication Status Producer',
                         status: constants.statusNotReady,
-                        site: 'site',
+                        site: 'site-crr',
                     }, {
                         component: 'Consumer',
                         status: constants.statusNotReady,
-                        site: 'site',
+                        site: 'site-crr',
                     },
                 ]
             );
+        });
+    });
+
+    describe('constructor', () => {
+        it('should use s3c site\'s host as a destination host', () => {
+            const config = getQueueProcessorConfig();
+            config[5].replicationEndpoint = {
+                site: 'site-crr',
+                servers: ['site-crr:8000'],
+            };
+            config[11] = 'site-crr';
+            const qp = new QueueProcessor(...config);
+            assert.deepStrictEqual(qp.destHosts.pickHost(), {
+                host: 'site-crr',
+                port: 8000,
+            });
+        });
+        it('should setup echo mode when configured for site', () => {
+            const config = getQueueProcessorConfig();
+            config[5].replicationEndpoint = {
+                site: 'site-crr',
+                servers: ['site-crr:8000'],
+                echo: true,
+            };
+            config[11] = 'site-crr';
+            const setupEchoStub = sinon.stub(QueueProcessor.prototype, '_setupEcho').returns();
+            const qp = new QueueProcessor(...config);
+            assert.deepStrictEqual(qp.destHosts.pickHost(), {
+                host: 'site-crr',
+                port: 8000,
+            });
+            assert(setupEchoStub.calledOnce);
+        });
+        it('should not set destination host when using a non scality type site', () => {
+            const config = getQueueProcessorConfig();
+            config[5].replicationEndpoint = {
+                site: 'site_aws',
+                type: 's3_aws',
+            };
+            config[11] = 'site_aws';
+            const qp = new QueueProcessor(...config);
+            assert.strictEqual(qp.destHosts, null);
         });
     });
 });

--- a/tests/unit/replication/ReplicateObject.spec.js
+++ b/tests/unit/replication/ReplicateObject.spec.js
@@ -181,4 +181,32 @@ describe('ReplicateObject', () => {
             });
         });
     });
+
+    describe('constructor', () => {
+        it('should use retry config of the relevent type', () => {
+            const task = new ReplicateObject({
+                getStateVars: () => ({
+                    repConfig: {
+                        queueProcessor: {
+                            retry: {
+                                scality: {
+                                    maxRetries: 5,
+                                },
+                                azure: {
+                                    maxRetries: 4,
+                                },
+                            },
+                        },
+                    },
+                    destConfig: {
+                        replicationEndpoint: {
+                            site: 'test-site',
+                            type: 'scality',
+                        },
+                    },
+                }),
+            });
+            assert.strictEqual(task.retryParams.maxRetries, 5);
+        });
+    });
 });


### PR DESCRIPTION
QueueProcessor currently sets the destination host to the host of the last crr site in the bootstrap list, so when having multiple crr locations configured this will not work.

Issue: BB-662