### PR TITLE
BB-676: Ignore bucket migration oplog operations

### DIFF
--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -355,7 +355,26 @@ class LogReader {
         });
     }
 
+    isSupportedOperation(record) {
+        // Check if the given record’s method is supported by this LogReader.
+        // Currently, only methods with an method ID < 10 are supported.
+        // This is intentional so that any future methods (>= 10) that are
+        // not explicitly supported will be rejected by default.
+        // List of methods defined in Metadata/lib/protocol.json.
+        return !record.method || record.method < 10;
+    }
+
     _processLogEntry(batchState, record, entry, cb) {
+        if (!this.isSupportedOperation(record)) {
+            this.log.debug('skipping unsupported operation',
+                {
+                    method: 'LogReader._processLogEntry',
+                    record,
+                    entry,
+                });
+            return cb();
+        }
+
         function _transformKey(key) {
             if (!key) {
                 return undefined;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "7.70.18",
+  "version": "7.70.19",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/lib/queuePopulator/LogReader.spec.js
+++ b/tests/unit/lib/queuePopulator/LogReader.spec.js
@@ -65,21 +65,22 @@ describe('LogReader', () => {
         processedKey: 'v1-version-key\u0000version-id',
     }].forEach(testCase => {
         it(`LogReader::_processLogEntry() should process entry with a ${testCase.desc}`, () => {
-            logReader._processLogEntry(null, { db: 'db' }, {
+            logReader._processLogEntry(null, { db: 'db', method: 8 }, {
                 type: 'put',
                 key: testCase.key,
                 value: '{}',
-            });
-            assert.deepStrictEqual(filteredEntry, {
-                type: 'put',
-                bucket: 'db',
-                key: testCase.processedKey,
-                value: '{}',
-                logReader,
-                overheadFields: {
-                    versionId: undefined,
-                    commitTimestamp: undefined,
-                },
+            }, () => {
+                assert.deepStrictEqual(filteredEntry, {
+                    type: 'put',
+                    bucket: 'db',
+                    key: testCase.processedKey,
+                    value: '{}',
+                    logReader,
+                    overheadFields: {
+                        versionId: undefined,
+                        commitTimestamp: undefined,
+                    },
+                });
             });
         });
     });
@@ -87,6 +88,7 @@ describe('LogReader', () => {
     it('should pass through overhead.versionId if available in record', () => {
         const record = {
             db: 'db',
+            method: 8,
         };
         const versionId = 'v1';
         const entry = {
@@ -97,17 +99,18 @@ describe('LogReader', () => {
                 versionId,
             },
         };
-        logReader._processLogEntry(null, record, entry);
-        assert.deepStrictEqual(filteredEntry, {
-            type: 'put',
-            bucket: 'db',
-            key: 'k1',
-            value: '{}',
-            logReader,
-            overheadFields: {
-                versionId,
-                commitTimestamp: undefined,
-            },
+        logReader._processLogEntry(null, record, entry, () => {
+            assert.deepStrictEqual(filteredEntry, {
+                type: 'put',
+                bucket: 'db',
+                key: 'k1',
+                value: '{}',
+                logReader,
+                overheadFields: {
+                    versionId,
+                    commitTimestamp: undefined,
+                },
+            });
         });
     });
 
@@ -116,23 +119,25 @@ describe('LogReader', () => {
         const record = {
             db: 'db',
             timestamp,
+            method: 8,
         };
         const entry = {
             type: 'put',
             key: 'k1',
             value: '{}',
         };
-        logReader._processLogEntry(null, record, entry);
-        assert.deepStrictEqual(filteredEntry, {
-            type: 'put',
-            bucket: 'db',
-            key: 'k1',
-            value: '{}',
-            logReader,
-            overheadFields: {
-                versionId: undefined,
-                commitTimestamp: timestamp,
-            },
+        logReader._processLogEntry(null, record, entry, () => {
+            assert.deepStrictEqual(filteredEntry, {
+                type: 'put',
+                bucket: 'db',
+                key: 'k1',
+                value: '{}',
+                logReader,
+                overheadFields: {
+                    versionId: undefined,
+                    commitTimestamp: timestamp,
+                },
+            });
         });
     });
 
@@ -156,6 +161,74 @@ describe('LogReader', () => {
         errorLogReader.setup(err => {
             assert.ifError(err);
             assert.strictEqual(errorLogReader.logOffset, 1);
+            done();
+        });
+    });
+
+    it('should ignore operations with method === 10', done => {
+        const filteredEntries = [];
+        const reader = new LogReader({
+            logId: 'test-log-reader',
+            zkClient: zkMock.createClient('localhost:2181'),
+            logConsumer: new MockLogConsumer(),
+            extensions: [{
+                filter: entry => { filteredEntries.push(entry); },
+                setBatch: () => {},
+                unsetBatch: () => {},
+            }],
+            logger: new Logger('test:logReader'),
+        });
+        reader._processReadRecords = (params, batchState, done) => done();
+        reader._processSaveLogOffset = (batchState, done) => done();
+        reader._processPrepareEntries = (batchState, done) => {
+            // eslint-disable-next-line no-param-reassign
+            batchState.logRes = {
+                info: {
+                    cseq: 12345,
+                },
+            };
+            batchState.currentRecords.push({
+                db: 'db',
+                method: 8,
+                entries: [
+                    {
+                        type: 'put',
+                        key: 'key',
+                        value: '{}',
+                    },
+                ],
+                timestamp: 't1',
+            });
+            batchState.currentRecords.push({
+                db: 'db',
+                method: 10,
+                entries: [
+                    {
+                        type: 'bucket_migration',
+                        value: '{}',
+                    },
+                ],
+                timestamp: 't2',
+            });
+            done();
+        };
+
+        reader.processLogEntries({}, () => {
+            assert.deepStrictEqual(filteredEntries,
+                [
+                    {
+                        type: 'put',
+                        bucket: 'db',
+                        key: 'key',
+                        value: '{}',
+                        logReader: reader,
+                        overheadFields: {
+                            versionId: undefined,
+                            commitTimestamp: 't1',
+                        },
+                    },
+                ]
+            );
             done();
         });
     });


### PR DESCRIPTION
In the context of handling bucket migration in SUR, we have introduced a new type of operations that appear in the Metadata oplog and are consumed by Backbeat.

The format the of new operation type is (using an example):
```
    {
      "db": "some-bucket",
      "method": 10,
      "entries": [
        {
          "type": "bucket_migration_stage",
          "value": "{\"currentStage\":\"finalize\",\"owner-id\":\"d6633a8b3cfa8ce37c1ed8530f2fbfaa4713f96c416bf3162499483e863757b2\",\"raftSessionType\":\"source\"}"
        }
      ],
      "timestamp": "2025-04-03T06:36:50.401Z"
    },
```

`method: 10` is a new method type, `APPEND_TO_LOG:` https://github.com/scality/MetaData/blob/f2f3bd87b4a47d4d0849fbf497dd55aedd8c052f/lib/protocol.json#L30 

To make sure that Backbeat ignores these operations, and any new operations added in the future (until we explicitly want to add support for  new operations), this change adds a check for operations that are known and supported by Backbeat.