### PR TITLE
INTEGRATION [PR#2635 > development/9.0] BB-676: Ignore bucket migration oplog operations

### DIFF
--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -510,7 +510,22 @@ class LogReader {
         return undefined;
     }
 
+    _isSupportedOperation(record) {
+        // List of methods defined in Metadata/lib/protocol.json.
+        return !record.method || record.method < 10;
+    }
+
     _processLogEntry(batchState, record, entry, cb) {
+        if (!this._isSupportedOperation(record)) {
+            this.log.debug('skipping unsupported operation',
+                {
+                    method: 'LogReader._processLogEntry',
+                    record,
+                    entry,
+                });
+            return cb();
+        }
+
         function _executeFilter(ext, entry, cb) {
             if (typeof ext.filterAsync === 'function') {
                 ext.filterAsync(entry, cb);

--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -355,7 +355,22 @@ class LogReader {
         });
     }
 
+    _isSupportedOperation(record) {
+        // List of methods defined in Metadata/lib/protocol.json.
+        return !record.method || record.method < 10;
+    }
+
     _processLogEntry(batchState, record, entry, cb) {
+        if (!this._isSupportedOperation(record)) {
+            this.log.debug('skipping unsupported operation',
+                {
+                    method: 'LogReader._processLogEntry',
+                    record,
+                    entry,
+                });
+            return cb();
+        }
+
         function _transformKey(key) {
             if (!key) {
                 return undefined;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.0.5",
+  "version": "9.0.6",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "7.70.18",
+  "version": "7.70.19",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/lib/queuePopulator/LogReader.spec.js
+++ b/tests/unit/lib/queuePopulator/LogReader.spec.js
@@ -65,21 +65,22 @@ describe('LogReader', () => {
         processedKey: 'v1-version-key\u0000version-id',
     }].forEach(testCase => {
         it(`LogReader::_processLogEntry() should process entry with a ${testCase.desc}`, () => {
-            logReader._processLogEntry(null, { db: 'db' }, {
+            logReader._processLogEntry(null, { db: 'db', method: 8 }, {
                 type: 'put',
                 key: testCase.key,
                 value: '{}',
-            });
-            assert.deepStrictEqual(filteredEntry, {
-                type: 'put',
-                bucket: 'db',
-                key: testCase.processedKey,
-                value: '{}',
-                logReader,
-                overheadFields: {
-                    versionId: undefined,
-                    commitTimestamp: undefined,
-                },
+            }, () => {
+                assert.deepStrictEqual(filteredEntry, {
+                    type: 'put',
+                    bucket: 'db',
+                    key: testCase.processedKey,
+                    value: '{}',
+                    logReader,
+                    overheadFields: {
+                        versionId: undefined,
+                        commitTimestamp: undefined,
+                    },
+                });
             });
         });
     });
@@ -87,6 +88,7 @@ describe('LogReader', () => {
     it('should pass through overhead.versionId if available in record', () => {
         const record = {
             db: 'db',
+            method: 8,
         };
         const versionId = 'v1';
         const entry = {
@@ -97,17 +99,18 @@ describe('LogReader', () => {
                 versionId,
             },
         };
-        logReader._processLogEntry(null, record, entry);
-        assert.deepStrictEqual(filteredEntry, {
-            type: 'put',
-            bucket: 'db',
-            key: 'k1',
-            value: '{}',
-            logReader,
-            overheadFields: {
-                versionId,
-                commitTimestamp: undefined,
-            },
+        logReader._processLogEntry(null, record, entry, () => {
+            assert.deepStrictEqual(filteredEntry, {
+                type: 'put',
+                bucket: 'db',
+                key: 'k1',
+                value: '{}',
+                logReader,
+                overheadFields: {
+                    versionId,
+                    commitTimestamp: undefined,
+                },
+            });
         });
     });
 
@@ -116,23 +119,25 @@ describe('LogReader', () => {
         const record = {
             db: 'db',
             timestamp,
+            method: 8,
         };
         const entry = {
             type: 'put',
             key: 'k1',
             value: '{}',
         };
-        logReader._processLogEntry(null, record, entry);
-        assert.deepStrictEqual(filteredEntry, {
-            type: 'put',
-            bucket: 'db',
-            key: 'k1',
-            value: '{}',
-            logReader,
-            overheadFields: {
-                versionId: undefined,
-                commitTimestamp: timestamp,
-            },
+        logReader._processLogEntry(null, record, entry, () => {
+            assert.deepStrictEqual(filteredEntry, {
+                type: 'put',
+                bucket: 'db',
+                key: 'k1',
+                value: '{}',
+                logReader,
+                overheadFields: {
+                    versionId: undefined,
+                    commitTimestamp: timestamp,
+                },
+            });
         });
     });
 
@@ -156,6 +161,74 @@ describe('LogReader', () => {
         errorLogReader.setup(err => {
             assert.ifError(err);
             assert.strictEqual(errorLogReader.logOffset, 1);
+            done();
+        });
+    });
+
+    it('should ignore operations with method === 10', done => {
+        const filteredEntries = [];
+        const reader = new LogReader({
+            logId: 'test-log-reader',
+            zkClient: zkMock.createClient('localhost:2181'),
+            logConsumer: new MockLogConsumer(),
+            extensions: [{
+                filter: entry => { filteredEntries.push(entry); },
+                setBatch: () => {},
+                unsetBatch: () => {},
+            }],
+            logger: new Logger('test:logReader'),
+        });
+        reader._processReadRecords = (params, batchState, done) => done();
+        reader._processSaveLogOffset = (batchState, done) => done();
+        reader._processPrepareEntries = (batchState, done) => {
+            // eslint-disable-next-line no-param-reassign
+            batchState.logRes = {
+                info: {
+                    cseq: 12345,
+                },
+            };
+            batchState.currentRecords.push({
+                db: 'db',
+                method: 8,
+                entries: [
+                    {
+                        type: 'put',
+                        key: 'key',
+                        value: '{}',
+                    },
+                ],
+                timestamp: 't1',
+            });
+            batchState.currentRecords.push({
+                db: 'db',
+                method: 10,
+                entries: [
+                    {
+                        type: 'bucket_migration',
+                        value: '{}',
+                    },
+                ],
+                timestamp: 't2',
+            });
+            done();
+        };
+
+        reader.processLogEntries({}, () => {
+            assert.deepStrictEqual(filteredEntries,
+                [
+                    {
+                        type: 'put',
+                        bucket: 'db',
+                        key: 'key',
+                        value: '{}',
+                        logReader: reader,
+                        overheadFields: {
+                            versionId: undefined,
+                            commitTimestamp: 't1',
+                        },
+                    },
+                ]
+            );
             done();
         });
     });

--- a/tests/unit/lib/queuePopulator/LogReader.spec.js
+++ b/tests/unit/lib/queuePopulator/LogReader.spec.js
@@ -391,6 +391,75 @@ describe('LogReader', () => {
                 done();
             });
         });
+
+        it('should ignore operations with method === 10', done => {
+            const filteredEntries = [];
+            const reader = new LogReader({
+                logId: 'test-log-reader',
+                zkClient: zkMock.createClient('localhost:2181'),
+                logConsumer: new MockLogConsumer(),
+                extensions: [{
+                    filter: entry => { filteredEntries.push(entry); },
+                    setBatch: () => {},
+                    unsetBatch: () => {},
+                }],
+                logger: new Logger('test:logReader'),
+            });
+            reader._processReadRecords = (params, batchState, done) => done();
+            reader._processSaveLogOffset = (batchState, done) => done();
+            reader._processPrepareEntries = (batchState, done) => {
+                // eslint-disable-next-line no-param-reassign
+                batchState.logRes = {
+                    info: {
+                        cseq: 12345,
+                    },
+                    log: {},
+                };
+                batchState.currentRecords.push({
+                    db: 'db',
+                    method: 8,
+                    entries: [
+                        {
+                            type: 'put',
+                            key: 'key',
+                            value: '{}',
+                        },
+                    ],
+                    timestamp: 't1',
+                });
+                batchState.currentRecords.push({
+                    db: 'db',
+                    method: 10,
+                    entries: [
+                        {
+                            type: 'bucket_migration',
+                            value: '{}',
+                        },
+                    ],
+                    timestamp: 't2',
+                });
+                done();
+            };
+
+            reader.processLogEntries({}, () => {
+                assert.deepStrictEqual(filteredEntries,
+                    [
+                        {
+                            type: 'put',
+                            bucket: 'db',
+                            key: 'key',
+                            value: '{}',
+                            logReader: reader,
+                            overheadFields: {
+                                opTimestamp: undefined,
+                                commitTimestamp: 't1',
+                            },
+                        },
+                    ]
+                );
+                done();
+            });
+        });
     });
 
     describe('_processPrepareEntries', () => {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #2635.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/9.0/improvement/BB-676`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/9.0/improvement/BB-676
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/9.0/improvement/BB-676
```

Please always comment pull request #2635 instead of this one.