### PR TITLE
Share S3 client between CRR tasks

### DIFF
--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -14,6 +14,7 @@ const RoundRobin = require('arsenal').network.RoundRobin;
 const BackbeatProducer = require('../../../lib/BackbeatProducer');
 const BackbeatConsumer = require('../../../lib/BackbeatConsumer');
 const VaultClientCache = require('../../../lib/clients/VaultClientCache');
+const ClientsManager = require('../../../lib/clients/ClientsManager');
 const QueueEntry = require('../../../lib/models/QueueEntry');
 const TaskScheduler = require('../../../lib/tasks/TaskScheduler');
 const { getTaskSchedulerQueueKey,
@@ -226,6 +227,7 @@ class QueueProcessor extends EventEmitter {
         this.echoMode = false;
         this.scheduledResume = null;
         this.circuitBreakerConfig = circuitBreakerConfig;
+        this.clientsManager = null;
 
         this.logger = new Logger(
             `Backbeat:Replication:QueueProcessor:${this.site}`);
@@ -253,6 +255,8 @@ class QueueProcessor extends EventEmitter {
         }
 
         this._setupVaultclientCache();
+        this._setupClientsManager();
+        
         if (redisConfig) {
             this._setupRedis(redisConfig);
         }
@@ -356,6 +360,14 @@ class QueueProcessor extends EventEmitter {
                     this.httpsConfig.ca);
             }
         }
+    }
+
+    _setupClientsManager() {
+        if (this.destConfig.auth.type !== libConstants.authTypeAssumeRole) {
+            return;
+        }
+        this.clientsManager = new ClientsManager(`crr-${this.site}`, this.logger);
+        this.clientsManager.initCredentialsManager();
     }
 
     _setupProducer(done) {
@@ -689,6 +701,7 @@ class QueueProcessor extends EventEmitter {
             destHTTPAgent: this.destHTTPAgent,
             vaultclientCache: this.vaultclientCache,
             accountCredsCache: this.accountCredsCache,
+            clientsManager: this.clientsManager,
             replicationStatusProducer: this.replicationStatusProducer,
             mProducer: this._mProducer,
             logger: this.logger,

--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -5,7 +5,6 @@ const errors = require('arsenal').errors;
 const jsutil = require('arsenal').jsutil;
 const ObjectMDLocation = require('arsenal').models.ObjectMDLocation;
 
-const ClientManager = require('../../../lib/clients/ClientManager');
 const BackbeatClient = require('../../../lib/clients/BackbeatClient');
 const BackbeatMetadataProxy = require('../../../lib/BackbeatMetadataProxy');
 
@@ -29,6 +28,10 @@ function _extractAccountIdFromRole(role) {
 
 function _extractRoleNameFromRole(role) {
     return role.split(':role/')[1];
+}
+
+function _buildClientId(accountId, targetRole) {
+    return `${accountId}-${targetRole}`;
 }
 
 // BACKBEAT_INJECT_REPLICATION_ERROR_RATE variable can be set to randomly introduce errors.
@@ -719,17 +722,17 @@ class ReplicateObject extends BackbeatTask {
         this.backbeatSourceProxy.setBackbeatClient(this.backbeatSource);
     }
 
-    _setupDestClients(targetRole, log) {
-        this.destBackbeatHost = this.destHosts.pickHost();
-
-        if (this.destConfig.auth.type === authTypeAssumeRole) {
-            const accountId = _extractAccountIdFromRole(targetRole);
-            const roleName = _extractRoleNameFromRole(targetRole);
-            this.clientManager = new ClientManager({
-                id: accountId,
+    _setupAssumeRoleDestClient(targetRole) {
+        const accountId = _extractAccountIdFromRole(targetRole);
+        const clientId = _buildClientId(accountId, targetRole);
+        const clientConfig = this.clientsManager.getClientConfig(clientId);
+        // Create a new client if it doesn't exist
+        if (!clientConfig) {
+            this.clientsManager.setClientConfig(clientId, {
+                accountId,
                 authConfig: {
                     type: authTypeAssumeRole,
-                    roleName,
+                    roleName: _extractRoleNameFromRole(targetRole),
                     sts: {
                         ...this.destConfig.auth.sts,
                         accessKey: locations[this.site].details.credentials.accessKey,
@@ -741,10 +744,29 @@ class ReplicateObject extends BackbeatTask {
                     port: this.destBackbeatHost.port,
                 },
                 transport: this.destConfig.transport,
-            }, this.logger);
-            this.clientManager.initSTSConfig();
-            this.clientManager.initCredentialsManager();
-            this.backbeatDest = this.clientManager.getBackbeatClient(accountId);
+            });
+        } else {
+            // S3 endpoint can change with retries, in this case update the s3 config
+            // and remove previously created clients
+            const s3HostUpdated =
+                (clientConfig.s3Config.host !== this.destBackbeatHost.host) ||
+                (clientConfig.s3Config.port !== this.destBackbeatHost.port);
+            if (s3HostUpdated) {
+                clientConfig.s3Config = {
+                    host: this.destBackbeatHost.host,
+                    port : this.destBackbeatHost.port,
+                };
+                this.clientsManager.removeClients(clientId);
+            }
+        }
+        this.backbeatDest = this.clientsManager.getBackbeatClient(clientId);
+    }
+
+    _setupDestClients(targetRole, log) {
+        this.destBackbeatHost = this.destHosts.pickHost();
+
+        if (this.destConfig.auth.type === authTypeAssumeRole) {
+            this._setupAssumeRoleDestClient(targetRole);
             return;
         }
 

--- a/lib/clients/ClientsManager.js
+++ b/lib/clients/ClientsManager.js
@@ -1,0 +1,286 @@
+const CredentialsManager = require('../credentials/CredentialsManager');
+const BackbeatMetadataProxy = require('../BackbeatMetadataProxy');
+const { createBackbeatClient, createS3Client } = require('./utils');
+const { authTypeAssumeRole } = require('../constants');
+const { http: HttpAgent, https: HttpsAgent } = require('httpagent');
+
+const DELETE_INACTIVE_CREDENTIALS_INTERVAL = 1000 * 60 * 30; // 30m
+const MAX_INACTIVE_DURATION = 1000 * 60 * 60 * 2; // 2hr
+
+/**
+ * @typedef {Object} StsConfig
+ * @property {string} host - STS host
+ * @property {string} port - STS port
+ * @property {string} [externalFile] - Path of the file containing the STS crendentials
+ * @property {string} [accessKey] - STS access key
+ * @property {string} [secretKey] - STS secret key
+ */
+
+/**
+ * @typedef {Object} AuthConfig
+ * @property {('account'|'service'|'assumeRole')} type - Authentication method
+ * @property {String} roleName - Role name to use in assumeRole
+ * @property {StsConfig} sts - STS config
+ */
+
+/**
+ * @typedef {Object} S3Config
+ * @property {string} host - S3 host
+ * @property {string} port - S3 port
+ */
+
+/**
+ * @typedef {('http'|'https')} Transport
+ */
+
+/**
+ * @typedef {Object} Config
+ * @property {String} accountId - account id
+ * @property {AuthConfig} authConfig - auth config
+ * @property {S3Config} s3Config - S3 config
+ * @property {Transport} transport - transport method
+ */
+
+/**
+ * @typedef {Object} ClientConfig
+ * @property {String} accountId - account id
+ * @property {AuthConfig} authConfig - auth config
+ * @property {S3Config} s3Config - S3 config
+ * @property {Transport} transport - transport method
+ * @property {(HttpAgent.Agent|HttpsAgent.Agent)} s3Agent - http agent to use for S3
+ * @property {(HttpAgent.Agent|HttpsAgent.Agent)} stsAgent - http agent to use for STS
+ */
+
+/**
+ * An improved version of the ClientManager Class
+ *
+ * Supports storing multiple clients with different
+ * auth configs.
+ */
+class ClientsManager {
+
+    /**
+     * @constructor
+     *
+     * @param {String} id id of the clients manager
+     * (used in the logs and as a suffix of the role session name)
+     * @param {Object} logger logger instance
+     */
+    constructor(id, logger) {
+        this._log = logger;
+        this._id = id;
+        this._configs = {};
+        this.s3Clients = {};
+        this.backbeatClients = {};
+        this.credentialsManager = new CredentialsManager(this._id, this._log);
+    }
+
+    /**
+     * Initializes the mecanism of credential deletion
+     * after they expires
+     * @returns {undefined}
+     */
+    initCredentialsManager() {
+        this.credentialsManager.on('deleteCredentials', clientId => {
+            delete this.s3Clients[clientId];
+            delete this.backbeatClients[clientId];
+        });
+
+        this._deleteInactiveCredentialsInterval = setInterval(() => {
+            this.credentialsManager.removeInactiveCredentials(MAX_INACTIVE_DURATION);
+        }, DELETE_INACTIVE_CREDENTIALS_INTERVAL);
+    }
+
+    /**
+     * @param {AuthConfig} authConfig
+     * @param {Transport} transport
+     * @param {HttpAgent.Agent|HttpsAgent.Agent} stsAgent
+     * @returns {Object}
+     */
+    _generateSTSConfig(authConfig, transport, stsAgent) {
+        if (authConfig.type === authTypeAssumeRole) {
+            const { sts } = authConfig;
+            const stsWithCreds = CredentialsManager.resolveExternalFileSync(sts, this._log);
+            return {
+                endpoint: `${transport||'http'}://${sts.host}:${sts.port}`,
+                credentials: {
+                    accessKeyId: stsWithCreds.accessKey,
+                    secretAccessKey: stsWithCreds.secretKey,
+                },
+                region: 'us-east-1',
+                signatureVersion: 'v4',
+                sslEnabled: transport === 'https',
+                httpOptions: { agent: stsAgent, timeout: 0 },
+                maxRetries: 0,
+            };
+        }
+        return null;
+    }
+
+    /**
+     * @param {Transport} transport
+     * @returns {Object}
+     */
+    _createAgents(transport) {
+        if (transport === 'https') {
+            return {
+                s3Agent: new HttpsAgent.Agent({ keepAlive: true }),
+                stsAgent: new HttpsAgent.Agent({ keepAlive: true }),
+            };
+        }
+        return {
+            s3Agent: new HttpAgent.Agent({ keepAlive: true }),
+            stsAgent: new HttpAgent.Agent({ keepAlive: true }),
+        };
+    }
+
+    /**
+     * @param {Config} config
+     * @returns {ClientConfig}
+     */
+    _generateClientConfig(config) {
+        const { accountId, authConfig, s3Config, transport } = config;
+        const { s3Agent, stsAgent } = this._createAgents(transport);
+        const stsConfig = this._generateSTSConfig(authConfig, transport, stsAgent);
+        return {
+            accountId,
+            authConfig,
+            s3Config,
+            transport: transport || 'http',
+            stsConfig,
+            s3Agent,
+            stsAgent,
+        };
+    }
+
+    /**
+     * @param {String} clientId 
+     * @param {Config} config 
+     */
+    setClientConfig(clientId, config) {
+        this._configs[clientId] = this._generateClientConfig(config);
+    }
+
+    /**
+     * @param {String} clientId 
+     * @returns {ClientConfig|null}
+     */
+    getClientConfig(clientId) {
+        return this._configs[clientId] || null;
+    }
+
+    /**
+     * Return an S3 client instance
+     * @param {String} clientId - The client id.
+     * @return {AWS.S3} The S3 client instance to make requests with
+     */
+    getS3Client(clientId) {
+        const config = this._configs[clientId];
+        if (!config) {
+            return null;
+        }
+
+        const credentials = this.credentialsManager.getCredentials({
+            id: clientId,
+            accountId: config.accountId,
+            stsConfig: config.stsConfig,
+            authConfig: config.authConfig,
+        });
+
+        if (credentials === null) {
+            return null;
+        }
+
+        const client = this.s3Clients[clientId];
+
+        if (client) {
+            return client;
+        }
+
+        this.s3Clients[clientId] = createS3Client({
+            transport: config.transport,
+            port: config.s3Config.port,
+            host: config.s3Config.host,
+            credentials,
+            agent: config.s3Agent,
+        });
+
+        return this.s3Clients[clientId];
+    }
+
+    /**
+     * Return an backbeat metadata proxy
+     * @param {String} clientId - The client id. .
+     * @return {BackbeatMetadataProxy} The S3 client instance to make requests with
+     */
+    getBackbeatMetadataProxy(clientId) {
+        const client = this.getBackbeatClient(clientId);
+        if (client === null) {
+            return null;
+        }
+
+        const config = this._configs[clientId];
+        if (!config) {
+            return null;
+        }
+
+        const { transport, s3Config, authConfig } = config;
+
+        return new BackbeatMetadataProxy(
+            `${transport}://${s3Config.host}:${s3Config.port}`,
+            authConfig,
+        ).setBackbeatClient(client);
+    }
+
+    /**
+     * Return an backbeat client instance
+     * @param {String} clientId - The client id.
+     * @return {BackbeatClient} The S3 client instance to make requests with
+     */
+    getBackbeatClient(clientId) {
+        const config = this._configs[clientId];
+        if (!config) {
+            return null;
+        }
+
+        const credentials = this.credentialsManager.getCredentials({
+            id: clientId,
+            accountId: config.accountId,
+            stsConfig: config.stsConfig,
+            authConfig: config.authConfig,
+        });
+
+        if (credentials === null) {
+            return null;
+        }
+
+        const client = this.backbeatClients[clientId];
+
+        if (client) {
+            return client;
+        }
+
+        this.backbeatClients[clientId] = createBackbeatClient({
+            transport: config.transport,
+            port: config.s3Config.port,
+            host: config.s3Config.host,
+            credentials,
+            agent: config.s3Agent,
+        });
+
+        return this.backbeatClients[clientId];
+    }
+
+    /**
+     * Delete BackbeatClient and S3Client of
+     * a specific ClientID
+     * @param {String} clientId 
+     * @returns {undefined}
+     */
+    removeClients(clientId) {
+        delete this.s3Clients[clientId];
+        delete this.backbeatClients[clientId];
+    }
+}
+
+module.exports = ClientsManager;

--- a/tests/unit/clients/ClientsManager.spec.js
+++ b/tests/unit/clients/ClientsManager.spec.js
@@ -1,0 +1,330 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const { http: HttpAgent, https: HttpsAgent } = require('httpagent');
+
+const AWS = require('aws-sdk');
+const BackbeatMetadataProxy = require('../../../lib/BackbeatMetadataProxy');
+const BackbeatClient = require('../../../lib/clients/BackbeatClient');
+
+
+const fakeLogger = require('../../utils/fakeLogger');
+
+const ClientsManager = require('../../../lib/clients/ClientsManager');
+
+describe('ClientsManager', () => {
+    let cm;
+
+    beforeEach(() => {
+        cm = new ClientsManager('tests', fakeLogger);
+    });
+
+    describe('initCredentialsManager', () => {
+        beforeEach(() => {
+            cm.initCredentialsManager();
+        });
+        afterEach(() => {
+            cm.credentialsManager.removeAllListeners('deleteCredentials');
+            clearInterval(cm._deleteInactiveCredentialsInterval);
+        });
+        it('should remove clients if credentials expire', () => {
+            cm.s3Clients['testClient'] = true;
+            cm.backbeatClients['testClient'] = true;
+            // simulate expiration of credentials
+            cm.credentialsManager.emit('deleteCredentials', 'testClient');
+            // clients should be removed
+            assert.strictEqual(cm.s3Clients['testClient'], undefined);
+            assert.strictEqual(cm.backbeatClients['testClient'], undefined);
+        });
+        it('should do nothing if credentials not attached to a client', () => {
+            cm.s3Clients['testClient'] = true;
+            cm.backbeatClients['testClient'] = true;
+            // simulate expiration of credentials
+            cm.credentialsManager.emit('deleteCredentials', 'nonAttached');
+            // clients should still exist
+            assert.strictEqual(cm.s3Clients['testClient'], true);
+            assert.strictEqual(cm.backbeatClients['testClient'], true);
+        });
+    });
+    
+    describe('_generateSTSConfig', () => {
+        it('should resolve credentials', () => {
+            const authConfig = {
+                type: 'assumeRole',
+                roleName: 'someRole',
+                sts: {
+                    host: 'localhost',
+                    port: '8900',
+                    externalFile: `${__dirname}/utils/credentials.json`,
+                },
+            };
+            const stsConfig = cm._generateSTSConfig(authConfig, 'http', null);
+            assert.strictEqual(stsConfig.endpoint, 'http://localhost:8900');
+            assert.deepStrictEqual(stsConfig.credentials, {
+                accessKeyId: 'HPZYD8TCLETBDZBPNTNQ',
+                secretAccessKey: 'prMKjH3Epf2O7+pLA0iwW9OcZjiFVRpHT=7ir3w6',
+            });
+        });
+        it('should keep sts crendentials in the config', () => {
+            const authConfig = {
+                type: 'assumeRole',
+                roleName: 'someRole',
+                sts: {
+                    host: 'localhost',
+                    port: '8900',
+                    accessKey: 'access',
+                    secretKey: 'secret',
+                },
+            };
+            const stsConfig = cm._generateSTSConfig(authConfig, 'http', null);
+            assert.strictEqual(stsConfig.endpoint, 'http://localhost:8900');
+            assert.deepStrictEqual(stsConfig.credentials, {
+                accessKeyId: 'access',
+                secretAccessKey: 'secret',
+            });
+        });
+        it('should return null if auth type is not assumeRole', () => {
+            const authConfig = {
+                type: 'service',
+                roleName: 'someRole',
+            };
+            const stsConfig = cm._generateSTSConfig(authConfig, 'http', null);
+            assert.strictEqual(stsConfig, null);
+        });
+        it('should use default transport if not specified', () => {
+            const authConfig = {
+                type: 'assumeRole',
+                roleName: 'someRole',
+                sts: {
+                    host: 'localhost',
+                    port: '8900',
+                },
+            };
+            const stsConfig = cm._generateSTSConfig(authConfig, undefined, null);
+            assert.strictEqual(stsConfig.endpoint, 'http://localhost:8900');
+        });
+    });
+    
+    describe('_createAgents', () => {
+        it('should create http agents if transport is http', () => {
+            const agents = cm._createAgents('http');
+            assert(agents.s3Agent instanceof HttpAgent.Agent);
+            assert(agents.stsAgent instanceof HttpAgent.Agent);
+        });
+        it('should create https agents if transport is https', () => {
+            it('should create http agents if transport is http', () => {
+                const agents = cm._createAgents('https');
+                assert(agents.s3Agent instanceof HttpsAgent.Agent);
+                assert(agents.stsAgent instanceof HttpsAgent.Agent);
+            });
+        });
+        it('should default to http agents if transport is not specified', () => {
+            const agents = cm._createAgents();
+            assert(agents.s3Agent instanceof HttpAgent.Agent);
+            assert(agents.stsAgent instanceof HttpAgent.Agent);
+        });
+    });
+    
+    describe('_generateClientConfig', () => {
+        it('should generate client config with default transport', () => {
+            const config = {
+                accountId: 'testAccount',
+                authConfig: { type: 'account', account: 'bart' },
+                s3Config: { host: 'localhost', port: 9000 },
+            };
+            const clientConfig = cm._generateClientConfig(config);
+            assert.strictEqual(clientConfig.accountId, 'testAccount');
+            assert.strictEqual(clientConfig.authConfig.type, 'account');
+            assert.strictEqual(clientConfig.s3Config.host, 'localhost');
+            assert.strictEqual(clientConfig.s3Config.port, 9000);
+            assert.strictEqual(clientConfig.transport, 'http');
+        });
+        it('should generate client config with specified transport', () => {
+            const config = {
+                accountId: 'testAccount',
+                authConfig: { type: 'account', account: 'bart' },
+                s3Config: { host: 'localhost', port: 9000 },
+                transport: 'https',
+            };
+            const clientConfig = cm._generateClientConfig(config);
+            assert.strictEqual(clientConfig.accountId, 'testAccount');
+            assert.strictEqual(clientConfig.authConfig.type, 'account');
+            assert.strictEqual(clientConfig.s3Config.host, 'localhost');
+            assert.strictEqual(clientConfig.s3Config.port, 9000);
+            assert.strictEqual(clientConfig.transport, 'https');
+        });
+        it('should generate client config with STS config', () => {
+            const config = {
+                accountId: 'testAccount',
+                authConfig: {
+                    type: 'assumeRole',
+                    roleName: 'someRole',
+                    sts: {
+                        host: 'localhost',
+                        port: 8900,
+                        accessKey: 'access',
+                        secretKey: 'secret',
+                    },
+                },
+                s3Config: { host: 'localhost', port: 9000 },
+            };
+            const clientConfig = cm._generateClientConfig(config);
+            assert.strictEqual(clientConfig.stsConfig.endpoint, 'http://localhost:8900');
+            assert.deepStrictEqual(clientConfig.stsConfig.credentials, {
+                accessKeyId: 'access',
+                secretAccessKey: 'secret',
+            });
+        });
+    });
+    
+    describe('setClientConfig', () => {
+        it('should set client config', () => {
+            const config = {
+                accountId: 'testAccount',
+                authConfig: { type: 'account', account: 'bart' },
+                s3Config: { host: 'localhost', port: 9000 },
+            };
+            cm.setClientConfig('testClient', config);
+            const clientConfig = cm._configs['testClient'];
+            assert.strictEqual(clientConfig.accountId, 'testAccount');
+            assert.strictEqual(clientConfig.authConfig.type, 'account');
+            assert.strictEqual(clientConfig.s3Config.host, 'localhost');
+            assert.strictEqual(clientConfig.s3Config.port, 9000);
+            assert.strictEqual(clientConfig.transport, 'http');
+            assert.strictEqual(clientConfig.stsConfig, null);
+            assert(clientConfig.s3Agent instanceof HttpAgent.Agent);
+            assert(clientConfig.stsAgent instanceof HttpAgent.Agent);
+        });
+    });
+    
+    describe('getClientConfig', () => {
+        it('should get client config', () => {
+            const config = {
+                accountId: 'testAccount',
+                authConfig: { type: 'account', account: 'bart' },
+                s3Config: { host: 'localhost', port: 9000 },
+            };
+            cm.setClientConfig('testClient', config);
+            const clientConfig = cm.getClientConfig('testClient');
+            assert.strictEqual(clientConfig.accountId, 'testAccount');
+            assert.strictEqual(clientConfig.authConfig.type, 'account');
+            assert.strictEqual(clientConfig.s3Config.host, 'localhost');
+            assert.strictEqual(clientConfig.s3Config.port, 9000);
+        });
+        it('should return null if client config does not exist', () => {
+            const clientConfig = cm.getClientConfig('nonExistentClient');
+            assert.strictEqual(clientConfig, null);
+        });
+    });
+
+    describe('getS3Client', () => {
+        it('should create an s3 client', () => {
+            const config = {
+                accountId: 'testAccount',
+                authConfig: { type: 'account', account: 'bart' },
+                s3Config: { host: 'localhost', port: 9000 },
+            };
+            cm.setClientConfig('testClient', config);
+            const client = cm.getS3Client('testClient');
+            assert(client instanceof AWS.S3);
+        });
+        it('should return null if client does not exist', () => {
+            const client = cm.getS3Client('nonExistentClient');
+            assert.strictEqual(client, null);
+        });
+        it('should return null if credentials are not available', () => {
+            const config = {
+                accountId: 'testAccount',
+                authConfig: { type: 'account', account: 'bart' },
+                s3Config: { host: 'localhost', port: 9000 },
+            };
+            cm.setClientConfig('testClient', config);
+            cm.credentialsManager.getCredentials = sinon.stub().returns(null);
+            const client = cm.getS3Client('testClient');
+            assert.strictEqual(client, null);
+        });
+        it('should return existing client if it exists', () => {
+            const config = {
+                accountId: 'testAccount',
+                authConfig: { type: 'account', account: 'bart' },
+                s3Config: { host: 'localhost', port: 9000 },
+            };
+            cm.setClientConfig('testClient', config);
+            const client1 = cm.getS3Client('testClient');
+            const client2 = cm.getS3Client('testClient');
+            assert.strictEqual(client1, client2);
+        });
+    });
+    
+    describe('getBackbeatMetadataProxy', () => {
+        it('should create a backbeat metadata proxy', () => {
+            const config = {
+                accountId: 'testAccount',
+                authConfig: { type: 'account', account: 'bart' },
+                s3Config: { host: 'localhost', port: 9000 },
+            };
+            cm.setClientConfig('testClient', config);
+            const client = cm.getBackbeatMetadataProxy('testClient');
+            assert(client instanceof BackbeatMetadataProxy);
+        });
+        it('should return null if client does not exist', () => {
+            const client = cm.getBackbeatMetadataProxy('nonExistentClient');
+            assert.strictEqual(client, null);
+        });
+    });
+    
+    describe('getBackbeatClient', () => {
+        it('should create an BackbeatClient', () => {
+            const config = {
+                accountId: 'testAccount',
+                authConfig: { type: 'account', account: 'bart' },
+                s3Config: { host: 'localhost', port: 9000 },
+            };
+            cm.setClientConfig('testClient', config);
+            const client = cm.getBackbeatClient('testClient');
+            assert(client instanceof BackbeatClient);
+        });
+        it('should return null if client does not exist', () => {
+            const client = cm.getBackbeatClient('nonExistentClient');
+            assert.strictEqual(client, null);
+        });
+        it('should return null if credentials are not available', () => {
+            const config = {
+                accountId: 'testAccount',
+                authConfig: { type: 'account', account: 'bart' },
+                s3Config: { host: 'localhost', port: 9000 },
+            };
+            cm.setClientConfig('testClient', config);
+            cm.credentialsManager.getCredentials = sinon.stub().returns(null);
+            const client = cm.getBackbeatClient('testClient');
+            assert.strictEqual(client, null);
+        });
+        it('should return existing client if it exists', () => {
+            const config = {
+                accountId: 'testAccount',
+                authConfig: { type: 'account', account: 'bart' },
+                s3Config: { host: 'localhost', port: 9000 },
+            };
+            cm.setClientConfig('testClient', config);
+            const client1 = cm.getBackbeatClient('testClient');
+            const client2 = cm.getBackbeatClient('testClient');
+            assert.strictEqual(client1, client2);
+        });
+    });
+    
+    describe('removeClients', () => {
+        it('should remove clients', () => {
+            cm.s3Clients['testClient'] = true;
+            cm.backbeatClients['testClient'] = true;
+            cm.removeClients('testClient');
+            assert.strictEqual(cm.s3Clients['testClient'], undefined);
+            assert.strictEqual(cm.backbeatClients['testClient'], undefined);
+        });
+        it('should do nothing if client does not exist', () => {
+            cm.s3Clients['testClient'] = true;
+            cm.backbeatClients['testClient'] = true;
+            cm.removeClients('nonExistentClient');
+            assert.strictEqual(cm.s3Clients['testClient'], true);
+            assert.strictEqual(cm.backbeatClients['testClient'], true);
+        });
+    });
+});

--- a/tests/unit/clients/utils/credentials.json
+++ b/tests/unit/clients/utils/credentials.json
@@ -1,0 +1,4 @@
+{
+    "accessKey": "HPZYD8TCLETBDZBPNTNQ",
+    "secretKey": "prMKjH3Epf2O7+pLA0iwW9OcZjiFVRpHT=7ir3w6"
+}

--- a/tests/unit/replication/QueueProcessor.spec.js
+++ b/tests/unit/replication/QueueProcessor.spec.js
@@ -177,4 +177,24 @@ describe('Queue Processor', () => {
             assert.strictEqual(qp.destHosts, null);
         });
     });
+
+    describe('_setupClientsManager', () => {
+        let qp;
+        afterEach(done => {
+            clearInterval(qp.clientsManager?._deleteInactiveCredentialsInterval);
+            qp.stop(done);
+        });
+        it('should set up clients manager if auth type us AssumeRole', () => {
+            const config = getQueueProcessorConfig();
+            config[5].auth.type = 'assumeRole';
+            qp = new QueueProcessor(...config);
+            assert.strictEqual(qp.clientsManager?._id, 'crr-site-crr');
+        });
+        it('should set up clients manager if auth type is not AssumeRole', () => {
+            const config = getQueueProcessorConfig();
+            config[5].auth.type = 'role';
+            qp = new QueueProcessor(...config);
+            assert.deepStrictEqual(qp.clientsManager, null);
+        });
+    });
 });

--- a/tests/unit/replication/ReplicateObject.spec.js
+++ b/tests/unit/replication/ReplicateObject.spec.js
@@ -3,11 +3,12 @@ const sinon = require('sinon');
 
 const QueueEntry = require('../../../lib/models/QueueEntry');
 const ReplicateObject = require('../../../extensions/replication/tasks/ReplicateObject');
-const ClientManager = require('../../../lib/clients/ClientManager');
+const ClientsManager = require('../../../lib/clients/ClientsManager');
 const locations = require('../../../conf/locationConfig.json');
 
 const { replicationEntry } = require('../../utils/kafkaEntries');
 const fakeLogger = require('../../utils/fakeLogger');
+const BackbeatClient = require('../../../lib/clients/BackbeatClient');
 
 describe('ReplicateObject', () => {
     let task;
@@ -137,33 +138,11 @@ describe('ReplicateObject', () => {
     });
 
     describe('_setupDestClients', () => {
-        it('should setup destination client with proper creds when using assumeRole', () => {
-            sinon.stub(ClientManager.prototype, 'initCredentialsManager').returns(null);
-            sinon.stub(ClientManager.prototype, 'getBackbeatClient').returns(null);
+        it('should create assumeRole client when using assumeRole', () => {
+            const setupClient = sinon.stub(task, '_setupAssumeRoleDestClient').returns();
             task._setupDestClients('arn:aws:iam::123456789012:role/crr-role', fakeLogger);
-            assert.deepStrictEqual(task.clientManager._id, '123456789012');
-            assert.deepStrictEqual(task.clientManager._authConfig, {
-                type: 'assumeRole',
-                roleName: 'crr-role',
-                sts: {
-                    host: 'sts.enpoint.com',
-                    port: 80,
-                    accessKey: 'accessKey1',
-                    secretKey: 'verySecretKey1',
-                },
-            });
-            assert.deepStrictEqual(task.clientManager._s3Config, {
-                host: 'localhost',
-                port: 9095,
-            });
-            assert.deepStrictEqual(task.clientManager._transport, 'http');
-            assert.deepStrictEqual(task.clientManager._stsConfig.endpoint, 'http://sts.enpoint.com:80');
-            assert.deepStrictEqual(task.clientManager._stsConfig.credentials, {
-                accessKeyId: 'accessKey1',
-                secretAccessKey: 'verySecretKey1',
-            });
+            assert(setupClient.calledOnce);
         });
-
         it('should setup destination BackbeatClient with proper creds when not in assumeRole', () => {
             task.destConfig.auth = {
                 type: 'service',
@@ -207,6 +186,44 @@ describe('ReplicateObject', () => {
                 }),
             });
             assert.strictEqual(task.retryParams.maxRetries, 5);
+        });
+    });
+
+    describe('_setupAssumeRoleDestClient', () => {
+        it('should create a new client if no client exists', () => {
+            task.destBackbeatHost = {
+                host: 'localhost',
+                port: 9095,
+            };
+            task.clientsManager = new ClientsManager('test', fakeLogger);
+            task._setupAssumeRoleDestClient('arn:aws:iam::123456789012:role/crr-role');
+            assert(task.backbeatDest instanceof BackbeatClient);
+        });
+        it('should reuse old client if it exists', () => {
+            task.destBackbeatHost = {
+                host: 'host1',
+                port: 9095,
+            };
+            task.clientsManager = new ClientsManager('test', fakeLogger);
+            task._setupAssumeRoleDestClient('arn:aws:iam::123456789012:role/crr-role');
+            const oldBackbeatClient = task.backbeatDest;
+            task._setupAssumeRoleDestClient('arn:aws:iam::123456789012:role/crr-role');
+            assert.deepStrictEqual(oldBackbeatClient, task.backbeatDest);
+            assert(task.backbeatDest instanceof BackbeatClient);
+        });
+        it('should create a new client if s3 config changed', () => {
+            task.destBackbeatHost = {
+                host: 'host1',
+                port: 9095,
+            };
+            task.clientsManager = new ClientsManager('test', fakeLogger);
+            task._setupAssumeRoleDestClient('arn:aws:iam::123456789012:role/crr-role');
+            const oldBackbeatClient = task.backbeatDest;
+            task.destBackbeatHost.host = 'host2';
+            task._setupAssumeRoleDestClient('arn:aws:iam::123456789012:role/crr-role');
+            assert.notDeepStrictEqual(oldBackbeatClient, task.backbeatDest);
+            assert(task.backbeatDest instanceof BackbeatClient);
+            assert.strictEqual(task.backbeatDest.endpoint.host, 'host2:9095');
         });
     });
 });


### PR DESCRIPTION
Share the same S3 clients (and their credentials) between multiple CRR tasks of the same site.

The `ClientsManager` class is an improved version of `ClientManager` that allows handling multiple clients with different auth configs. For now we still keep the `ClientManager` class to limit the scope of this PR, but code that uses it should be updated to use the newer class. This will be done in another PR.

Issue: BB-663