### PR TITLE
Make sure calls to consume() are sequential

### DIFF
--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -149,6 +149,10 @@ class BackbeatConsumer extends EventEmitter {
         this._consumedEventTimeout = null;
         this._drainProcessQueueTimeout = null;
         this._tryConsumedTimeout = null;
+        // This variable is set to true when tasks have been completed
+        // since the last consume, and is used to trigger a new consume
+        // immediately after the current one
+        this._tasksCompletedSinceLastConsume = false;
 
         /** @type {ConsumerStats} */
         this.consumerStats = { lag: {} };
@@ -391,6 +395,16 @@ class BackbeatConsumer extends EventEmitter {
             // processing pipeline is 100% busy, do not attempt to consume
             return undefined;
         }
+
+        // Calls to consume() should be done sequentially to make sure messages
+        // are consumed in order, as there might be delay in the transport
+        // layer causing the responses of the consume() calls to be received
+        // out of order in a case of concurrent calls.
+        if (this._nConsumePendingRequests > 0) {
+            this._tasksCompletedSinceLastConsume = true;
+            return undefined;
+        }
+
         this._nConsumePendingRequests += nNewConsumeRequests;
         return this._consumer.consume(nNewConsumeRequests, (err, entries) => {
             this._nConsumePendingRequests -= nNewConsumeRequests;
@@ -435,6 +449,13 @@ class BackbeatConsumer extends EventEmitter {
                         entry.timestamp / 1000);
                     return undefined;
                 });
+                // Immediately try to consume more messages
+                // if tasks have completed since the last consume
+                if (this._tasksCompletedSinceLastConsume) {
+                    this._tasksCompletedSinceLastConsume = false;
+                    process.nextTick(() => this._tryConsume());
+                    return;
+                }
             }
             if (err || entries.length < nNewConsumeRequests) {
                 this._log.debug(err ? `error, retry in 1s: ${err.message}` :

--- a/tests/unit/backbeatConsumer.js
+++ b/tests/unit/backbeatConsumer.js
@@ -33,127 +33,208 @@ describe('backbeatConsumer', () => {
         });
         assert.strictEqual(backbeatConsumer._topic, 'testing.my-test-topic');
     });
-});
+    
+    describe('pause/resume topic partitions on circuit breaker', () => {
+        let consumer;
 
-describe('pause/resume topic partitions on circuit breaker', () => {
-    let consumer;
+        beforeEach(() => {
+            consumer = new BackbeatConsumerMock({
+                kafka,
+                groupId: 'unittest-group',
+                topic: 'my-test-topic',
+            });
 
-    beforeEach(() => {
-        consumer = new BackbeatConsumerMock({
-            kafka,
-            groupId: 'unittest-group',
-            topic: 'my-test-topic',
+            const mockConsumer = {
+                pause: sinon.stub().returns(),
+                resume: sinon.stub().returns(),
+                isConnected: () => false,
+            };
+            consumer._consumer = mockConsumer;
         });
 
-        const mockConsumer = {
-            pause: sinon.stub().returns(),
-            resume: sinon.stub().returns(),
-            isConnected: () => false,
-        };
-        consumer._consumer = mockConsumer;
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        describe('_pauseAssignments', () => {
+            it('should not pause when consumer not connected', () => {
+                consumer._consumer.isConnected = () => false;
+                consumer._consumer.subscription = () => ['example-topic'];
+                consumer._pauseAssignments();
+                assert(consumer._consumer.pause.notCalled);
+            });
+
+            it('should not call pause when no paritions assigned', () => {
+                consumer._consumer.isConnected = () => true;
+                consumer._consumer.subscription = () => ['example-topic'];
+                consumer._consumer.assignments = () => [];
+                consumer._pauseAssignments();
+                assert(consumer._consumer.pause.notCalled);
+            });
+
+            it('should pause all assignments', () => {
+                consumer._consumer.isConnected = () => true;
+                consumer._consumer.subscription = () => ['example-topic'];
+
+                const assignments = [
+                    { topic: 'my-test-topic', partition: 0 },
+                    { topic: 'my-test-topic', partition: 1 },
+                    { topic: 'my-test-topic', partition: 2 },
+                ];
+                consumer._consumer.assignments = () => assignments;
+
+                consumer._pauseAssignments();
+                assert(consumer._consumer.pause.calledWithMatch([
+                    { topic: 'my-test-topic', partition: 0 },
+                    { topic: 'my-test-topic', partition: 1 },
+                    { topic: 'my-test-topic', partition: 2 },
+                ]));
+            });
+        });
+
+        describe('_resumePausedPartitions', () => {
+            it('should not resume when consumer not connected', () => {
+                consumer._consumer.isConnected = () => false;
+                consumer._consumer.subscription = () => ['example-topic'];
+                consumer._resumePausedPartitions();
+                assert(consumer._consumer.resume.notCalled);
+            });
+
+            it('should not call resume when no paritions are paused', () => {
+                consumer._consumer.isConnected = () => true;
+                consumer._consumer.subscription = () => ['example-topic'];
+                consumer._consumer.assignments = () => [];
+                consumer._resumePausedPartitions();
+                assert(consumer._consumer.resume.notCalled);
+            });
+
+            it('should resume all paused partitions', () => {
+                consumer._consumer.isConnected = () => true;
+                consumer._consumer.subscription = () => ['example-topic'];
+                consumer._consumer.assignments = () => [
+                    { topic: 'my-test-topic', partition: 0 },
+                    { topic: 'my-test-topic', partition: 1 },
+                    { topic: 'my-test-topic', partition: 2 },
+                ];
+
+                consumer._resumePausedPartitions();
+                assert(consumer._consumer.resume.calledWithMatch([
+                    { topic: 'my-test-topic', partition: 0 },
+                    { topic: 'my-test-topic', partition: 1 },
+                    { topic: 'my-test-topic', partition: 2 },
+                ]));
+            });
+        });
+
+        describe('_onCircuitBreakerStateChanged', () => {
+            it('should resume consumption when circuit breaker state is nominal', () => {
+                const stub = sinon.stub(consumer, '_resumePausedPartitions');
+                consumer._onCircuitBreakerStateChanged(BreakerState.Nominal);
+                assert(stub.calledOnce);
+            });
+
+            it('should pause consumption when circuit breaker state got tripped', () => {
+                const stub = sinon.stub(consumer, '_pauseAssignments');
+                consumer._onCircuitBreakerStateChanged(BreakerState.Tripped);
+                assert(stub.calledOnce);
+            });
+
+            it('should keep old state when circuit breaker state is stabilizing', () => {
+                const resumeStub = sinon.stub(consumer, '_resumePausedPartitions');
+                const pauseStub = sinon.stub(consumer, '_pauseAssignments');
+                consumer._onCircuitBreakerStateChanged(BreakerState.Stabilizing);
+                assert(resumeStub.notCalled);
+                assert(pauseStub.notCalled);
+            });
+
+            it('should do nothing when state is unknown', () => {
+                const resumeStub = sinon.stub(consumer, '_resumePausedPartitions');
+                const pauseStub = sinon.stub(consumer, '_pauseAssignments');
+                consumer._onCircuitBreakerStateChanged(-1);
+                assert(resumeStub.notCalled);
+                assert(pauseStub.notCalled);
+            });
+        });
     });
 
-    afterEach(() => {
-        sinon.restore();
-    });
+    describe('sequentialy consume from topic', () => {
+        let consumer;
 
-    describe('_pauseAssignments', () => {
-        it('should not pause when consumer not connected', () => {
-            consumer._consumer.isConnected = () => false;
-            consumer._consumer.subscription = () => ['example-topic'];
-            consumer._pauseAssignments();
-            assert(consumer._consumer.pause.notCalled);
+        beforeEach(() => {
+            consumer = new BackbeatConsumerMock({
+                kafka,
+                groupId: 'unittest-group',
+                topic: 'my-test-topic',
+            });
         });
 
-        it('should not call pause when no paritions assigned', () => {
-            consumer._consumer.isConnected = () => true;
-            consumer._consumer.subscription = () => ['example-topic'];
-            consumer._consumer.assignments = () => [];
-            consumer._pauseAssignments();
-            assert(consumer._consumer.pause.notCalled);
+        afterEach(() => {
+            sinon.restore();
+            clearTimeout(consumer._tryConsumedTimeout);
         });
 
-        it('should pause all assignments', () => {
-            consumer._consumer.isConnected = () => true;
-            consumer._consumer.subscription = () => ['example-topic'];
-
-            const assignments = [
-                { topic: 'my-test-topic', partition: 0 },
-                { topic: 'my-test-topic', partition: 1 },
-                { topic: 'my-test-topic', partition: 2 },
-            ];
-            consumer._consumer.assignments = () => assignments;
-
-            consumer._pauseAssignments();
-            assert(consumer._consumer.pause.calledWithMatch([
-                { topic: 'my-test-topic', partition: 0 },
-                { topic: 'my-test-topic', partition: 1 },
-                { topic: 'my-test-topic', partition: 2 },
-            ]));
-        });
-    });
-
-    describe('_resumePausedPartitions', () => {
-        it('should not resume when consumer not connected', () => {
-            consumer._consumer.isConnected = () => false;
-            consumer._consumer.subscription = () => ['example-topic'];
-            consumer._resumePausedPartitions();
-            assert(consumer._consumer.resume.notCalled);
+        it('should not consume new messages when a call to consume is already in progress', () => {
+            consumer._concurrency = 2;
+            consumer._consumer = {
+                consume: sinon.stub(),
+            };
+            consumer._processingQueue = {
+                running: sinon.stub()
+                    .returns(0)
+                    .onFirstCall().returns(1),
+                length: () => 0,
+            };
+            // consume() is called here but hangs as we never return
+            consumer._tryConsume();
+            // this call should return without calling consume()
+            consumer._tryConsume();
+            assert(consumer._consumer.consume.calledOnce);
+            assert.strictEqual(consumer._tasksCompletedSinceLastConsume, true);
         });
 
-        it('should not call resume when no paritions are paused', () => {
-            consumer._consumer.isConnected = () => true;
-            consumer._consumer.subscription = () => ['example-topic'];
-            consumer._consumer.assignments = () => [];
-            consumer._resumePausedPartitions();
-            assert(consumer._consumer.resume.notCalled);
+        it('should immediatly try to consume if a task completed since the last consume', done => {
+            consumer._concurrency = 2;
+            // setting to true to simulate a task completed
+            consumer._tasksCompletedSinceLastConsume = true;
+            consumer._consumer = {
+                consume: sinon.stub().yields(null, [{}, {}]),
+            };
+            consumer._processingQueue = {
+                running: sinon.stub()
+                    .returns(0)
+                    .onFirstCall().returns(1),
+                length: () => 0,
+            };
+            const tryConsumeSpy = sinon.spy(consumer, '_tryConsume');
+            consumer._tryConsume();
+            consumer._consumer.consume.onSecondCall().callsFake(() => {
+                assert(tryConsumeSpy.calledTwice);
+                assert.strictEqual(consumer._tasksCompletedSinceLastConsume, false);
+                done();
+            });
         });
 
-        it('should resume all paused partitions', () => {
-            consumer._consumer.isConnected = () => true;
-            consumer._consumer.subscription = () => ['example-topic'];
-            consumer._consumer.assignments = () => [
-                { topic: 'my-test-topic', partition: 0 },
-                { topic: 'my-test-topic', partition: 1 },
-                { topic: 'my-test-topic', partition: 2 },
-            ];
-
-            consumer._resumePausedPartitions();
-            assert(consumer._consumer.resume.calledWithMatch([
-                { topic: 'my-test-topic', partition: 0 },
-                { topic: 'my-test-topic', partition: 1 },
-                { topic: 'my-test-topic', partition: 2 },
-            ]));
-        });
-    });
-
-    describe('_onCircuitBreakerStateChanged', () => {
-        it('should resume consumption when circuit breaker state is nominal', () => {
-            const stub = sinon.stub(consumer, '_resumePausedPartitions');
-            consumer._onCircuitBreakerStateChanged(BreakerState.Nominal);
-            assert(stub.calledOnce);
-        });
-
-        it('should pause consumption when circuit breaker state got tripped', () => {
-            const stub = sinon.stub(consumer, '_pauseAssignments');
-            consumer._onCircuitBreakerStateChanged(BreakerState.Tripped);
-            assert(stub.calledOnce);
-        });
-
-        it('should keep old state when circuit breaker state is stabilizing', () => {
-            const resumeStub = sinon.stub(consumer, '_resumePausedPartitions');
-            const pauseStub = sinon.stub(consumer, '_pauseAssignments');
-            consumer._onCircuitBreakerStateChanged(BreakerState.Stabilizing);
-            assert(resumeStub.notCalled);
-            assert(pauseStub.notCalled);
-        });
-
-        it('should do nothing when state is unknown', () => {
-            const resumeStub = sinon.stub(consumer, '_resumePausedPartitions');
-            const pauseStub = sinon.stub(consumer, '_pauseAssignments');
-            consumer._onCircuitBreakerStateChanged(-1);
-            assert(resumeStub.notCalled);
-            assert(pauseStub.notCalled);
+        it('should only consume once if no tasks completed since last consume', done => {
+            consumer._concurrency = 2;
+            consumer._tasksCompletedSinceLastConsume = false;
+            consumer._consumer = {
+                consume: sinon.stub().yields(null, [{}, {}]),
+            };
+            consumer._processingQueue = {
+                running: sinon.stub()
+                    .returns(0)
+                    .onFirstCall().returns(1),
+                length: () => 0,
+            };
+            const tryConsumeSpy = sinon.spy(consumer, '_tryConsume');
+            consumer._tryConsume();
+            // consume is called asynchronously, waiting 500ms to make
+            // sure it didn't get called at the end of the first one.
+            setTimeout(() => {
+                assert(tryConsumeSpy.calledOnce);
+                assert.strictEqual(consumer._tasksCompletedSinceLastConsume, false);
+                done();
+            }, 500);
         });
     });
 });


### PR DESCRIPTION
Calls to consume() should be done sequentially to make sure messages are consumed in order, as there might be delay in the transport layer causing the responses of the consume() calls to be received out of order in a case of concurrent calls.

Consuming the messages out of order also triggers a behaviour in the OffsetLedger where it considers this a replay scenario (can happen after a rebalance) and proceeds by removing all offsets larger than the most recently consumed message, this causes the offsets to never be committed until new messages with a larger offset are consumed. In Zenko this triggers lag alerts which is problematic.

Issue: BB-666