### PR TITLE
use auth v4 in backbeat client

### DIFF
--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -8,7 +8,7 @@
         "protocol": "rest-json",
         "serviceAbbreviation": "Backbeat",
         "serviceFullName": "Backbeat Internal Routes",
-        "signatureVersion": "s3",
+        "signatureVersion": "v4",
         "timestampFormat": "rfc822",
         "uid": "backbeat-2017-07-01"
     },
@@ -95,7 +95,8 @@
                     }
                 },
                 "payload": "Location"
-            }
+            },
+            "authtype": "v4-unsigned-body"
         },
         "MultipleBackendPutObject": {
             "http": {
@@ -187,7 +188,8 @@
                         }
                     }
                 }
-            }
+            },
+            "authtype": "v4-unsigned-body"
         },
         "DeleteObjectFromExpiration": {
             "http": {
@@ -381,7 +383,8 @@
                         "type": "long"
                     }
                 }
-            }
+            },
+            "authtype": "v4-unsigned-body"
         },
         "MultipleBackendInitiateMPU": {
             "http": {


### PR DESCRIPTION
Modify the backbeat client definition file to force it to use authv4, so that Cloudserver contacts Vault with POST requests, avoiding errors due to limitations on token header size.

I had to disable signing of the POST body, which is not supported in streaming mode by the AWS v2 client.

Issue: BB-682