### PR TITLE
use `{Key+}` in DeleteObjectFromExpiration URI to prevent signature mismatch

### DIFF
--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -194,7 +194,7 @@
         "DeleteObjectFromExpiration": {
             "http": {
                 "method": "DELETE",
-                "requestUri": "/_/backbeat/expiration/{Bucket}/{Key}"
+                "requestUri": "/_/backbeat/expiration/{Bucket}/{Key+}"
             },
             "input": {
                 "type": "structure",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.0.10",
+  "version": "9.0.11",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The DeleteObjectFromExpiration operation was previously using `{Key}` in its requestUri path. This caused issues when object keys contained slashes, as `{Key}` only matches a single path segment. As a result, requests for objects with multi-segment keys would not match the intended route, leading to incorrect canonical request construction and AWS Signature V4 verification failures (signature mismatch errors).

This fix updates the requestUri to use `{Key+}` instead, ensuring that the full object key—including any slashes—is correctly captured and signed. This change aligns the route with S3 API conventions and prevents signature mismatch errors for keys with slashes.

Issue: BB-689