### PR TITLE
Fix handling of buckets with disabled bucket notifications

### DIFF
--- a/extensions/notification/NotificationQueuePopulator.js
+++ b/extensions/notification/NotificationQueuePopulator.js
@@ -217,91 +217,101 @@ class NotificationQueuePopulator extends QueuePopulatorExtension {
      * @return {undefined}
      */
     async _processObjectEntry(bucket, key, value, type, overheadFields) {
-        this._metricsStore.notifEvent();
-        if (!this._shouldProcessEntry(key, value)) {
+        try {
+            this._metricsStore.notifEvent();
+            if (!this._shouldProcessEntry(key, value)) {
+                return undefined;
+            }
+            const { eventMessageProperty, deleteEvent } = notifConstants;
+            let eventType = value[eventMessageProperty.eventType];
+            if (eventType === undefined && type === 'del') {
+                eventType = deleteEvent;
+            }
+            if (!this._isNotificationEventSupported(eventType)) {
+                return undefined;
+            }
+            const baseKey = this._extractVersionedBaseKey(key);
+            const versionId = this._getVersionId(value, overheadFields);
+            const dateTime = this._getEventDateTime(value, overheadFields);
+            const config = await this.bnConfigManager.getConfig(bucket);
+            if (config && Object.keys(config).length > 0) {
+                const ent = {
+                    bucket,
+                    key: baseKey,
+                    eventType,
+                    versionId,
+                    dateTime,
+                };
+                this.log.debug('validating entry', {
+                    method: 'NotificationQueuePopulator._processObjectEntry',
+                    bucket,
+                    key,
+                    eventType,
+                });
+                const pushedToTopic = new Map();
+                // validate and push kafka message foreach destination topic
+                this.notificationConfig.destinations.forEach(destination => {
+                    const topic = destination.internalTopic ||
+                        this.notificationConfig.topic;
+                    // avoid pushing a message multiple times to the
+                    // same internal topic
+                    if (pushedToTopic[topic]) {
+                        return undefined;
+                    }
+                    // get destination specific notification config
+                    const queueConfig = config.notificationConfiguration.queueConfig.filter(
+                        c => c.queueArn.split(':').pop() === destination.resource
+                    );
+                    if (!queueConfig.length) {
+                        // skip, if there is no config for the current
+                        // destination resource
+                        return undefined;
+                    }
+                    // pass only destination resource specific config to
+                    // validate entry
+                    const destConfig = {
+                        bucket,
+                        notificationConfiguration: {
+                            queueConfig,
+                        },
+                    };
+                    const { isValid, matchingConfig } = configUtil.validateEntry(destConfig, ent);
+                    if (isValid) {
+                        const message
+                            = messageUtil.addLogAttributes(value, ent);
+                        this.log.info('publishing message', {
+                            method: 'NotificationQueuePopulator._processObjectEntry',
+                            bucket,
+                            key: message.key,
+                            versionId,
+                            eventType,
+                            eventTime: message.dateTime,
+                            matchingConfig,
+                        });
+                        this.publish(topic,
+                            // keeping all messages for same object
+                            // in the same partition to keep the order.
+                            // here we use the object name and not the
+                            // "_id" which also includes the versionId
+                            `${bucket}/${message.key}`,
+                            JSON.stringify(message));
+                        // keep track of internal topics we have pushed to
+                        pushedToTopic[topic] = true;
+                    }
+                    return undefined;
+                });
+            }
+            // skip if there is no bucket notification configuration
             return undefined;
-        }
-        const { eventMessageProperty, deleteEvent } = notifConstants;
-        let eventType = value[eventMessageProperty.eventType];
-        if (eventType === undefined && type === 'del') {
-            eventType = deleteEvent;
-        }
-        if (!this._isNotificationEventSupported(eventType)) {
-            return undefined;
-        }
-        const baseKey = this._extractVersionedBaseKey(key);
-        const versionId = this._getVersionId(value, overheadFields);
-        const dateTime = this._getEventDateTime(value, overheadFields);
-        const config = await this.bnConfigManager.getConfig(bucket);
-        if (config && Object.keys(config).length > 0) {
-            const ent = {
-                bucket,
-                key: baseKey,
-                eventType,
-                versionId,
-                dateTime,
-            };
-            this.log.debug('validating entry', {
+        } catch (error) {
+            this.log.error('Error processing object entry', {
                 method: 'NotificationQueuePopulator._processObjectEntry',
                 bucket,
                 key,
-                eventType,
+                error: error.message,
             });
-            const pushedToTopic = new Map();
-            // validate and push kafka message foreach destination topic
-            this.notificationConfig.destinations.forEach(destination => {
-                const topic = destination.internalTopic ||
-                    this.notificationConfig.topic;
-                // avoid pushing a message multiple times to the
-                // same internal topic
-                if (pushedToTopic[topic]) {
-                    return undefined;
-                }
-                // get destination specific notification config
-                const queueConfig = config.notificationConfiguration.queueConfig.filter(
-                    c => c.queueArn.split(':').pop() === destination.resource
-                );
-                if (!queueConfig.length) {
-                    // skip, if there is no config for the current
-                    // destination resource
-                    return undefined;
-                }
-                // pass only destination resource specific config to
-                // validate entry
-                const destConfig = {
-                    bucket,
-                    notificationConfiguration: {
-                        queueConfig,
-                    },
-                };
-                const { isValid, matchingConfig } = configUtil.validateEntry(destConfig, ent);
-                if (isValid) {
-                    const message
-                        = messageUtil.addLogAttributes(value, ent);
-                    this.log.info('publishing message', {
-                        method: 'NotificationQueuePopulator._processObjectEntry',
-                        bucket,
-                        key: message.key,
-                        versionId,
-                        eventType,
-                        eventTime: message.dateTime,
-                        matchingConfig,
-                    });
-                    this.publish(topic,
-                        // keeping all messages for same object
-                        // in the same partition to keep the order.
-                        // here we use the object name and not the
-                        // "_id" which also includes the versionId
-                        `${bucket}/${message.key}`,
-                        JSON.stringify(message));
-                    // keep track of internal topics we have pushed to
-                    pushedToTopic[topic] = true;
-                }
-                return undefined;
-            });
+            throw error;
         }
-        // skip if there is no bucket notification configuration
-        return undefined;
     }
 
     /**

--- a/extensions/notification/configManager/MongoConfigManager.js
+++ b/extensions/notification/configManager/MongoConfigManager.js
@@ -155,9 +155,18 @@ class MongoConfigManager extends BaseConfigManager {
             case 'replace':
             case 'update':
                 if (cachedConfig) {
-                    // add() replaces the value of an entry if it exists in cache
-                    this._cachedConfigs.add(change.documentKey._id, bucketNotificationConfiguration);
-                    onConfigManagerCacheUpdate('update');
+                    // disabling bucket notification works by setting
+                    // the configuration to an empty object
+                    if (!bucketNotificationConfiguration ||
+                        !Object.keys(bucketNotificationConfiguration).length
+                    ) {
+                        this._cachedConfigs.remove(change.documentKey._id);
+                        onConfigManagerCacheUpdate('delete');
+                    } else {
+                        // add() replaces the value of an entry if it exists in cache
+                        this._cachedConfigs.add(change.documentKey._id, bucketNotificationConfiguration);
+                        onConfigManagerCacheUpdate('update');
+                    }
                 }
                 break;
             default:
@@ -269,7 +278,8 @@ class MongoConfigManager extends BaseConfigManager {
             const notificationConfiguration = bucketMetadata?.value?.notificationConfiguration;
             const delay = (Date.now() - startTime) / 1000;
             onConfigManagerConfigGet(false, delay);
-            if (!notificationConfiguration) {
+            // when disabled after being enabled bucket notification configuration is set to an empty object
+            if (!notificationConfiguration || !Object.keys(notificationConfiguration).length) {
                 return undefined;
             }
             // caching the bucket configuration

--- a/tests/unit/notification/NotificationQueuePopulator.js
+++ b/tests/unit/notification/NotificationQueuePopulator.js
@@ -98,7 +98,7 @@ describe('NotificationQueuePopulator ::', () => {
                     'md-model-version': '1',
                 });
                 assert.strictEqual(publishStub.getCall(0).args.at(0), 'internal-notification-topic-destination2');
-            });
+        });
 
         it('should not publish object entry in notification topic if ' +
             'config validation failed', async () => {
@@ -564,7 +564,21 @@ describe('NotificationQueuePopulator ::', () => {
             });
         });
     });
+
+    describe('_processObjectEntryCb ::', () => {
+        it('should properly throw an error if entry value parse fails', done => {
+            notificationQueuePopulator._metricsStore = {
+                notifEvent: sinon.stub().throws(new Error('Error processing entry')),
+            };
+            notificationQueuePopulator._processObjectEntryCb('example-bucket', 'example-key', {}, 'put', {}, err => {
+                assert(err);
+                assert.strictEqual(err.message, 'Error processing entry');
+                return done();
+            });
+        });
+    });
 });
+
 
 describe('NotificationQueuePopulator with multiple rules ::', () => {
     let bnConfigManager;

--- a/tests/unit/notification/configManager/MongoConfigManager.spec.js
+++ b/tests/unit/notification/configManager/MongoConfigManager.spec.js
@@ -278,6 +278,31 @@ describe('MongoConfigManager ::', () => {
                 notificationConfiguration);
             assert.strictEqual(manager._cachedConfigs.count(), 1);
         });
+
+        it('should remove a bucket config when it has been disabled', () => {
+            const changeStreamEvent = {
+                _id: 'resumeToken',
+                operationType: 'update',
+                documentKey: {
+                    _id: 'example-bucket-1',
+                },
+                fullDocument: {
+                    _id: 'example-bucket-1',
+                    value: {
+                        notificationConfiguration: {},
+                    }
+                }
+            };
+            const manager = new MongoConfigManager(params);
+            // populating cache
+            manager._cachedConfigs.add('example-bucket-1', notificationConfiguration);
+            assert.strictEqual(manager._cachedConfigs.count(), 1);
+            assert(manager._cachedConfigs.get('example-bucket-1'));
+            // handling change stream event
+            manager._handleChangeStreamChangeEvent(changeStreamEvent);
+            // cache should be empty
+            assert.strictEqual(manager._cachedConfigs.count(), 0);
+        });
     });
 
     describe('_setMetastoreChangeStream ::', () =>  {
@@ -360,6 +385,24 @@ describe('MongoConfigManager ::', () => {
                 assert.deepEqual(err, errors.InternalError);
                 done();
             });
+        });
+
+        it('should return undefined when bucket doesn\'t have notification configuration', async () => {
+            const manager = new MongoConfigManager(params);
+            manager._metastore = {
+                findOne: () => ({ value: { notificationConfiguration: null } }),
+            };
+            const config = await manager.getConfig('example-bucket-1');
+            assert.deepEqual(config, undefined);
+        });
+
+        it('should return undefined when notification configuration have been disabled in the bucket', async () => {
+            const manager = new MongoConfigManager(params);
+            manager._metastore = {
+                findOne: () => ({ value: { notificationConfiguration: {} } }),
+            };
+            const config = await manager.getConfig('example-bucket-1');
+            assert.deepEqual(config, undefined);
         });
     });
 


### PR DESCRIPTION
- Added try/catch to _processObjectEntry to catch exception
and log them before returning an error
- When bucket notifications are disabled after being enabled,
the configuration is set to an empty object. Previously, this
case was not handled properly, leading to crashes as the
notification producer and processor incorrectly considered the
configuration available. This fix ensures proper handling of
empty configurations to prevent such issues.

Issue: BB-697