### PR TITLE
logReader: manually commit offset when using kafka logConsumer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,6 @@ COPY --from=builder /usr/local/bin/dockerize /usr/local/bin/
 
 ENV AWS_SDK_JS_SUPPRESS_MAINTENANCE_MODE_MESSAGE=1
 
-ENTRYPOINT ["tini", "--", "/usr/src/app/docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "-g", "--", "/usr/src/app/docker-entrypoint.sh"]
 
 EXPOSE 8900

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -14,17 +14,12 @@ const {
     startCircuitBreakerMetricsExport,
 } = require('./CircuitBreaker');
 const { observeKafkaStats } = require('./util/probe');
+const { unassignStatus } = require('./constants');
 
 // controls the number of messages to process in parallel
 const CONCURRENCY_DEFAULT = 1;
 const CLIENT_ID = 'BackbeatConsumer';
 const { withTopicPrefix } = require('./util/topic');
-
-const UNASSIGN_STATUS = {
-    IDLE: 'idle',
-    DRAINED: 'drained',
-    TIMEOUT: 'timeout',
-};
 
 /**
  * Stats on how we are consuming Kafka
@@ -720,11 +715,11 @@ class BackbeatConsumer extends EventEmitter {
             });
 
             if (!this._processingQueue || this._processingQueue.idle()) {
-                unassign(UNASSIGN_STATUS.IDLE);
+                unassign(unassignStatus.IDLE);
                 return;
             }
 
-            this._processingQueue.drain = () => unassign(UNASSIGN_STATUS.DRAINED);
+            this._processingQueue.drain = () => unassign(unassignStatus.DRAINED);
 
             // Set timeout of `max.poll.interval.ms`), to ensure we complete the rebalance
             // eventually (even if a task is really stuck), and don't get kicked out of the consumer
@@ -732,7 +727,7 @@ class BackbeatConsumer extends EventEmitter {
             // disconnect the consumer, so that the healthcheck will fail and the process will get
             // restarted.
             this._drainProcessQueueTimeout = setTimeout(() => {
-                unassign(UNASSIGN_STATUS.TIMEOUT);
+                unassign(unassignStatus.TIMEOUT);
 
                 this._log.error('rdkafka.rebalance timeout: consumer stuck, disconnecting');
                 this._consumer.disconnect();

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -10,6 +10,11 @@ const constants = {
             taskProcessingTime: 's3_backbeat_queue_task_processing_time_seconds',
         },
     },
+    unassignStatus: {
+        IDLE: 'idle',
+        DRAINED: 'drained',
+        TIMEOUT: 'timeout',
+    },
     statusReady: 'READY',
     statusUndefined: 'UNDEFINED',
     statusNotReady: 'NOT_READY',

--- a/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
+++ b/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
@@ -348,8 +348,8 @@ class LogConsumer extends EventEmitter {
                         // to initiate the rebalance process
                         // allowing the message processing to finish
                         // and offsets to be committed
-                        this._consumer.unsubscribe();
                         this.once(EVENTS.UNASSIGNED, () => next());
+                        this._consumer.unsubscribe();
                         return null;
                     }
                 }
@@ -357,8 +357,8 @@ class LogConsumer extends EventEmitter {
             },
             next => {
                 if (this._consumer?.isConnected()) {
-                    this._consumer.disconnect();
                     this._consumer.once('disconnected', () => next());
+                    this._consumer.disconnect();
                     return null;
                 }
                 return next();

--- a/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
+++ b/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
@@ -146,7 +146,7 @@ class LogConsumer extends EventEmitter {
                     return;
                 }
                 // wait for consumed messages to finish being processed
-                if (this._topicPartition && this._topicPartition.length > 0) {
+                if (this._hasUnprocessedMessages()) {
                     return;
                 }
                 // everything processed but not yet committed
@@ -201,11 +201,14 @@ class LogConsumer extends EventEmitter {
      */
     _consumeKafkaMessages(limit, cb) {
         this._resetRecordStream();
-        if (!this._consumer.isConnected()) {
-            this._log.info('Consumer is not ready, skipping message consumption', {
+        const isConnected = this._consumer.isConnected();
+        if (!isConnected || this._hasUnprocessedMessages()) {
+            this._log.info('Skipping message consumption', {
                 method: 'LogConsumer._consumeKafkaMessages',
                 topic: this._topic,
                 consumerGroupId: this._consumerGroupId,
+                reason: !isConnected ? 'consumer not connected' :
+                    'awaiting processing of previous batch',
             });
             return cb();
         }
@@ -264,7 +267,7 @@ class LogConsumer extends EventEmitter {
      * @returns {undefined}
      */
     storeOffsets() {
-        if (!this._topicPartition || this._topicPartition.length === 0) {
+        if (!this._hasUnprocessedMessages()) {
             this._log.debug('No offsets to store', {
                 method: 'LogConsumer.storeOffsets',
                 topic: this._topic,
@@ -280,6 +283,10 @@ class LogConsumer extends EventEmitter {
         });
         this._pendingCommit = true;
         this._topicPartition = null;
+    }
+
+    _hasUnprocessedMessages() {
+        return this._topicPartition?.length > 0;
     }
 
     /**

--- a/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
+++ b/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
@@ -2,9 +2,6 @@ const kafka = require('node-rdkafka');
 const async = require('async');
 const ListRecordStream = require('./ListRecordStream');
 
-// maximum time to wait for consumer group to rebalance (ms)
-const maxDelayRebalanceMs = 120000;
-
 class LogConsumer {
 
     /**
@@ -16,17 +13,20 @@ class LogConsumer {
      * @param {Logger} logger logger
      */
     constructor(kafkaConfig, logger) {
-        const { hosts, topic, consumerGroupId } = kafkaConfig;
+        const { hosts, topic, consumerGroupId, maxPollIntervalMs } = kafkaConfig;
         this._kafkaHosts = hosts;
+        this._maxPollIntervalMs = maxPollIntervalMs || 300000; // default to 5 minutes
         this._topic = topic;
         this._consumerGroupId = consumerGroupId;
         this._topicPartition = null;
+        this._pendingCommit = false;
         this._log = logger;
+        this._consumer = null;
     }
 
     /**
      * Get partition offsets
-     * Offsets are stored in kafka are not managed
+     * Offsets are stored in kafka and not managed
      * by the logReader, only keeping this function
      * to not alter the logic path in the logReader
      * @returns {null}
@@ -50,6 +50,7 @@ class LogConsumer {
             // Default auto-commit interval is 5 seconds
             'enable.auto.commit': true,
             'offset_commit_cb': this._onOffsetCommit.bind(this),
+            'rebalance_cb': this._onRebalance.bind(this),
             'metadata.broker.list': this._kafkaHosts,
             'group.id': this._consumerGroupId,
             'max.poll.interval.ms': this._maxPollIntervalMs,
@@ -63,33 +64,6 @@ class LogConsumer {
             this._consumer.subscribe([this._topic]);
             done();
         });
-    }
-
-    /**
-     * Waits for consumer group to rebalance
-     * @param {number} wait amount of time to wait already waited for, in milliseconds
-     * @param {Function} cb callback
-     * @returns {undefined}
-     */
-    _waitForAssignment(wait, cb) {
-        setTimeout(() => {
-            // assignements contain the partitions
-            // assigned to this consumer, they are only
-            // set once consumer group is balanced
-            const assignments = this._consumer.assignments();
-            if (assignments.length === 0) {
-                if (wait > maxDelayRebalanceMs) {
-                    this._log.error('Timeout waiting for consumer to be assigned to partitions', {
-                        method: 'LogConsumer._waitForAssignment',
-                        topic: this._topic,
-                        consumerGroupId: this._consumerGroupId,
-                    });
-                    return cb();
-                }
-                return this._waitForAssignment(wait + 2000, cb);
-            }
-            return cb();
-        }, 2000);
     }
 
     /**
@@ -115,12 +89,95 @@ class LogConsumer {
             });
             return undefined;
         }
+        this._pendingCommit = false;
         this._log.debug('Offsets committed', {
             method: 'LogConsumer._onOffsetCommit',
             topicPartitions,
             groupId: this._consumerGroupId
         });
         return undefined;
+    }
+
+    /**
+     * @param {kafka.KafkaError} err Rebalance event
+     * @param {TopicPartition[]} assignment List of (un)assigned partitions
+     * @returns {void}
+     */
+    _onRebalance(err, assignment) {
+        if (err.code === kafka.CODES.ERRORS.ERR__ASSIGN_PARTITIONS) {
+            this._log.info('rdkafka.assign', {
+                method: 'LogConsumer._onRebalance',
+                assignment,
+                topic: this._topic,
+                consumerGroupId: this._consumerGroupId,
+            });
+            try {
+                this._consumer.assign(assignment);
+            } catch (e) {
+                const logger = this._consumer.isConnected() ? this._log.error : this._log.debug;
+                logger.bind(this._log)('rdkafka.assign failed', {
+                    method: 'LogConsumer._onRebalance',
+                    error: e.toString(),
+                    assignment,
+                    topic: this._topic,
+                    consumerGroupId: this._consumerGroupId,
+                });
+            }
+        } else if (err.code === kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
+            this._log.info('rdkafka.revoke', {
+                method: 'LogConsumer._onRebalance',
+                assignment,
+                topic: this._topic,
+                consumerGroupId: this._consumerGroupId,
+            });
+            const startTime = Date.now();
+            const rebalanceTimeoutInterval = setInterval(() => {
+                const elapsed = Date.now() - startTime;
+                if (elapsed >= this._maxPollIntervalMs - 1000) {
+                    this._log.error('rdkafka.unassign timeout: consumer stuck, disconnecting', {
+                        method: 'LogConsumer._onRebalance',
+                        topic: this._topic,
+                        consumerGroupId: this._consumerGroupId,
+                    });
+                    clearInterval(rebalanceTimeoutInterval);
+                    this._consumer.disconnect();
+                    return;
+                }
+                // wait for consumed messages to finish being processed
+                if (this._topicPartition && this._topicPartition.length > 0) {
+                    return;
+                }
+                // everything processed but not yet committed
+                if (this._pendingCommit) {
+                    // The following call is not a synchronous operation,
+                    // it simply notifies the consumer that there are offsets to commit.
+                    this._consumer.commit();
+                    // We wait for the commit callback to be triggered before continuing
+                    return;
+                }
+                clearInterval(rebalanceTimeoutInterval);
+                try {
+                    this._consumer.unassign();
+                } catch (e) {
+                    const logger = this._consumer.isConnected() ? this._log.error : this._log.info;
+                    logger.bind(this._log)('rdkafka.unassign failed', {
+                        method: 'LogConsumer._onRebalance',
+                        error: e.toString(),
+                        assignment,
+                        topic: this._topic,
+                        consumerGroupId: this._consumerGroupId,
+                    });
+                }
+            }, 1000);
+        } else {
+            this._log.error('rdkafka.rebalance', {
+                method: 'LogConsumer._onRebalance',
+                err,
+                assignment,
+                topic: this._topic,
+                consumerGroupId: this._consumerGroupId,
+            });
+        }
     }
 
     /**
@@ -141,7 +198,15 @@ class LogConsumer {
      */
     _consumeKafkaMessages(limit, cb) {
         this._resetRecordStream();
-        this._consumer.consume(limit, (err, messages) => {
+        if (!this._consumer.isConnected()) {
+            this._log.info('Consumer is not ready, skipping message consumption', {
+                method: 'LogConsumer._consumeKafkaMessages',
+                topic: this._topic,
+                consumerGroupId: this._consumerGroupId,
+            });
+            return cb();
+        }
+        return this._consumer.consume(limit, (err, messages) => {
             if (err) {
                 this._log.error('An error occured while consuming messages', {
                     method: 'LogConsumer.readRecords',
@@ -180,8 +245,6 @@ class LogConsumer {
      */
     readRecords(params, cb) {
         async.series([
-            // waiting for the consumer group to rebalance
-            next => this._waitForAssignment(0, next),
             // consuming the desired number of messages at most
             next => this._consumeKafkaMessages(params.limit, next),
             next => {
@@ -189,7 +252,7 @@ class LogConsumer {
                 this._listRecordStream.end();
                 return next(null, { log: this._listRecordStream, tailable: false });
             }
-        ], (err, res) => cb(err, res?.[2]));
+        ], (err, res) => cb(err, res?.[1]));
     }
 
     /**

--- a/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
+++ b/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
@@ -1,7 +1,15 @@
 const { EventEmitter } = require('events');
 const kafka = require('node-rdkafka');
 const async = require('async');
+const jsutil = require('arsenal').jsutil;
 const ListRecordStream = require('./ListRecordStream');
+const KafkaBacklogMetrics = require('../../KafkaBacklogMetrics');
+const { unassignStatus } = require('../../constants');
+
+const EVENTS = {
+    DRAINED: 'drained',
+    UNASSIGNED: 'unassigned',
+};
 
 class LogConsumer extends EventEmitter {
 
@@ -92,6 +100,9 @@ class LogConsumer extends EventEmitter {
             return undefined;
         }
         this._pendingCommit = false;
+        if (!this._hasUnprocessedMessages()) {
+            this.emit(EVENTS.DRAINED);
+        }
         this._log.debug('Offsets committed', {
             method: 'LogConsumer._onOffsetCommit',
             topicPartitions,
@@ -113,18 +124,7 @@ class LogConsumer extends EventEmitter {
                 topic: this._topic,
                 consumerGroupId: this._consumerGroupId,
             });
-            try {
-                this._consumer.assign(assignment);
-            } catch (e) {
-                const logger = this._consumer.isConnected() ? this._log.error : this._log.debug;
-                logger.bind(this._log)('rdkafka.assign failed', {
-                    method: 'LogConsumer._onRebalance',
-                    error: e.toString(),
-                    assignment,
-                    topic: this._topic,
-                    consumerGroupId: this._consumerGroupId,
-                });
-            }
+            this._assignPartitions(assignment);
         } else if (err.code === kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
             this._log.info('rdkafka.revoke', {
                 method: 'LogConsumer._onRebalance',
@@ -132,46 +132,7 @@ class LogConsumer extends EventEmitter {
                 topic: this._topic,
                 consumerGroupId: this._consumerGroupId,
             });
-            const startTime = Date.now();
-            const rebalanceTimeoutInterval = setInterval(() => {
-                const elapsed = Date.now() - startTime;
-                if (elapsed >= this._maxPollIntervalMs - 1000) {
-                    this._log.error('rdkafka.unassign timeout: consumer stuck, disconnecting', {
-                        method: 'LogConsumer._onRebalance',
-                        topic: this._topic,
-                        consumerGroupId: this._consumerGroupId,
-                    });
-                    clearInterval(rebalanceTimeoutInterval);
-                    this._consumer.disconnect();
-                    return;
-                }
-                // wait for consumed messages to finish being processed
-                if (this._hasUnprocessedMessages()) {
-                    return;
-                }
-                // everything processed but not yet committed
-                if (this._pendingCommit) {
-                    // The following call is not a synchronous operation,
-                    // it simply notifies the consumer that there are offsets to commit.
-                    this._consumer.commit();
-                    // We wait for the commit callback to be triggered before continuing
-                    return;
-                }
-                clearInterval(rebalanceTimeoutInterval);
-                try {
-                    this._consumer.unassign();
-                } catch (e) {
-                    const logger = this._consumer.isConnected() ? this._log.error : this._log.info;
-                    logger.bind(this._log)('rdkafka.unassign failed', {
-                        method: 'LogConsumer._onRebalance',
-                        error: e.toString(),
-                        assignment,
-                        topic: this._topic,
-                        consumerGroupId: this._consumerGroupId,
-                    });
-                }
-                this.emit('unassigned');
-            }, 1000);
+            this._drainAndUnassign();
         } else {
             this._log.error('rdkafka.rebalance', {
                 method: 'LogConsumer._onRebalance',
@@ -181,6 +142,80 @@ class LogConsumer extends EventEmitter {
                 consumerGroupId: this._consumerGroupId,
             });
         }
+    }
+
+    /**
+     * Assign partitions to the consumer
+     * @param {TopicPartition[]} assignment
+     */
+    _assignPartitions(assignment) {
+        try {
+            this._consumer.assign(assignment);
+        } catch (e) {
+            const logger = this._consumer.isConnected() ? this._log.error : this._log.debug;
+            logger.bind(this._log)('rdkafka.assign failed', {
+                method: 'LogConsumer._onRebalance',
+                error: e.toString(),
+                assignment,
+                topic: this._topic,
+                consumerGroupId: this._consumerGroupId,
+            });
+        }
+    }
+
+    /**
+     * Unassign partitions from the consumer
+     * @returns {void}
+     */
+    _unassignPartitions() {
+        try {
+            this._consumer.unassign();
+        } catch (e) {
+            const logger = this._consumer.isConnected() ? this._log.error : this._log.info;
+            logger.bind(this._log)('rdkafka.unassign failed', {
+                method: 'LogConsumer._onRebalance',
+                error: e.toString(),
+                topic: this._topic,
+                consumerGroupId: this._consumerGroupId,
+            });
+        }
+        this.emit(EVENTS.UNASSIGNED);
+    }
+
+    /**
+     * Waits for all messages to be processed before unassigning
+     * the partitions from the consumer
+     * @returns {void}
+     */
+    _drainAndUnassign() {
+        let drainTimeout;
+        const drainHandler = () => unassign(unassignStatus.DRAINED);
+
+        const unassign = jsutil.once(status => {
+            this.removeListener(EVENTS.DRAINED, drainHandler);
+            clearTimeout(drainTimeout);
+            drainTimeout = null;
+            KafkaBacklogMetrics.onRebalance(this._topic, this._consumerGroupId, status);
+            this._unassignPartitions();
+        });
+
+        if (!this._hasUnprocessedMessages() && !this._pendingCommit) {
+            return unassign(unassignStatus.IDLE);
+        }
+
+        this.once(EVENTS.DRAINED, drainHandler);
+
+        drainTimeout = setTimeout(() => {
+            unassign(unassignStatus.TIMEOUT);
+            this._log.error('Timeout waiting for messages to be processed', {
+                method: 'LogConsumer._drainAndUnassign',
+                topic: this._topic,
+                consumerGroupId: this._consumerGroupId,
+            });
+            this._consumer.disconnect();
+        }, this._maxPollIntervalMs - 1000);
+
+        return undefined;
     }
 
     /**
@@ -314,7 +349,7 @@ class LogConsumer extends EventEmitter {
                         // allowing the message processing to finish
                         // and offsets to be committed
                         this._consumer.unsubscribe();
-                        this.once('unassigned', () => next());
+                        this.once(EVENTS.UNASSIGNED, () => next());
                         return null;
                     }
                 }

--- a/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
+++ b/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
@@ -20,17 +20,19 @@ class LogConsumer {
         this._kafkaHosts = hosts;
         this._topic = topic;
         this._consumerGroupId = consumerGroupId;
+        this._topicPartition = null;
         this._log = logger;
-        this._offsets = {};
     }
 
     /**
      * Get partition offsets
-     * @returns {string} stored partition offsets
+     * Offsets are stored in kafka are not managed
+     * by the logReader, only keeping this function
+     * to not alter the logic path in the logReader
+     * @returns {null}
      */
     _getOffset() {
-        // Format: [{ topic: 'oplog-topic', partition: 0, offset: 0 }]
-        return JSON.stringify(this._offsets);
+        return null;
     }
 
     /**
@@ -42,19 +44,24 @@ class LogConsumer {
     setup(done) {
         // partition offsets will be managed by kafka
         const consumerParams = {
-            'enable.auto.offset.store': true,
+            // Manually manage storing offsets to ensure they are only stored
+            // after the batch processing is fully completed.
+            'enable.auto.offset.store': false,
+            // Default auto-commit interval is 5 seconds
+            'enable.auto.commit': true,
+            'offset_commit_cb': this._onOffsetCommit.bind(this),
             'metadata.broker.list': this._kafkaHosts,
             'group.id': this._consumerGroupId,
+            'max.poll.interval.ms': this._maxPollIntervalMs,
         };
         const topicParams = {
             'auto.offset.reset': 'earliest',
-            'enable.auto.commit': true,
         };
         this._consumer = new kafka.KafkaConsumer(consumerParams, topicParams);
         this._consumer.connect();
-        this._consumer.on('ready', () => {
+        this._consumer.once('ready', () => {
             this._consumer.subscribe([this._topic]);
-            return done();
+            done();
         });
     }
 
@@ -86,26 +93,34 @@ class LogConsumer {
     }
 
     /**
-     * Queries last commited partition offsets
-     * and stores them
-     * @param {Function} cb callback
+     * Offset commit callback
+     * @param {Error} err
+     * @param {Object} topicPartitions
      * @returns {undefined}
      */
-    _storeCurrentOffsets(cb) {
-        this._consumer.committed(5000, (err, topicPartitions) => {
-            if (err) {
-                this._log.error('Error while getting offsets', {
-                    method: 'LogConsumer._storeCurrentOffsets',
-                    topic: this._topic,
-                    error: err.message,
-                    consumerGroupId: this._consumerGroupId,
-                });
-                return cb();
+    _onOffsetCommit(err, topicPartitions) {
+        if (err) {
+            // NO_OFFSET is a "soft error" meaning that the same
+            // offset is already committed, which occurs because of
+            // auto-commit (e.g. if nothing was done by the producer
+            // on this partition since last commit).
+            if (err.code === kafka.CODES.ERRORS.ERR__NO_OFFSET) {
+                return undefined;
             }
-            // saving offsets
-            this._offsets = topicPartitions;
-            return cb();
+            this._log.error('Error committing offsets to kafka', {
+                method: 'LogConsumer._onOffsetCommit',
+                errorCode: err,
+                topicPartitions,
+                groupId: this._consumerGroupId,
+            });
+            return undefined;
+        }
+        this._log.debug('Offsets committed', {
+            method: 'LogConsumer._onOffsetCommit',
+            topicPartitions,
+            groupId: this._consumerGroupId
         });
+        return undefined;
     }
 
     /**
@@ -136,8 +151,20 @@ class LogConsumer {
                 });
                 return cb();
             }
-            // writing consumed messages to the stream
-            messages.forEach(message => this._listRecordStream.write(message));
+            // Use a Map to store the latest offset for each partition
+            const topicPartition = new Map();
+             // store next offsets to commit
+            messages.forEach(message => {
+                topicPartition.set(`${message.topic}-${message.partition}`, {
+                    topic: message.topic,
+                    partition: message.partition,
+                    offset: message.offset + 1, // next offset to commit
+                });
+                // writing consumed messages to the stream
+                this._listRecordStream.write(message);
+            });
+            // format offsets for commit
+            this._topicPartition = Array.from(topicPartition.values());
             return cb();
         });
     }
@@ -155,8 +182,6 @@ class LogConsumer {
         async.series([
             // waiting for the consumer group to rebalance
             next => this._waitForAssignment(0, next),
-            // saving last commited offset
-            next => this._storeCurrentOffsets(next),
             // consuming the desired number of messages at most
             next => this._consumeKafkaMessages(params.limit, next),
             next => {
@@ -164,7 +189,31 @@ class LogConsumer {
                 this._listRecordStream.end();
                 return next(null, { log: this._listRecordStream, tailable: false });
             }
-        ], (err, res) => cb(err, res[3]));
+        ], (err, res) => cb(err, res?.[2]));
+    }
+
+    /**
+     * Stores the offsets locally for the consumer to
+     * auto commit them at a later time
+     * @returns {undefined}
+     */
+    storeOffsets() {
+        if (!this._topicPartition || this._topicPartition.length === 0) {
+            this._log.debug('No offsets to store', {
+                method: 'LogConsumer.storeOffsets',
+                topic: this._topic,
+                consumerGroupId: this._consumerGroupId,
+            });
+            return;
+        }
+        this._consumer.offsetsStore(this._topicPartition);
+        this._log.info('Offsets stored', {
+            method: 'LogConsumer.storeOffsets',
+            consumerGroupId: this._consumerGroupId,
+            topicPartition: this._topicPartition,
+        });
+        this._pendingCommit = true;
+        this._topicPartition = null;
     }
 }
 

--- a/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
+++ b/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
@@ -1,8 +1,9 @@
+const { EventEmitter } = require('events');
 const kafka = require('node-rdkafka');
 const async = require('async');
 const ListRecordStream = require('./ListRecordStream');
 
-class LogConsumer {
+class LogConsumer extends EventEmitter {
 
     /**
      * @constructor
@@ -13,6 +14,7 @@ class LogConsumer {
      * @param {Logger} logger logger
      */
     constructor(kafkaConfig, logger) {
+        super();
         const { hosts, topic, consumerGroupId, maxPollIntervalMs } = kafkaConfig;
         this._kafkaHosts = hosts;
         this._maxPollIntervalMs = maxPollIntervalMs || 300000; // default to 5 minutes
@@ -168,6 +170,7 @@ class LogConsumer {
                         consumerGroupId: this._consumerGroupId,
                     });
                 }
+                this.emit('unassigned');
             }, 1000);
         } else {
             this._log.error('rdkafka.rebalance', {
@@ -288,6 +291,38 @@ class LogConsumer {
         return this._consumer.isConnected();
     }
 
+    /**
+     * Closes the consumer connection, while making sure
+     * that all messages are processed and offsets are committed.
+     * @param {Function} cb
+     */
+    close(cb) {
+        async.series([
+            next => {
+                if (this._consumer?.isConnected()) {
+                    const subscription = this._consumer.subscription() || [];
+                    if (subscription.length > 0) {
+                        // we first unsubscribe from the topic
+                        // to initiate the rebalance process
+                        // allowing the message processing to finish
+                        // and offsets to be committed
+                        this._consumer.unsubscribe();
+                        this.once('unassigned', () => next());
+                        return null;
+                    }
+                }
+                return next();
+            },
+            next => {
+                if (this._consumer?.isConnected()) {
+                    this._consumer.disconnect();
+                    this._consumer.once('disconnected', () => next());
+                    return null;
+                }
+                return next();
+            },
+        ], cb);
+    }
 }
 
 module.exports = LogConsumer;

--- a/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
+++ b/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
@@ -278,6 +278,16 @@ class LogConsumer {
         this._pendingCommit = true;
         this._topicPartition = null;
     }
+
+    /**
+     * LogConsumer is considered ready if it is connected
+     * to the Kafka broker and ready to consume messages.
+     * @returns {boolean}
+     */
+    isReady() {
+        return this._consumer.isConnected();
+    }
+
 }
 
 module.exports = LogConsumer;

--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -799,6 +799,10 @@ class LogReader {
         return this._batchTimedOut;
     }
 
+    isLogConsumerReady() {
+        return this.logConsumer?.isReady?.() ?? true;
+    }
+
     /**
      * Return a boolean value indicating whether the offset is managed
      * by the log reader. This means that the log reader is responsible

--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -111,10 +111,18 @@ class LogReader {
      * @return {undefined}
      */
     close(cb) {
-        async.each(
-            Object.values(this._producers),
-            (producer, done) => producer.close(done),
-            cb);
+        async.series([
+            next => {
+                if (this.logConsumer?.close) {
+                    return this.logConsumer.close(next);
+                }
+                return next();
+            },
+            next => async.each(
+                Object.values(this._producers),
+                (producer, done) => producer.close(done),
+                next),
+        ], cb);
     }
 
     /**

--- a/lib/queuePopulator/LogReader.js
+++ b/lib/queuePopulator/LogReader.js
@@ -134,7 +134,7 @@ class LogReader {
             return done();
         }
         const pathToLogOffset = this.pathToLogOffset;
-        this.zkClient.getData(pathToLogOffset, (err, data) => {
+        return this.zkClient.getData(pathToLogOffset, (err, data) => {
             if (err) {
                 this._updateZkMetrics('read', 'error');
                 if (err.name !== 'NO_NODE') {
@@ -538,7 +538,7 @@ class LogReader {
                 process.nextTick(cb);
             }
         }
-        async.eachSeries(this._extensions, (ext, next) => {
+        return async.eachSeries(this._extensions, (ext, next) => {
             const overheadFields = {
                 ...entry.overhead,
                 commitTimestamp: record.timestamp,
@@ -712,25 +712,47 @@ class LogReader {
         });
     }
 
+    /**
+     * Determine if the log offset should be updated.
+     * @param {Object} logRes - Log response object
+     * @param {Number} nextLogOffset - Next log offset
+     * @returns {Boolean} - True if the log offset should be updated
+     */
+    _shouldUpdateLogOffset(logRes, nextLogOffset) {
+        return nextLogOffset !== undefined &&
+            nextLogOffset !== this.logOffset &&
+            (!logRes.log.reachedUnpublishedListing || logRes.log.reachedUnpublishedListing());
+    }
+
+    /**
+     * Update metrics for Raft backend.
+     * @param {Object} logInfo - Log information object
+     * @returns {undefined}
+     */
+    _updateMetrics(logInfo) {
+        const logSize = logInfo.cseq || logInfo.end;
+        this._metricsHandler.logReadOffset(this.getMetricLabels(), this.logOffset);
+        this._metricsHandler.logSize(this.getMetricLabels(), logSize);
+    }
+    
     _processSaveLogOffset(batchState, done) {
         const { logRes, nextLogOffset, logger } = batchState;
-        if (this.isOffsetManaged() &&
-            nextLogOffset !== undefined &&
-            nextLogOffset !== this.logOffset &&
-            (!logRes.log.reachedUnpublishedListing ||
-             logRes.log.reachedUnpublishedListing())) {
 
+        if (!this.isOffsetManaged()) {
+            this.logConsumer.storeOffsets();
+            return done();
+        } else if (this.isOffsetManaged() && this._shouldUpdateLogOffset(logRes, nextLogOffset)) {
             this.logOffset = nextLogOffset;
 
-            // Skip metrics if we are not using Raft backend
+            // Update metrics for Raft backend
             if (logRes.info) {
-                const logSize = logRes.info.cseq || logRes.info.end;
-                this._metricsHandler.logReadOffset(this.getMetricLabels(), this.logOffset);
-                this._metricsHandler.logSize(this.getMetricLabels(), logSize);
+                this._updateMetrics(logRes.info);
             }
 
             return this._writeLogOffset(logger, done);
         }
+
+        // No offset update required
         return process.nextTick(() => done());
     }
 

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -625,6 +625,13 @@ class QueuePopulator {
                     status: constants.statusTimedOut,
                 });
             }
+
+            if (!reader.isLogConsumerReady()) {
+                responses.push({
+                    component: 'log consumer',
+                    status: constants.statusNotReady,
+                });
+            }
         });
 
         log.debug('verbose liveness', verboseLiveness);

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -269,6 +269,11 @@ class QueuePopulator {
     close(cb) {
         async.series([
             next => this._closeLogState(next),
+            next => async.each(
+                this.logReaders,
+                (logReader, cb) => logReader.close(cb),
+                next,
+            ),
             next => {
                 this._circuitBreaker.stop();
                 return next();

--- a/tests/unit/QueuePopulator.spec.js
+++ b/tests/unit/QueuePopulator.spec.js
@@ -51,6 +51,7 @@ describe('QueuePopulator', () => {
             mockLogReader.getProducerStatus = sinon.fake(() => prodStatus);
             mockLogReader.getLogInfo = sinon.fake(() => logInfo);
             mockLogReader.batchProcessTimedOut = sinon.fake(() => false);
+            mockLogReader.isLogConsumerReady = sinon.fake(() => true);
             qp.logReaders = [
                 mockLogReader,
             ];
@@ -75,6 +76,7 @@ describe('QueuePopulator', () => {
             mockLogReader.getProducerStatus = sinon.fake(() => prodStatus);
             mockLogReader.getLogInfo = sinon.fake(() => logInfo);
             mockLogReader.batchProcessTimedOut = sinon.fake(() => false);
+            mockLogReader.isLogConsumerReady = sinon.fake(() => true);
             qp.logReaders = [
                 mockLogReader,
             ];
@@ -102,6 +104,7 @@ describe('QueuePopulator', () => {
             }));
             mockLogReader.getLogInfo = sinon.fake(() => {});
             mockLogReader.batchProcessTimedOut = sinon.fake(() => true);
+            mockLogReader.isLogConsumerReady = sinon.fake(() => true);
             qp.logReaders = [
                 mockLogReader,
             ];
@@ -116,6 +119,33 @@ describe('QueuePopulator', () => {
                     {
                         component: 'log reader',
                         status: constants.statusTimedOut,
+                    },
+                ])
+            );
+        });
+
+        it('returns proper details when log consumer is not ready', () => {
+            const mockLogReader = sinon.spy();
+            mockLogReader.getProducerStatus = sinon.fake(() => ({
+                topicA: true,
+            }));
+            mockLogReader.getLogInfo = sinon.fake(() => {});
+            mockLogReader.batchProcessTimedOut = sinon.fake(() => false);
+            mockLogReader.isLogConsumerReady = sinon.fake(() => false);
+            qp.logReaders = [
+                mockLogReader,
+            ];
+            qp.zkClient = {
+                getState: () => zookeeper.State.SYNC_CONNECTED,
+            };
+            qp.handleLiveness(mockRes, mockLog);
+            sinon.assert.calledOnceWithExactly(mockRes.writeHead, 500);
+            sinon.assert.calledOnceWithExactly(
+                mockRes.end,
+                JSON.stringify([
+                    {
+                        component: 'log consumer',
+                        status: constants.statusNotReady,
                     },
                 ])
             );
@@ -186,6 +216,147 @@ describe('QueuePopulator', () => {
             qp._processLogEntries({}, err => {
                 assert.deepEqual(err, errors.InternalError);
                 assert(qp.logReaders[0].processLogEntries.calledOnce);
+                return done();
+            });
+        });
+    });
+
+    describe('close', () => {
+        let mockLogReader1;
+        let mockLogReader2;
+        let mockCircuitBreaker;
+        let mockMProducer;
+        let mockMConsumer;
+
+        beforeEach(() => {
+            mockLogReader1 = {
+                close: sinon.stub().yields(),
+            };
+            mockLogReader2 = {
+                close: sinon.stub().yields(),
+            };
+            mockCircuitBreaker = {
+                stop: sinon.stub(),
+            };
+            mockMProducer = {
+                close: sinon.stub().yields(),
+            };
+            mockMConsumer = {
+                close: sinon.stub().yields(),
+            };
+
+            qp.logReaders = [mockLogReader1, mockLogReader2];
+            qp._circuitBreaker = mockCircuitBreaker;
+            qp._mProducer = mockMProducer;
+            qp._mConsumer = mockMConsumer;
+            qp.raftIdDispatcher = undefined;
+        });
+
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        it('should call close on all logReaders', done => {
+            qp.close(err => {
+                assert.ifError(err);
+                sinon.assert.calledOnce(mockLogReader1.close);
+                sinon.assert.calledOnce(mockLogReader2.close);
+                sinon.assert.calledOnce(mockCircuitBreaker.stop);
+                sinon.assert.calledOnce(mockMProducer.close);
+                sinon.assert.calledOnce(mockMConsumer.close);
+                return done();
+            });
+        });
+
+        it('should call close on single logReader', done => {
+            qp.logReaders = [mockLogReader1];
+            qp.close(err => {
+                assert.ifError(err);
+                sinon.assert.calledOnce(mockLogReader1.close);
+                sinon.assert.notCalled(mockLogReader2.close);
+                sinon.assert.calledOnce(mockCircuitBreaker.stop);
+                return done();
+            });
+        });
+
+        it('should handle empty logReaders array', done => {
+            qp.logReaders = [];
+            qp.close(err => {
+                assert.ifError(err);
+                sinon.assert.notCalled(mockLogReader1.close);
+                sinon.assert.notCalled(mockLogReader2.close);
+                sinon.assert.calledOnce(mockCircuitBreaker.stop);
+                return done();
+            });
+        });
+
+        it('should handle logReader close error', done => {
+            const closeError = new Error('Close failed');
+            mockLogReader1.close = sinon.stub().yields(closeError);
+            
+            qp.close(err => {
+                assert.strictEqual(err, closeError);
+                sinon.assert.calledOnce(mockLogReader1.close);
+                sinon.assert.notCalled(mockLogReader2.close);
+                sinon.assert.notCalled(mockCircuitBreaker.stop);
+                return done();
+            });
+        });
+
+        it('should handle metrics producer close error', done => {
+            const closeError = new Error('Metrics producer close failed');
+            mockMProducer.close = sinon.stub().yields(closeError);
+            
+            qp.close(err => {
+                assert.strictEqual(err, closeError);
+                sinon.assert.calledOnce(mockLogReader1.close);
+                sinon.assert.calledOnce(mockLogReader2.close);
+                sinon.assert.calledOnce(mockCircuitBreaker.stop);
+                sinon.assert.calledOnce(mockMProducer.close);
+                sinon.assert.notCalled(mockMConsumer.close);
+                return done();
+            });
+        });
+
+        it('should handle metrics consumer close error', done => {
+            const closeError = new Error('Metrics consumer close failed');
+            mockMConsumer.close = sinon.stub().yields(closeError);
+            
+            qp.close(err => {
+                assert.strictEqual(err, closeError);
+                sinon.assert.calledOnce(mockLogReader1.close);
+                sinon.assert.calledOnce(mockLogReader2.close);
+                sinon.assert.calledOnce(mockCircuitBreaker.stop);
+                sinon.assert.calledOnce(mockMProducer.close);
+                sinon.assert.calledOnce(mockMConsumer.close);
+                return done();
+            });
+        });
+
+        it('should work when no metrics producer exists', done => {
+            qp._mProducer = null;
+            
+            qp.close(err => {
+                assert.ifError(err);
+                sinon.assert.calledOnce(mockLogReader1.close);
+                sinon.assert.calledOnce(mockLogReader2.close);
+                sinon.assert.calledOnce(mockCircuitBreaker.stop);
+                sinon.assert.notCalled(mockMProducer.close);
+                sinon.assert.calledOnce(mockMConsumer.close);
+                return done();
+            });
+        });
+
+        it('should work when no metrics consumer exists', done => {
+            qp._mConsumer = null;
+            
+            qp.close(err => {
+                assert.ifError(err);
+                sinon.assert.calledOnce(mockLogReader1.close);
+                sinon.assert.calledOnce(mockLogReader2.close);
+                sinon.assert.calledOnce(mockCircuitBreaker.stop);
+                sinon.assert.calledOnce(mockMProducer.close);
+                sinon.assert.notCalled(mockMConsumer.close);
                 return done();
             });
         });

--- a/tests/unit/lib/queuePopulator/LogReader.spec.js
+++ b/tests/unit/lib/queuePopulator/LogReader.spec.js
@@ -621,14 +621,6 @@ describe('LogReader', () => {
                 shouldSave: false,
             },
             {
-                desc: 'should not save the offset if offsets are not managed',
-                managed: false,
-                hasStoreOffsetsFn: false,
-                currentOffset: 0,
-                nextLogOffset: 1,
-                shouldSave: false,
-            },
-            {
                 desc: 'should use storeOffsets to save the offset when offsets are not managed',
                 managed: false,
                 hasStoreOffsetsFn: true,
@@ -791,6 +783,156 @@ describe('LogReader', () => {
                 });
                 assert.deepStrictEqual(reader.isOffsetManaged(), params.expected);
             });
+        });
+    });
+
+    describe('close', () => {
+        let mockProducer1;
+        let mockProducer2;
+        let mockLogConsumer;
+
+        beforeEach(() => {
+            mockProducer1 = {
+                close: sinon.stub().yields(),
+            };
+            mockProducer2 = {
+                close: sinon.stub().yields(),
+            };
+            mockLogConsumer = {
+                close: sinon.stub().yields(),
+            };
+
+            // Set up producers
+            logReader._producers = {
+                producer1: mockProducer1,
+                producer2: mockProducer2,
+            };
+        });
+
+        it('should call close on all producers', done => {
+            logReader.close(err => {
+                assert.ifError(err);
+                sinon.assert.calledOnce(mockProducer1.close);
+                sinon.assert.calledOnce(mockProducer2.close);
+                return done();
+            });
+        });
+
+        it('should call close on logConsumer if it exists and has close method', done => {
+            logReader.logConsumer = mockLogConsumer;
+            
+            logReader.close(err => {
+                assert.ifError(err);
+                sinon.assert.calledOnce(mockProducer1.close);
+                sinon.assert.calledOnce(mockProducer2.close);
+                sinon.assert.calledOnce(mockLogConsumer.close);
+                return done();
+            });
+        });
+
+        it('should not call close on logConsumer if it does not exist', done => {
+            logReader.logConsumer = null;
+            
+            logReader.close(err => {
+                assert.ifError(err);
+                sinon.assert.calledOnce(mockProducer1.close);
+                sinon.assert.calledOnce(mockProducer2.close);
+                sinon.assert.notCalled(mockLogConsumer.close);
+                return done();
+            });
+        });
+
+        it('should not call close on logConsumer if it does not have close method', done => {
+            logReader.logConsumer = {
+                someOtherMethod: sinon.stub(),
+            };
+            
+            logReader.close(err => {
+                assert.ifError(err);
+                sinon.assert.calledOnce(mockProducer1.close);
+                sinon.assert.calledOnce(mockProducer2.close);
+                sinon.assert.notCalled(mockLogConsumer.close);
+                return done();
+            });
+        });
+
+        it('should handle producer close error', done => {
+            const closeError = new Error('Producer close failed');
+            mockProducer1.close = sinon.stub().yields(closeError);
+            
+            logReader.close(err => {
+                assert.strictEqual(err, closeError);
+                sinon.assert.calledOnce(mockProducer1.close);
+                return done();
+            });
+        });
+
+        it('should handle logConsumer close error', done => {
+            const closeError = new Error('LogConsumer close failed');
+            mockLogConsumer.close = sinon.stub().yields(closeError);
+            logReader.logConsumer = mockLogConsumer;
+            
+            logReader.close(err => {
+                assert.strictEqual(err, closeError);
+                sinon.assert.calledOnce(mockLogConsumer.close);
+                return done();
+            });
+        });
+
+        it('should handle empty producers object', done => {
+            logReader._producers = {};
+            logReader.logConsumer = mockLogConsumer;
+            
+            logReader.close(err => {
+                assert.ifError(err);
+                sinon.assert.notCalled(mockProducer1.close);
+                sinon.assert.notCalled(mockProducer2.close);
+                sinon.assert.calledOnce(mockLogConsumer.close);
+                return done();
+            });
+        });
+
+        it('should work with no producers and no logConsumer', done => {
+            logReader._producers = {};
+            logReader.logConsumer = null;
+            
+            logReader.close(err => {
+                assert.ifError(err);
+                sinon.assert.notCalled(mockProducer1.close);
+                sinon.assert.notCalled(mockProducer2.close);
+                sinon.assert.notCalled(mockLogConsumer.close);
+                return done();
+            });
+        });
+    });
+
+    describe('isLogConsumerReady', () => {
+        it('should return true when logConsumer is undefined', () => {
+            logReader.logConsumer = undefined;
+            assert.strictEqual(logReader.isLogConsumerReady(), true);
+        });
+
+        it('should return true when logConsumer exists but has no isReady method', () => {
+            logReader.logConsumer = {
+                someOtherMethod: sinon.stub(),
+            };
+            assert.strictEqual(logReader.isLogConsumerReady(), true);
+        });
+
+        it('should return true when logConsumer.isReady() returns true', () => {
+            logReader.logConsumer = {
+                isReady: sinon.stub().returns(true),
+            };
+            assert.strictEqual(logReader.isLogConsumerReady(), true);
+            sinon.assert.calledOnce(logReader.logConsumer.isReady);
+        });
+
+        it('should return false when logConsumer.isReady() returns false', () => {
+            logReader.logConsumer = {
+                isReady: sinon.stub().returns(false),
+            };
+            assert.strictEqual(logReader.isLogConsumerReady(), false);
+            sinon.assert.calledOnce(logReader.logConsumer.isReady);
         });
     });
 });

--- a/tests/unit/lib/queuePopulator/LogReader.spec.js
+++ b/tests/unit/lib/queuePopulator/LogReader.spec.js
@@ -599,6 +599,7 @@ describe('LogReader', () => {
             {
                 desc: 'should save the offset when offsets are managed',
                 managed: true,
+                hasStoreOffsetsFn: false,
                 currentOffset: 0,
                 nextLogOffset: 1,
                 shouldSave: true,
@@ -606,6 +607,7 @@ describe('LogReader', () => {
             {
                 desc: 'should not save the offset when the next offset is undefined',
                 managed: true,
+                hasStoreOffsetsFn: false,
                 currentOffset: 0,
                 nextLogOffset: undefined,
                 shouldSave: false,
@@ -613,6 +615,7 @@ describe('LogReader', () => {
             {
                 desc: 'should not save the offset if the offset did not change',
                 managed: true,
+                hasStoreOffsetsFn: false,
                 currentOffset: 0,
                 nextLogOffset: 0,
                 shouldSave: false,
@@ -620,9 +623,18 @@ describe('LogReader', () => {
             {
                 desc: 'should not save the offset if offsets are not managed',
                 managed: false,
+                hasStoreOffsetsFn: false,
                 currentOffset: 0,
                 nextLogOffset: 1,
                 shouldSave: false,
+            },
+            {
+                desc: 'should use storeOffsets to save the offset when offsets are not managed',
+                managed: false,
+                hasStoreOffsetsFn: true,
+                currentOffset: 0,
+                nextLogOffset: 1,
+                shouldSave: true,
             },
         ].forEach(params => {
             it(params.desc, done => {
@@ -646,12 +658,15 @@ describe('LogReader', () => {
                     logger: logReader.log,
                 };
                 sinon.stub(logReader, 'logOffset').value(params.currentOffset);
-                const offsetManagedStub = sinon.stub(logReader, 'isOffsetManaged').returns(params.managed);
-                const writeLogOffsetStub = sinon.stub(logReader, '_writeLogOffset').yields();
+                sinon.stub(logReader, 'isOffsetManaged').returns(params.managed);
+                let storeOffsetStub = sinon.stub(logReader, '_writeLogOffset').yields();
+                if (params.hasStoreOffsetsFn) {
+                    logReader.logConsumer.storeOffsets = () => {};
+                    storeOffsetStub = sinon.stub(logReader.logConsumer, 'storeOffsets').returns();
+                }
                 logReader._processSaveLogOffset(batchState, err => {
                     assert.ifError(err);
-                    assert(offsetManagedStub.calledOnce);
-                    assert(params.shouldSave ? writeLogOffsetStub.calledOnce : writeLogOffsetStub.notCalled);
+                    assert(params.shouldSave  ? storeOffsetStub.calledOnce : storeOffsetStub.notCalled);
                     done();
                 });
             });

--- a/tests/unit/lib/queuePopulator/kafkaLogConsumer/LogConsumer.js
+++ b/tests/unit/lib/queuePopulator/kafkaLogConsumer/LogConsumer.js
@@ -62,25 +62,6 @@ describe('LogConsumer', () => {
         sinon.restore();
     });
 
-    describe('_waitForAssignment', () => {
-        it('should wait for consumer group to balance', done => {
-            const waitAssignementSpy = sinon.spy(logConsumer, '_waitForAssignment');
-            const getAssignemntsStub = sinon.stub();
-            getAssignemntsStub.onCall(0).returns([]);
-            getAssignemntsStub.onCall(1).returns([{
-                topic: 'backbeat-oplog-topic',
-                partition: 0,
-            }]);
-            logConsumer._consumer = {
-                assignments: getAssignemntsStub,
-            };
-            logConsumer._waitForAssignment(0, () => {
-                assert.strictEqual(waitAssignementSpy.getCall(1).args.at(0), 2000);
-                return done();
-            });
-        }).timeout(5000);
-    });
-
     describe('_resetRecordStream', () => {
         it('should initialize record stream', () => {
             logConsumer._resetRecordStream();
@@ -96,6 +77,7 @@ describe('LogConsumer', () => {
             consumeStub.callsArgWith(1, null, [kafkaMessage]);
             logConsumer._consumer = {
                 consume: consumeStub,
+                isConnected: () => true,
             };
             logConsumer._consumeKafkaMessages(1, err => {
                 assert.ifError(err);
@@ -118,25 +100,70 @@ describe('LogConsumer', () => {
             });
         });
 
-        it('should save next partition offsets', done => {
+        it('should skip consuming when the consumer is not ready', done => {
+            const consumeStub = sinon.stub();
+            logConsumer._consumer = {
+                consume: consumeStub,
+                isConnected: () => false,
+            };
+            logConsumer._consumeKafkaMessages(5, err => {
+                assert.ifError(err);
+                sinon.assert.notCalled(consumeStub);
+                return done();
+            });
+        });
+
+        it('should store topicPartitions correctly after consuming messages with duplicate partitions', done => {
             const consumeStub = sinon.stub();
             consumeStub.callsArgWith(1, null, [
-                getKafkaMessage(0, 10),
-                getKafkaMessage(1, 20),
-                getKafkaMessage(2, 30),
+                getKafkaMessage(0, 5),
+                getKafkaMessage(1, 10),
+                getKafkaMessage(0, 8),
+                getKafkaMessage(2, 15),
+                getKafkaMessage(1, 12),
             ]);
             logConsumer._consumer = {
                 consume: consumeStub,
+                isConnected: () => true,
             };
-            logConsumer._consumeKafkaMessages(3, err => {
+            logConsumer._consumeKafkaMessages(5, err => {
                 assert.ifError(err);
-                logConsumer._listRecordStream.once('data', () => {
-                    assert.deepEqual(logConsumer._topicPartition, [
-                        { topic: 'oplog-topic', partition: 0, offset: 11 },
-                        { topic: 'oplog-topic', partition: 1, offset: 21 },
-                        { topic: 'oplog-topic', partition: 2, offset: 31 },
-                    ]);
-                });
+                assert.deepEqual(logConsumer._topicPartition, [
+                    { topic: 'oplog-topic', partition: 0, offset: 9 },
+                    { topic: 'oplog-topic', partition: 1, offset: 13 },
+                    { topic: 'oplog-topic', partition: 2, offset: 16 },
+                ]);
+                return done();
+            });
+        });
+
+        it('should store empty topicPartitions when no messages are consumed', done => {
+            const consumeStub = sinon.stub();
+            consumeStub.callsArgWith(1, null, []);
+            logConsumer._consumer = {
+                consume: consumeStub,
+                isConnected: () => true,
+            };
+            logConsumer._consumeKafkaMessages(10, err => {
+                assert.ifError(err);
+                sinon.assert.calledOnce(consumeStub);
+                assert.deepEqual(logConsumer._topicPartition, []);
+                return done();
+            });
+        });
+
+        it('should handle consumer errors gracefully and not store topicPartitions', done => {
+            const consumeStub = sinon.stub();
+            const consumerError = new Error('Consumer error');
+            consumeStub.callsArgWith(1, consumerError);
+            logConsumer._consumer = {
+                consume: consumeStub,
+                isConnected: () => true,
+            };
+            logConsumer._consumeKafkaMessages(5, err => {
+                assert.ifError(err);
+                sinon.assert.calledOnce(consumeStub);
+                assert.strictEqual(logConsumer._topicPartition, null);
                 return done();
             });
         });
@@ -144,13 +171,10 @@ describe('LogConsumer', () => {
 
     describe('readRecords', () => {
         it('should return stream', done => {
-            const waitAssignementStub = sinon.stub(logConsumer, '_waitForAssignment')
-                .callsArg(1);
             const consumeKafkaStub = sinon.stub(logConsumer, '_consumeKafkaMessages')
                 .callsArg(1);
             logConsumer._resetRecordStream();
             logConsumer.readRecords({ limit: 1 }, (err, res) => {
-                assert(waitAssignementStub.called);
                 assert(consumeKafkaStub.called);
                 assert.ifError(err);
                 assert(res.log instanceof ListRecordStream);
@@ -160,23 +184,10 @@ describe('LogConsumer', () => {
             });
         });
 
-        it('should fail if consumer group failed to stabilize', done => {
-            const waitAssignementStub = sinon.stub(logConsumer, '_waitForAssignment')
-                .callsArgWith(1, errors.InternalError);
-            logConsumer.readRecords({ limit: 1 }, err => {
-                assert(waitAssignementStub.called);
-                assert.deepEqual(err, errors.InternalError);
-                return done();
-            });
-        });
-
         it('should fail if it can\'t consume kafka messages', done => {
-            const waitAssignementStub = sinon.stub(logConsumer, '_waitForAssignment')
-                .callsArg(1);
             const consumeKafkaStub = sinon.stub(logConsumer, '_consumeKafkaMessages')
                 .callsArgWith(1, errors.InternalError);
             logConsumer.readRecords({ limit: 1 }, err => {
-                assert(waitAssignementStub.called);
                 assert(consumeKafkaStub.called);
                 assert.deepEqual(err, errors.InternalError);
                 return done();
@@ -185,17 +196,59 @@ describe('LogConsumer', () => {
     });
 
     describe('storeOffsets', () => {
-        it('should not store offsets if there are none', () => {
+        it('should not call offsetsStore when topicPartition is undefined', () => {
             const offsetsStore = sinon.stub(logConsumer._consumer, 'offsetsStore').returns(null);
+            logConsumer._topicPartition = undefined;
+            
+            logConsumer.storeOffsets();
+            
+            sinon.assert.notCalled(offsetsStore);
+            assert.strictEqual(logConsumer._pendingCommit, false);
+        });
+
+        it('should not store offsets if topicPartition is empty array', () => {
+            const offsetsStore = sinon.stub(logConsumer._consumer, 'offsetsStore').returns(null);
+            logConsumer._topicPartition = [];
             logConsumer.storeOffsets();
             assert(offsetsStore.notCalled);
+            assert.strictEqual(logConsumer._pendingCommit, false);
         });
+
         it('should reset topicPartition after storing offsets', () => {
             const offsetsStore = sinon.stub(logConsumer._consumer, 'offsetsStore').returns(null);
-            logConsumer._topicPartition = [{ topic: 'oplog-topic', partition: 0, offset: 1 }];
+            const topicPartition = [{ topic: 'oplog-topic', partition: 0, offset: 1 }];
+            logConsumer._topicPartition = topicPartition;
             logConsumer.storeOffsets();
-            assert(offsetsStore.calledWithMatch([{ topic: 'oplog-topic', partition: 0, offset: 1 }]));
+            assert(offsetsStore.calledWithMatch(topicPartition));
             assert.strictEqual(logConsumer._topicPartition, null);
+            assert.strictEqual(logConsumer._pendingCommit, true);
+        });
+
+        it('should store multiple partition offsets correctly', () => {
+            const offsetsStore = sinon.stub(logConsumer._consumer, 'offsetsStore').returns(null);
+            const topicPartition = [
+                { topic: 'oplog-topic', partition: 0, offset: 10 },
+                { topic: 'oplog-topic', partition: 1, offset: 20 },
+                { topic: 'oplog-topic', partition: 2, offset: 30 },
+            ];
+            logConsumer._topicPartition = topicPartition;
+            logConsumer.storeOffsets();
+            
+            sinon.assert.calledOnce(offsetsStore);
+            sinon.assert.calledWith(offsetsStore, topicPartition);
+            assert.strictEqual(logConsumer._topicPartition, null);
+            assert.strictEqual(logConsumer._pendingCommit, true);
+        });
+
+        it('should set pendingCommit to true when storing offsets', () => {
+            const offsetsStore = sinon.stub(logConsumer._consumer, 'offsetsStore').returns(null);
+            logConsumer._topicPartition = [{ topic: 'oplog-topic', partition: 0, offset: 5 }];
+            logConsumer._pendingCommit = false;
+            
+            logConsumer.storeOffsets();
+            
+            assert.strictEqual(logConsumer._pendingCommit, true);
+            sinon.assert.calledOnce(offsetsStore);
         });
     });
 
@@ -207,22 +260,253 @@ describe('LogConsumer', () => {
     });
 
     describe('_onOffsetCommit', () => {
-        it('should not log an error if it receives a NO_OFFSET error', () => {
+        it('should not log error and not change pendingCommit on NO_OFFSET error', () => {
             const logErrorSpy = sinon.spy(logConsumer._log, 'error');
-            logConsumer._onOffsetCommit({ code: kafka.CODES.ERRORS.ERR__NO_OFFSET }, null);
-            assert(logErrorSpy.notCalled);
-        });
-        it('should log an error if it receives an error other than NO_OFFSET', () => {
-            const logErrorSpy = sinon.spy(logConsumer._log, 'error');
-            const error = { code: kafka.CODES.ERRORS.ERR__UNKNOWN_TOPIC };
-            logConsumer._onOffsetCommit(error, null);
-            assert(logErrorSpy.calledOnce);
-        });
-        it('should log debug message on successful commit', () => {
             const logDebugSpy = sinon.spy(logConsumer._log, 'debug');
-            const topicPartitions = [{ topic: 'oplog-topic', partition: 0, offset: 1 }];
-            logConsumer._onOffsetCommit(null, topicPartitions);
-            assert(logDebugSpy.calledOnce);
+            logConsumer._pendingCommit = true;
+            
+            const result = logConsumer._onOffsetCommit({ code: kafka.CODES.ERRORS.ERR__NO_OFFSET }, null);
+            
+            sinon.assert.notCalled(logErrorSpy);
+            sinon.assert.notCalled(logDebugSpy);
+            assert.strictEqual(logConsumer._pendingCommit, true);
+            assert.strictEqual(result, undefined);
+        });
+
+        it('should log error and not change pendingCommit on non-NO_OFFSET errors', () => {
+            const logErrorSpy = sinon.spy(logConsumer._log, 'error');
+            const logDebugSpy = sinon.spy(logConsumer._log, 'debug');
+            const error = { code: kafka.CODES.ERRORS.ERR__UNKNOWN_TOPIC };
+            const topicPartitions = [{ topic: 'test-topic', partition: 1, offset: 5 }];
+            logConsumer._pendingCommit = true;
+            
+            const result = logConsumer._onOffsetCommit(error, topicPartitions);
+            
+            sinon.assert.calledOnce(logErrorSpy);
+            sinon.assert.notCalled(logDebugSpy);
+            assert.strictEqual(logConsumer._pendingCommit, true);
+            assert.strictEqual(result, undefined);
+        });
+
+        it('should set pendingCommit to false on successful commit', () => {
+            const topicPartitions = [
+                { topic: 'oplog-topic', partition: 0, offset: 10 },
+                { topic: 'oplog-topic', partition: 1, offset: 20 }
+            ];
+            logConsumer._pendingCommit = true;
+            
+            const result = logConsumer._onOffsetCommit(null, topicPartitions);
+            
+            assert.strictEqual(logConsumer._pendingCommit, false);
+            assert.strictEqual(result, undefined);
+        });
+    });
+
+    describe('_onRebalance', () => {
+        beforeEach(() => {
+            logConsumer._topic = 'test-topic';
+            logConsumer._consumerGroupId = 'test-group';
+            logConsumer._maxPollIntervalMs = 300000;
+        });
+
+        describe('partition assignment (ERR__ASSIGN_PARTITIONS)', () => {
+            it('should assign partitions on successful assignment', () => {
+                const assignStub = sinon.stub();
+                const assignment = [{ topic: 'test-topic', partition: 0 }];
+                logConsumer._consumer = {
+                    assign: assignStub,
+                };
+
+                logConsumer._onRebalance({ code: kafka.CODES.ERRORS.ERR__ASSIGN_PARTITIONS }, assignment);
+
+                sinon.assert.calledOnce(assignStub);
+                sinon.assert.calledWith(assignStub, assignment);
+            });
+        });
+
+        describe('partition revocation (ERR__REVOKE_PARTITIONS)', () => {
+            let clock;
+
+            beforeEach(() => {
+                clock = sinon.useFakeTimers();
+            });
+
+            afterEach(() => {
+                clock.restore();
+            });
+
+            it('should immediately unassign when no pending messages or commits', done => {
+                const unassignStub = sinon.stub();
+                const assignment = [{ topic: 'test-topic', partition: 0 }];
+                logConsumer._consumer = {
+                    unassign: unassignStub,
+                    isConnected: () => true,
+                };
+                logConsumer._topicPartition = [];
+                logConsumer._pendingCommit = false;
+
+                logConsumer.once('unassigned', () => {
+                    sinon.assert.calledOnce(unassignStub);
+                    done();
+                });
+
+                logConsumer._onRebalance({ code: kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS }, assignment);
+                clock.tick(1000);
+            });
+
+            it('should wait for pending messages to be processed and committed before unassigning', done => {
+                const unassignStub = sinon.stub();
+                const commitStub = sinon.stub();
+                logConsumer._consumer = {
+                    unassign: unassignStub,
+                    commit: commitStub,
+                    isConnected: () => true,
+                };
+                logConsumer._topicPartition = [{ topic: 'test', partition: 0, offset: 1 }];
+                logConsumer._pendingCommit = false;
+
+                logConsumer._onRebalance({ code: kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS }, []);
+
+                // First tick - should not unassign yet due to pending messages
+                clock.tick(1000);
+                sinon.assert.notCalled(unassignStub);
+
+                // simulate end of processing
+                logConsumer._topicPartition = null;
+                logConsumer._pendingCommit = true;
+
+                // second tick - should not unassign yet due to pending commit
+                clock.tick(1000);
+                sinon.assert.notCalled(unassignStub);
+
+                // simulate a successful commit
+                logConsumer._pendingCommit = false;
+
+                logConsumer.once('unassigned', () => {
+                    sinon.assert.calledOnce(commitStub);
+                    sinon.assert.calledOnce(unassignStub);
+                    done();
+                });
+
+                // Third tick - should now unassign
+                clock.tick(1000);
+            });
+
+            it('should disconnect consumer on timeout', () => {
+                const logErrorSpy = sinon.spy(logConsumer._log, 'error');
+                const disconnectStub = sinon.stub();
+                logConsumer._consumer = {
+                    disconnect: disconnectStub,
+                    isConnected: () => true,
+                };
+                logConsumer._maxPollIntervalMs = 5000;
+                logConsumer._topicPartition = [{ topic: 'test', partition: 0, offset: 1 }];
+
+                logConsumer._onRebalance({ code: kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS }, []);
+
+                // Advance time to trigger timeout
+                clock.tick(4000);
+
+                sinon.assert.calledOnce(logErrorSpy);
+                sinon.assert.calledOnce(disconnectStub);
+            });
+        });
+
+        describe('unknown error handling', () => {
+            it('should log error for unknown rebalance errors', () => {
+                const logErrorSpy = sinon.spy(logConsumer._log, 'error');
+                const unknownError = { code: kafka.CODES.ERRORS.ERR__UNKNOWN };
+                const assignment = [{ topic: 'test-topic', partition: 0 }];
+
+                logConsumer._onRebalance(unknownError, assignment);
+
+                sinon.assert.calledOnce(logErrorSpy);
+            });
+        });
+    });
+
+    describe('isReady', () => {
+        it('should return true when consumer is connected', () => {
+            logConsumer._consumer = {
+                isConnected: () => true,
+            };
+
+            assert.strictEqual(logConsumer.isReady(), true);
+        });
+
+        it('should return false when consumer is not connected', () => {
+            logConsumer._consumer = {
+                isConnected: () => false,
+            };
+            
+            assert.strictEqual(logConsumer.isReady(), false);
+        });
+    });
+
+    describe('close', () => {
+        it('should close consumer that is connected and subscribed', done => {
+            const unsubscribeStub = sinon.stub();
+            const disconnectStub = sinon.stub();
+            logConsumer._consumer = {
+                isConnected: () => true,
+                subscription: () => ['test-topic'],
+                unsubscribe: unsubscribeStub,
+                disconnect: disconnectStub,
+                once: sinon.stub(),
+            };
+            
+            logConsumer._consumer.once.withArgs('disconnected').callsArg(1);
+            
+            logConsumer.close(err => {
+                assert.ifError(err);
+                sinon.assert.calledOnce(unsubscribeStub);
+                sinon.assert.calledOnce(disconnectStub);
+                sinon.assert.calledWith(logConsumer._consumer.once, 'disconnected');
+                return done();
+            });
+            
+            setImmediate(() => {
+                logConsumer.emit('unassigned');
+            });
+        });
+
+        it('should close consumer that is connected but not subscribed', done => {
+            const disconnectStub = sinon.stub();
+            logConsumer._consumer = {
+                isConnected: () => true,
+                subscription: () => [],
+                disconnect: disconnectStub,
+                once: sinon.stub(),
+            };
+            
+            logConsumer._consumer.once.withArgs('disconnected').callsArg(1);
+            
+            logConsumer.close(err => {
+                assert.ifError(err);
+                sinon.assert.calledOnce(disconnectStub);
+                sinon.assert.calledWith(logConsumer._consumer.once, 'disconnected');
+                return done();
+            });
+        });
+
+        it('should handle case when consumer is not connected', done => {
+            logConsumer._consumer = {
+                isConnected: () => false,
+            };
+            
+            logConsumer.close(err => {
+                assert.ifError(err);
+                return done();
+            });
+        });
+
+        it('should handle case when consumer is null', done => {
+            logConsumer._consumer = null;
+            
+            logConsumer.close(err => {
+                assert.ifError(err);
+                return done();
+            });
         });
     });
 });

--- a/tests/unit/lib/queuePopulator/kafkaLogConsumer/LogConsumer.js
+++ b/tests/unit/lib/queuePopulator/kafkaLogConsumer/LogConsumer.js
@@ -349,7 +349,7 @@ describe('LogConsumer', () => {
                 clock.restore();
             });
 
-            it('should immediately unassign when no pending messages or commits', done => {
+            it('should immediately unassign when no pending messages or commits', async () => {
                 const unassignStub = sinon.stub();
                 const assignment = [{ topic: 'test-topic', partition: 0 }];
                 logConsumer._consumer = {
@@ -359,16 +359,20 @@ describe('LogConsumer', () => {
                 logConsumer._topicPartition = [];
                 logConsumer._pendingCommit = false;
 
-                logConsumer.once('unassigned', () => {
-                    sinon.assert.calledOnce(unassignStub);
-                    done();
-                });
+                let unassignHandler;
+                const unassignPromise = new Promise(resolve => { unassignHandler = resolve; });
+
+                logConsumer.once('unassigned', unassignHandler);
 
                 logConsumer._onRebalance({ code: kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS }, assignment);
                 clock.tick(1000);
+
+                void await unassignPromise;
+
+                sinon.assert.calledOnce(unassignStub);
             });
 
-            it('should wait for pending messages to be processed and committed before unassigning', done => {
+            it('should wait for pending messages to be processed and committed before unassigning', async () => {
                 const unassignStub = sinon.stub();
                 const commitStub = sinon.stub();
                 logConsumer._consumer = {
@@ -379,49 +383,59 @@ describe('LogConsumer', () => {
                 logConsumer._topicPartition = [{ topic: 'test', partition: 0, offset: 1 }];
                 logConsumer._pendingCommit = false;
 
+                let unassignHandler;
+                const unassignPromise = new Promise(resolve => { unassignHandler = resolve; });
+
+                logConsumer.once('unassigned', unassignHandler);
+
                 logConsumer._onRebalance({ code: kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS }, []);
 
                 // First tick - should not unassign yet due to pending messages
                 clock.tick(1000);
                 sinon.assert.notCalled(unassignStub);
 
-                // simulate end of processing
+                // Simulate processing completion and commit
                 logConsumer._topicPartition = null;
                 logConsumer._pendingCommit = true;
 
-                // second tick - should not unassign yet due to pending commit
+                // Second tick - should not unassign yet due to pending commit
                 clock.tick(1000);
                 sinon.assert.notCalled(unassignStub);
 
-                // simulate a successful commit
+                // Simulate successful commit by emitting drained event
                 logConsumer._pendingCommit = false;
+                logConsumer.emit('drained');
 
-                logConsumer.once('unassigned', () => {
-                    sinon.assert.calledOnce(commitStub);
-                    sinon.assert.calledOnce(unassignStub);
-                    done();
-                });
+                void await unassignPromise;
 
-                // Third tick - should now unassign
-                clock.tick(1000);
+                sinon.assert.calledOnce(unassignStub);
             });
 
-            it('should disconnect consumer on timeout', () => {
-                const logErrorSpy = sinon.spy(logConsumer._log, 'error');
+            it('should disconnect consumer on timeout', async () => {
                 const disconnectStub = sinon.stub();
+                const unassignStub = sinon.stub();
                 logConsumer._consumer = {
                     disconnect: disconnectStub,
+                    unassign: unassignStub,
                     isConnected: () => true,
                 };
                 logConsumer._maxPollIntervalMs = 5000;
                 logConsumer._topicPartition = [{ topic: 'test', partition: 0, offset: 1 }];
+                logConsumer._pendingCommit = false;
+
+                let unassignHandler;
+                const unassignPromise = new Promise(resolve => { unassignHandler = resolve; });
+
+                logConsumer.once('unassigned', unassignHandler);
 
                 logConsumer._onRebalance({ code: kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS }, []);
 
-                // Advance time to trigger timeout
+                // Advance time to trigger timeout (maxPollIntervalMs - 1000)
                 clock.tick(4000);
 
-                sinon.assert.calledOnce(logErrorSpy);
+                void await unassignPromise;
+
+                sinon.assert.calledOnce(unassignStub);
                 sinon.assert.calledOnce(disconnectStub);
             });
         });

--- a/tests/unit/lib/queuePopulator/kafkaLogConsumer/LogConsumer.js
+++ b/tests/unit/lib/queuePopulator/kafkaLogConsumer/LogConsumer.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const sinon = require('sinon');
 const werelogs = require('werelogs');
 const { errors } = require('arsenal');
+const kafka = require('node-rdkafka');
 const logger = new werelogs.Logger('KafkaLogConsumer');
 const ListRecordStream =
     require('../../../../../lib/queuePopulator/KafkaLogConsumer/ListRecordStream');
@@ -35,20 +36,30 @@ const changeStreamDocument = {
         }
     }
 };
-const kafkaMessage = {
-    value: Buffer.from(JSON.stringify(changeStreamDocument)),
-    timestamp: Date.now(),
-    size: 2,
-    topic: 'oplog-topic',
-    offset: 1337,
-    partition: 0,
-    key: Buffer.from('key'),
-};
+
+function getKafkaMessage(partition = 0, offset = 0) {
+    return {
+        value: Buffer.from(JSON.stringify(changeStreamDocument)),
+        timestamp: Date.now(),
+        size: 2,
+        topic: 'oplog-topic',
+        offset,
+        partition,
+        key: Buffer.from('key'),
+    };
+}
 
 describe('LogConsumer', () => {
     let logConsumer;
     beforeEach(() => {
         logConsumer = new LogConsumer(kafkaConfig, logger);
+        logConsumer._consumer = {
+            offsetsStore: () => null,
+        };
+    });
+
+    afterEach(() => {
+        sinon.restore();
     });
 
     describe('_waitForAssignment', () => {
@@ -70,29 +81,6 @@ describe('LogConsumer', () => {
         }).timeout(5000);
     });
 
-    describe('_storeCurrentOffsets', () => {
-        it('should store offsets', done => {
-            const committedStub = sinon.stub();
-            committedStub.callsArgWith(1, null, [{
-                topic: 'backbeat-oplog-topic',
-                partition: 0,
-                offset: 0
-            }]);
-            logConsumer._consumer = {
-                committed: committedStub,
-            };
-            logConsumer._storeCurrentOffsets(err => {
-                assert.ifError(err);
-                assert.deepEqual(logConsumer._offsets, [{
-                    topic: 'backbeat-oplog-topic',
-                    partition: 0,
-                    offset: 0
-                }]);
-                return done();
-            });
-        });
-    });
-
     describe('_resetRecordStream', () => {
         it('should initialize record stream', () => {
             logConsumer._resetRecordStream();
@@ -104,6 +92,7 @@ describe('LogConsumer', () => {
     describe('_consumeKafkaMessages', () => {
         it('should consume kafka messages', done => {
             const consumeStub = sinon.stub();
+            const kafkaMessage = getKafkaMessage(0, 0);
             consumeStub.callsArgWith(1, null, [kafkaMessage]);
             logConsumer._consumer = {
                 consume: consumeStub,
@@ -128,20 +117,40 @@ describe('LogConsumer', () => {
                 });
             });
         });
+
+        it('should save next partition offsets', done => {
+            const consumeStub = sinon.stub();
+            consumeStub.callsArgWith(1, null, [
+                getKafkaMessage(0, 10),
+                getKafkaMessage(1, 20),
+                getKafkaMessage(2, 30),
+            ]);
+            logConsumer._consumer = {
+                consume: consumeStub,
+            };
+            logConsumer._consumeKafkaMessages(3, err => {
+                assert.ifError(err);
+                logConsumer._listRecordStream.once('data', () => {
+                    assert.deepEqual(logConsumer._topicPartition, [
+                        { topic: 'oplog-topic', partition: 0, offset: 11 },
+                        { topic: 'oplog-topic', partition: 1, offset: 21 },
+                        { topic: 'oplog-topic', partition: 2, offset: 31 },
+                    ]);
+                });
+                return done();
+            });
+        });
     });
 
     describe('readRecords', () => {
         it('should return stream', done => {
             const waitAssignementStub = sinon.stub(logConsumer, '_waitForAssignment')
                 .callsArg(1);
-            const storeOffsetsStub = sinon.stub(logConsumer, '_storeCurrentOffsets')
-                .callsArg(0);
             const consumeKafkaStub = sinon.stub(logConsumer, '_consumeKafkaMessages')
                 .callsArg(1);
             logConsumer._resetRecordStream();
             logConsumer.readRecords({ limit: 1 }, (err, res) => {
                 assert(waitAssignementStub.called);
-                assert(storeOffsetsStub.called);
                 assert(consumeKafkaStub.called);
                 assert.ifError(err);
                 assert(res.log instanceof ListRecordStream);
@@ -161,33 +170,59 @@ describe('LogConsumer', () => {
             });
         });
 
-        it('should fail if it can\'t store offsets', done => {
-            const waitAssignementStub = sinon.stub(logConsumer, '_waitForAssignment')
-                .callsArg(1);
-            const storeOffsetsStub = sinon.stub(logConsumer, '_storeCurrentOffsets')
-                .callsArgWith(0, errors.InternalError);
-            logConsumer.readRecords({ limit: 1 }, err => {
-                assert(waitAssignementStub.called);
-                assert(storeOffsetsStub.called);
-                assert.deepEqual(err, errors.InternalError);
-                return done();
-            });
-        });
-
         it('should fail if it can\'t consume kafka messages', done => {
             const waitAssignementStub = sinon.stub(logConsumer, '_waitForAssignment')
                 .callsArg(1);
-            const storeOffsetsStub = sinon.stub(logConsumer, '_storeCurrentOffsets')
-                .callsArg(0);
             const consumeKafkaStub = sinon.stub(logConsumer, '_consumeKafkaMessages')
                 .callsArgWith(1, errors.InternalError);
             logConsumer.readRecords({ limit: 1 }, err => {
                 assert(waitAssignementStub.called);
-                assert(storeOffsetsStub.called);
                 assert(consumeKafkaStub.called);
                 assert.deepEqual(err, errors.InternalError);
                 return done();
             });
+        });
+    });
+
+    describe('storeOffsets', () => {
+        it('should not store offsets if there are none', () => {
+            const offsetsStore = sinon.stub(logConsumer._consumer, 'offsetsStore').returns(null);
+            logConsumer.storeOffsets();
+            assert(offsetsStore.notCalled);
+        });
+        it('should reset topicPartition after storing offsets', () => {
+            const offsetsStore = sinon.stub(logConsumer._consumer, 'offsetsStore').returns(null);
+            logConsumer._topicPartition = [{ topic: 'oplog-topic', partition: 0, offset: 1 }];
+            logConsumer.storeOffsets();
+            assert(offsetsStore.calledWithMatch([{ topic: 'oplog-topic', partition: 0, offset: 1 }]));
+            assert.strictEqual(logConsumer._topicPartition, null);
+        });
+    });
+
+    describe('_getOffset', () => {
+        it('should return null', () => {
+            const result = logConsumer._getOffset();
+            assert.strictEqual(result, null);
+        });
+    });
+
+    describe('_onOffsetCommit', () => {
+        it('should not log an error if it receives a NO_OFFSET error', () => {
+            const logErrorSpy = sinon.spy(logConsumer._log, 'error');
+            logConsumer._onOffsetCommit({ code: kafka.CODES.ERRORS.ERR__NO_OFFSET }, null);
+            assert(logErrorSpy.notCalled);
+        });
+        it('should log an error if it receives an error other than NO_OFFSET', () => {
+            const logErrorSpy = sinon.spy(logConsumer._log, 'error');
+            const error = { code: kafka.CODES.ERRORS.ERR__UNKNOWN_TOPIC };
+            logConsumer._onOffsetCommit(error, null);
+            assert(logErrorSpy.calledOnce);
+        });
+        it('should log debug message on successful commit', () => {
+            const logDebugSpy = sinon.spy(logConsumer._log, 'debug');
+            const topicPartitions = [{ topic: 'oplog-topic', partition: 0, offset: 1 }];
+            logConsumer._onOffsetCommit(null, topicPartitions);
+            assert(logDebugSpy.calledOnce);
         });
     });
 });

--- a/tests/unit/lib/queuePopulator/kafkaLogConsumer/LogConsumer.js
+++ b/tests/unit/lib/queuePopulator/kafkaLogConsumer/LogConsumer.js
@@ -113,6 +113,20 @@ describe('LogConsumer', () => {
             });
         });
 
+        it('should skip consuming when previously consumed batch was not processed yet', done => {
+            const consumeStub = sinon.stub();
+            logConsumer._consumer = {
+                consume: consumeStub,
+                isConnected: () => true,
+            };
+            logConsumer._topicPartition = [{ topic: 'oplog-topic', partition: 0, offset: 1 }];
+            logConsumer._consumeKafkaMessages(5, err => {
+                assert.ifError(err);
+                sinon.assert.notCalled(consumeStub);
+                return done();
+            });
+        });
+
         it('should store topicPartitions correctly after consuming messages with duplicate partitions', done => {
             const consumeStub = sinon.stub();
             consumeStub.callsArgWith(1, null, [


### PR DESCRIPTION
Kafka log consumer currently auto-commits messages after they are consumed. This is an issue as it means we loose messages after restart or crash even if their processing didn't finish.

Like we do with other logConsumer implementations, we now manually store offsets after the end of each batch. The auto-commit mechanism commits offsets stored locally after each 5 seconds.

Contrary to the BackbeatConsumer, there is no risk of offsets being committed in disorder as only one batch is processed at a time, and a partition is only assigned to a single instance of the QueuePopulator.

Issue: BB-698