### PR TITLE
BB-705: Bump rdkafka to fix DEP0048 util.isError()

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "minimatch": "^10.0.1",
     "mongodb": "^6.11.0",
     "node-forge": "^1.3.1",
-    "node-rdkafka": "^2.12.0",
+    "node-rdkafka": "^3.6.0",
     "node-rdkafka-prometheus": "^1.0.0",
     "node-schedule": "^2.1.1",
     "node-zookeeper-client": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4805,10 +4805,15 @@ ms@^2.0.0, ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nan@^2.14.0, nan@^2.17.0, nan@^2.18.0, nan@^2.3.2:
+nan@^2.14.0, nan@^2.18.0, nan@^2.3.2:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.22.0.tgz#31bc433fc33213c97bad36404bb68063de604de3"
   integrity sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==
+
+nan@^2.22.0:
+  version "2.23.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.23.0.tgz#24aa4ddffcc37613a2d2935b97683c1ec96093c6"
+  integrity sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==
 
 napi-macros@~2.0.0:
   version "2.0.0"
@@ -4935,13 +4940,13 @@ node-rdkafka-prometheus@^1.0.0:
     "@log4js-node/log4js-api" "^1.0.0"
     prom-client "^12.0.0"
 
-node-rdkafka@^2.12.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-2.18.0.tgz#116950e49dfe804932c8bc6dbc68949793e72ee2"
-  integrity sha512-jYkmO0sPvjesmzhv1WFOO4z7IMiAFpThR6/lcnFDWgSPkYL95CtcuVNo/R5PpjujmqSgS22GMkL1qvU4DTAvEQ==
+node-rdkafka@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-3.6.0.tgz#d67c041ab4858262a37db876e0b47a72c1994086"
+  integrity sha512-FntdqNV+Q6D7Yb54xn2IuQIBGr/cT+MjFo/4JTXKRikSP0rRkEMY7vZoNd0HJY334b/oaY7dv3+OnY7DGsSbiQ==
   dependencies:
     bindings "^1.3.1"
-    nan "^2.17.0"
+    nan "^2.22.0"
 
 node-releases@^2.0.19:
   version "2.0.19"


### PR DESCRIPTION
This deprecation warning spams stderr logs

Fix done in this release: https://github.com/Blizzard/node-rdkafka/releases/tag/v3.3.1

Going from 2.18.0 to 3.4.1 updates librdkafka from 2.3.0 to 2.10.1