### PR TITLE
Fix conductor always triggering v1 listing when using bucketd

### DIFF
--- a/extensions/lifecycle/conductor/LifecycleConductor.js
+++ b/extensions/lifecycle/conductor/LifecycleConductor.js
@@ -226,12 +226,12 @@ class LifecycleConductor {
     }
 
     _indexesGetOrCreate(task, log, cb) {
-        if (!task.isLifecycled) {
-            return process.nextTick(cb, null, lifecycleTaskVersions.v1);
-        }
-
         if (this._bucketSource !== 'mongodb') {
             return process.nextTick(cb, null, lifecycleTaskVersions.v2);
+        }
+
+        if (!task.isLifecycled) {
+            return process.nextTick(cb, null, lifecycleTaskVersions.v1);
         }
 
         const backbeatMetadataProxy = this.clientManager.getBackbeatMetadataProxy(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.0.15",
+  "version": "9.0.16",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/functional/lifecycle/LifecycleConductor.spec.js
+++ b/tests/functional/lifecycle/LifecycleConductor.spec.js
@@ -37,12 +37,12 @@ const s3Config = {
 
 const bucketTasksTopic = 'backbeat-lifecycle-bucket-tasks-spec';
 
-const expected2Messages = [
+const expected2Messages = (version='v2') => ([
     {
         value: {
             action: 'processObjects',
             contextInfo: { reqId: 'test-request-id' },
-            target: { bucket: 'bucket1', owner: 'owner1', taskVersion: 'v1' },
+            target: { bucket: 'bucket1', owner: 'owner1', taskVersion: version },
             details: {},
         },
     },
@@ -50,18 +50,18 @@ const expected2Messages = [
         value: {
             action: 'processObjects',
             contextInfo: { reqId: 'test-request-id' },
-            target: { bucket: 'bucket1-2', owner: 'owner1', taskVersion: 'v1' },
+            target: { bucket: 'bucket1-2', owner: 'owner1', taskVersion: version },
             details: {},
         },
     },
-];
+]);
 
-const expected4Messages = [
+const expected4Messages = (version='v2') => ([
     {
         value: {
             action: 'processObjects',
             contextInfo: { reqId: 'test-request-id' },
-            target: { bucket: 'bucket1', owner: 'owner1', taskVersion: 'v1' },
+            target: { bucket: 'bucket1', owner: 'owner1', taskVersion: version },
             details: {},
         },
     },
@@ -69,7 +69,7 @@ const expected4Messages = [
         value: {
             action: 'processObjects',
             contextInfo: { reqId: 'test-request-id' },
-            target: { bucket: 'bucket1-2', owner: 'owner1', taskVersion: 'v1' },
+            target: { bucket: 'bucket1-2', owner: 'owner1', taskVersion: version },
             details: {},
         },
     },
@@ -77,7 +77,7 @@ const expected4Messages = [
         value: {
             action: 'processObjects',
             contextInfo: { reqId: 'test-request-id' },
-            target: { bucket: 'bucket3', owner: 'owner3', taskVersion: 'v1' },
+            target: { bucket: 'bucket3', owner: 'owner3', taskVersion: version },
             details: {},
         },
     },
@@ -85,11 +85,11 @@ const expected4Messages = [
         value: {
             action: 'processObjects',
             contextInfo: { reqId: 'test-request-id' },
-            target: { bucket: 'bucket4', owner: 'owner4', taskVersion: 'v1' },
+            target: { bucket: 'bucket4', owner: 'owner4', taskVersion: version },
             details: {},
         },
     },
-];
+]);
 
 const baseLCConfig = {
     zookeeperPath: '/test/lifecycle',
@@ -430,6 +430,8 @@ describe('lifecycle conductor', function lifecycleConductor() {
             };
         }
 
+        const expectedTaskVersion = validatedLifecycleConfig.forceLegacyListing ? 'v1' : 'v2';
+
         return describe(description, () => {
             beforeEach(done => {
                 bucketdListing = [];
@@ -519,13 +521,15 @@ describe('lifecycle conductor', function lifecycleConductor() {
                     bucketPopulatorStep1,
                     next => {
                         lcConductor.processBuckets();
-                        consumer.expectUnorderedMessages(transformExpectedMessages(expected2Messages),
+                        consumer.expectUnorderedMessages(
+                            transformExpectedMessages(expected2Messages(expectedTaskVersion)),
                             CONSUMER_TIMEOUT, next);
                     },
                     bucketPopulatorStep2,
                     next => {
                         lcConductor.processBuckets();
-                        consumer.expectUnorderedMessages(transformExpectedMessages(expected4Messages),
+                        consumer.expectUnorderedMessages(
+                            transformExpectedMessages(expected4Messages(expectedTaskVersion)),
                             CONSUMER_TIMEOUT, next);
                     },
                 ], err => {
@@ -553,8 +557,35 @@ describe('lifecycle conductor', function lifecycleConductor() {
     });
 
     describeConductorSpec({
+        description: 'with auth `account` and buckets from bucketd (legacy listing mode)',
+        lifecycleConfig: {
+            ...baseLCConfig,
+            forceLegacyListing: true,
+            conductor: {
+                ...baseLCConfig.conductor,
+                bucketSource: 'bucketd',
+                bucketd: {
+                    host: '127.0.0.1',
+                },
+            },
+        },
+        mockBucketd: true,
+        transformExpectedMessages: identity,
+    });
+
+    describeConductorSpec({
         description: 'with auth `account` and buckets from zookeeper (compat mode)',
         lifecycleConfig: baseLCConfig,
+        setupZookeeper: true,
+        transformExpectedMessages: identity,
+    });
+
+    describeConductorSpec({
+        description: 'with auth `account` and buckets from zookeeper (legacy listing mode)',
+        lifecycleConfig: {
+            ...baseLCConfig,
+            forceLegacyListing: true,
+        },
         setupZookeeper: true,
         transformExpectedMessages: identity,
     });

--- a/tests/unit/lifecycle/LifecycleConductor.spec.js
+++ b/tests/unit/lifecycle/LifecycleConductor.spec.js
@@ -21,11 +21,13 @@ const {
 } = require('../../functional/lifecycle/configObjects');
 const { BackbeatMetadataProxyMock } = require('../mocks');
 
-const testTask = {
-    bucketName: 'testbucket',
-    canonicalId: 'testid',
-    isLifecycled: true,
-};
+function getTask(isLifecycled = true) {
+    return {
+        bucketName: 'testbucket',
+        canonicalId: 'testid',
+        isLifecycled,
+    };
+}
 
 const accountName1 = 'account1';
 const account1 = 'ab288756448dc58f61482903131e7ae533553d20b52b0e2ef80235599a1b9143';
@@ -244,7 +246,7 @@ describe('Lifecycle Conductor', () => {
     describe('_indexesGetOrCreate', () => {
         it('should return v2 for bucketd bucket sources', done => {
             conductor._bucketSource = 'bucketd';
-            conductor._indexesGetOrCreate(testTask, log, (err, taskVersion) => {
+            conductor._indexesGetOrCreate(getTask(undefined), log, (err, taskVersion) => {
                 assert.ifError(err);
                 assert.deepStrictEqual(taskVersion, lifecycleTaskVersions.v2);
                 done();
@@ -253,7 +255,7 @@ describe('Lifecycle Conductor', () => {
 
         it('should return v2 for zookeeper bucket sources', done => {
             conductor._bucketSource = 'zookeeper';
-            conductor._indexesGetOrCreate(testTask, log, (err, taskVersion) => {
+            conductor._indexesGetOrCreate(getTask(undefined), log, (err, taskVersion) => {
                 assert.ifError(err);
                 assert.deepStrictEqual(taskVersion, lifecycleTaskVersions.v2);
                 done();
@@ -262,8 +264,7 @@ describe('Lifecycle Conductor', () => {
 
         it('should return v1 for non-lifecyled buckets', done => {
             conductor._bucketSource = 'mongodb';
-            const task = Object.assign({}, testTask, { isLifecyled: false });
-            conductor._indexesGetOrCreate(task, log, (err, taskVersion) => {
+            conductor._indexesGetOrCreate(getTask(false), log, (err, taskVersion) => {
                 assert.ifError(err);
                 assert.deepStrictEqual(taskVersion, lifecycleTaskVersions.v1);
                 done();
@@ -271,8 +272,9 @@ describe('Lifecycle Conductor', () => {
         });
 
         it('should return v1 if backbeat client cannot be created', done => {
+            conductor._bucketSource = 'mongodb';
             conductor.clientManager.getBackbeatMetadataProxy = () => null;
-            conductor._indexesGetOrCreate(testTask, log, (err, taskVersion) => {
+            conductor._indexesGetOrCreate(getTask(true), log, (err, taskVersion) => {
                 assert.ifError(err);
                 assert.deepStrictEqual(taskVersion, lifecycleTaskVersions.v1);
                 done();
@@ -412,7 +414,7 @@ describe('Lifecycle Conductor', () => {
                 client.indexesObj = getIndexes;
                 client.error = mockError;
 
-                conductor._indexesGetOrCreate(testTask, log, (err, taskVersion) => {
+                conductor._indexesGetOrCreate(getTask(true), log, (err, taskVersion) => {
                     assert.ifError(err);
                     assert.deepStrictEqual(client.receivedIdxObj, putIndexes);
                     assert.deepStrictEqual(conductor.activeIndexingJobs, expectedJobs);


### PR DESCRIPTION
bucketd and zookeeper listing don't include the property `isLifecycled` in the task object.

Issue: BB-709