### PR TITLE
BB-711: BackbeatClient extract html error

### DIFF
--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -243,6 +243,7 @@ class ReplicateObject extends BackbeatTask {
                         origin: 'source',
                         peer: this.sourceConfig.s3,
                         error: err.message,
+                        err,
                         httpStatus: err.statusCode,
                     });
                 return cb(err);
@@ -325,6 +326,7 @@ class ReplicateObject extends BackbeatTask {
                             origin: 'target',
                             peer,
                             error: err.message,
+                            err,
                         });
                     return cb(err);
                 }
@@ -495,6 +497,7 @@ class ReplicateObject extends BackbeatTask {
                         origin: 'source',
                         peer: this.sourceConfig.s3,
                         error: err.message,
+                        err,
                         httpStatus: err.statusCode,
                     });
             }
@@ -523,6 +526,7 @@ class ReplicateObject extends BackbeatTask {
                         origin: 'source',
                         peer: this.sourceConfig.s3,
                         error: err.message,
+                        err,
                     });
             }
             return doneOnce(err);
@@ -558,6 +562,7 @@ class ReplicateObject extends BackbeatTask {
                             origin: 'target',
                             peer: this.destBackbeatHost,
                             error: err.message,
+                            err,
                         });
                 }
                 return doneOnce(err);
@@ -614,6 +619,7 @@ class ReplicateObject extends BackbeatTask {
                         origin: 'target',
                         peer: this.destBackbeatHost,
                         error: err.message,
+                        err,
                     });
                 return cbOnce(err);
             }
@@ -650,6 +656,7 @@ class ReplicateObject extends BackbeatTask {
                         origin: 'target',
                         peer: this.destBackbeatHost,
                         error: err.message,
+                        err,
                     });
                 writtenLocations.forEach(location => {
                     log.error('orphan data location was not deleted', {

--- a/lib/clients/BackbeatClient.js
+++ b/lib/clients/BackbeatClient.js
@@ -21,4 +21,36 @@ BackbeatClient.prototype.validateService = function validateService() {
     }
 };
 
+// Override setupRequestListeners to add custom extractError listener
+BackbeatClient.prototype.setupRequestListeners = function setupRequestListeners(request) {
+    request.addListener('extractError', this.extractError);
+};
+
+// Override default extractError to preserve HTTP response body for HTML responses
+// Because S3C has an nginx proxy that can return HTML error responses
+// For example a 400 Request Header Or Cookie Too Large
+// That would be converted to UnknownError: BadRequest
+BackbeatClient.prototype.extractError = function extractErrorHtml(resp) {
+    const httpResponse = resp.httpResponse || {};
+    const code = httpResponse.statusCode;
+    const statusMessage = httpResponse.statusMessage;
+    const body = httpResponse.body;
+    const headers = httpResponse.headers || {};
+    const contentType = (headers['content-type'] || '').toLowerCase();
+
+    if (contentType.includes('text/html')) {
+        const html = body && body.toString() || '';
+        const title = html.match(/<title[^>]*>([^<]+)<\/title>/i);
+        const message = title && title[1] || 'HTML error response';
+
+        // eslint-disable-next-line no-param-reassign
+        resp.error = AWS.util.error(new Error(), {
+            code: `HTML ${statusMessage || 'Error'}`,
+            message,
+            statusCode: code,
+            rawBody: html,
+        });
+    }
+};
+
 module.exports = BackbeatClient;

--- a/tests/functional/lib/BackbeatClient.js
+++ b/tests/functional/lib/BackbeatClient.js
@@ -151,4 +151,26 @@ describe('BackbeatClient unit tests with mock server', () => {
             return done();
         });
     });
+
+    it('should handle openresty HTML error response for putData', done => {
+        const destReq = backbeatClient.putData({
+            Bucket: 'bkterr',
+            Key: 'objerr',
+            CanonicalID: 'test-canonical-id',
+            ContentLength: 0,
+            Body: '',
+            VersioningRequired: true,
+        });
+        return destReq.send(err => {
+            assert(err, 'Expected an error');
+            assert.strictEqual(err.code, 'HTML Bad Request');
+            assert.strictEqual(err.message, '400 Request Header Or Cookie Too Large');
+            assert.strictEqual(err.statusCode, 400);
+            assert(err.rawBody);
+            assert(err.rawBody.includes('<title>400 Request Header Or Cookie Too Large</title>'));
+            assert(err.rawBody.includes('<center>Request Header Or Cookie Too Large</center>'));
+            assert(err.rawBody.includes('<center>openresty</center>'));
+            return done();
+        });
+    });
 });

--- a/tests/functional/utils/MetadataMock.js
+++ b/tests/functional/utils/MetadataMock.js
@@ -96,6 +96,14 @@ class MetadataMock {
                         res.end('ok');
                 });
             }
+        } else if (req.method === 'PUT') {
+            const resObj = mockRes.PUT.responses[req.url];
+            if (resObj && resObj.resType === 'htmlError') {
+                res.writeHead(resObj.statusCode, resObj.statusMessage, {
+                    'Content-Type': resObj['content-type'],
+                });
+                res.end(resObj.body);
+            }
         }
     }
 }

--- a/tests/functional/utils/mockRes.json
+++ b/tests/functional/utils/mockRes.json
@@ -62,6 +62,17 @@
     "POST": {
         "responses": {}
     },
+    "PUT": {
+        "responses": {
+            "/_/backbeat/data/bkterr/objerr?v2": {
+                "resType": "htmlError",
+                "statusCode": 400,
+                "statusMessage": "Bad Request",
+                "content-type": "text/html",
+                "body": "<html>\r\n<head><title>400 Request Header Or Cookie Too Large</title></head>\r\n<body>\r\n<center><h1>400 Bad Request</h1></center>\r\n<center>Request Header Or Cookie Too Large</center>\r\n<hr><center>openresty</center>\r\n</body>\r\n</html>"
+            }
+        }
+    },
     "healthcheck": {
         "ok": {}
     },


### PR DESCRIPTION
S3C has nginx proxy that can return html error body
The default error extract function cannot parse that html
and convert to `UnknownError: BadRequest`

```html
HTTP/1.1 400 Bad Request
Server: openresty
Date: Fri, 22 Aug 2025 18:56:11 GMT
Content-Type: text/html
Content-Length: 230
Connection: close

<html>
<head><title>400 Request Header Or Cookie Too Large</title></head>
<body>
<center><h1>400 Bad Request</h1></center>
<center>Request Header Or Cookie Too Large</center>
<hr><center>openresty</center>
</body>
</html>
```