### PR TITLE
add replicateObject policy to the bucket processor

### DIFF
--- a/extensions/lifecycle/bucketProcessor/policy.json
+++ b/extensions/lifecycle/bucketProcessor/policy.json
@@ -13,7 +13,8 @@
                 "s3:GetObjectTagging",
                 "s3:GetObjectVersionTagging",
                 "s3:GetObject",
-                "s3:GetObjectVersion"
+                "s3:GetObjectVersion",
+                "s3:ReplicateObject"
             ],
             "Resource": [
                 "*"


### PR DESCRIPTION
The bucket processor needs extra permissions to use backbeat routes such as GetMetadata

Issue: BB-712