### PR TITLE
BB-714: Revert back from go to python supervisord

### DIFF
--- a/images/federation/Dockerfile
+++ b/images/federation/Dockerfile
@@ -2,13 +2,6 @@ ARG BACKBEAT_VERSION=latest
 FROM ghcr.io/scality/backbeat:${BACKBEAT_VERSION} AS builder
 
 ####################################################################################################
-FROM ghcr.io/scality/backbeat:${BACKBEAT_VERSION} AS supervisord
-
-ARG SUPERVISORD_VERSION=0.7.3
-ADD https://github.com/ochinchina/supervisord/releases/download/v${SUPERVISORD_VERSION}/supervisord_${SUPERVISORD_VERSION}_Linux_64-bit.tar.gz /tmp/supervisord.tar.gz
-RUN tar -xzvf /tmp/supervisord.tar.gz -C /usr/local/bin --strip-components 1 --wildcards '*/supervisord'
-
-####################################################################################################
 FROM ghcr.io/scality/backbeat:${BACKBEAT_VERSION} AS ballot
 
 ARG BALLOT_VERSION=1.0.4
@@ -18,9 +11,13 @@ RUN chmod +x /usr/src/app/ballot
 ####################################################################################################
 FROM ghcr.io/scality/backbeat:${BACKBEAT_VERSION}
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+      supervisor \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install external dependencies
 COPY --from=ballot /usr/src/app/ballot /usr/local/bin/
-COPY --from=supervisord /usr/local/bin/supervisord /usr/local/bin/
 
 # Prepare runtime environment
 ENV USER="scality"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.0.16",
+  "version": "9.0.17",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The go version is not a perfect replacement it has multiple changes that would require to update supervisor conf.

Breaking changes includes:

- log files name changes
  - process number starts count at 1 instead of 0
  - include full process_name with number in logfile
- no supervisorctl, replaced by superivsord ctl with less option
- no interactive supervisor ctl, if used without command it rewrite the superivsord.sock and then we lose access to supervisord ctl
- replaced priority with depends_on
- replaced %(ENV_X)s with envFiles

Overrall we’d like to avoid breaking changes until we resolve correct usage of the go version and apply it in every component at once.