### PR TITLE
Prevent crash when processing a paused location

### DIFF
--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -770,6 +770,9 @@ class IngestionPopulator {
     }
 
     _processLogReaderEntries(logReader, params, cb) {
+        if (!logReader) {
+            return process.nextTick(cb);
+        }
         // skipping if circuit breaker tripped
         if (this._circuitBreaker.state !== BreakerState.Nominal) {
             this.log.debug('circuitbreaker tripped, retrying later', {

--- a/tests/unit/ingestion/IngestionPopulator.js
+++ b/tests/unit/ingestion/IngestionPopulator.js
@@ -346,5 +346,12 @@ describe('Ingestion Populator', () => {
                 assert(logReaderMock.processLogEntries.calledOnce);
             });
         });
+
+        it('should handle undefined logReader gracefully', done => {
+            ip._processLogReaderEntries(undefined, {}, err => {
+                assert.ifError(err);
+                done();
+            });
+        });
     });
 });


### PR DESCRIPTION
A race condition could occur in `IngestionPopulator` if a location is paused while its `logReader` is being processed. This pause action removes the `logReader` from the active list.

If the asynchronous processing completes and attempts a recursive call to `_processLogReaderEntries`, it could do so with a `logReader` that is now `undefined`, causing a crash.

Issue: BB-716