### PR TITLE
Use special location when expiring delete marker

### DIFF
--- a/extensions/lifecycle/LifecycleMetrics.js
+++ b/extensions/lifecycle/LifecycleMetrics.js
@@ -6,6 +6,8 @@ const LIFECYCLE_LABEL_STATUS = 'status';
 const LIFECYCLE_LABEL_LOCATION = 'location';
 const LIFECYCLE_LABEL_TYPE = 'type';
 
+const LIFECYCLE_MARKER_METRICS_LOCATION = '-delete-marker-';
+
 const conductorLatestBatchStartTime = ZenkoMetrics.createGauge({
     name: 's3_lifecycle_latest_batch_start_time',
     help: 'Timestamp of latest lifecycle batch start time',
@@ -246,4 +248,5 @@ class LifecycleMetrics {
 
 module.exports = {
     LifecycleMetrics,
+    LIFECYCLE_MARKER_METRICS_LOCATION,
 };

--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -15,7 +15,7 @@ const { attachReqUids } = require('../../../lib/clients/utils');
 const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
 const ActionQueueEntry = require('../../../lib/models/ActionQueueEntry');
 const ReplicationAPI = require('../../replication/ReplicationAPI');
-const { LifecycleMetrics } = require('../LifecycleMetrics');
+const { LifecycleMetrics, LIFECYCLE_MARKER_METRICS_LOCATION } = require('../LifecycleMetrics');
 const locationsConfig = require('../../../conf/locationConfig.json') || {};
 const { decode } = versioning.VersionID;
 
@@ -1449,6 +1449,7 @@ class LifecycleTask extends BackbeatTask {
                         .setAttribute('target.key', deleteMarker.Key)
                         .setAttribute('target.accountId', bucketData.target.accountId)
                         .setAttribute('target.version', deleteMarker.VersionId)
+                        .setAttribute('details.dataStoreName', LIFECYCLE_MARKER_METRICS_LOCATION)
                         // EODM applies only once all other versions have been deleted, so transition
                         // time is not `lastModified`, but the time when the "last" version was
                         // removed. We still need to pass a transitionTime for metrics though, so
@@ -1504,6 +1505,8 @@ class LifecycleTask extends BackbeatTask {
                 }
             }
 
+            const storageClass = this._isDeleteMarker(verToExpire) ?
+                LIFECYCLE_MARKER_METRICS_LOCATION : verToExpire.StorageClass;
             const entry = ActionQueueEntry.create('deleteObject')
                 .addContext({
                     origin: 'lifecycle',
@@ -1515,8 +1518,8 @@ class LifecycleTask extends BackbeatTask {
                 .setAttribute('target.accountId', bucketData.target.accountId)
                 .setAttribute('target.key', verToExpire.Key)
                 .setAttribute('target.version', verToExpire.VersionId)
-                .setAttribute('details.dataStoreName', verToExpire.StorageClass || '')
-                // details.lastModified is not set for NCVE...
+                .setAttribute('details.dataStoreName', storageClass || '')
+                .setAttribute('details.lastModified', verToExpire.LastModified)
                 .setAttribute('transitionTime',
                     this._lifecycleDateTime.getTransitionTimestamp(
                         { Days: rules[ncve][ncd] }, staleDate)

--- a/tests/unit/lifecycle/LifecycleTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleTask.spec.js
@@ -1498,26 +1498,36 @@ describe('lifecycle task helper methods', () => {
                 Key: 'testkey',
                 VersionId: '4',
                 staleDate: new Date(testDate - (1 * DAY)).toISOString(),
+                LastModified: new Date(testDate - (1 * DAY)).toISOString(),
+                StorageClass: 'eu-west-1',
             },
             {
                 Key: 'testkey',
                 VersionId: '3',
                 staleDate: new Date(testDate - (2 * DAY)).toISOString(),
+                LastModified: new Date(testDate - (2 * DAY)).toISOString(),
+                StorageClass: 'eu-west-2',
             },
             {
                 Key: 'testkey',
                 VersionId: '1',
                 staleDate: new Date(testDate - (4 * DAY)).toISOString(),
+                LastModified: new Date(testDate - (4 * DAY)).toISOString(),
+                // no storage class, to "simulate" a delete marker
             },
             {
                 Key: 'testkey',
                 VersionId: '2',
                 staleDate: new Date(testDate - (3 * DAY)).toISOString(),
+                LastModified: new Date(testDate - (3 * DAY)).toISOString(),
+                StorageClass: 'eu-west-4',
             },
             {
                 Key: 'testkey',
                 VersionId: '0',
                 staleDate: new Date(testDate - (5 * DAY)).toISOString(),
+                LastModified: new Date().toISOString(),
+                StorageClass: 'eu-west-5',
             },
         ];
 
@@ -1580,9 +1590,15 @@ describe('lifecycle task helper methods', () => {
                         }
                     );
 
+                    const expectedStorageClass = expectedEntries[idx].StorageClass || '-delete-marker-';
+
                     assert.strictEqual(latestEntry.getActionType(), 'deleteObject');
                     assert.deepStrictEqual(
                         latestEntry.getAttribute('target'), expectedTarget);
+                    assert.deepStrictEqual(
+                        latestEntry.getAttribute('details.dataStoreName'), expectedStorageClass);
+                    assert.deepStrictEqual(
+                        latestEntry.getAttribute('details.lastModified'), expectedEntries[idx].LastModified);
                 });
             });
         });


### PR DESCRIPTION
When expiring a delete marker, the value in the metrics used to be `undefined`. Use a special marker instead when expiring a delete marker, to make it easier to analyze.

Issue: BB-720
