### PR TITLE
Do not set lastModified in NCV action message

### DIFF
--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -1519,7 +1519,6 @@ class LifecycleTask extends BackbeatTask {
                 .setAttribute('target.key', verToExpire.Key)
                 .setAttribute('target.version', verToExpire.VersionId)
                 .setAttribute('details.dataStoreName', storageClass || '')
-                .setAttribute('details.lastModified', verToExpire.LastModified)
                 .setAttribute('transitionTime',
                     this._lifecycleDateTime.getTransitionTimestamp(
                         { Days: rules[ncve][ncd] }, staleDate)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "8.6.56",
+  "version": "8.6.57",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/lifecycle/LifecycleTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleTask.spec.js
@@ -1597,8 +1597,14 @@ describe('lifecycle task helper methods', () => {
                         latestEntry.getAttribute('target'), expectedTarget);
                     assert.deepStrictEqual(
                         latestEntry.getAttribute('details.dataStoreName'), expectedStorageClass);
+
+                    // `details.lastModified` must not be set for NCV expiration, as it is used to
+                    // check that the master version has not changed. This check is not relevant for
+                    // NCV (if anything, we may check that the current version is actually newer
+                    // than this one), and in particular may fail if current revision is a delete
+                    // marker
                     assert.deepStrictEqual(
-                        latestEntry.getAttribute('details.lastModified'), expectedEntries[idx].LastModified);
+                        latestEntry.getAttribute('details.lastModified'), undefined);
                 });
             });
         });


### PR DESCRIPTION
`details.lastModified` must not be set in the kafka message, as it's purpose is to let the object-processor make an extra check that the “object” was not modified (i.e. no new version).
This is done through a `s3:HeadObject` call on the object, (without versionId), which:
- is not relevant for `NCVE (if anything, we may instead check that the versionId being expired is indeed not the current one)
- in particular may fail is the current version is a delete markers)

Issue: BB-726
