### PR TITLE
BB-727: Log Zookeeper details

### DIFF
--- a/lib/clients/ZookeeperManager.js
+++ b/lib/clients/ZookeeperManager.js
@@ -21,6 +21,20 @@ class ZookeeperManager extends EventEmitter {
         this._connect();
     }
 
+    zkDetails(client) {
+        const localAddress = client.connectionManager?.socket?.address();
+        const sessionId = client.getSessionId?.();
+        return {
+            sessionId: sessionId ? `0x${sessionId.toString('hex')}` : null,
+            socket: localAddress ? `${localAddress.address || ''}:${localAddress.port || ''}` : null,
+            state: client.getState?.() || null,
+            xid: client.connectionManager?.xid,
+            zxid: client.connectionManager?.zxid?.toString('hex'),
+            nextServerIndex: client.connectionManager?.nextServerIndex,
+            serverAttempts: client.connectionManager?.serverAttempts,
+        };
+    }
+
     /**
      * Establishes a connection to the ZooKeeper server.
      *
@@ -51,6 +65,10 @@ class ZookeeperManager extends EventEmitter {
         async.series([
             // Check zookeeper client is connected
             next => this.client.once('connected', next),
+            next => {
+                this.log.info('connected to zookeeper', { zk: this.zkDetails(this.client) });
+                next();
+            },
             // Create namespace if it exists and options.autoCreateNamespace is true
             next => {
                 // TODO: ARTESCA-10337 The 'autoCreateNamespace' functionality is currently specific to
@@ -82,7 +100,12 @@ class ZookeeperManager extends EventEmitter {
                 const hostPort = this.connectionString.slice(0, nsIndex);
                 rootZkClient = zookeeper.createClient(hostPort, this.options);
                 rootZkClient.connect();
-                rootZkClient.once('connected', () => next());
+                rootZkClient.once('connected', () => {
+                    this.log.info('connected to root zookeeper', {
+                        zk: this.zkDetails(rootZkClient),
+                    });
+                    next();
+                });
             },
             // Once connected, use the root zookeeper client to create the namespace
             next => rootZkClient.mkdirp(namespace, err => {
@@ -99,15 +122,17 @@ class ZookeeperManager extends EventEmitter {
         this.client.once('expired', () => {
             this.log.info('zookeeper client expired', {
                 method: 'ZookeeperManager.once.expired',
+                zk: this.zkDetails(this.client),
             });
             // establish a new session with the ZooKeeper.
             this._connect();
         });
 
         this.client.on('state', state => {
-            this.log.debug('zookeeper new state', {
+            this.log.info('zookeeper new state', {
                 state,
                 method: 'ZookeeperManager.on.state',
+                zk: this.zkDetails(this.client),
             });
         });
 
@@ -131,6 +156,7 @@ class ZookeeperManager extends EventEmitter {
      * @return {undefined}
      */
     close() {
+        this.log.info('closing existing zookeeper client', { zk: this.zkDetails(this.client) });
         this.client.close();
         return;
     }

--- a/tests/unit/clients/ZookeeperManager.js
+++ b/tests/unit/clients/ZookeeperManager.js
@@ -12,6 +12,17 @@ describe('ZookeeperManager', () => {
     beforeEach(() => {
         // Create a mock client
         mockClient = {
+            connectionManager: {
+                socket: {
+                    address: () => ({ address: '127.0.0.1', port: 42000 }),
+                },
+                xid: 1,
+                zxid: Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x11, 0xFF]),
+                nextServerIndex: 1,
+                serverAttempts: 1,
+            },
+            getSessionId: () => Buffer.from([0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88]),
+            getState: () => ({ name: 'SYNC_CONNECTED', code: 3 }),
             on: sinon.stub(),
             once: sinon.stub(),
             connect: sinon.stub(),


### PR DESCRIPTION
This will help correlate connection with zookeeper logs that show client port and session id

```json
{"name":"Backbeat:Notification:QueueProcessor","time":1767700325481,"state":{"name":"SYNC_CONNECTED","code":3},"method":"ZookeeperManager.on.state","zk":{"sessionId":"0x0300001c3694000a","socket":"127.0.0.1:55702","state":{"name":"SYNC_CONNECTED","code":3},"xid":0,"zxid":"0000000000000000","nextServerIndex":1,"serverAttempts":0},"level":"info","message":"zookeeper new state","hostname":"rocky-8-3xl-nd-gcloud-707990ef-9e40-49f4-8bd6-29e3cf76e111","pid":34}
```