### PR TITLE
BB-729 Fix CRR role policy permissions for echo mode

### DIFF
--- a/extensions/replication/utils/SetupReplication.js
+++ b/extensions/replication/utils/SetupReplication.js
@@ -429,6 +429,7 @@ class SetupReplication extends BackbeatTask {
             const objActions = [
                 's3:GetObjectVersion',
                 's3:GetObjectVersionAcl',
+                's3:ReplicateObject',
             ];
             if (this._targetIsExternal) {
                 objActions.push('s3:GetObjectVersionTagging');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.0.19",
+  "version": "9.0.20",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Since the implementation of [ CLDSRV-731](https://scality.atlassian.net/browse/CLDSRV-731), internal services now require the appropriate permissions to access Backbeat routes.
We therefore need to provide the correct policy for CRR echo mode.


Context: 

CRR needs to call internal getMetadata / putMetadata to update the replication status of the version in the source bucket once replication is complete.
To enable this, we must add the s3:ReplicateObject permission action to the CRR role’s policy for the source bucket.


Tested in Integration.