### PR TITLE
BB-731 upgrade kafka version used on tests

### DIFF
--- a/.github/dockerfiles/ft/docker-compose.yaml
+++ b/.github/dockerfiles/ft/docker-compose.yaml
@@ -51,12 +51,24 @@ services:
     image: ${REDIS_IMAGE}
     ports:
       - 6379:6379
+  zookeeper:
+    profiles: ['s3c']
+    image: zookeeper:3.9.4
+    ports:
+      - 2181:2181
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
   kafka:
     profiles: ['s3c']
     image: ${KAFKA_IMAGE}
+    depends_on:
+      - zookeeper
     ports:
       - 9092:9092
-      - 2181:2181
     environment:
-      ADVERTISED_HOST: "localhost"
-      ADVERTISED_PORT: 9092
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1

--- a/.github/dockerfiles/kafka/Dockerfile
+++ b/.github/dockerfiles/kafka/Dockerfile
@@ -1,3 +1,28 @@
-FROM spotify/kafka
+FROM eclipse-temurin:17-jre
 
-RUN echo "message.max.bytes=5000020" >> /opt/kafka_2.11-0.10.1.0/config/server.properties
+# Install required tools
+RUN apt-get update && \
+    apt-get install -y wget netcat-traditional && \
+    rm -rf /var/lib/apt/lists/*
+
+# Download and install Kafka 3.9.0
+ENV KAFKA_VERSION=3.9.0
+ENV SCALA_VERSION=2.13
+ENV KAFKA_HOME=/opt/kafka
+
+RUN wget -q "https://archive.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" && \
+    tar -xzf "kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz" && \
+    mv "kafka_${SCALA_VERSION}-${KAFKA_VERSION}" ${KAFKA_HOME} && \
+    rm "kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz"
+
+# Add start script
+COPY --chmod=755 start-kafka.sh /usr/local/bin/start-kafka.sh
+
+RUN echo "message.max.bytes=5000020" >> ${KAFKA_HOME}/config/server.properties
+
+WORKDIR ${KAFKA_HOME}
+
+# Expose Kafka broker port
+EXPOSE 9092
+
+CMD ["/usr/local/bin/start-kafka.sh"]

--- a/.github/dockerfiles/kafka/start-kafka.sh
+++ b/.github/dockerfiles/kafka/start-kafka.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+# Configure Kafka broker based on environment variables
+if [ -n "$KAFKA_BROKER_ID" ]; then
+  echo "broker.id=${KAFKA_BROKER_ID}" >> ${KAFKA_HOME}/config/server.properties
+fi
+
+if [ -n "$KAFKA_ZOOKEEPER_CONNECT" ]; then
+  echo "zookeeper.connect=${KAFKA_ZOOKEEPER_CONNECT}" >> ${KAFKA_HOME}/config/server.properties
+else
+  echo "zookeeper.connect=localhost:2181" >> ${KAFKA_HOME}/config/server.properties
+fi
+
+if [ -n "$KAFKA_ADVERTISED_LISTENERS" ]; then
+  echo "advertised.listeners=${KAFKA_ADVERTISED_LISTENERS}" >> ${KAFKA_HOME}/config/server.properties
+fi
+
+if [ -n "$KAFKA_LISTENERS" ]; then
+  echo "listeners=${KAFKA_LISTENERS}" >> ${KAFKA_HOME}/config/server.properties
+fi
+
+if [ -n "$KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR" ]; then
+  echo "offsets.topic.replication.factor=${KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR}" >> ${KAFKA_HOME}/config/server.properties
+fi
+
+# Handle legacy environment variables for backward compatibility
+if [ -n "$ADVERTISED_HOST" ]; then
+  echo "advertised.listeners=PLAINTEXT://${ADVERTISED_HOST}:${ADVERTISED_PORT:-9092}" >> ${KAFKA_HOME}/config/server.properties
+fi
+
+# Wait for Zookeeper to be ready if KAFKA_ZOOKEEPER_CONNECT is set
+if [ -n "$KAFKA_ZOOKEEPER_CONNECT" ]; then
+  ZK_HOST=$(echo $KAFKA_ZOOKEEPER_CONNECT | cut -d: -f1)
+  ZK_PORT=$(echo $KAFKA_ZOOKEEPER_CONNECT | cut -d: -f2 | cut -d/ -f1)
+  echo "Waiting for Zookeeper at ${ZK_HOST}:${ZK_PORT}..."
+  while ! nc -z ${ZK_HOST} ${ZK_PORT}; do
+    sleep 1
+  done
+  echo "Zookeeper is ready"
+fi
+
+# Start Kafka
+echo "Starting Kafka..."
+exec ${KAFKA_HOME}/bin/kafka-server-start.sh ${KAFKA_HOME}/config/server.properties

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -108,17 +108,26 @@ jobs:
         image: ghcr.io/${{ github.repository }}/syntheticbucketd:${{ github.sha }}
         ports:
         - 9001:9001
+      zookeeper:
+        image: zookeeper:3.9.4
+        ports:
+        - 2181:2181
+        env:
+          ZOOKEEPER_CLIENT_PORT: 2181
+          ZOOKEEPER_TICK_TIME: 2000
       kafka:
         image: ghcr.io/${{ github.repository }}/ci-kafka:${{ github.sha }}
         credentials:
           username: ${{ github.repository_owner }}
           password: ${{ github.token }}
         ports:
-        - 2181:2181
         - 9092:9092
         env:
-          ADVERTISED_HOST: "localhost"
-          ADVERTISED_PORT: 9092
+          KAFKA_BROKER_ID: 1
+          KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+          KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
+          KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
+          KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       mongo:
         image: ghcr.io/${{ github.repository}}/ci-mongodb:${{ github.sha }}
         ports:
@@ -252,17 +261,17 @@ jobs:
       - name: Create Zookeeper paths for tests with metadata
         run: |-
           # Setup zookeeper paths for backbeat like we do in federation
-          docker exec ft-kafka-1 /opt/kafka_2.11-0.10.1.0/bin/zookeeper-shell.sh localhost:2181 create /backbeat ""
-          docker exec ft-kafka-1 /opt/kafka_2.11-0.10.1.0/bin/zookeeper-shell.sh localhost:2181 create /backbeat/replication-populator ""
-          docker exec ft-kafka-1 /opt/kafka_2.11-0.10.1.0/bin/zookeeper-shell.sh localhost:2181 create /backbeat/replication-populator/raft-id-dispatcher ""
-          docker exec ft-kafka-1 /opt/kafka_2.11-0.10.1.0/bin/zookeeper-shell.sh localhost:2181 create /backbeat/replication-populator/raft-id-dispatcher/owners ""
-          docker exec ft-kafka-1 /opt/kafka_2.11-0.10.1.0/bin/zookeeper-shell.sh localhost:2181 create /backbeat/replication-populator/raft-id-dispatcher/leaders ""
-          docker exec ft-kafka-1 /opt/kafka_2.11-0.10.1.0/bin/zookeeper-shell.sh localhost:2181 create /backbeat/replication-populator/raft-id-dispatcher/provisions ""
+          docker exec ft-kafka-1 /opt/kafka/bin/zookeeper-shell.sh zookeeper:2181 create /backbeat ""
+          docker exec ft-kafka-1 /opt/kafka/bin/zookeeper-shell.sh zookeeper:2181 create /backbeat/replication-populator ""
+          docker exec ft-kafka-1 /opt/kafka/bin/zookeeper-shell.sh zookeeper:2181 create /backbeat/replication-populator/raft-id-dispatcher ""
+          docker exec ft-kafka-1 /opt/kafka/bin/zookeeper-shell.sh zookeeper:2181 create /backbeat/replication-populator/raft-id-dispatcher/owners ""
+          docker exec ft-kafka-1 /opt/kafka/bin/zookeeper-shell.sh zookeeper:2181 create /backbeat/replication-populator/raft-id-dispatcher/leaders ""
+          docker exec ft-kafka-1 /opt/kafka/bin/zookeeper-shell.sh zookeeper:2181 create /backbeat/replication-populator/raft-id-dispatcher/provisions ""
           # provision raft ids, we configure 4 raft sessions in metadata config
-          docker exec ft-kafka-1 /opt/kafka_2.11-0.10.1.0/bin/zookeeper-shell.sh localhost:2181 create /backbeat/replication-populator/raft-id-dispatcher/provisions/0 ""
-          docker exec ft-kafka-1 /opt/kafka_2.11-0.10.1.0/bin/zookeeper-shell.sh localhost:2181 create /backbeat/replication-populator/raft-id-dispatcher/provisions/1 ""
-          docker exec ft-kafka-1 /opt/kafka_2.11-0.10.1.0/bin/zookeeper-shell.sh localhost:2181 create /backbeat/replication-populator/raft-id-dispatcher/provisions/2 ""
-          docker exec ft-kafka-1 /opt/kafka_2.11-0.10.1.0/bin/zookeeper-shell.sh localhost:2181 create /backbeat/replication-populator/raft-id-dispatcher/provisions/3 ""
+          docker exec ft-kafka-1 /opt/kafka/bin/zookeeper-shell.sh zookeeper:2181 create /backbeat/replication-populator/raft-id-dispatcher/provisions/0 ""
+          docker exec ft-kafka-1 /opt/kafka/bin/zookeeper-shell.sh zookeeper:2181 create /backbeat/replication-populator/raft-id-dispatcher/provisions/1 ""
+          docker exec ft-kafka-1 /opt/kafka/bin/zookeeper-shell.sh zookeeper:2181 create /backbeat/replication-populator/raft-id-dispatcher/provisions/2 ""
+          docker exec ft-kafka-1 /opt/kafka/bin/zookeeper-shell.sh zookeeper:2181 create /backbeat/replication-populator/raft-id-dispatcher/provisions/3 ""
         if: ${{ matrix.profile == 's3c' }}
       - name: Run QueuePopulator functional tests
         env:


### PR DESCRIPTION
Since we are upgrading kafka at the product level, doing some housekeeping to keep the version used in the tests up to date, a bit more synced with the product as this one was very outdated.

Downloading the kafka package directly instead of using the kafka image the 3.9.0 version of it does not support zookeeper anymore.

And since spotify/kafka used to come with zookeeper + kafka, we are now executing both separately.