### PR TITLE
Supporting passing Kafka basic auth creds in environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ FROM node:${NODE_VERSION}
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
+        ca-certificates \
         jq \
         openssl \
         tini \

--- a/extensions/notification/NotificationConfigValidator.js
+++ b/extensions/notification/NotificationConfigValidator.js
@@ -21,10 +21,19 @@ const kerberosAuthSchema = saslAuthSchema.append({
     serviceName: joi.string().required(),
 });
 
-const basicAuthSchema = saslAuthSchema.append({
+const basicAuthBaseSchema = saslAuthSchema.append({
     type: joi.string().valid('basic').required(),
-    credentialsFile: joi.string().required(),
 });
+
+const basicAuthSchema = joi.alternatives().try(
+    basicAuthBaseSchema.append({
+        credentialsFile: joi.string().required(),
+    }),
+    basicAuthBaseSchema.append({
+        username: joi.string().required(),
+        password: joi.string().required(),
+    }),
+);
 
 const credentialsFileSchema = joi.object({
     username: joi.string().required(),

--- a/extensions/notification/queueProcessor/task.js
+++ b/extensions/notification/queueProcessor/task.js
@@ -38,7 +38,11 @@ let destinationAuth = {
     keytab: process.env.KEYTAB,
     principal: process.env.PRINCIPAL,
     serviceName: process.env.SERVICE_NAME,
+    username: process.env.BASIC_USERNAME,
+    password: process.env.BASIC_PASSWORD,
 };
+// Drop undefined environment variables to prevent hitting unknown fields when validating the auth schema.
+Object.keys(destinationAuth).forEach(key => destinationAuth[key] === undefined ? delete destinationAuth[key] : {});
 const isDestinationAuthEmpty = Object.values(destinationAuth)
     .every(x => !x);
 if (isDestinationAuthEmpty) {

--- a/extensions/notification/utils/auth.js
+++ b/extensions/notification/utils/auth.js
@@ -85,19 +85,26 @@ function generateKafkaAuthObject(auth) {
             break;
         }
         case 'basic': {
-            const { protocol, credentialsFile } = auth;
+            const { protocol, credentialsFile, username, password } = auth;
             if (!supportedSaslProtocols.includes(protocol)) {
                 throw new Error(`Unsupported security.protocol: ${protocol}`);
             }
-            const credsFilePath = getAuthFilePath(credentialsFile);
-            if (credsFilePath === null) {
-                throw new Error(`Credentials file ${credentialsFile} not found in ${authFilesFolder}`);
-            }
-            const credentials = readCredentialsFile(credsFilePath);
             authObject['sasl.mechanisms'] = 'PLAIN';
             authObject['security.protocol'] = protocol;
-            authObject['sasl.username'] = credentials.username;
-            authObject['sasl.password'] = credentials.password;
+            if (credentialsFile) {
+                const credsFilePath = getAuthFilePath(credentialsFile);
+                if (credsFilePath === null) {
+                    throw new Error(`Credentials file ${credentialsFile} not found in ${authFilesFolder}`);
+                }
+                const credentials = readCredentialsFile(credsFilePath);
+                authObject['sasl.username'] = credentials.username;
+                authObject['sasl.password'] = credentials.password;
+            } else if (username && password) {
+                authObject['sasl.username'] = username;
+                authObject['sasl.password'] = password;
+            } else {
+                throw new Error('Missing credentials');
+            }
             break;
         }
         default: {

--- a/tests/unit/notification/NotificationConfigValidator.js
+++ b/tests/unit/notification/NotificationConfigValidator.js
@@ -162,7 +162,7 @@ describe('NotificationConfigValidator ::', () => {
         },
         {
             valid: true,
-            description: 'basic auth',
+            description: 'basic auth credentialsFile',
             destinationConfig: {
                 resource: 'resource',
                 type: 'kafka',
@@ -177,8 +177,25 @@ describe('NotificationConfigValidator ::', () => {
             },
         },
         {
+            valid: true,
+            description: 'basic auth username/password',
+            destinationConfig: {
+                resource: 'resource',
+                type: 'kafka',
+                host: 'host',
+                port: 8000,
+                topic: 'topic',
+                auth: {
+                    type: 'basic',
+                    protocol: 'SASL_PLAINTEXT',
+                    username: 'foo',
+                    password: 'bar',
+                }
+            },
+        },
+        {
             valid: false,
-            description: 'basic auth no credentialsFile',
+            description: 'basic auth missing credentials',
             destinationConfig: {
                 resource: 'resource',
                 type: 'kafka',

--- a/tests/unit/notification/utils/auth.js
+++ b/tests/unit/notification/utils/auth.js
@@ -136,12 +136,36 @@ describe('generateKafkaAuthObject', () => {
             },
         },
         {
+            description: 'Basic authentication with inline credentials',
+            valid: true,
+            input: {
+                type: 'basic',
+                protocol: 'SASL_PLAINTEXT',
+                username: 'testuser',
+                password: 'testpassword',
+            },
+            expected: {
+                'security.protocol': 'SASL_PLAINTEXT',
+                'sasl.mechanisms': 'PLAIN',
+                'sasl.username': 'testuser',
+                'sasl.password': 'testpassword',
+            },
+        },
+        {
             description: 'Basic authentication with missing credentials file',
             valid: false,
             input: {
                 type: 'basic',
                 protocol: 'SASL_PLAINTEXT',
                 credentialsFile: 'nonexistent.json',
+            },
+        },
+        {
+            description: 'Basic authentication with missing credentials',
+            valid: false,
+            input: {
+                type: 'basic',
+                protocol: 'SASL_PLAINTEXT',
             },
         },
         {


### PR DESCRIPTION
Used by Zenko, that uses environement variables rather than a configuration file currently.

Issue: BB-732