### PR TITLE
BB-731 downgrade to kafka 3.8.1 for lifecycle compat

### DIFF
--- a/.github/dockerfiles/kafka/Dockerfile
+++ b/.github/dockerfiles/kafka/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update && \
     apt-get install -y wget netcat-traditional && \
     rm -rf /var/lib/apt/lists/*
 
-# Download and install Kafka 3.9.0
-ENV KAFKA_VERSION=3.9.0
+# Download and install Kafka
+ENV KAFKA_VERSION=3.8.1
 ENV SCALA_VERSION=2.13
 ENV KAFKA_HOME=/opt/kafka
 


### PR DESCRIPTION
As we are most likely heading towards using kafka 3.8.1, since there are some incompatibilities on backbeat-lifecycle testsuite suggesting to downgrade a bit to keep things in sync. But we can also chose not to merge and keep ourselves more up to date. 

 