### PR TITLE
Prevent duplicate lifecycle bucket continuation processing

### DIFF
--- a/extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor.js
+++ b/extensions/lifecycle/bucketProcessor/LifecycleBucketProcessor.js
@@ -85,6 +85,7 @@ class LifecycleBucketProcessor {
         this._repConfig = repConfig;
         this._mongoConfig = mongoConfig;
         this._lcOptions = lcOptions;
+        this._consumer = null;
         this._producer = null;
         this._kafkaBacklogMetrics = null;
 
@@ -132,12 +133,12 @@ class LifecycleBucketProcessor {
 
         // The task scheduler for processing lifecycle tasks concurrently.
         this._internalTaskScheduler = async.queue((ctx, cb) => {
-            const { task, rules, value, s3target, backbeatMetadataProxy } = ctx;
+            const { task, rules, value, s3target, backbeatMetadataProxy, entry } = ctx;
             return this.retryWrapper.retry({
                 actionDesc: 'process bucket lifecycle entry',
                 logFields: { value },
                 actionFunc: (done, nbRetries) => task.processBucketEntry(
-                    rules, value, s3target, backbeatMetadataProxy, nbRetries, done),
+                    rules, value, s3target, backbeatMetadataProxy, entry, nbRetries, done),
                 shouldRetryFunc: err => err.retryable,
                 log: this._log,
             }, cb);
@@ -175,6 +176,7 @@ class LifecycleBucketProcessor {
      */
     getStateVars() {
         return {
+            consumer: this._consumer,
             producer: this._producer,
             processConfig: this._lcConfig.bucketProcessor,
             bootstrapList: this._repConfig.destination.bootstrapList,
@@ -351,6 +353,7 @@ class LifecycleBucketProcessor {
                 value: result,
                 s3target: s3,
                 backbeatMetadataProxy,
+                entry,
             }, cb);
         });
     }
@@ -382,7 +385,8 @@ class LifecycleBucketProcessor {
             kafka: { hosts: this._kafkaConfig.hosts },
             maxRequestSize: this._kafkaConfig.maxRequestSize,
             compressionType: this._kafkaConfig.compressionType,
-            requiredAcks: this._kafkaConfig.requiredAcks,
+            // Duplicate processing can result in exponential continuation. Conservatively enable idempotence.
+            idempotent: true,
             topic: this._lcConfig.objectTasksTopic,
         });
         producer.once('error', err => {

--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -1810,12 +1810,13 @@ class LifecycleTask extends BackbeatTask {
      *   handling versioned buckets
      * @param {AWS.S3} s3target - s3 instance
      * @param {BackbeatMetadataProxy} backbeatMetadataProxy - The metadata proxy
+     * @param {object} entry - Kafka entry
      * @param {number} nbRetries - Number of time the process has been retried
      * @param {function} done - callback(error)
      * @return {undefined}
      */
     processBucketEntry(bucketLCRules, bucketData, s3target,
-    backbeatMetadataProxy, nbRetries, done) {
+    backbeatMetadataProxy, entry, nbRetries, done) {
         const log = this.log.newRequestLogger();
         this.s3target = s3target;
         this.backbeatMetadataProxy = backbeatMetadataProxy;
@@ -1843,6 +1844,11 @@ class LifecycleTask extends BackbeatTask {
             contextInfo: bucketData.contextInfo,
             details: bucketData.details,
         });
+
+        // Commit now to avoid re-processing this entry after pushing continuation entries below.
+        if (entry) {
+            this.consumer.onEntryCommittable(entry);
+        }
 
         // Initially, processing a Bucket entry should check mpu AND
         // (versioned OR non-versioned) objects

--- a/lib/BackbeatProducer.js
+++ b/lib/BackbeatProducer.js
@@ -57,7 +57,12 @@ class BackbeatProducer extends EventEmitter {
                 pollIntervalMs: joi.number().default(DEFAULT_POLL_INTERVAL),
                 maxRequestSize: joi.number().default(KAFKA_PRODUCER_MESSAGE_MAX_BYTES),
                 compressionType: joi.string().default(KAFKA_PRODUCER_DEFAULT_COMPRESSION_TYPE),
-                requiredAcks: joi.number().default(KAFKA_PRODUCER_DEFAULT_REQUIRED_ACKS),
+                // When idempotence is enabled, all acks must be requested.
+                requiredAcks: joi.number().default(KAFKA_PRODUCER_DEFAULT_REQUIRED_ACKS).when('idempotent', {
+                    is: true,
+                    then: joi.valid(-1).failover(-1),
+                }),
+                idempotent: joi.boolean().default(false),
             }
         );
     }
@@ -81,6 +86,7 @@ class BackbeatProducer extends EventEmitter {
             'dr_cb': true,
             'compression.type': this._compressionType,
             'statistics.interval.ms': 1000,
+            'enable.idempotence': this._idempotent,
         };
 
         if (process.env.RDKAFKA_DEBUG_LOGS) {
@@ -125,6 +131,7 @@ class BackbeatProducer extends EventEmitter {
             maxRequestSize,
             compressionType,
             requiredAcks,
+            idempotent,
         } = joiResult;
         this._kafkaHosts = kafka.hosts;
         this._topic = topic && withTopicPrefix(topic);
@@ -132,6 +139,7 @@ class BackbeatProducer extends EventEmitter {
         this._maxRequestSize = maxRequestSize;
         this._compressionType = compressionType;
         this._requiredAcks = requiredAcks;
+        this._idempotent = idempotent;
     }
 
     connect() {

--- a/tests/functional/lifecycle/LifecycleTask.js
+++ b/tests/functional/lifecycle/LifecycleTask.js
@@ -475,7 +475,7 @@ class LifecycleBucketProcessorMock {
 function wrapProcessBucketEntry(bucketLCRules, bucketEntry,
 s3mock, params, cb) {
     params.lcTask.processBucketEntry(bucketLCRules, bucketEntry,
-    s3mock, backbeatMetadataProxyMock, 0, err => {
+    s3mock, backbeatMetadataProxyMock, null, 0, err => {
         assert.ifError(err);
         const entries = params.lcp.getEntries();
 

--- a/tests/functional/lifecycle/LifecycleTaskV2-versioned.js
+++ b/tests/functional/lifecycle/LifecycleTaskV2-versioned.js
@@ -114,7 +114,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(nonCurrentExpirationRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             assert.strictEqual(kafkaEntries.length, 0);
             // test that the non-current listing is triggered
@@ -142,7 +142,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(transitionRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             assert.strictEqual(kafkaEntries.length, 0);
             // test that the non-current listing is triggered
@@ -179,7 +179,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(nonCurrentExpirationRule, bd, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the current listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'current');
@@ -216,7 +216,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(nonCurrentExpirationRule, bd, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the non-current listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'noncurrent');
@@ -265,7 +265,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(expirationRule, bd, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the orphan listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'orphan');
@@ -294,7 +294,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(nonCurrentExpirationRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the non-current listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'noncurrent');
@@ -329,7 +329,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(transitionRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the non-current listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'noncurrent');
@@ -374,7 +374,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(transitionRule, bucketData, s3,
-            backbeatMetadataProxy, nbRetries, err => {
+            backbeatMetadataProxy, null, nbRetries, err => {
                 assert.ifError(err);
                 // test that the non-current listing is triggered
                 assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'noncurrent');
@@ -409,7 +409,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(transitionRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the non-current listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'noncurrent');
@@ -449,7 +449,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(transitionRule, bucketData, s3,
-            backbeatMetadataProxy, nbRetries, err => {
+            backbeatMetadataProxy, null, nbRetries, err => {
                 assert.ifError(err);
                 // test that the non-current listing is triggered
                 assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'noncurrent');
@@ -483,7 +483,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(expirationRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the current listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'current');
@@ -525,7 +525,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(
-            transitionRule, bucketData, s3, backbeatMetadataProxy, nbRetries, err => {
+            transitionRule, bucketData, s3, backbeatMetadataProxy, null, nbRetries, err => {
                 assert.ifError(err);
                 // test that the current listing is triggered
                 assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'current');
@@ -561,7 +561,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(transitionRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the current listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'current');
@@ -612,7 +612,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(rules, bucketData, s3,
-            backbeatMetadataProxy, nbRetries, err => {
+            backbeatMetadataProxy, null, nbRetries, err => {
                 assert.ifError(err);
                 // test that the current listing is triggered
                 assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'current');
@@ -669,7 +669,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(rules, bucketData, s3,
-            backbeatMetadataProxy, nbRetries, err => {
+            backbeatMetadataProxy, null, nbRetries, err => {
                 assert.ifError(err);
                 // test that the current listing is triggered
                 assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'current');
@@ -714,7 +714,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(transitionRule, bucketData, s3,
-            backbeatMetadataProxy, nbRetries, err => {
+            backbeatMetadataProxy, null, nbRetries, err => {
                 assert.ifError(err);
                 // test that the current listing is triggered
                 assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'current');
@@ -758,7 +758,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(expitationRule, bd, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the orphan listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'orphan');
@@ -805,7 +805,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(expitationRule, bd, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the orphan listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'orphan');
@@ -842,7 +842,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(expitationRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the orphan listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'orphan');
@@ -871,7 +871,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         lifecycleTask.processBucketEntry(nonCurrentExpirationRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the non-current listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'noncurrent');
@@ -912,7 +912,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(transitionRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the non-current listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'noncurrent');
@@ -949,7 +949,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(nonCurrentExpirationRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             assert.strictEqual(kafkaEntries.length, 2);
             // test that the current listing is triggered
@@ -997,7 +997,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(multipleRules, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the current listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'noncurrent');
@@ -1038,7 +1038,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(nonCurrentExpirationRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the non-current listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'noncurrent');
@@ -1074,7 +1074,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(nonCurrentExpirationRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the non-current listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'noncurrent');
@@ -1116,7 +1116,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(nonCurrentExpirationRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
 
             kafkaEntries = [];
@@ -1131,7 +1131,7 @@ describe('LifecycleTaskV2 with bucket versioned', () => {
             }];
 
             return lifecycleTask.processBucketEntry(nonCurrentExpirationRule2, bucketData, s3,
-                backbeatMetadataProxy, nbRetries, err => {
+                backbeatMetadataProxy, null, nbRetries, err => {
                     assert.ifError(err);
                     // test that the non-current listing is triggered
                     assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'noncurrent');

--- a/tests/functional/lifecycle/LifecycleTaskV2.js
+++ b/tests/functional/lifecycle/LifecycleTaskV2.js
@@ -112,7 +112,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(expirationRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             assert.strictEqual(kafkaEntries.length, 0);
             // test that the current listing is triggered
@@ -142,7 +142,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(disabledRule, bucketData, s3,
-            backbeatMetadataProxy, nbRetries, err => {
+            backbeatMetadataProxy, null, nbRetries, err => {
                 assert.ifError(err);
                 assert.strictEqual(kafkaEntries.length, 0);
                 // test that listing has not been triggered
@@ -160,7 +160,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(expirationRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             assert.strictEqual(kafkaEntries.length, 0);
             // test that the current listing is triggered
@@ -185,7 +185,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(expirationRule, bd, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             assert.strictEqual(kafkaEntries.length, 0);
             // test that listing has not been triggered
@@ -207,7 +207,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(expirationRule, bd, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             assert.strictEqual(kafkaEntries.length, 0);
             // test that listing has not been triggered
@@ -236,7 +236,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(transitionRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             assert.strictEqual(kafkaEntries.length, 0);
             // test that the current listing is triggered
@@ -271,7 +271,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(expirationRule, bd, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the current listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'current');
@@ -301,7 +301,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(expirationRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the current listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'current');
@@ -345,7 +345,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(ruleWithTags, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the current listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'current');
@@ -387,7 +387,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
         }];
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(ruleWithTags, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             assert.strictEqual(kafkaEntries.length, 0);
 
@@ -419,7 +419,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(transitionRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the current listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'current');
@@ -469,7 +469,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(rules, bucketData, s3,
-            backbeatMetadataProxy, nbRetries, err => {
+            backbeatMetadataProxy, null, nbRetries, err => {
                 assert.ifError(err);
                 // test that the current listing is triggered
                 assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'current');
@@ -520,7 +520,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(rules, bucketData, s3,
-            backbeatMetadataProxy, nbRetries, err => {
+            backbeatMetadataProxy, null, nbRetries, err => {
                 assert.ifError(err);
                 // test that the current listing is triggered
                 assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'current');
@@ -560,7 +560,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(transitionRule, bucketData, s3,
-            backbeatMetadataProxy, nbRetries, err => {
+            backbeatMetadataProxy, null, nbRetries, err => {
                 assert.ifError(err);
                 // test that the current listing is triggered
                 assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'current');
@@ -595,7 +595,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(transitionRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the current listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'current');
@@ -635,7 +635,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(
-            transitionRule, bucketData, s3, backbeatMetadataProxy, nbRetries, err => {
+            transitionRule, bucketData, s3, backbeatMetadataProxy, null, nbRetries, err => {
                 assert.ifError(err);
                 // test that the current listing is triggered
                 assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'current');
@@ -662,7 +662,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(expirationRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the current listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'current');
@@ -701,7 +701,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(transitionRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the current listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'current');
@@ -736,7 +736,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 1;
         return lifecycleTask.processBucketEntry(expirationRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             assert.strictEqual(kafkaEntries.length, 0);
             // test that the current listing is triggered
@@ -759,7 +759,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(expirationRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             assert.strictEqual(kafkaEntries.length, 2);
             // test that the current listing is triggered
@@ -807,7 +807,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(multipleRules, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that the current listing is triggered
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, 'current');
@@ -854,7 +854,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 1;
         return lifecycleTask.processBucketEntry(multipleRules, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             assert.strictEqual(kafkaEntries.length, 0);
             // test that the current listing is triggered
@@ -901,7 +901,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(mpuRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that listing has not been triggered.
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, null);
@@ -951,7 +951,7 @@ describe('LifecycleTaskV2 with bucket non-versioned', () => {
 
         const nbRetries = 0;
         return lifecycleTask.processBucketEntry(mpuRule, bucketData, s3,
-        backbeatMetadataProxy, nbRetries, err => {
+        backbeatMetadataProxy, null, nbRetries, err => {
             assert.ifError(err);
             // test that listing has not been triggered.
             assert.strictEqual(backbeatMetadataProxy.listLifecycleType, null);

--- a/tests/unit/lifecycle/LifecycleTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleTask.spec.js
@@ -2183,7 +2183,7 @@ describe('lifecycle task helper methods', () => {
             };
             const snapshot = sinon.stub(lct, '_snapshotDataMoverTopicOffsets').returns();
             lct.setSupportedRules(ValidLifecycleRules);
-            lct.processBucketEntry(bucketLCRules, bucketData, s3target, backbeatMetadataProxy, 0, err => {
+            lct.processBucketEntry(bucketLCRules, bucketData, s3target, backbeatMetadataProxy, null, 0, err => {
                 assert.deepEqual(err, errors.NoSuchBucket);
                 assert(snapshot.calledOnce);
                 done();
@@ -2215,7 +2215,7 @@ describe('lifecycle task helper methods', () => {
                 'NoncurrentVersionExpiration',
                 'AbortIncompleteMultipartUpload',
             ]);
-            lct.processBucketEntry(bucketLCRules, bucketData, s3target, backbeatMetadataProxy, 0, err => {
+            lct.processBucketEntry(bucketLCRules, bucketData, s3target, backbeatMetadataProxy, null, 0, err => {
                 assert.deepEqual(err, errors.NoSuchBucket);
                 assert(snapshot.notCalled);
                 done();


### PR DESCRIPTION
This commit adds:
- Idempotence on the lifecycle bucket processor producer, ensuring at-most-once producing on that topic. Enabling idempotence is safe, as this was enabled by default in Kafka 3.x [1], and a study by Apache showed that there was no significant performance impact to this [2].
- Committing bucket entries that are being processed, before pushing continuation entries. Previously, we could possibly create continuation entries first, then fail (due to e.g. Kafka network issues), and fail/skip committing offsets. This moves committing before pushing conitnuation entries, such that in the worst case, we now stop processing the bucket rather than push a duplicate.

[1]: https://cwiki.apache.org/confluence/display/KAFKA/KIP-679%3A+Producer+will+enable+the+strongest+delivery+guarantee+by+default
[2]: https://cwiki.apache.org/confluence/display/KAFKA/An+analysis+of+the+impact+of+max.in.flight.requests.per.connection+and+acks+on+Producer+performance

Issue: BB-723