### PR TITLE
BB-736 Improve logs when CRR fails due to missing s3:ReplicateObject

### DIFF
--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -10,6 +10,7 @@ const BackbeatMetadataProxy = require('../../../lib/BackbeatMetadataProxy');
 
 const mapLimitWaitPendingIfError = require('../../../lib/util/mapLimitWaitPendingIfError');
 const { attachReqUids, TIMEOUT_MS } = require('../../../lib/clients/utils');
+const { isAccessDeniedError, getAccessDeniedLogFields } = require('../../../lib/util/replicationPermissionError');
 const getExtMetrics = require('../utils/getExtMetrics');
 const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
 const { getAccountCredentials } = require('../../../lib/credentials/AccountCredentials');
@@ -350,10 +351,15 @@ class ReplicateObject extends BackbeatTask {
         return this.backbeatSource.getMetadata(params, (err, blob) => {
             if (err) {
                 err.origin = 'source'; // eslint-disable-line no-param-reassign
-                log.error('error getting metadata blob from S3', {
+                const logFields = {
                     method: 'ReplicateObject._refreshSourceEntry',
                     error: err,
-                });
+                };
+                if (isAccessDeniedError(err)) {
+                    Object.assign(logFields, getAccessDeniedLogFields(
+                        sourceEntry.getBucket(), this.sourceRole));
+                }
+                log.error('error getting metadata blob from S3', logFields);
                 return cb(err);
             }
             const parsedEntry = ObjectQueueEntry.createFromBlob(blob.Body);

--- a/extensions/replication/tasks/UpdateReplicationStatus.js
+++ b/extensions/replication/tasks/UpdateReplicationStatus.js
@@ -17,6 +17,7 @@ const {
     getSortedSetMember,
     getSortedSetKey,
 } = require('../../../lib/util/sortedSetHelper');
+const { isAccessDeniedError, getAccessDeniedLogFields } = require('../../../lib/util/replicationPermissionError');
 
 class UpdateReplicationStatus extends BackbeatTask {
     /**
@@ -63,10 +64,16 @@ class UpdateReplicationStatus extends BackbeatTask {
         return this.backbeatSourceClient
         .getMetadata(params, log, (err, blob) => {
             if (err) {
-                log.error('error getting metadata blob from S3', {
-                    method: 'ReplicateObject._refreshSourceEntry',
+                const logFields = {
+                    method: 'UpdateReplicationStatus._refreshSourceEntry',
                     error: err,
-                });
+                };
+                if (isAccessDeniedError(err)) {
+                    const sourceRole = sourceEntry.getReplicationRoles()?.split(',')[0];
+                    Object.assign(logFields, getAccessDeniedLogFields(
+                        sourceEntry.getBucket(), sourceRole));
+                }
+                log.error('error getting metadata blob from S3', logFields);
                 return cb(err);
             }
             const parsedEntry = ObjectQueueEntry.createFromBlob(blob.Body);
@@ -283,13 +290,20 @@ class UpdateReplicationStatus extends BackbeatTask {
         }, log, err => {
             const replicationStatus = updatedSourceEntry.getReplicationStatus();
             if (err) {
-                log.error('an error occurred when updating metadata', {
+                const logFields = {
+                    method: 'UpdateReplicationStatus._putMetadata',
                     entry: updatedSourceEntry.getLogInfo(),
                     origin: 'source',
                     peer: this.sourceConfig.s3,
                     replicationStatus,
                     error: err.message,
-                });
+                };
+                if (isAccessDeniedError(err)) {
+                    const sourceRole = updatedSourceEntry.getReplicationRoles()?.split(',')[0];
+                    Object.assign(logFields, getAccessDeniedLogFields(
+                        updatedSourceEntry.getBucket(), sourceRole));
+                }
+                log.error('an error occurred when updating metadata', logFields);
                 return cb(err);
             }
             this.metricsHandler.status({ replicationStatus });

--- a/lib/util/replicationPermissionError.js
+++ b/lib/util/replicationPermissionError.js
@@ -1,0 +1,34 @@
+/**
+ * Helper utilities for detecting and logging CRR permission errors.
+ */
+
+/**
+ * Check if an error is an AccessDenied error
+ * @param {Error} err - The error object
+ * @returns {boolean} True if the error is an AccessDenied error
+ */
+function isAccessDeniedError(err) {
+    return err && (err.code === 'AccessDenied');
+}
+
+/**
+ * Get enhanced log fields for AccessDenied errors.
+ * These fields provide context to help diagnose permission issues.
+ *
+ * @param {string} bucket - The source bucket name
+ * @param {string} sourceRole - The CRR source role ARN
+ * @returns {object} Log fields with contextual information
+ */
+function getAccessDeniedLogFields(bucket, sourceRole) {
+    return {
+        accessDeniedHint: 'Verify that the source role has the required ' +
+            'permissions on the source bucket.',
+        sourceRole,
+        bucket,
+    };
+}
+
+module.exports = {
+    isAccessDeniedError,
+    getAccessDeniedLogFields,
+};

--- a/tests/unit/lib/util/replicationPermissionError.spec.js
+++ b/tests/unit/lib/util/replicationPermissionError.spec.js
@@ -1,0 +1,55 @@
+const assert = require('assert');
+
+const {
+    isAccessDeniedError,
+    getAccessDeniedLogFields,
+} = require('../../../../lib/util/replicationPermissionError');
+
+describe('isAccessDeniedError', () => {
+    it('should return true for AccessDenied error code', () => {
+        const err = { code: 'AccessDenied' };
+        assert(isAccessDeniedError(err));
+    });
+
+    it('should return false for other error codes', () => {
+        const err = { code: 'NoSuchKey' };
+        assert(!isAccessDeniedError(err));
+    });
+
+    it('should return false for null error', () => {
+        assert(!isAccessDeniedError(null));
+    });
+
+    it('should return false for undefined error', () => {
+        assert(!isAccessDeniedError(undefined));
+    });
+
+    it('should return false for error without code', () => {
+        const err = { message: 'some error' };
+        assert(!isAccessDeniedError(err));
+    });
+});
+
+describe('getAccessDeniedLogFields', () => {
+    it('should return log fields with bucket and sourceRole', () => {
+        const bucket = 'test-bucket';
+        const sourceRole = 'arn:aws:iam::123456789012:role/replication-role';
+        const result = getAccessDeniedLogFields(bucket, sourceRole);
+        assert.deepStrictEqual(result, {
+            accessDeniedHint: 'Verify that the source role has the required ' +
+                'permissions on the source bucket.',
+            sourceRole: 'arn:aws:iam::123456789012:role/replication-role',
+            bucket: 'test-bucket',
+        });
+    });
+
+    it('should handle undefined values', () => {
+        const result = getAccessDeniedLogFields(undefined, undefined);
+        assert.deepStrictEqual(result, {
+            accessDeniedHint: 'Verify that the source role has the required ' +
+                'permissions on the source bucket.',
+            sourceRole: undefined,
+            bucket: undefined,
+        });
+    });
+});


### PR DESCRIPTION
**Summary**
Since version 9.5.2, Backbeat checks IAM permissions on internal routes. The CRR source role must now allow s3:ReplicateObject on the source bucket.
Many existing CRR role policies do not include this permission. Hence replication fails with AccessDenied errors. The current logs do not clearly explain what permission is missing.
This ticket improves logging so customers can quickly understand and fix the issue.

**Root Cause**
In 9.5.2, a security change made Backbeat internal routes enforce IAM policy checks. These routes require the s3:ReplicateObject permission.
CRR source role policies often miss this permission, which causes failures when:
metadata is read during replication
replication status is written back
The resulting AccessDenied errors are hard to diagnose with the current logs.

Log before:

```
{
  "name": "Backbeat:Replication:ReplicationStatusProcessor",
  "method": "UpdateReplicationStatus._refreshSourceEntry",
  "error": {
    "message": "Access Denied",
    "code": "AccessDenied",
    "[resource]": "See error.resource for details.",
    "[requestId]": "See error.requestId for details.",
    "time": "2026-01-15T09:25:02.930Z",
    "statusCode": 403,
    "retryable": false,
    "origin": "source"
  },
  "time": 1768469102932,
  "req_id": "c58e9e768944b020ab67",
  "level": "error",
  "message": "error getting metadata blob from S3",
  "hostname": "Host-003.lan",
  "pid": 3284
}
```

Log after:

```
{
  "name": "Backbeat:Replication:ReplicationStatusProcessor",
  "method": "UpdateReplicationStatus._refreshSourceEntry",
  "error": {
    "message": "Access Denied",
    "code": "AccessDenied",
    "[resource]": "See error.resource for details.",
    "[requestId]": "See error.requestId for details.",
    "time": "2026-01-15T09:25:02.930Z",
    "statusCode": 403,
    "retryable": false,
    "origin": "source"
  },
  "accessDeniedHint": "Verify that the source role has the required permissions on the source bucket.",
  "sourceRole": "arn:aws:iam::545567001488:role/crr-trust-role",
  "bucket": "source",
  "time": 1768469102932,
  "req_id": "c58e9e768944b020ab67",
  "level": "error",
  "message": "error getting metadata blob from S3",
  "hostname": "Host-003.lan",
  "pid": 3284
}
```