### PR TITLE
BB-743 missing scality group on docker image

### DIFF
--- a/images/federation/Dockerfile
+++ b/images/federation/Dockerfile
@@ -30,10 +30,12 @@ ENV HOME_DIR="/home/${USER}" \
     DATA_DIR="/data" \
     SUP_RUN_DIR="/var/run/supervisor"
 
-RUN mv /home/node ${HOME_DIR} && usermod --login ${USER} --shell /bin/bash -d ${HOME_DIR} node
-RUN mkdir ${LOG_DIR} && chown ${USER} ${LOG_DIR} &&\
-    mkdir ${CONF_DIR} && chown ${USER} ${CONF_DIR} &&\
-    mkdir ${DATA_DIR} && chown ${USER} ${DATA_DIR} &&\
+RUN mv /home/node ${HOME_DIR} && \
+    useradd -ms /bin/bash ${USER} && \
+    usermod -aG node ${USER} && \
+    mkdir ${LOG_DIR} && chown ${USER} ${LOG_DIR} && \
+    mkdir ${CONF_DIR} && chown ${USER} ${CONF_DIR} && \
+    mkdir ${DATA_DIR} && chown ${USER} ${DATA_DIR} && \
     mkdir -m 777 ${SUP_RUN_DIR} && chown ${USER} ${SUP_RUN_DIR}
 
 USER ${USER}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.0.22",
+  "version": "9.0.23",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
A `scality` user and group is required for the federation image. Now creating both and adding the `scality` user to the `node` group

Before:
```shell
scality@c3de243e2c65:~/backbeat$ id scality          
uid=1000(scality) gid=1000(node) groups=1000(node)   
```
After:
```shell
scality@e506d63687e3:~/backbeat$ id                                            
uid=1001(scality) gid=1001(scality) groups=1001(scality),1000(node)            
```