### PR TITLE
Skip deleted objects in lifecycle requeue batch instead of aborting

### DIFF
--- a/extensions/lifecycle/tasks/LifecycleRequeueTask.js
+++ b/extensions/lifecycle/tasks/LifecycleRequeueTask.js
@@ -140,11 +140,18 @@ class LifecycleRequeueTask extends BackbeatTask {
                             rest.try,
                             log,
                             (err, res) => {
-                                if (err) {
-                                    return nextObject(err);
+                                if (!err) {
+                                    return nextObject(null, res + objsPerBucket);
                                 }
 
-                                return nextObject(null, res + objsPerBucket);
+                                if (err.name === 'ObjNotFound' || err.name === 'NoSuchBucket') {
+                                    log.warn(`${err.name}, skipping`, {
+                                        bucketName, objectKey, objectVersion,
+                                    });
+                                    return nextObject(null, objsPerBucket);
+                                }
+
+                                return nextObject(err);
                             }
                         ),
                     (err, res) => next(err, res)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.1.8",
+  "version": "9.1.9",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/lifecycle/LifecycleRequeueTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleRequeueTask.spec.js
@@ -1,0 +1,169 @@
+'use strict';
+
+const assert = require('assert');
+const werelogs = require('werelogs');
+
+const { ObjectMD } = require('arsenal').models;
+const ActionQueueEntry = require('../../../lib/models/ActionQueueEntry');
+const { LifecycleResetTransitionInProgressTask } = require(
+    '../../../extensions/lifecycle/tasks/LifecycleResetTransitionInProgressTask');
+
+const {
+    BackbeatMetadataProxyMock,
+    ProcessorMock,
+} = require('../mocks');
+
+const makeMd = () => new ObjectMD()
+    .setContentMd5('etag1')
+    .setTransitionInProgress(true)
+    .setUserMetadata({
+        'x-amz-meta-scal-s3-transition-attempt': 0,
+    });
+
+describe('LifecycleRequeueTask::handleBatch', () => {
+    let backbeatMetadataProxyClient;
+    let task;
+
+    beforeEach(() => {
+        backbeatMetadataProxyClient = new BackbeatMetadataProxyMock();
+
+        const objectProcessor = new ProcessorMock(
+            null,
+            null,
+            null,
+            backbeatMetadataProxyClient,
+            null,
+            null,
+            null,
+            new werelogs.Logger('test:LifecycleRequeueTask'));
+
+        task = new LifecycleResetTransitionInProgressTask(objectProcessor);
+    });
+
+    describe('ObjNotFound handling in batch', () => {
+        it('should skip deleted objects and continue processing valid ones', done => {
+            const batchEntry = ActionQueueEntry.create('requeueTransition')
+                .setAttribute('target', {
+                    byAccount: {
+                        123: {
+                            bucket1: [
+                                { objectKey: 'obj1', objectVersion: 'v1', eTag: '"etag1"', try: 1 },
+                                { objectKey: 'obj2', objectVersion: 'v2', eTag: '"etag1"', try: 1 },
+                                { objectKey: 'obj3', objectVersion: 'v3', eTag: '"etag1"', try: 1 },
+                            ],
+                        },
+                    },
+                });
+
+            backbeatMetadataProxyClient.setMdObjForKey('obj1', makeMd());
+            backbeatMetadataProxyClient.setErrorForKey('obj2', { name: 'ObjNotFound' });
+            backbeatMetadataProxyClient.setMdObjForKey('obj3', makeMd());
+
+            task.processActionEntry(batchEntry, err => {
+                assert.ifError(err);
+                assert.deepStrictEqual(
+                    backbeatMetadataProxyClient._putCalls.sort(),
+                    ['obj1', 'obj3'],
+                );
+                done();
+            });
+        });
+
+        it('should complete without error when all objects are deleted', done => {
+            const batchEntry = ActionQueueEntry.create('requeueTransition')
+                .setAttribute('target', {
+                    byAccount: {
+                        123: {
+                            bucket1: [
+                                { objectKey: 'obj1', objectVersion: 'v1', eTag: '"etag1"', try: 1 },
+                                { objectKey: 'obj2', objectVersion: 'v2', eTag: '"etag1"', try: 1 },
+                            ],
+                        },
+                    },
+                });
+
+            backbeatMetadataProxyClient.setErrorForKey('obj1', { name: 'ObjNotFound' });
+            backbeatMetadataProxyClient.setErrorForKey('obj2', { name: 'ObjNotFound' });
+
+            task.processActionEntry(batchEntry, err => {
+                assert.ifError(err);
+                assert.deepStrictEqual(backbeatMetadataProxyClient._putCalls, []);
+                done();
+            });
+        });
+
+        it('should abort batch on non-ObjNotFound errors', done => {
+            const batchEntry = ActionQueueEntry.create('requeueTransition')
+                .setAttribute('target', {
+                    byAccount: {
+                        123: {
+                            bucket1: [
+                                { objectKey: 'obj1', objectVersion: 'v1', eTag: '"etag1"', try: 1 },
+                                { objectKey: 'obj2', objectVersion: 'v2', eTag: '"etag1"', try: 1 },
+                            ],
+                        },
+                    },
+                });
+
+            backbeatMetadataProxyClient.setErrorForKey('obj1', { name: 'InternalError' });
+            backbeatMetadataProxyClient.setMdObjForKey('obj2', makeMd());
+
+            task.processActionEntry(batchEntry, err => {
+                assert.ok(err);
+                assert.strictEqual(err.name, 'InternalError');
+                assert.deepStrictEqual(backbeatMetadataProxyClient._putCalls, []);
+                done();
+            });
+        });
+    });
+
+    describe('NoSuchBucket handling in batch', () => {
+        it('should skip objects from deleted bucket and continue other buckets', done => {
+            const batchEntry = ActionQueueEntry.create('requeueTransition')
+                .setAttribute('target', {
+                    byAccount: {
+                        123: {
+                            deletedBucket: [
+                                { objectKey: 'obj1', objectVersion: 'v1', eTag: '"etag1"', try: 1 },
+                            ],
+                            validBucket: [
+                                { objectKey: 'obj2', objectVersion: 'v2', eTag: '"etag1"', try: 1 },
+                            ],
+                        },
+                    },
+                });
+
+            backbeatMetadataProxyClient.setErrorForKey('obj1', { name: 'NoSuchBucket' });
+            backbeatMetadataProxyClient.setMdObjForKey('obj2', makeMd());
+
+            task.processActionEntry(batchEntry, err => {
+                assert.ifError(err);
+                assert.deepStrictEqual(backbeatMetadataProxyClient._putCalls, ['obj2']);
+                done();
+            });
+        });
+
+        it('should complete without error when all objects are in a deleted bucket', done => {
+            const batchEntry = ActionQueueEntry.create('requeueTransition')
+                .setAttribute('target', {
+                    byAccount: {
+                        123: {
+                            deletedBucket: [
+                                { objectKey: 'obj1', objectVersion: 'v1', eTag: '"etag1"', try: 1 },
+                                { objectKey: 'obj2', objectVersion: 'v2', eTag: '"etag1"', try: 1 },
+                            ],
+                        },
+                    },
+                });
+
+            backbeatMetadataProxyClient.setErrorForKey('obj1', { name: 'NoSuchBucket' });
+            backbeatMetadataProxyClient.setErrorForKey('obj2', { name: 'NoSuchBucket' });
+
+            task.processActionEntry(batchEntry, err => {
+                assert.ifError(err);
+                assert.deepStrictEqual(backbeatMetadataProxyClient._putCalls, []);
+                done();
+            });
+        });
+    });
+});

--- a/tests/unit/mocks.js
+++ b/tests/unit/mocks.js
@@ -100,20 +100,37 @@ class BackbeatMetadataProxyMock {
         this.indexesObj = null;
         this.receivedIdxObj = null;
         this.error = null;
+        this._mdByKey = {};
+        this._errorByKey = {};
+        this._putCalls = [];
     }
 
     setMdObj(mdObj) {
         this.mdObj = mdObj;
     }
 
+    setMdObjForKey(objectKey, mdObj) {
+        this._mdByKey[objectKey] = mdObj;
+    }
+
+    setErrorForKey(objectKey, error) {
+        this._errorByKey[objectKey] = error;
+    }
+
     getMetadata(params, log, cb) {
+        const keyError = this._errorByKey[params.objectKey];
+        if (keyError) {
+            return cb(keyError);
+        }
         if (this.error) {
             return cb(this.error);
         }
-        return cb(null, { Body: this.mdObj.getSerialized() });
+        const md = this._mdByKey[params.objectKey] || this.mdObj;
+        return cb(null, { Body: md.getSerialized() });
     }
 
     putMetadata(params, log, cb) {
+        this._putCalls.push(params.objectKey);
         this.receivedMd = JSON.parse(params.mdBlob);
         this.mdObj = ObjectMD.createFromBlob(params.mdBlob).result;
         return cb();


### PR DESCRIPTION
When a TAR archive batch fails in sorbet, for example because one object was deleted while the transition was in progress causing a 404 on GetObject, all objects in the batch are marked as failed and sent to the sorbet Dead Letter Queue. To recover, an operator runs sorbetctl forward list failed with the trigger-retry flag, which reads all failed archive entries from the DLQ, groups them into a single requeueTransition Kafka message grouped by account and bucket, and sends it to the backbeat-lifecycle-transition-tasks topic.

Backbeat's LifecycleRequeueTask.handleBatch then processes each object in the batch sequentially using async.reduce. For each object, it calls getMetadata to read the object's metadata from cloudserver, resets the transitionInProgress flag, and writes the metadata back with putMetadata. Once the flag is reset, the lifecycle system naturally re-detects the object and sends a new archive request to sorbet.

The problem is that when getMetadata returns ObjNotFound for a deleted object, the error is returned via the callback in requeueObjectVersion, which propagates to nextObject(err) in handleBatch. This aborts the async.reduce loop, and all remaining objects in the batch are never processed. Despite the batch aborting with an error, BackbeatConsumer still commits the Kafka offset because processActionEntry calls done(err) without passing committable false as a second argument, so the consumer treats the message as committable regardless of the error. The result is that all objects in the batch, including the ones that still exist and could have been successfully requeued, are silently lost. The deleted object blocks recovery of every other object in the same batch.

The fix catches ObjNotFound errors in handleBatch and logs them instead of propagating them to async.reduce. The deleted object is skipped and the batch continues processing the remaining valid objects.

The error behavior for the deleted object is the same before and after this fix. Before, the ObjNotFound error propagated up to BackbeatConsumer which logged "error processing an entry", emitted an error event on the consumer, and committed the offset. The deleted object was not retried and was lost. After, the ObjNotFound error is logged directly in handleBatch as "object not found, skipping" and the offset is committed after the batch completes. The deleted object is not retried and is lost. In both cases a deleted object will never be successfully requeued since it no longer exists, so there is no behavior change for that object. The only difference is that the valid objects in the same batch are now actually processed instead of being silently dropped, and the error event is no longer emitted on the consumer for this specific case.

Issue: BB-749