### PR TITLE
Fix ingestion from raft session >=10

### DIFF
--- a/lib/clients/backbeat-2017-07-01.api.json
+++ b/lib/clients/backbeat-2017-07-01.api.json
@@ -1142,7 +1142,13 @@
                 }
             },
             "output": {
-                "type": "string"
+                "type": "structure",
+                "payload": "RaftId",
+                "members": {
+                    "RaftId": {
+                        "type": "string"
+                    }
+                }
             }
         },
         "GetRaftLog": {

--- a/lib/queuePopulator/IngestionProducer.js
+++ b/lib/queuePopulator/IngestionProducer.js
@@ -132,9 +132,9 @@ class IngestionProducer {
                 });
                 IngestionPopulatorMetrics.onIngestionSourceOp('getRaftId', 'error');
                 return done(err);
-            } else if (data && data[0]) {
+            } else if (data?.RaftId) {
                 IngestionPopulatorMetrics.onIngestionSourceOp('getRaftId', 'success');
-                return done(null, data[0]);
+                return done(null, data.RaftId);
             }
             this.log.error(`empty response for raftid of ${bucketName}`,
             { method: 'getRaftId', bucketName });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.1.9",
+  "version": "9.1.10",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/functional/ingestion/IngestionProducer.js
+++ b/tests/functional/ingestion/IngestionProducer.js
@@ -158,4 +158,15 @@ describe('ingestion producer tests with mock', () => {
             return done();
         });
     });
+
+    it('should return the full raft ID for multi-digit raft sessions',
+    done => {
+        this.iProducer.getRaftId('bucket-raft13', (err, res) => {
+            assert.ifError(err);
+            assert.strictEqual(typeof res, 'string');
+            // must return '13', not '1' (first character)
+            assert.strictEqual(res, '13');
+            return done();
+        });
+    });
 });

--- a/tests/functional/lib/BackbeatClient.js
+++ b/tests/functional/lib/BackbeatClient.js
@@ -71,7 +71,7 @@ describe('BackbeatClient unit tests with mock server', () => {
         });
         return destReq.send((err, data) => {
             assert.ifError(err);
-            assert.strictEqual(data[0], '1');
+            assert.strictEqual(data.RaftId, '1');
             return done();
         });
     });

--- a/tests/functional/utils/mockRes.json
+++ b/tests/functional/utils/mockRes.json
@@ -37,6 +37,10 @@
                 "resType": "raftId",
                 "name": "bucket2"
             },
+            "/_/metadata/admin/buckets/bucket-raft13/id": {
+                "resType": "raftId",
+                "name": "bucket-raft13"
+            },
             "/_/metadata/admin/raft_sessions/1/log": {
                 "resType": "raftLogs",
                 "name": "1"
@@ -678,7 +682,8 @@
     },
     "raftId": {
         "bucket1": 1,
-        "bucket2": 5
+        "bucket2": 5,
+        "bucket-raft13": 13
     },
     "raftInformation": {
         "1": {


### PR DESCRIPTION
The JSON was causing the raftId string (which is the http body of the response) to be returned to
the code as an array of string : [ '1', '3' ]. Which was worked-around by taking the first element.
That fix worked for raft sesion < 10, but breaks when raft session cluster grows.

The fix is to properly define the model, with the `payload` attribute allowing to indicate that the
body of the request should map to a specified field of the model.

Impact is limited since we only make a call to this API in a single place.

Issue: BB-759
