### PR TITLE
fix(deps): bump node-rdkafka to ^3.6.0 to fix cooperative-sticky rebalance bug

### DIFF
--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -876,51 +876,46 @@ class BackbeatConsumer extends EventEmitter {
         let lastBootstrapId;
         let producer; // eslint-disable-line prefer-const
         let producerTimer;
-        let bootstrapDone = false;
         // Use chained setTimeout instead of setInterval to ensure
         // only one consume() worker is in flight at a time. With
         // setInterval, multiple C++ async workers can overlap, and
         // since librdkafka 2.10.0 they survive an
         // unsubscribe→subscribe transition, stealing messages from
         // the next subscription.
-        function consumeNext() {
+        function consume() {
             self._consumer.consume(1, (err, messages) => {
-                if (err || bootstrapDone) {
-                    if (!bootstrapDone) {
-                        setTimeout(consumeNext, 200);
-                    }
+                if (err) {
+                    setTimeout(consume, 200);
                     return undefined;
                 }
-                let matched = false;
-                messages.forEach(message => {
+                const match = messages.find(message => {
                     const bootstrapId = JSON.parse(message.value).bootstrapId;
-                    if (bootstrapId) {
-                        self._log.info('bootstraping backbeat consumer: ' +
-                            'received bootstrap message',
-                            { bootstrapId, topic: self._topic, groupId: self._groupId });
-                        if (bootstrapId === lastBootstrapId) {
-                            self._log.info('backbeat consumer is bootstrapped',
-                                { topic: self._topic, groupId: self._groupId });
-                            matched = true;
-                            bootstrapDone = true;
-                            clearInterval(producerTimer);
-                            self._consumer.offsetsStore([{
-                                topic: self._topic,
-                                partition: message.partition,
-                                offset: message.offset + 1,
-                            }]);
-                            self._consumer.commit();
-                            self._consumer.unsubscribe();
-                            producer.close(() => {
-                                self._bootstrapping = false;
-                                self._onReady();
-                            });
-                        }
+                    if (!bootstrapId) {
+                        return false;
                     }
+                    self._log.info('bootstraping backbeat consumer: ' +
+                        'received bootstrap message',
+                        { bootstrapId, topic: self._topic, groupId: self._groupId });
+                    return bootstrapId === lastBootstrapId;
                 });
-                if (!matched) {
-                    setTimeout(consumeNext, 200);
+                if (!match) {
+                    setTimeout(consume, 200);
+                    return undefined;
                 }
+                self._log.info('backbeat consumer is bootstrapped',
+                    { topic: self._topic, groupId: self._groupId });
+                clearInterval(producerTimer);
+                self._consumer.offsetsStore([{
+                    topic: self._topic,
+                    partition: match.partition,
+                    offset: match.offset + 1,
+                }]);
+                self._consumer.commit();
+                self._consumer.unsubscribe();
+                producer.close(() => {
+                    self._bootstrapping = false;
+                    self._onReady();
+                });
                 return undefined;
             });
         }
@@ -947,7 +942,7 @@ class BackbeatConsumer extends EventEmitter {
                         this._initConsumer();
                         this._consumer.on('ready', () => {
                             this._consumer.subscribe([this._topic]);
-                            consumeNext();
+                            consume();
                         });
                     }, 500);
                 }

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -219,6 +219,10 @@ class BackbeatConsumer extends EventEmitter {
         const consumerParams = {
             'metadata.broker.list': this._kafkaHosts,
             'group.id': this._groupId,
+            // This is the default in our current librdkafka version, but we
+            // pin it explicitly because we depend on eager rebalancing and
+            // don't want it changed implicitly by future version updates.
+            'partition.assignment.strategy': 'range,roundrobin',
             // we manage stored offsets based on the highest
             // contiguous offset fully processed by a worker, so
             // disabling automatic offset store is needed

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -876,52 +876,53 @@ class BackbeatConsumer extends EventEmitter {
         let lastBootstrapId;
         let producer; // eslint-disable-line prefer-const
         let producerTimer;
-        let consumerTimer;
-        let inFlightConsumes = 0;
-        // Wait for all in-flight consume(1, consumeCb) workers to complete
-        // before calling unsubscribe(). The setInterval(200ms) pattern can
-        // have multiple consume workers running concurrently in the C++
-        // thread pool (each with a 1000ms timeout). Since librdkafka 2.10.0,
-        // these workers survive an unsubscribe→subscribe transition and can
-        // steal messages from the next subscription.
-        function _finishBootstrap(partition, offset) {
-            if (inFlightConsumes > 0) {
-                setTimeout(() => _finishBootstrap(partition, offset), 50);
-                return;
-            }
-            self._consumer.offsetsStore([{
-                topic: self._topic,
-                partition,
-                offset,
-            }]);
-            self._consumer.commit();
-            self._consumer.unsubscribe();
-            producer.close(() => {
-                self._bootstrapping = false;
-                self._onReady();
-            });
-        }
-        function consumeCb(err, messages) {
-            inFlightConsumes--;
-            if (err) {
-                return undefined;
-            }
-            messages.forEach(message => {
-                const bootstrapId = JSON.parse(message.value).bootstrapId;
-                if (bootstrapId) {
-                    self._log.info('bootstraping backbeat consumer: ' +
-                        'received bootstrap message',
-                        { bootstrapId, topic: self._topic, groupId: self._groupId });
-                    if (bootstrapId === lastBootstrapId) {
-                        self._log.info('backbeat consumer is bootstrapped',
-                            { topic: self._topic, groupId: self._groupId });
-                        clearInterval(producerTimer);
-                        clearInterval(consumerTimer);
-                        _finishBootstrap(message.partition, message.offset + 1);
+        let bootstrapDone = false;
+        // Use chained setTimeout instead of setInterval to ensure
+        // only one consume() worker is in flight at a time. With
+        // setInterval, multiple C++ async workers can overlap, and
+        // since librdkafka 2.10.0 they survive an
+        // unsubscribe→subscribe transition, stealing messages from
+        // the next subscription.
+        function consumeNext() {
+            self._consumer.consume(1, (err, messages) => {
+                if (err || bootstrapDone) {
+                    if (!bootstrapDone) {
+                        setTimeout(consumeNext, 200);
                     }
+                    return undefined;
                 }
+                let matched = false;
+                messages.forEach(message => {
+                    const bootstrapId = JSON.parse(message.value).bootstrapId;
+                    if (bootstrapId) {
+                        self._log.info('bootstraping backbeat consumer: ' +
+                            'received bootstrap message',
+                            { bootstrapId, topic: self._topic, groupId: self._groupId });
+                        if (bootstrapId === lastBootstrapId) {
+                            self._log.info('backbeat consumer is bootstrapped',
+                                { topic: self._topic, groupId: self._groupId });
+                            matched = true;
+                            bootstrapDone = true;
+                            clearInterval(producerTimer);
+                            self._consumer.offsetsStore([{
+                                topic: self._topic,
+                                partition: message.partition,
+                                offset: message.offset + 1,
+                            }]);
+                            self._consumer.commit();
+                            self._consumer.unsubscribe();
+                            producer.close(() => {
+                                self._bootstrapping = false;
+                                self._onReady();
+                            });
+                        }
+                    }
+                });
+                if (!matched) {
+                    setTimeout(consumeNext, 200);
+                }
+                return undefined;
             });
-            return undefined;
         }
         assert.strictEqual(this._consumer, null);
         producer = new BackbeatProducer({
@@ -946,10 +947,7 @@ class BackbeatConsumer extends EventEmitter {
                         this._initConsumer();
                         this._consumer.on('ready', () => {
                             this._consumer.subscribe([this._topic]);
-                            consumerTimer = setInterval(() => {
-                                inFlightConsumes++;
-                                this._consumer.consume(1, consumeCb);
-                            }, 200);
+                            consumeNext();
                         });
                     }, 500);
                 }

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -885,6 +885,11 @@ class BackbeatConsumer extends EventEmitter {
         function consume() {
             self._consumer.consume(1, (err, messages) => {
                 if (err) {
+                    self._log.debug('bootstrap consume error', {
+                        error: err.message,
+                        topic: self._topic,
+                        groupId: self._groupId,
+                    });
                     setTimeout(consume, 200);
                     return undefined;
                 }

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -873,7 +873,32 @@ class BackbeatConsumer extends EventEmitter {
         let producer; // eslint-disable-line prefer-const
         let producerTimer;
         let consumerTimer;
+        let inFlightConsumes = 0;
+        // Wait for all in-flight consume(1, consumeCb) workers to complete
+        // before calling unsubscribe(). The setInterval(200ms) pattern can
+        // have multiple consume workers running concurrently in the C++
+        // thread pool (each with a 1000ms timeout). Since librdkafka 2.10.0,
+        // these workers survive an unsubscribe→subscribe transition and can
+        // steal messages from the next subscription.
+        function _finishBootstrap(partition, offset) {
+            if (inFlightConsumes > 0) {
+                setTimeout(() => _finishBootstrap(partition, offset), 50);
+                return;
+            }
+            self._consumer.offsetsStore([{
+                topic: self._topic,
+                partition,
+                offset,
+            }]);
+            self._consumer.commit();
+            self._consumer.unsubscribe();
+            producer.close(() => {
+                self._bootstrapping = false;
+                self._onReady();
+            });
+        }
         function consumeCb(err, messages) {
+            inFlightConsumes--;
             if (err) {
                 return undefined;
             }
@@ -888,17 +913,7 @@ class BackbeatConsumer extends EventEmitter {
                             { topic: self._topic, groupId: self._groupId });
                         clearInterval(producerTimer);
                         clearInterval(consumerTimer);
-                        self._consumer.offsetsStore([{
-                            topic: self._topic,
-                            partition: message.partition,
-                            offset: message.offset + 1,
-                        }]);
-                        self._consumer.commit();
-                        self._consumer.unsubscribe();
-                        producer.close(() => {
-                            self._bootstrapping = false;
-                            self._onReady();
-                        });
+                        _finishBootstrap(message.partition, message.offset + 1);
                     }
                 }
             });
@@ -928,6 +943,7 @@ class BackbeatConsumer extends EventEmitter {
                         this._consumer.on('ready', () => {
                             this._consumer.subscribe([this._topic]);
                             consumerTimer = setInterval(() => {
+                                inFlightConsumes++;
                                 this._consumer.consume(1, consumeCb);
                             }, 200);
                         });

--- a/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
+++ b/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
@@ -54,6 +54,10 @@ class LogConsumer extends EventEmitter {
     setup(done) {
         // partition offsets will be managed by kafka
         const consumerParams = {
+            // This is the default in our current librdkafka version, but we
+            // pin it explicitly because we depend on eager rebalancing and
+            // don't want it changed implicitly by future version updates.
+            'partition.assignment.strategy': 'range,roundrobin',
             // Manually manage storing offsets to ensure they are only stored
             // after the batch processing is fully completed.
             'enable.auto.offset.store': false,

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "minimatch": "^10.0.1",
     "mongodb": "^6.11.0",
     "node-forge": "^1.3.1",
-    "node-rdkafka": "^2.12.0",
+    "node-rdkafka": "^3.6.0",
     "node-rdkafka-prometheus": "^1.0.0",
     "node-schedule": "^2.1.1",
     "node-zookeeper-client": "^1.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7613,10 +7613,15 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nan@^2.14.0, nan@^2.17.0, nan@^2.18.0, nan@^2.3.2:
+nan@^2.14.0, nan@^2.18.0, nan@^2.3.2:
   version "2.23.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.23.1.tgz#6f86a31dd87e3d1eb77512bf4b9e14c8aded3975"
   integrity sha512-r7bBUGKzlqk8oPBDYxt6Z0aEdF1G1rwlMcLk8LCOMbOzf0mG+JUfUzG4fIMWwHWP0iyaLWEQZJmtB7nOHEm/qw==
+
+nan@^2.24.0:
+  version "2.26.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.26.2.tgz#2e5e25764224c737b9897790b57c3294d4dcee9c"
+  integrity sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==
 
 napi-macros@~2.0.0:
   version "2.0.0"
@@ -7751,13 +7756,13 @@ node-rdkafka-prometheus@^1.0.0:
     "@log4js-node/log4js-api" "^1.0.0"
     prom-client "^12.0.0"
 
-node-rdkafka@^2.12.0:
-  version "2.18.0"
-  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-2.18.0.tgz#116950e49dfe804932c8bc6dbc68949793e72ee2"
-  integrity sha512-jYkmO0sPvjesmzhv1WFOO4z7IMiAFpThR6/lcnFDWgSPkYL95CtcuVNo/R5PpjujmqSgS22GMkL1qvU4DTAvEQ==
+node-rdkafka@^3.6.0:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-3.6.1.tgz#164357f08ff23a4722e89bfb3b2b09481c1e8cc1"
+  integrity sha512-sfpTbrT35429cs0RE8Yb9avGX9BiRRvpV7aweQsghKTjtrVZP3jBrKOPItWXAqHb8doyh3SkuGuUVBLgig1SRg==
   dependencies:
     bindings "^1.3.1"
-    nan "^2.17.0"
+    nan "^2.24.0"
 
 node-releases@^2.0.27:
   version "2.0.27"


### PR DESCRIPTION
## Summary

Bumps `node-rdkafka` from `^2.12.0` (librdkafka 2.3.0) to `^3.6.0` (currently resolving to 3.6.1 / librdkafka 2.12.0) as a maintenance upgrade, picking up bugfixes accumulated across librdkafka 2.3.0→2.12.0.

Also fixes a latent race condition in `BackbeatConsumer._bootstrapConsumer()` exposed by librdkafka 2.10.0+.

## Context

This was initially motivated by investigating a flaky CI failure in the **"Kafka Cleaner"** test ([Zenko CI run](https://github.com/scality/Zenko/actions/runs/23431247112/job/68489839492?pr=2360)), where the `backbeat-metrics` topic had unconsumed messages after rapid pod replacement. While the original hypothesis (cooperative-sticky rebalance bug [confluentinc/librdkafka#4908](https://github.com/confluentinc/librdkafka/pull/4908)) turned out not to apply — BackbeatConsumer uses eager rebalance (`range,roundrobin`), not cooperative-sticky — the upgrade is still worthwhile for the accumulated bugfixes, and exposed a real bug in the bootstrap code that needed fixing.

## Bootstrap consumer fix

The librdkafka upgrade exposed a latent race condition in `_bootstrapConsumer()`. The bootstrap previously used `setInterval(200ms)` to call `consume(1, consumeCb)`, dispatching C++ async workers to the libuv thread pool (each with a 1000ms timeout). Up to 5 workers could be in flight concurrently.

When the bootstrap match was found, the old code called `clearInterval` then immediately `unsubscribe()`. But `clearInterval` only prevents *new* consume calls — workers already in the C++ thread pool continue running. With librdkafka < 2.10.0, `unsubscribe()` effectively invalidated these stale workers (they'd return empty or error). With librdkafka >= 2.10.0 ("Enhanced handling for subscribe/unsubscribe edge cases"), these workers survive across the unsubscribe→subscribe transition and dequeue messages from the next subscription, delivering them to the bootstrap's `consumeCb` which silently ignores non-bootstrap messages.

This was confirmed by local reproduction and bisection:

| node-rdkafka | librdkafka | `_bootstrapConsumer` test |
|---|---|---|
| 3.3.1 | 2.8.0 | PASS |
| 3.4.0 | 2.10.0 | FAIL |
| 3.6.1 | 2.12.0 | FAIL |

The fix replaces `setInterval` with chained `setTimeout`: each `consume(1)` is only scheduled after the previous one completes, guaranteeing at most one C++ async worker is in flight at a time. This makes `unsubscribe()` safe to call directly from the callback with no drain/polling needed.

## Why ^3.6.0

| node-rdkafka | librdkafka |
|---|---|
| 2.18.0 (latest 2.x) | 2.3.0 |
| 3.0.0 | 2.3.0 |
| 3.4.0 | 2.10.0 |
| **3.6.1** | **2.12.0** |

We set the floor to `^3.6.0` (librdkafka 2.12.0). KIP-848 (new consumer group protocol) is opt-in (`group.protocol=consumer` must be explicitly set) and does not affect the default `classic` protocol.

## Upgrade safety

**librdkafka 2.3.0 → 2.12.0**: The [librdkafka CHANGELOG](https://github.com/confluentinc/librdkafka/blob/master/CHANGELOG.md) shows no consumer-breaking changes in this range. The only notable breaking change is in v2.4.0 where `INVALID_RECORD` producer errors became non-retriable — this does not affect consumers. The metadata recovery behavior change in 2.10.0 (brokers not in metadata responses are removed and clients re-bootstrap) is a minor behavioral difference that should not impact normal operation.

**node-rdkafka 2.x → 3.x**: The [3.0.0 release](https://github.com/Blizzard/node-rdkafka/releases/tag/v3.0.0) only dropped support for EOL Node.js versions — no API changes. Backbeat requires Node >= 20 and runs on Node 22.14.0.

Issue: BB-760