### PR TITLE
Skip lifecycle index creation when disk space is insufficient

### DIFF
--- a/extensions/lifecycle/conductor/LifecycleConductor.js
+++ b/extensions/lifecycle/conductor/LifecycleConductor.js
@@ -285,26 +285,57 @@ class LifecycleConductor {
                 return cb(null, lifecycleTaskVersions.v1);
             }
 
-            LifecycleMetrics.onLegacyTask(log, 'putBucketIndexes');
-
-            this.activeIndexingJobs.push({
-                bucket: task.bucketName,
-                indexes: indexesForFeature.lifecycle.v2,
-            });
-
-            return backbeatMetadataProxy.putBucketIndexes(
-                task.bucketName,
-                indexesForFeature.lifecycle.v2,
-                log,
-                err => {
-                    if (err) {
-                        log.warn('unable to create lifecycle indexes', {
-                            bucket: task.bucketName,
-                            error: err,
-                        });
-                    }
+            return async.series({
+                diskUsage: done => this._mongodbClient.getDiskUsage(done),
+                collStats: done => this._mongodbClient.getCollectionStats(
+                    task.bucketName, log, done),
+            }, (err, results) => {
+                if (err) {
+                    log.warn('unable to check disk space, skipping index creation', {
+                        bucket: task.bucketName,
+                        error: err,
+                    });
+                    LifecycleMetrics.onLegacyTask(log, 'diskSpaceCheckFailed');
                     return cb(null, lifecycleTaskVersions.v1);
+                }
+
+                const fsFreeSize = results.diskUsage.free;
+                // Each lifecycle index is roughly the same size as the
+                // _id_ index. We create two, so 3x gives a safe margin
+                // accounting for _id_ index bloat from incremental inserts.
+                const idIndexSize = results.collStats.indexSizes?._id_ || 0;
+
+                if (fsFreeSize < 3 * idIndexSize) {
+                    log.warn('insufficient disk space for index creation', {
+                        bucket: task.bucketName,
+                        fsFreeSize,
+                        threshold: 3 * idIndexSize,
+                    });
+                    LifecycleMetrics.onLegacyTask(log, 'insufficientDiskSpace');
+                    return cb(null, lifecycleTaskVersions.v1);
+                }
+
+                LifecycleMetrics.onLegacyTask(log, 'putBucketIndexes');
+
+                this.activeIndexingJobs.push({
+                    bucket: task.bucketName,
+                    indexes: indexesForFeature.lifecycle.v2,
                 });
+
+                return backbeatMetadataProxy.putBucketIndexes(
+                    task.bucketName,
+                    indexesForFeature.lifecycle.v2,
+                    log,
+                    err => {
+                        if (err) {
+                            log.warn('unable to create lifecycle indexes', {
+                                bucket: task.bucketName,
+                                error: err,
+                            });
+                        }
+                        return cb(null, lifecycleTaskVersions.v1);
+                    });
+            });
         });
     }
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@scality/cloudserverclient": "^1.0.3",
     "@smithy/node-http-handler": "^3.3.3",
     "JSONStream": "^1.3.5",
-    "arsenal": "git+https://github.com/scality/arsenal#8.3.0",
+    "arsenal": "git+https://github.com/scality/arsenal#8.3.9",
     "async": "^2.3.0",
     "backo": "^1.1.0",
     "breakbeat": "scality/breakbeat#v1.0.3",

--- a/tests/unit/lifecycle/LifecycleConductor.spec.js
+++ b/tests/unit/lifecycle/LifecycleConductor.spec.js
@@ -411,6 +411,12 @@ describe('Lifecycle Conductor', () => {
                 conductor.activeIndexingJobsRetrieved = getInProgressSucceeded;
                 conductor.activeIndexingJobs = inJobs;
                 conductor._bucketSource = bucektSource;
+                conductor._mongodbClient = {
+                    getDiskUsage: cb => cb(null, { available: 10000000000, free: 10000000000, total: 20000000000 }),
+                    getCollectionStats: (bucketName, _log, cb) => cb(null, {
+                        indexSizes: { _id_: 80000 },
+                    }),
+                };
                 client.indexesObj = getIndexes;
                 client.error = mockError;
 
@@ -422,6 +428,54 @@ describe('Lifecycle Conductor', () => {
                     done();
                 });
             }));
+
+        it('should return v1: missing indexes + disk space check fails', done => {
+            const client = new BackbeatMetadataProxyMock();
+            conductor.clientManager.getBackbeatMetadataProxy = () => client;
+            conductor.activeIndexingJobsRetrieved = true;
+            conductor.activeIndexingJobs = [];
+            conductor._bucketSource = 'mongodb';
+            conductor._mongodbClient = {
+                getDiskUsage: cb => cb(new Error('dbStats failed')),
+                getCollectionStats: (bucketName, _log, cb) => cb(null, {
+                    indexSizes: { _id_: 80000 },
+                }),
+            };
+            client.indexesObj = [];
+            client.error = null;
+
+            conductor._indexesGetOrCreate(getTask(true), log, (err, taskVersion) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(client.receivedIdxObj, null);
+                assert.deepStrictEqual(conductor.activeIndexingJobs, []);
+                assert.deepStrictEqual(taskVersion, lifecycleTaskVersions.v1);
+                done();
+            });
+        });
+
+        it('should return v1: missing indexes + insufficient disk space', done => {
+            const client = new BackbeatMetadataProxyMock();
+            conductor.clientManager.getBackbeatMetadataProxy = () => client;
+            conductor.activeIndexingJobsRetrieved = true;
+            conductor.activeIndexingJobs = [];
+            conductor._bucketSource = 'mongodb';
+            conductor._mongodbClient = {
+                getDiskUsage: cb => cb(null, { available: 100000, free: 100000, total: 20000000000 }),
+                getCollectionStats: (bucketName, _log, cb) => cb(null, {
+                    indexSizes: { _id_: 80000000 },
+                }),
+            };
+            client.indexesObj = [];
+            client.error = null;
+
+            conductor._indexesGetOrCreate(getTask(true), log, (err, taskVersion) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(client.receivedIdxObj, null);
+                assert.deepStrictEqual(conductor.activeIndexingJobs, []);
+                assert.deepStrictEqual(taskVersion, lifecycleTaskVersions.v1);
+                done();
+            });
+        });
     });
 
     describe('listBuckets', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1698,10 +1698,45 @@
     events "^3.0.0"
     tslib "^2.8.1"
 
+"@azure/storage-blob@^12.31.0":
+  version "12.31.0"
+  resolved "https://registry.yarnpkg.com/@azure/storage-blob/-/storage-blob-12.31.0.tgz#97b09be2bf6ab59739b862edd8124798362ce720"
+  integrity sha512-DBgNv10aCSxopt92DkTDD0o9xScXeBqPKGmR50FPZQaEcH4JLQ+GEOGEDv19V5BMkB7kxr+m4h6il/cCDPvmHg==
+  dependencies:
+    "@azure/abort-controller" "^2.1.2"
+    "@azure/core-auth" "^1.9.0"
+    "@azure/core-client" "^1.9.3"
+    "@azure/core-http-compat" "^2.2.0"
+    "@azure/core-lro" "^2.2.0"
+    "@azure/core-paging" "^1.6.2"
+    "@azure/core-rest-pipeline" "^1.19.1"
+    "@azure/core-tracing" "^1.2.0"
+    "@azure/core-util" "^1.11.0"
+    "@azure/core-xml" "^1.4.5"
+    "@azure/logger" "^1.1.4"
+    "@azure/storage-common" "^12.3.0"
+    events "^3.0.0"
+    tslib "^2.8.1"
+
 "@azure/storage-common@^12.1.1":
   version "12.1.1"
   resolved "https://registry.yarnpkg.com/@azure/storage-common/-/storage-common-12.1.1.tgz#cd0768188f7cf8ea7202d584067ad5f3eba89744"
   integrity sha512-eIOH1pqFwI6UmVNnDQvmFeSg0XppuzDLFeUNO/Xht7ODAzRLgGDh7h550pSxoA+lPDxBl1+D2m/KG3jWzCUjTg==
+  dependencies:
+    "@azure/abort-controller" "^2.1.2"
+    "@azure/core-auth" "^1.9.0"
+    "@azure/core-http-compat" "^2.2.0"
+    "@azure/core-rest-pipeline" "^1.19.1"
+    "@azure/core-tracing" "^1.2.0"
+    "@azure/core-util" "^1.11.0"
+    "@azure/logger" "^1.1.4"
+    events "^3.3.0"
+    tslib "^2.8.1"
+
+"@azure/storage-common@^12.3.0":
+  version "12.3.0"
+  resolved "https://registry.yarnpkg.com/@azure/storage-common/-/storage-common-12.3.0.tgz#5bf257383836e67a426c91d7e9678479afe802a9"
+  integrity sha512-/OFHhy86aG5Pe8dP5tsp+BuJ25JOAl9yaMU3WZbkeoiFMHFtJ7tu5ili7qEdBXNW9G5lDB19trwyI6V49F/8iQ==
   dependencies:
     "@azure/abort-controller" "^2.1.2"
     "@azure/core-auth" "^1.9.0"
@@ -4001,16 +4036,16 @@ arraybuffer.prototype.slice@^1.0.4:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#8.3.0":
-  version "8.3.0"
-  resolved "git+https://github.com/scality/arsenal#7c6c73a01c37e241e0e054edbdc9e3a379c16a77"
+"arsenal@git+https://github.com/scality/arsenal#8.3.9":
+  version "8.3.9"
+  resolved "git+https://github.com/scality/arsenal#51e5b761f7f0612a722c828fa3d43b438c50ab7c"
   dependencies:
     "@aws-sdk/client-kms" "^3.975.0"
     "@aws-sdk/client-s3" "^3.975.0"
     "@aws-sdk/credential-providers" "^3.975.0"
     "@aws-sdk/lib-storage" "^3.975.0"
     "@azure/identity" "^4.13.0"
-    "@azure/storage-blob" "^12.28.0"
+    "@azure/storage-blob" "^12.31.0"
     "@js-sdsl/ordered-set" "^4.4.2"
     "@scality/hdclient" "^1.3.1"
     "@smithy/node-http-handler" "^4.3.0"


### PR DESCRIPTION
## Summary

- Before attempting to create lifecycle v2 indexes, check available disk space and estimate the index creation cost.
- If `fsFreeSize < 3 * _id_ index size`, skip index creation and fall back to v1 listing.
- On error checking disk space, also fall back to v1 (consistent with existing error handling in `_indexesGetOrCreate`).

## Context

When a large bucket fills the MongoDB PV, operators need lifecycle to empty it. The conductor tries to create v2 indexes for the bucket, which either fails (ENOSPC) or — worse — **crashes the MongoDB shard**. We confirmed this on a test cluster: attempting index creation with 50MB free on a 10GB PV caused "Connection closed by peer" and the shard went into a crash loop (560+ restarts). Removing the filler files was required to recover.

This change adds a proactive disk space check using two MongoDB metadata calls run sequentially (~11ms total, no locks):
- `getDiskUsage()` (`dbStats`) — filesystem free space
- `getCollectionStats()` (`collStats`) — per-collection index sizes

## Why `3 * _id_` index size?

After running `compact` on a test collection with 1.37M objects, all three indexes (`_id_`, both lifecycle) are the same size (~60MB each). However, the `_id_` index is typically bloated from incremental inserts (101MB before compact vs 58MB after). Since each lifecycle index is freshly built at its compact size, `3 * _id_` provides a safe margin:
- When `_id_` is bloated (101MB): threshold = 303MB, actual cost ~120MB — conservative, safe
- When `_id_` is compact (58MB): threshold = 174MB, actual cost ~120MB — still safe

## Design decisions

- **Calls run sequentially** (`async.series`) to avoid creating extra MongoDB connections/sessions. Latency is not critical here.
- **Check happens per-bucket in `_indexesGetOrCreate`**, only for buckets that actually need index creation (indexes don't exist, auto-create enabled, not at concurrent limit). Most buckets already have indexes and return early.
- **Falls back to v1 on any error** — consistent with every other error path in this method.
- **Depends on Arsenal PR** scality/Arsenal#2605 for the fixed `getDiskUsage` and new `getCollectionStats` methods.