### PR TITLE
Harden onEntryCommittable against ERR__STATE

### DIFF
--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -882,10 +882,24 @@ class BackbeatConsumer extends EventEmitter {
         });
         // ensure consumer is active when calling offsetsStore() on
         // it, to avoid raising an exception (invalid state)
-        // TODO : potential issue here, see BB-758
-        if (committableOffset !== null && !this.isPaused()) {
-            this._consumer.offsetsStore([{ topic, partition,
-                                           offset: committableOffset }]);
+        if (committableOffset !== null && this._consumer.isConnected() && !this.isPaused()) {
+            try {
+                this._consumer.offsetsStore([{ topic, partition, offset: committableOffset }]);
+            } catch (e) {
+                // offsetsStore() should not throw given the guards above;
+                // if it does (e.g. ERR__STATE on a still-connected
+                // consumer whose partition was revoked), log as error
+                // but do not crash — the message will be re-delivered
+                // and committed by whichever consumer holds the
+                // partition next.
+                this._log.error('offsetsStore failed', {
+                    error: e.toString(),
+                    topic,
+                    partition,
+                    offset: committableOffset,
+                    groupId: this._groupId,
+                });
+            }
         }
     }
 

--- a/tests/unit/backbeatConsumer.js
+++ b/tests/unit/backbeatConsumer.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const sinon = require('sinon');
 
 const BackbeatConsumer = require('../../lib/BackbeatConsumer');
+const { CODES } = require('node-rdkafka');
 
 const { kafka } = require('../config.json');
 const { BreakerState } = require('breakbeat').CircuitBreaker;
@@ -235,6 +236,80 @@ describe('backbeatConsumer', () => {
                 assert.strictEqual(consumer._tasksCompletedSinceLastConsume, false);
                 done();
             }, 500);
+        });
+    });
+
+    describe('onEntryCommittable', () => {
+        let consumer;
+        let mockConsumer;
+
+        const entry = {
+            topic: 'my-test-topic',
+            partition: 2,
+            offset: 280,
+            key: null,
+            timestamp: Date.now(),
+        };
+
+        beforeEach(() => {
+            consumer = new BackbeatConsumerMock({
+                kafka,
+                groupId: 'unittest-group',
+                topic: 'my-test-topic',
+            });
+
+            mockConsumer = {
+                offsetsStore: sinon.stub(),
+                subscription: sinon.stub().returns(['my-test-topic']),
+                isConnected: sinon.stub().returns(true),
+            };
+            consumer._consumer = mockConsumer;
+
+            // pre-register the offset as consumed so onOffsetProcessed returns a value
+            consumer._offsetLedger.onOffsetConsumed(entry.topic, entry.partition, entry.offset);
+        });
+
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        it('should call offsetsStore when consumer is active and connected', () => {
+            consumer.onEntryCommittable(entry);
+            assert(mockConsumer.offsetsStore.calledOnce);
+        });
+
+        it('should not call offsetsStore when consumer is paused (unsubscribed)', () => {
+            mockConsumer.subscription.returns([]);
+            consumer.onEntryCommittable(entry);
+            assert(mockConsumer.offsetsStore.notCalled);
+        });
+
+        it('should not call offsetsStore when consumer is not connected', () => {
+            mockConsumer.isConnected.returns(false);
+            consumer.onEntryCommittable(entry);
+            assert(mockConsumer.offsetsStore.notCalled);
+        });
+
+        it('should not throw and always log at error level when offsetsStore throws', () => {
+            const errState = new Error('Local: Erroneous state');
+            errState.code = CODES.ERRORS.ERR__STATE;
+            mockConsumer.offsetsStore.throws(errState);
+
+            const errorSpy = sinon.spy(consumer._log, 'error');
+
+            assert.doesNotThrow(() => consumer.onEntryCommittable(entry));
+            assert(errorSpy.calledOnce);
+        });
+
+        it('should not throw and log at error level when offsetsStore throws an unexpected error', () => {
+            const unexpectedErr = new Error('unexpected kafka error');
+            unexpectedErr.code = -1;
+            mockConsumer.offsetsStore.throws(unexpectedErr);
+
+            const errorSpy = sinon.spy(consumer._log, 'error');
+
+            assert.doesNotThrow(() => consumer.onEntryCommittable(entry));
+            assert(errorSpy.calledOnce);
         });
     });
 


### PR DESCRIPTION
**TL;DR** — defense-in-depth around `onEntryCommittable`. The known sync and async races that caused the BB-758 crash are closed structurally by BB-776 (#2739, merged) and BB-777 (#2740, merged). This PR is the small safety net for residual edge cases: late callbacks after the outer-timeout disconnect, the BB-772 poison-pill paths, and any future race we haven't enumerated. Log and move on instead of crashing.

## Background

BB-758 was a worker crash with `ERR__STATE` (-172) when `onEntryCommittable` called `offsetsStore` after the partition had been revoked. Two structural fixes have since landed:

- **BB-776 (#2739)** — closes the synchronous tail: `TaskScheduler` now invokes the per-task `done` callback before triggering the drain check, so the rebalance handler can't observe an "idle" queue while the last `offsetsStore` call is still in flight on its caller's stack.
- **BB-777 (#2740)** — closes the asynchronous tail: the rebalance handler now waits for the `OffsetLedger` to drain (in addition to the processing queue) before unassigning. Deferred `onEntryCommittable` callbacks (the `committable: false` flow used by replication) land safely before the partition is released.

## What this PR adds

In `BackbeatConsumer.onEntryCommittable`:

1. An additional `this._consumer.isConnected()` guard alongside the existing `!this.isPaused()` check.
2. A `try/catch` around `offsetsStore()` that logs at error level instead of crashing.

The offset will be re-committed after the partition is re-assigned, so swallowing the error costs at most a duplicate delivery.

## Why keep it after BB-776 + BB-777

A few cases still slip past the structural fixes:

- **Late callback after the outer-timeout disconnect.** If a deferred ack (e.g. a Kafka status producer's delivery callback) lands more than `max.poll.interval - 1s` after the rebalance starts, BB-777 has already disconnected the consumer. The next `onEntryCommittable` would crash.
- **BB-772 poison-pill paths.** `GarbageCollectorTask` and `LifecycleColdStatusArchiveTask` use `committable: false` without ever calling `onEntryCommittable`. They trigger the outer timeout today. Until BB-772 lands, the residual `onEntryCommittable` calls from other tasks in the same process can race the disconnect.
- **Future races we haven't enumerated.** The `try/catch` is ~5 lines and costs nothing in the happy path.

## Tests

5 unit tests on `onEntryCommittable` cover the new guards and catch:
- calls `offsetsStore` when active + connected
- does not call when paused (unsubscribed)
- does not call when not connected
- does not throw + logs error on `ERR__STATE`
- does not throw + logs error on unexpected error

The original functional test was dropped after the rebase: with BB-777 in place, it would deadlock on `consumer1.once('unassign', ...)` (the unassign now waits for the ledger to drain, and the test only drains the ledger inside the `unassign` callback) and "pass" only after the 5-minute outer-timeout fires. The unit tests cover the change directly and cheaply.

Issue: BB-758