### PR TITLE
BB-763 Update GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/actions/ft-test/action.yaml
+++ b/.github/actions/ft-test/action.yaml
@@ -27,7 +27,7 @@ runs:
       env:
         BACKBEAT_CONFIG_FILE: ${{ inputs.config }}
 
-    - uses: codecov/codecov-action@v5
+    - uses: codecov/codecov-action@v6
       with:
         token: ${{ inputs.token }}
         directory: ./coverage/ft_test:${{ inputs.testsuite }}

--- a/.github/workflows/alerts.yaml
+++ b/.github/workflows/alerts.yaml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Render and test lifecycle 
         uses: scality/action-prom-render-test@1.0.3

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -20,13 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildk
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -33,7 +33,7 @@ jobs:
           password: ${{ github.token }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true
@@ -42,7 +42,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push federation image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: images/federation
           push: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -59,7 +59,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
 
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
         go-version: '1.16.2'
         cache-dependency-path: bucket-scanner/go.sum

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,7 +44,7 @@ jobs:
         password: ${{ github.token }}
 
     - name: Build and push ${{ matrix.name }}
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         push: true
         context: ${{ matrix.context }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,13 +31,13 @@ jobs:
             file: ""
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Login to Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - uses: actions/setup-go@v5
       with:
@@ -74,7 +74,7 @@ jobs:
                -nodes 1 -stream -timeout 5m -slowSpecThreshold 60
       working-directory: bucket-scanner
 
-    - uses: codecov/codecov-action@v5
+    - uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: bucket-scanner
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - uses: actions/setup-node@v6
       with:
         node-version: '22'
@@ -132,7 +132,7 @@ jobs:
         - 27019:27019
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - uses: actions/setup-node@v6
       with:
         node-version: '22'
@@ -146,7 +146,7 @@ jobs:
         BACKBEAT_CONFIG_FILE: tests/config.json
         TEST_SUITE: test
 
-    - uses: codecov/codecov-action@v5
+    - uses: codecov/codecov-action@v6
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         directory: ./coverage/test
@@ -215,7 +215,7 @@ jobs:
         - 27019:27019
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - uses: actions/setup-node@v6
       with:
         node-version: '22'
@@ -283,7 +283,7 @@ jobs:
         - 27019:27019
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - uses: actions/setup-node@v6
       with:
         node-version: '22'
@@ -320,7 +320,7 @@ jobs:
         cloudserver_tag: [ '9.0.19' ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: '22'
@@ -328,7 +328,7 @@ jobs:
       - name: Install node dependencies
         run: yarn install --ignore-engines --frozen-lockfile --network-concurrency 1
       - name: Login to Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -363,7 +363,7 @@ jobs:
           PROFILE: ${{ matrix.profile }}
           TEST_SUITE: ft_test:queuepopulator
         run: yarn run cover
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./coverage/ft_test:queuepopulator


### PR DESCRIPTION
## Summary
Update GitHub Actions workflow files to use action versions running on Node 24.

Closes BB-763

## Context
GitHub is deprecating Node 20 as the JavaScript runtime for GitHub Actions runners:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Timeline:
- June 2, 2026: Runners default to Node 24 (deprecation warnings)
- Fall 2026: Node 20 completely removed

## Changes
Updated action versions across all workflow files to Node 24-compatible versions:
- `actions/checkout@v4` → `@v6`
- `docker/setup-buildx-action@v3` → `@v4`
- `docker/login-action@v3` → `@v4`
- `softprops/action-gh-release@v2` → `@v3`
- `codecov/codecov-action@v4/@v5` → `@v6`