### PR TITLE
fix: store offset before drain on rebalance tail

### DIFF
--- a/lib/tasks/TaskScheduler.js
+++ b/lib/tasks/TaskScheduler.js
@@ -77,8 +77,8 @@ class TaskScheduler {
                 delete this._dedupeCache[dedupeKey];
             }
             this._running--;
-            this._tryDrain();
             done(...args);
+            this._tryDrain();
         };
         if (this._getDedupeKeyFunc) {
             dedupeKey = this._getDedupeKeyFunc(ctx);

--- a/tests/functional/lib/BackbeatConsumer.js
+++ b/tests/functional/lib/BackbeatConsumer.js
@@ -380,6 +380,132 @@ describe('BackbeatConsumer rebalance tests', () => {
     }).timeout(60000);
 });
 
+describe('BackbeatConsumer rebalance during batch processing', () => {
+    // Smoke test that exercises the rebalance handler while a batch of
+    // messages is being processed. Catches regressions where offsets
+    // can be dropped at the boundary between processing and rebalance.
+    // The pinpoint sync-tail race is covered by the TaskScheduler unit
+    // test (`should run the per-task callback before drain when the
+    // last task completes`).
+    const topic = 'backbeat-consumer-spec-sync-tail';
+    const groupId = `replication-group-sync-tail-${Math.random()}`;
+    let producer;
+    let consumer1;
+    let consumer2;
+
+    before(function before(done) {
+        this.timeout(60000);
+        producer = new BackbeatProducer({
+            kafka: producerKafkaConf, topic,
+            pollIntervalMs: 100,
+            compressionType: 'none',
+        });
+        consumer1 = new BackbeatConsumer({
+            clientId: 'BackbeatConsumer-SYNC-TAIL-1',
+            zookeeper: zookeeperConf,
+            kafka: { ...consumerKafkaConf, compressionType: 'none' },
+            groupId, topic,
+            queueProcessor: (_msg, cb) => cb(),
+            bootstrap: true,
+        });
+        async.parallel([
+            innerDone => producer.on('ready', innerDone),
+            innerDone => consumer1.on('ready', innerDone),
+        ], err => {
+            if (err) {return done(err);}
+            consumer2 = new BackbeatConsumer({
+                clientId: 'BackbeatConsumer-SYNC-TAIL-2',
+                zookeeper: zookeeperConf,
+                kafka: { ...consumerKafkaConf, compressionType: 'none' },
+                groupId, topic,
+                queueProcessor: (_msg, cb) => cb(),
+            });
+            return consumer2.on('ready', done);
+        });
+    });
+
+    after(function after(done) {
+        this.timeout(10000);
+        async.parallel([
+            innerDone => producer.close(innerDone),
+            innerDone => consumer1.close(innerDone),
+            innerDone => (consumer2 ? consumer2.close(innerDone) : innerDone()),
+        ], done);
+    });
+
+    it('commits all task offsets when rebalance fires during a batch', done => {
+        const N = 10;
+        let processed = 0;
+        consumer1._queueProcessor = (_message, cb) => {
+            processed++;
+            process.nextTick(cb);
+        };
+        consumer2._queueProcessor = (_msg, cb) => process.nextTick(cb);
+
+        consumer2._consumer.committed(
+            [{ topic, partition: 0 }], 5000, (e1, base) => {
+                assert.ifError(e1);
+                const baseline = base[0].offset;
+
+                consumer1.subscribe();
+                const messages = [];
+                for (let i = 0; i < N; i++) {
+                    messages.push({ key: `k${i}`, message: `{"i":${i}}` });
+                }
+                producer.send(messages, err => {
+                    assert.ifError(err);
+                });
+
+                // Trigger consumer2.subscribe() once consumer1 has
+                // started processing the batch — that way the
+                // rebalance fires while the batch is in flight (some
+                // tasks already done, some still running). The
+                // synchronous-tail ordering matters for whichever task
+                // happens to be the last to flip the queue's running
+                // counter to zero.
+                let triggered = false;
+                consumer1.on('consumed', () => {
+                    if (triggered) {return;}
+                    triggered = true;
+                    consumer2.subscribe();
+                });
+
+                // Wait for processing + rebalance to settle, then
+                // verify all N offsets reached the broker. Use consumer1
+                // (still connected) and retry on transient "Local:
+                // Timed out" errors that can occur while the rebalance
+                // is mid-flight.
+                const queryCommitted = (attempts, finalCb) => {
+                    consumer1._consumer.committed(
+                        [{ topic, partition: 0 }], 5000, (e2, c) => {
+                            if (e2 && attempts > 0) {
+                                return setTimeout(
+                                    () => queryCommitted(attempts - 1,
+                                        finalCb),
+                                    1000);
+                            }
+                            return finalCb(e2, c);
+                        });
+                };
+                const checkInterval = setInterval(() => {
+                    if (processed < N) {
+                        return;
+                    }
+                    clearInterval(checkInterval);
+                    setTimeout(() => queryCommitted(10, (e2, c) => {
+                        assert.ifError(e2);
+                        assert.strictEqual(c[0].offset, baseline + N,
+                            'expected committed offset to advance ' +
+                            `from ${baseline} to ${baseline + N} ` +
+                            `after ${N} tasks processed during ` +
+                            `rebalance, but it stayed at ${c[0].offset}`);
+                        done();
+                    }), 3000);
+                }, 100);
+            });
+    }).timeout(60000);
+});
+
 describe('BackbeatConsumer concurrency tests', () => {
     const topicConc = 'backbeat-consumer-spec-conc-1000';
     const groupIdConc = `replication-group-conc-${Math.random()}`;

--- a/tests/unit/lib/tasks/TaskScheduler.spec.js
+++ b/tests/unit/lib/tasks/TaskScheduler.spec.js
@@ -233,6 +233,23 @@ describe('TaskScheduler', () => {
             sinon.stub(taskScheduler, 'idle').returns(false);
             assert.doesNotThrow(() => taskScheduler._tryDrain());
         });
+
+        it('should run the per-task callback before drain when the last ' +
+           'task completes', done => {
+            const order = [];
+            const taskScheduler = new TaskScheduler(
+                (ctx, cb) => process.nextTick(cb));
+            taskScheduler.setDrain(() => {
+                order.push('drain');
+                try {
+                    assert.deepStrictEqual(order, ['done', 'drain']);
+                    done();
+                } catch (e) {
+                    done(e);
+                }
+            });
+            taskScheduler.push({}, () => order.push('done'));
+        });
     });
 
     describe('setDrain', () => {


### PR DESCRIPTION
## TL;DR

A two-line reorder in `TaskScheduler.onTaskEnd` so the per-task callback runs before the drain callback. This closes a synchronous race during Kafka consumer rebalances that prevents the last task's offset from being committed and produces the `LibrdKafkaError: Local: Erroneous state` (`ERR__STATE`) crashes reported in BB-758. The crash was previously contained by a `try/catch` in `BackbeatConsumer.onEntryCommittable`; this PR fixes the underlying ordering bug.

## What this changes

`lib/tasks/TaskScheduler.js`, inside the `onTaskEnd` function created in `push`:

\`\`\`diff
 this._running--;
-this._tryDrain();
 done(...args);
+this._tryDrain();
\`\`\`

That's the whole behavior change. Plus a unit test that asserts the new ordering, and a functional smoke test at the BackbeatConsumer integration level.

## What the bug is

`BackbeatConsumer` uses `TaskScheduler` to run incoming Kafka messages through a user-supplied `queueProcessor`. When a task finishes, `onTaskEnd` runs three things in sequence:

1. Decrement the running-task counter.
2. Maybe fire the drain callback (if the queue is now idle).
3. Call the per-task callback (`done(...args)`), which is `BackbeatConsumer`'s `_onEntryProcessingDone` → `onEntryCommittable` → librdkafka `offsetsStore`.

Before this PR, the order is `_tryDrain()` then `done(...args)`. During a rebalance, the drain callback is the one that runs `_consumer.commit()` and `_consumer.unassign()`. So when the **last** task of a batch completes while a rebalance is pending:

1. The drain callback runs, queueing `commit()` and `unassign()` ops to librdkafka's main thread.
2. `done(...args)` runs, calling `offsetsStore` for that task's offset.
3. By the time step 2 reaches librdkafka, the main thread may have already processed the `unassign` op and cleared the partition's internal `RD_KAFKA_TOPPAR_F_ASSIGNED` flag.
4. `offsetsStore` returns `RD_KAFKA_RESP_ERR__STATE` ("Partition is not assigned"). The error throws into JS and bubbles up out of `onTaskEnd`.

That's the production stack trace recorded in BB-758 (visible in CI artifacts from `lifecycle-bucket-processor`, `queue-populator`, `notification-processor`, etc.).

The race only affects the **last** task of a batch — the one that flips the running counter to zero. Earlier tasks don't trigger the drain callback, so their `offsetsStore` always runs while the partition is still assigned.

## Why the swap is the right fix

`offsetsStore` checks exactly one piece of state inside librdkafka: the `RD_KAFKA_TOPPAR_F_ASSIGNED` flag on the topic partition. That flag is cleared in `rd_kafka_assignment_serve_removals` (in `librdkafka/src/rdkafka_assignment.c`), which only runs **in response to the application's `unassign()` call**. Until the application calls `unassign()`, the flag stays set, and `offsetsStore` succeeds.

With the new order:

1. `done(...args)` runs. `offsetsStore` is invoked while the partition is still assigned — succeeds, the offset is locally stored in librdkafka.
2. `_tryDrain()` runs. The drain callback calls `_consumer.commit()` (synchronous in JS, queued as an op for the main thread). `commit()` picks up the just-stored offset and flushes it to the broker.
3. The drain callback then calls `_consumer.unassign()`. The main thread eventually clears `F_ASSIGNED`.

The offset is committed before the partition is released. The race is closed by construction, not by timing luck.

## Why this is safe

- `setDrain` is only called by `BackbeatConsumer`'s rebalance handler (`lib/BackbeatConsumer.js:725` and `:768`). Audited all other `TaskScheduler` callers (`extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js`, `extensions/replication/queueProcessor/QueueProcessor.js`) — both only use `push()`, no `setDrain`. Ingestion goes through `BackbeatConsumer` indirectly. No production caller depends on drain firing before per-task callbacks.
- All 25 pre-existing `TaskScheduler` unit tests pass unchanged.
- The new unit test deterministically demonstrates the bug on the pre-PR code (`expected ['done', 'drain'] but got ['drain']`) and passes after the swap. Runs in ~5ms without any Kafka dependency.

## Background

BB-441 introduced rebalance drain handling in October 2023 with the stated goal "ensure the offsets are stored (and committed) on rebalance." The implementation waited for `_processingQueue.idle()`, but the synchronous tail of `onTaskEnd` left this race intact. This PR finishes that work for the `committable: true` path.

## Tests

- **`tests/unit/lib/tasks/TaskScheduler.spec.js`** — new `it()` "should run the per-task callback before drain when the last task completes". Pinpoint discriminator for the ordering invariant: passes with the swap, fails with a clear diff without it. Deterministic, no Kafka, ~5ms.
- **`tests/functional/lib/BackbeatConsumer.js`** — new "BackbeatConsumer rebalance during batch processing > commits all task offsets when rebalance fires during a batch". Integration smoke test: sends 10 messages, triggers consumer2 mid-batch, asserts all offsets committed. Doesn't pinpoint the sync-tail race (timing makes the original bug hard to reproduce deterministically at the integration layer with `backlogMetrics` enabled and `concurrency=1` + `nextTick` queueProcessor), but catches end-to-end regressions of the rebalance-during-processing path.

## What this PR does NOT fix

- The async `committable: false` race (deferred `onEntryCommittable` called from a Kafka producer's delivery callback after `unassign` has already run). Addressed in #2740 (BB-777).
- The "poison pill" `committable: false` on error paths in GC and lifecycle (tracked separately in BB-772).

Both are unrelated to the ordering bug fixed here.

Issue: BB-776