### PR TITLE
oplogPopulator: synthesise oplog key via $addFields in connector pipeline

### DIFF
--- a/extensions/oplogPopulator/constants.js
+++ b/extensions/oplogPopulator/constants.js
@@ -23,10 +23,6 @@ const constants = {
         'output.format.value': 'json',
         'value.converter.schemas.enable': false,
         'value.converter': 'org.apache.kafka.connect.storage.StringConverter',
-        // Kafka message key config
-        // The message key is set to only contain the bucket where the event happend.
-        // This will make events of the same bucket always land in the same partition
-        // as they will have the same key
         'output.format.key': 'schema',
         'output.schema.key': JSON.stringify({
             type: 'record',
@@ -42,22 +38,8 @@ const constants = {
                         }],
                     }, 'null'],
             }, {
-                name: 'fullDocument',
-                type: [{
-                   type: 'record',
-                   name: 'fullDocumentRecord',
-                   fields: [{
-                        name: 'value',
-                        type: [{
-                            type: 'record',
-                            name: 'valueRecord',
-                            fields: [{
-                                name: 'key',
-                                type: ['string', 'null'],
-                            }],
-                        }, 'null'],
-                   }],
-                }, 'null'],
+                name: 'key',
+                type: ['string', 'null'],
             }],
         }),
     },

--- a/extensions/oplogPopulator/pipeline/PipelineFactory.js
+++ b/extensions/oplogPopulator/pipeline/PipelineFactory.js
@@ -70,6 +70,21 @@ class PipelineFactory {
         }
         const pipeline = [
             stage,
+            // Synthesise a top-level 'key' from fullDocument.value.key
+            // (insert/replace) or updateDescription.updatedFields.value.key
+            // (update). Relies on object MD writes always $set-ing the whole
+            // 'value' subdocument; a partial dotted $set would mis-partition.
+            // See BB-768 (superseded SMT alternative in PR #2741).
+            {
+                $addFields: {
+                    key: {
+                        $ifNull: [
+                            '$fullDocument.value.key',
+                            '$updateDescription.updatedFields.value.key',
+                        ],
+                    },
+                },
+            },
         ];
         if (this._locationStrippingBytesThreshold > 0) {
             pipeline.push({

--- a/lib/queuePopulator/KafkaLogConsumer/KafkaLogConsumerMetrics.js
+++ b/lib/queuePopulator/KafkaLogConsumer/KafkaLogConsumerMetrics.js
@@ -1,0 +1,38 @@
+const { ZenkoMetrics } = require('arsenal').metrics;
+
+// Counts consumed oplog events that downstream queue populators will
+// process but that lack a top-level 'key' field — i.e., the synthesised
+// partitioning key produced by the connector pipeline (see BB-768).
+// Should stay at zero in steady-state; a non-zero rate signals that
+// metadata grew a write path that doesn't $set the whole 'value'
+// subdocument, regressing the per-object partitioning fix.
+const oplogEventMissingKey = ZenkoMetrics.createCounter({
+    name: 's3_oplog_event_missing_key_total',
+    help: 'Total number of oplog events processed by queue populators ' +
+        'with the synthesised top-level "key" field missing or null',
+    labelNames: ['opType'],
+});
+
+class KafkaLogConsumerMetrics {
+    static onMissingKey(log, opType) {
+        try {
+            oplogEventMissingKey.inc({
+                opType: opType || 'unknown',
+            });
+        } catch (err) {
+            KafkaLogConsumerMetrics.handleError(
+                log, err, 'KafkaLogConsumerMetrics.onMissingKey');
+        }
+    }
+
+    static handleError(log, err, method) {
+        if (log && log.error) {
+            log.error('failed to update prometheus metrics', {
+                method,
+                error: err.message,
+            });
+        }
+    }
+}
+
+module.exports = KafkaLogConsumerMetrics;

--- a/lib/queuePopulator/KafkaLogConsumer/ListRecordStream.js
+++ b/lib/queuePopulator/KafkaLogConsumer/ListRecordStream.js
@@ -1,4 +1,5 @@
 const stream = require('stream');
+const KafkaLogConsumerMetrics = require('./KafkaLogConsumerMetrics');
 
 class ListRecordStream extends stream.Transform {
     /**
@@ -121,6 +122,10 @@ class ListRecordStream extends stream.Transform {
         if (!objectMd) {
             // skipping empty events
             return callback(null, null);
+        }
+        if (changeStreamDocument.key === null || changeStreamDocument.key === undefined) {
+            KafkaLogConsumerMetrics.onMissingKey(
+                this._logger, changeStreamDocument.operationType);
         }
         const opType = this._getType(changeStreamDocument.operationType, objectMd);
         const streamObject = {

--- a/tests/functional/oplogPopulator/PipelineFactory.js
+++ b/tests/functional/oplogPopulator/PipelineFactory.js
@@ -19,6 +19,7 @@ describe('PipelineFactory', function () {
     const collectionName = 'test-pipeline-stripping';
     let collection;
     let setStage;
+    let addFieldsStage;
 
     before(async () => {
         await client.connect();
@@ -26,7 +27,8 @@ describe('PipelineFactory', function () {
 
         const factory = new MultipleBucketsPipelineFactory(THRESHOLD);
         const pipeline = JSON.parse(factory.getPipeline(['test-bucket']));
-        setStage = pipeline[1];
+        addFieldsStage = pipeline[1];
+        setStage = pipeline[2];
     });
 
     afterEach(async () => {
@@ -145,6 +147,47 @@ describe('PipelineFactory', function () {
                 results[0].updateDescription.updatedFields.value.location,
                 undefined
             );
+        });
+    });
+
+    describe('key synthesis ($addFields)', () => {
+        it('should populate key from fullDocument.value.key on insert-shaped docs', async () => {
+            const doc = { fullDocument: { value: { key: 'my/object' } } };
+            await collection.insertOne(doc);
+            const results = await collection.aggregate([addFieldsStage]).toArray();
+            assert.strictEqual(results.length, 1);
+            assert.strictEqual(results[0].key, 'my/object');
+        });
+
+        it('should populate key from updateDescription.updatedFields.value.key on update-shaped docs', async () => {
+            const doc = { updateDescription: { updatedFields: { value: { key: 'my/object' } } } };
+            await collection.insertOne(doc);
+            const results = await collection.aggregate([addFieldsStage]).toArray();
+            assert.strictEqual(results.length, 1);
+            assert.strictEqual(results[0].key, 'my/object');
+        });
+
+        it('should prefer fullDocument.value.key when both are present', async () => {
+            const doc = {
+                fullDocument: { value: { key: 'from-full' } },
+                updateDescription: { updatedFields: { value: { key: 'from-update' } } },
+            };
+            await collection.insertOne(doc);
+            const results = await collection.aggregate([addFieldsStage]).toArray();
+            assert.strictEqual(results[0].key, 'from-full');
+        });
+
+        it('should leave key absent when neither path is populated', async () => {
+            // $ifNull returns missing (not null) when all inputs are missing.
+            // The connector's nullable Avro key schema emits this as null on
+            // the wire, so the partition outcome is the same as an explicit
+            // null. In production deletes are ignored, so this case doesn't
+            // occur for consumed events.
+            const doc = { fullDocument: null };
+            await collection.insertOne(doc);
+            const results = await collection.aggregate([addFieldsStage]).toArray();
+            assert.strictEqual(results.length, 1);
+            assert.strictEqual(results[0].key, undefined);
         });
     });
 });

--- a/tests/unit/lib/queuePopulator/kafkaLogConsumer/KafkaLogConsumerMetrics.js
+++ b/tests/unit/lib/queuePopulator/kafkaLogConsumer/KafkaLogConsumerMetrics.js
@@ -1,0 +1,41 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const { ZenkoMetrics } = require('arsenal').metrics;
+const KafkaLogConsumerMetrics =
+    require('../../../../../lib/queuePopulator/KafkaLogConsumer/KafkaLogConsumerMetrics');
+
+describe('KafkaLogConsumerMetrics', () => {
+    const log = { error: sinon.stub() };
+
+    afterEach(() => {
+        sinon.restore();
+        log.error.resetHistory();
+    });
+
+    describe('onMissingKey', () => {
+        it('should increment the s3_oplog_event_missing_key_total counter', () => {
+            const metric = ZenkoMetrics.getMetric('s3_oplog_event_missing_key_total');
+            const incStub = sinon.stub(metric, 'inc');
+            KafkaLogConsumerMetrics.onMissingKey(log, 'update');
+            assert(incStub.calledOnceWith({ opType: 'update' }));
+            assert(log.error.notCalled);
+        });
+
+        it('should label as "unknown" when opType is missing', () => {
+            const metric = ZenkoMetrics.getMetric('s3_oplog_event_missing_key_total');
+            const incStub = sinon.stub(metric, 'inc');
+            KafkaLogConsumerMetrics.onMissingKey(log, undefined);
+            assert(incStub.calledOnceWith({ opType: 'unknown' }));
+        });
+
+        it('should swallow + log errors from inc', () => {
+            const metric = ZenkoMetrics.getMetric('s3_oplog_event_missing_key_total');
+            sinon.stub(metric, 'inc').throws(new Error('boom'));
+            assert.doesNotThrow(() => KafkaLogConsumerMetrics.onMissingKey(log, 'insert'));
+            assert(log.error.calledOnce);
+            assert(log.error.calledWithMatch('failed to update prometheus metrics', {
+                method: 'KafkaLogConsumerMetrics.onMissingKey',
+            }));
+        });
+    });
+});

--- a/tests/unit/lib/queuePopulator/kafkaLogConsumer/ListRecordStream.js
+++ b/tests/unit/lib/queuePopulator/kafkaLogConsumer/ListRecordStream.js
@@ -1,8 +1,11 @@
 const assert = require('assert');
+const sinon = require('sinon');
 const werelogs = require('werelogs');
 const logger = new werelogs.Logger('ListRecordStream');
 const ListRecordStream =
     require('../../../../../lib/queuePopulator/KafkaLogConsumer/ListRecordStream');
+const KafkaLogConsumerMetrics =
+    require('../../../../../lib/queuePopulator/KafkaLogConsumer/KafkaLogConsumerMetrics');
 
 const changeStreamDocument = {
     ns: {
@@ -155,6 +158,32 @@ describe('ListRecordStream', () => {
                         timestamp: '2023-11-29T15:05:57.000Z',
                     }],
                 });
+                return done();
+            });
+        });
+
+        it('should call onMissingKey when key is absent on a processed event', done => {
+            // changeStreamDocument has no top-level 'key' field — emulates an
+            // event that slipped past the $addFields stage. Should still be
+            // processed (objectMd is present) but the metric helper should fire.
+            const stub = sinon.stub(KafkaLogConsumerMetrics, 'onMissingKey');
+            const kafkaMessage = getKafkaMessage(JSON.stringify(changeStreamDocument));
+            listRecordStream.write(kafkaMessage);
+            listRecordStream.once('data', () => {
+                assert(stub.calledOnceWith(logger, 'insert'));
+                stub.restore();
+                return done();
+            });
+        });
+
+        it('should NOT call onMissingKey when key is present', done => {
+            const stub = sinon.stub(KafkaLogConsumerMetrics, 'onMissingKey');
+            const doc = { ...changeStreamDocument, key: 'example-key' };
+            const kafkaMessage = getKafkaMessage(JSON.stringify(doc));
+            listRecordStream.write(kafkaMessage);
+            listRecordStream.once('data', () => {
+                assert(stub.notCalled);
+                stub.restore();
                 return done();
             });
         });

--- a/tests/unit/oplogPopulator/ConnectorsManager.js
+++ b/tests/unit/oplogPopulator/ConnectorsManager.js
@@ -44,22 +44,8 @@ const connectorConfig = {
                     }],
                 }, 'null'],
         }, {
-            name: 'fullDocument',
-            type: [{
-               type: 'record',
-               name: 'fullDocumentRecord',
-               fields: [{
-                    name: 'value',
-                    type: [{
-                        type: 'record',
-                        name: 'valueRecord',
-                        fields: [{
-                            name: 'key',
-                            type: ['string', 'null'],
-                        }],
-                    }, 'null'],
-               }],
-            }, 'null'],
+            name: 'key',
+            type: ['string', 'null'],
         }],
     }),
     'heartbeat.interval.ms': 10000,

--- a/tests/unit/oplogPopulator/pipeline/MultipleBucketsPipelineFactory.js
+++ b/tests/unit/oplogPopulator/pipeline/MultipleBucketsPipelineFactory.js
@@ -46,25 +46,52 @@ describe('MultipleBucketsPipelineFactory', () => {
             assert.strictEqual(result, '[]');
         });
 
-        it('should return the pipeline with buckets and location stripping', () => {
+        it('should return the pipeline with buckets, key synthesis and location stripping', () => {
             const buckets = ['bucket1', 'bucket2'];
             const result = multipleBucketsPipelineFactory.getPipeline(buckets);
             const pipeline = JSON.parse(result);
 
-            assert.strictEqual(pipeline.length, 2);
+            assert.strictEqual(pipeline.length, 3);
             assert.deepStrictEqual(pipeline[0], {$match:{'ns.coll':{$in:['bucket1','bucket2']}}});
-            assert.deepStrictEqual(pipeline[1].$set['fullDocument.value.location'], {
+            assert.deepStrictEqual(pipeline[1], {
+                $addFields: {
+                    key: {
+                        $ifNull: [
+                            '$fullDocument.value.key',
+                            '$updateDescription.updatedFields.value.key',
+                        ],
+                    },
+                },
+            });
+            assert.deepStrictEqual(pipeline[2].$set['fullDocument.value.location'], {
                 $cond: {
                     if: { $gte: ['$fullDocument.value.content-length', thresholdBytes] },
                     then: '$$REMOVE',
                     else: '$fullDocument.value.location',
                 },
             });
-            assert.deepStrictEqual(pipeline[1].$set['updateDescription.updatedFields.value.location'], {
+            assert.deepStrictEqual(pipeline[2].$set['updateDescription.updatedFields.value.location'], {
                 $cond: {
                     if: { $gte: ['$updateDescription.updatedFields.value.content-length', thresholdBytes] },
                     then: '$$REMOVE',
                     else: '$updateDescription.updatedFields.value.location',
+                },
+            });
+        });
+
+        it('should return the pipeline with key synthesis when location stripping is disabled', () => {
+            const factory = new MultipleBucketsPipelineFactory(0);
+            const pipeline = JSON.parse(factory.getPipeline(['bucket1']));
+            assert.strictEqual(pipeline.length, 2);
+            assert.deepStrictEqual(pipeline[0], {$match:{'ns.coll':{$in:['bucket1']}}});
+            assert.deepStrictEqual(pipeline[1], {
+                $addFields: {
+                    key: {
+                        $ifNull: [
+                            '$fullDocument.value.key',
+                            '$updateDescription.updatedFields.value.key',
+                        ],
+                    },
                 },
             });
         });

--- a/tests/unit/oplogPopulator/pipeline/WildcardPipelineFactory.js
+++ b/tests/unit/oplogPopulator/pipeline/WildcardPipelineFactory.js
@@ -33,21 +33,31 @@ describe('WildcardPipelineFactory', () => {
     });
 
     describe('getPipeline', () => {
-        it('should return the pipeline with buckets and location stripping', () => {
+        it('should return the pipeline with buckets, key synthesis and location stripping', () => {
             const buckets = ['bucket1', 'bucket2'];
             const result = wildcardPipelineFactory.getPipeline(buckets);
             const pipeline = JSON.parse(result);
 
-            assert.strictEqual(pipeline.length, 2);
+            assert.strictEqual(pipeline.length, 3);
             assert.deepStrictEqual(pipeline[0], {$match:{'ns.coll':{$not:{$regex:'^(mpuShadowBucket|__).*'}}}});
-            assert.deepStrictEqual(pipeline[1].$set['fullDocument.value.location'], {
+            assert.deepStrictEqual(pipeline[1], {
+                $addFields: {
+                    key: {
+                        $ifNull: [
+                            '$fullDocument.value.key',
+                            '$updateDescription.updatedFields.value.key',
+                        ],
+                    },
+                },
+            });
+            assert.deepStrictEqual(pipeline[2].$set['fullDocument.value.location'], {
                 $cond: {
                     if: { $gte: ['$fullDocument.value.content-length', thresholdBytes] },
                     then: '$$REMOVE',
                     else: '$fullDocument.value.location',
                 },
             });
-            assert.deepStrictEqual(pipeline[1].$set['updateDescription.updatedFields.value.location'], {
+            assert.deepStrictEqual(pipeline[2].$set['updateDescription.updatedFields.value.location'], {
                 $cond: {
                     if: { $gte: ['$updateDescription.updatedFields.value.content-length', thresholdBytes] },
                     then: '$$REMOVE',
@@ -56,14 +66,24 @@ describe('WildcardPipelineFactory', () => {
             });
         });
 
-        it('should return the pipeline with buckets and no location stripping if disabled', () => {
+        it('should return the pipeline with key synthesis and no location stripping if disabled', () => {
             const wildcardPipelineFactoryNoStripping = new WildcardPipelineFactory(0);
 
             const buckets = ['bucket1', 'bucket2'];
             const result = wildcardPipelineFactoryNoStripping.getPipeline(buckets);
             const pipeline = JSON.parse(result);
 
-            assert.strictEqual(pipeline.length, 1);
+            assert.strictEqual(pipeline.length, 2);
+            assert.deepStrictEqual(pipeline[1], {
+                $addFields: {
+                    key: {
+                        $ifNull: [
+                            '$fullDocument.value.key',
+                            '$updateDescription.updatedFields.value.key',
+                        ],
+                    },
+                },
+            });
         });
     });
 


### PR DESCRIPTION
## Summary

Two commits on this branch:

1. **`oplogPopulator: synthesise oplog key via $addFields in connector pipeline`**
    - `extensions/oplogPopulator/pipeline/PipelineFactory.js`: insert a `$addFields` stage into the connector's change-stream pipeline (right after `$match`, before the conditional location-strip `$set`) that synthesises a top-level `key` field via `$ifNull` coalescing `$fullDocument.value.key` and `$updateDescription.updatedFields.value.key`.
    - `extensions/oplogPopulator/constants.js`: replace the broken `fullDocument` nested record in `output.schema.key` with a top-level `key: [string, null]` field. The existing `ns: {coll}` projection is preserved, so the Kafka message key remains `{ns: {coll: <bucket>}, key: <object-key>}` — bucket-level isolation is unchanged.
    - Tests updated in both pipeline-factory subclasses, the functional pipeline test (real-mongo aggregation against the new stage), and the `connectorConfig` fixture used by `ConnectorsManager` tests.
2. **`queuePopulator: counter for oplog events processed without a synthesised key`**
    - New `lib/queuePopulator/KafkaLogConsumer/KafkaLogConsumerMetrics.js` module (mirrors `LifecycleMetrics`: static class, per-method `try`/`catch` + `handleError`).
    - Counter `s3_oplog_event_missing_key_total` labelled by `opType`, incremented from `ListRecordStream._transform` when a consumed event passes the `objectMd` check but lacks the top-level `key`. Defensive observability — added per review.

Pure Backbeat change. No SMT, no Zenko image change, no operator flag. Always on.

## Context

[BB-768](https://scality.atlassian.net/browse/BB-768): the current key schema projects `fullDocument.value.key`, which is `null` on `update` events (since BB-355 removed `change.stream.full.document=updateLookup`). Every update for a given bucket therefore serialises to the same key Struct (`{ns:{coll:<bucket>}, fullDocument:null}`) and lands on **one** partition — both an ordering problem (insert → update on different partitions for the same object) and a throughput problem (a hot bucket's update traffic can't scale with partition count, blocking [BB-756](https://scality.atlassian.net/browse/BB-756)).

After ticket discussion ([Jira comment 477122](https://scality.atlassian.net/browse/BB-768?focusedCommentId=477122)) we picked the pipeline-`$addFields` route over a Kafka Connect SMT: it's a single-repo fix, and the measured server-side cost is ~600–900 ns/event ≈ ~1–2% of one core at 20k ops/s — not a throughput concern.

For the same logical S3 object — insert (key in `fullDocument.value.key`), master PUT update (key in `updatedFields.value.key`), replication-status update, delete-marker update — all yield the same `key` value → same partition. Master and version documents both store the same `value.key`, so master/version events also collapse to the same partition without prefix-stripping.

## Coupling caveat

The `$ifNull` variant relies on metadata always writing the **whole** `value` subdocument (full `$set`). Confirmed today against arsenal — there's no partial dotted-`$set` path for object MD. A future partial update (`$set: {"value.x": …}`) would not populate `updatedFields.value.key` and the resulting event would mis-partition. Accepted risk per the ticket discussion. The `s3_oplog_event_missing_key_total` counter exists to detect exactly this regression.

## Migration

The change is propagated to existing connectors via the existing in-place `PUT /connectors/{name}/config` reconciliation (no recreate, no resume-token loss — the change touches the key schema + the added `$addFields` stage only, not the `$match` stage). Downstream oplog consumers don't read the Kafka message key, so the new key shape is consumer-transparent. See [this comment](https://github.com/scality/backbeat/pull/2744#issuecomment-4575409482) for the full migration trace.

Issue: BB-768

[BB-768]: https://scality.atlassian.net/browse/BB-768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ