### PR TITLE
feat(lifecycle): restrict v2 lifecycle indexes to master entries

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,17 +1,13 @@
 const { versioning, algorithms } = require('arsenal');
 
-// Bounds of the v1 master key range in the metadata collection.
-// MASTER_KEY_PREFIX is arsenal's DbPrefixes.Master (\x7fM); MASTER_KEY_PREFIX_END
-// is the inclusive-exclusive upper bound on master keys, derived the same way
-// as arsenal's listingParamsMasterKeysV0ToV1.
-const MASTER_KEY_PREFIX = versioning.VersioningConstants.DbPrefixes.Master;
-const MASTER_KEY_PREFIX_END = algorithms.listTools.DelimiterTools.inc(MASTER_KEY_PREFIX);
+// Bounds of the v1 master key range in the metadata collection. Derived the
+// same way as arsenal's listingParamsMasterKeysV0ToV1.
+const masterKeyPrefix = versioning.VersioningConstants.DbPrefixes.Master;
+const masterKeyPrefixEnd = algorithms.listTools.DelimiterTools.inc(masterKeyPrefix);
 
 const constants = {
-    keyPrefixes: {
-        master: MASTER_KEY_PREFIX,
-        masterEnd: MASTER_KEY_PREFIX_END,
-    },
+    masterKeyPrefix,
+    masterKeyPrefixEnd,
     kafkaBacklogMetrics: {
         promMetricNames: {
             latestPublishedMessageTimestamp: 's3_backbeat_queue_latest_published_message_timestamp',
@@ -69,7 +65,7 @@ const constants = {
                     ],
                     name: 'V2LifecycleLastModifiedPrefixed',
                     partialFilterExpression: {
-                        _id: { $gte: MASTER_KEY_PREFIX, $lt: MASTER_KEY_PREFIX_END },
+                        _id: { $gte: masterKeyPrefix, $lt: masterKeyPrefixEnd },
                     },
                 },
                 {
@@ -80,7 +76,7 @@ const constants = {
                     ],
                     name: 'V2LifecycleDataStoreNamePrefixed',
                     partialFilterExpression: {
-                        _id: { $gte: MASTER_KEY_PREFIX, $lt: MASTER_KEY_PREFIX_END },
+                        _id: { $gte: masterKeyPrefix, $lt: masterKeyPrefixEnd },
                     },
                 },
             ],

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,4 +1,17 @@
+const { versioning, algorithms } = require('arsenal');
+
+// Bounds of the v1 master key range in the metadata collection.
+// MASTER_KEY_PREFIX is arsenal's DbPrefixes.Master (\x7fM); MASTER_KEY_PREFIX_END
+// is the inclusive-exclusive upper bound on master keys, derived the same way
+// as arsenal's listingParamsMasterKeysV0ToV1.
+const MASTER_KEY_PREFIX = versioning.VersioningConstants.DbPrefixes.Master;
+const MASTER_KEY_PREFIX_END = algorithms.listTools.DelimiterTools.inc(MASTER_KEY_PREFIX);
+
 const constants = {
+    keyPrefixes: {
+        master: MASTER_KEY_PREFIX,
+        masterEnd: MASTER_KEY_PREFIX_END,
+    },
     kafkaBacklogMetrics: {
         promMetricNames: {
             latestPublishedMessageTimestamp: 's3_backbeat_queue_latest_published_message_timestamp',
@@ -45,9 +58,9 @@ const constants = {
     },
     indexesForFeature: {
         lifecycle: {
-            // Restrict to master entries (v1 \x7fM... prefix): v2 Current
-            // listings only query masters, so excluding versions shrinks
-            // the index and skips them at scan time.
+            // Restrict to master entries: v2 Current listings only query
+            // masters, so excluding versions shrinks the index and skips
+            // them at scan time.
             v2: [
                 {
                     keys: [
@@ -55,7 +68,9 @@ const constants = {
                         { key: '_id', order: 1 },
                     ],
                     name: 'V2LifecycleLastModifiedPrefixed',
-                    partialFilterExpression: { _id: { $gte: '\x7fM', $lt: '\x7fN' } },
+                    partialFilterExpression: {
+                        _id: { $gte: MASTER_KEY_PREFIX, $lt: MASTER_KEY_PREFIX_END },
+                    },
                 },
                 {
                     keys: [
@@ -64,7 +79,9 @@ const constants = {
                         { key: '_id', order: 1 },
                     ],
                     name: 'V2LifecycleDataStoreNamePrefixed',
-                    partialFilterExpression: { _id: { $gte: '\x7fM', $lt: '\x7fN' } },
+                    partialFilterExpression: {
+                        _id: { $gte: MASTER_KEY_PREFIX, $lt: MASTER_KEY_PREFIX_END },
+                    },
                 },
             ],
         },

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -45,6 +45,9 @@ const constants = {
     },
     indexesForFeature: {
         lifecycle: {
+            // Restrict to master entries (v1 \x7fM... prefix): v2 Current
+            // listings only query masters, so excluding versions shrinks
+            // the index and skips them at scan time.
             v2: [
                 {
                     keys: [
@@ -52,6 +55,7 @@ const constants = {
                         { key: '_id', order: 1 },
                     ],
                     name: 'V2LifecycleLastModifiedPrefixed',
+                    partialFilterExpression: { _id: { $gte: '\x7fM', $lt: '\x7fN' } },
                 },
                 {
                     keys: [
@@ -60,6 +64,7 @@ const constants = {
                         { key: '_id', order: 1 },
                     ],
                     name: 'V2LifecycleDataStoreNamePrefixed',
+                    partialFilterExpression: { _id: { $gte: '\x7fM', $lt: '\x7fN' } },
                 },
             ],
         },

--- a/tests/unit/lifecycle/LifecycleConductor.spec.js
+++ b/tests/unit/lifecycle/LifecycleConductor.spec.js
@@ -10,7 +10,8 @@ const LifecycleConductor = require(
 const {
     lifecycleTaskVersions,
     indexesForFeature,
-    keyPrefixes,
+    masterKeyPrefix,
+    masterKeyPrefixEnd,
 } = require('../../../lib/constants');
 
 const {
@@ -121,7 +122,7 @@ function makeLifecycleConductorWithFilters(options, markers) {
 
 describe('indexesForFeature.lifecycle.v2', () => {
     it('should restrict both indexes to master entries via partialFilterExpression', () => {
-        const expected = { _id: { $gte: keyPrefixes.master, $lt: keyPrefixes.masterEnd } };
+        const expected = { _id: { $gte: masterKeyPrefix, $lt: masterKeyPrefixEnd } };
         const indexes = indexesForFeature.lifecycle.v2;
         assert.strictEqual(indexes.length, 2);
         for (const idx of indexes) {
@@ -131,8 +132,8 @@ describe('indexesForFeature.lifecycle.v2', () => {
     });
 
     it('should derive master key range from arsenal DbPrefixes', () => {
-        assert.strictEqual(keyPrefixes.master, '\x7fM');
-        assert.strictEqual(keyPrefixes.masterEnd, '\x7fN');
+        assert.strictEqual(masterKeyPrefix, '\x7fM');
+        assert.strictEqual(masterKeyPrefixEnd, '\x7fN');
     });
 });
 

--- a/tests/unit/lifecycle/LifecycleConductor.spec.js
+++ b/tests/unit/lifecycle/LifecycleConductor.spec.js
@@ -9,7 +9,8 @@ const LifecycleConductor = require(
     '../../../extensions/lifecycle/conductor/LifecycleConductor');
 const {
     lifecycleTaskVersions,
-    indexesForFeature
+    indexesForFeature,
+    keyPrefixes,
 } = require('../../../lib/constants');
 
 const {
@@ -120,13 +121,18 @@ function makeLifecycleConductorWithFilters(options, markers) {
 
 describe('indexesForFeature.lifecycle.v2', () => {
     it('should restrict both indexes to master entries via partialFilterExpression', () => {
-        const expected = { _id: { $gte: '\x7fM', $lt: '\x7fN' } };
+        const expected = { _id: { $gte: keyPrefixes.master, $lt: keyPrefixes.masterEnd } };
         const indexes = indexesForFeature.lifecycle.v2;
         assert.strictEqual(indexes.length, 2);
         for (const idx of indexes) {
             assert.deepStrictEqual(idx.partialFilterExpression, expected,
                 `${idx.name} should have partialFilterExpression restricting to masters`);
         }
+    });
+
+    it('should derive master key range from arsenal DbPrefixes', () => {
+        assert.strictEqual(keyPrefixes.master, '\x7fM');
+        assert.strictEqual(keyPrefixes.masterEnd, '\x7fN');
     });
 });
 

--- a/tests/unit/lifecycle/LifecycleConductor.spec.js
+++ b/tests/unit/lifecycle/LifecycleConductor.spec.js
@@ -118,6 +118,18 @@ function makeLifecycleConductorWithFilters(options, markers) {
     return lcConductor;
 }
 
+describe('indexesForFeature.lifecycle.v2', () => {
+    it('should restrict both indexes to master entries via partialFilterExpression', () => {
+        const expected = { _id: { $gte: '\x7fM', $lt: '\x7fN' } };
+        const indexes = indexesForFeature.lifecycle.v2;
+        assert.strictEqual(indexes.length, 2);
+        for (const idx of indexes) {
+            assert.deepStrictEqual(idx.partialFilterExpression, expected,
+                `${idx.name} should have partialFilterExpression restricting to masters`);
+        }
+    });
+});
+
 describe('Lifecycle Conductor', () => {
     let conductor;
     let lcc;


### PR DESCRIPTION
## Summary

Add `partialFilterExpression: { _id: { $gte: '\x7fM', $lt: '\x7fN' } }` to both v2 lifecycle indexes (`V2LifecycleLastModifiedPrefixed`, `V2LifecycleDataStoreNamePrefixed`) so they only contain master entries.

v2 Current listings only ever query masters; including versions in these indexes was inflating their size and forcing the planner to skip past version entries at scan time.

## Migration

Existing lifecycled buckets are unaffected: the conductor matches indexes by name in `_indexesGetOrCreate`, so non-partial indexes stay in place. Only newly-lifecycled buckets get the partial spec. Lazy migration, no script.

## v0 buckets

The filter matches no v0 entries; for any v0 bucket somehow running v2 lifecycle, the partial index would be empty and MongoDB transparently falls back to `_id_` — same as today's no-index path, no regression.

Full rationale, empirical measurements (3–58× index size reduction), and discussion of trade-offs: [BB-773](https://scality.atlassian.net/browse/BB-773).

Issue: BB-773

[BB-773]: https://scality.atlassian.net/browse/BB-773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ