### PR TITLE
feat(lifecycle): skip index creation on Veeam SosAPI buckets

### DIFF
--- a/extensions/lifecycle/conductor/LifecycleConductor.js
+++ b/extensions/lifecycle/conductor/LifecycleConductor.js
@@ -265,7 +265,7 @@ class LifecycleConductor {
                 // Veeam buckets (SosAPI enabled) manage cleanup via their own
                 // S3 calls, not lifecycle policies. Skip the expensive index
                 // build and stick with v1.
-                log.trace('skipping index creation: SosAPI bucket');
+                log.trace('skipping index creation: SosAPI/Veeam has its own cleanup management');
                 LifecycleMetrics.onLegacyTask(log, 'sosApi');
                 return cb(null, lifecycleTaskVersions.v1);
             }

--- a/extensions/lifecycle/conductor/LifecycleConductor.js
+++ b/extensions/lifecycle/conductor/LifecycleConductor.js
@@ -261,6 +261,15 @@ class LifecycleConductor {
                 return cb(null, lifecycleTaskVersions.v2);
             }
 
+            if (task.hasSosApi) {
+                // Veeam buckets (SosAPI enabled) manage cleanup via their own
+                // S3 calls, not lifecycle policies. Skip the expensive index
+                // build and stick with v1.
+                log.trace('skipping index creation: SosAPI bucket');
+                LifecycleMetrics.onLegacyTask(log, 'sosApi');
+                return cb(null, lifecycleTaskVersions.v1);
+            }
+
             if (!this.lcConfig.autoCreateIndexes) {
                 log.trace('skipping index creation: auto creation of indexes disabled');
                 LifecycleMetrics.onLegacyTask(log, 'noIndex');
@@ -759,7 +768,12 @@ class LifecycleConductor {
                 const cursor = this._mongodbClient
                     .getCollection('__metastore')
                     .find(filter)
-                    .project({ '_id': 1, 'value.owner': 1, 'value.lifecycleConfiguration': 1 });
+                    .project({
+                        '_id': 1,
+                        'value.owner': 1,
+                        'value.lifecycleConfiguration': 1,
+                        'value.capabilities.VeeamSOSApi': 1,
+                    });
 
                 return done(null, cursor);
             },
@@ -797,6 +811,7 @@ class LifecycleConductor {
                                         bucketName: name,
                                         canonicalId: doc.value.owner,
                                         isLifecycled: !!doc.value.lifecycleConfiguration,
+                                        hasSosApi: !!doc.value.capabilities?.VeeamSOSApi,
                                     });
                                     nEnqueued += 1;
                                     lastSentId = doc._id;

--- a/tests/unit/lifecycle/LifecycleConductor.spec.js
+++ b/tests/unit/lifecycle/LifecycleConductor.spec.js
@@ -429,6 +429,42 @@ describe('Lifecycle Conductor', () => {
                 });
             }));
 
+        it('should return v1: SosAPI bucket skips index creation', done => {
+            const client = new BackbeatMetadataProxyMock();
+            conductor.clientManager.getBackbeatMetadataProxy = () => client;
+            conductor.activeIndexingJobsRetrieved = true;
+            conductor.activeIndexingJobs = [];
+            conductor._bucketSource = 'mongodb';
+            client.indexesObj = [];
+            client.error = null;
+
+            const sosTask = { ...getTask(true), hasSosApi: true };
+            conductor._indexesGetOrCreate(sosTask, log, (err, taskVersion) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(client.receivedIdxObj, null);
+                assert.deepStrictEqual(conductor.activeIndexingJobs, []);
+                assert.deepStrictEqual(taskVersion, lifecycleTaskVersions.v1);
+                done();
+            });
+        });
+
+        it('should still return v2 when SosAPI bucket already has indexes built', done => {
+            const client = new BackbeatMetadataProxyMock();
+            conductor.clientManager.getBackbeatMetadataProxy = () => client;
+            conductor.activeIndexingJobsRetrieved = true;
+            conductor.activeIndexingJobs = [];
+            conductor._bucketSource = 'mongodb';
+            client.indexesObj = indexesForFeature.lifecycle.v2;
+            client.error = null;
+
+            const sosTask = { ...getTask(true), hasSosApi: true };
+            conductor._indexesGetOrCreate(sosTask, log, (err, taskVersion) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(taskVersion, lifecycleTaskVersions.v2);
+                done();
+            });
+        });
+
         it('should return v1: missing indexes + disk space check fails', done => {
             const client = new BackbeatMetadataProxyMock();
             conductor.clientManager.getBackbeatMetadataProxy = () => client;
@@ -805,6 +841,45 @@ describe('Lifecycle Conductor', () => {
                         ],
                     },
                 });
+                done();
+            });
+        });
+
+        it('should populate hasSosApi from bucket capabilities when listing from mongodb', done => {
+            const lcConductor = makeLifecycleConductorWithFilters({
+                bucketSource: 'mongodb',
+            }, []);
+
+            const docs = [
+                { _id: 'veeam-bucket', value: { owner: 'acc', capabilities: { VeeamSOSApi: { foo: 'bar' } } } },
+                { _id: 'normal-bucket', value: { owner: 'acc' } },
+            ];
+            let idx = 0;
+            const cursor = {
+                hasNext: () => Promise.resolve(idx < docs.length),
+                next: () => Promise.resolve(docs[idx++]),
+            };
+            const projectStub = sinon.stub().returns(cursor);
+            const findStub = sinon.stub().returns({ project: projectStub });
+
+            lcConductor._mongodbClient = {
+                getIndexingJobs: (_, cb) => cb(null, []),
+                getCollection: name => {
+                    if (name === '__metastore') {return { find: findStub };}
+                    return { collectionName: name };
+                },
+                _isSpecialCollection: () => false,
+            };
+            sinon.stub(lcConductor._zkClient, 'getData').yields(null, null, null);
+
+            lcConductor.listBuckets(queue, fakeLogger, err => {
+                assert.ifError(err);
+                // VeeamSOSApi field must be in the projection so we can read it
+                assert.strictEqual(projectStub.getCall(0).args[0]['value.capabilities.VeeamSOSApi'], 1);
+                const tasks = queue.list();
+                assert.strictEqual(tasks.length, 2);
+                assert.strictEqual(tasks.find(t => t.bucketName === 'veeam-bucket').hasSosApi, true);
+                assert.strictEqual(tasks.find(t => t.bucketName === 'normal-bucket').hasSosApi, false);
                 done();
             });
         });


### PR DESCRIPTION
## Summary

If a bucket has Veeam's SosAPI capability enabled (`bucketInfo.capabilities.VeeamSOSApi`), skip auto-creating the v2 lifecycle indexes and stick with v1.

Veeam manages object cleanup via its own S3 calls rather than S3 lifecycle policies, so the indexes are dead weight on these buckets. Avoiding the build saves disk space and conductor cycles.

## Behavior

- New: SosAPI bucket without indexes → conductor returns v1, no auto-create.
- Existing: SosAPI bucket that already has the v2 indexes → still uses v2 (the indexes are there, no reason to ignore them).
- Non-SosAPI buckets: unchanged.
- New `sosApi` metric tag on `LifecycleMetrics.onLegacyTask` for visibility.

## Implementation

- `listMongodbBuckets` now projects `value.capabilities.VeeamSOSApi` from the metastore and plumbs `hasSosApi` through the task object — zero extra round trips.
- `_indexesGetOrCreate` checks `task.hasSosApi` after the existing-indexes check, returning v1 before the auto-create path.

Full rationale in [BB-778](https://scality.atlassian.net/browse/BB-778).

Issue: BB-778

[BB-778]: https://scality.atlassian.net/browse/BB-778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ