### PR TITLE
feat(lifecycle): emit putBucketIndexesFailed metric on index creation errors

### DIFF
--- a/extensions/lifecycle/conductor/LifecycleConductor.js
+++ b/extensions/lifecycle/conductor/LifecycleConductor.js
@@ -341,6 +341,7 @@ class LifecycleConductor {
                                 bucket: task.bucketName,
                                 error: err,
                             });
+                            LifecycleMetrics.onLegacyTask(log, 'putBucketIndexesFailed');
                         }
                         return cb(null, lifecycleTaskVersions.v1);
                     });

--- a/tests/unit/lifecycle/LifecycleConductor.spec.js
+++ b/tests/unit/lifecycle/LifecycleConductor.spec.js
@@ -7,6 +7,8 @@ const { splitter } = require('arsenal').constants;
 
 const LifecycleConductor = require(
     '../../../extensions/lifecycle/conductor/LifecycleConductor');
+const { LifecycleMetrics } = require(
+    '../../../extensions/lifecycle/LifecycleMetrics');
 const {
     lifecycleTaskVersions,
     indexesForFeature
@@ -509,6 +511,34 @@ describe('Lifecycle Conductor', () => {
                 assert.deepStrictEqual(client.receivedIdxObj, null);
                 assert.deepStrictEqual(conductor.activeIndexingJobs, []);
                 assert.deepStrictEqual(taskVersion, lifecycleTaskVersions.v1);
+                done();
+            });
+        });
+
+        it('should emit putBucketIndexesFailed metric when putBucketIndexes errors', done => {
+            const client = new BackbeatMetadataProxyMock();
+            conductor.clientManager.getBackbeatMetadataProxy = () => client;
+            conductor.activeIndexingJobsRetrieved = true;
+            conductor.activeIndexingJobs = [];
+            conductor._bucketSource = 'mongodb';
+            conductor._mongodbClient = {
+                getDiskUsage: cb => cb(null, { free: 1e12, total: 2e12 }),
+                getCollectionStats: (bucketName, _log, cb) => cb(null, {
+                    indexSizes: { _id_: 1000 },
+                }),
+            };
+            client.indexesObj = [];
+            client.putBucketIndexes = (bucket, indexes, _log, cb) =>
+                cb(new Error('mongo createIndexes failed'));
+
+            const metricsSpy = sinon.spy(LifecycleMetrics, 'onLegacyTask');
+
+            conductor._indexesGetOrCreate(getTask(true), log, (err, taskVersion) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(taskVersion, lifecycleTaskVersions.v1);
+                assert(metricsSpy.calledWith(sinon.match.any, 'putBucketIndexesFailed'),
+                    'expected LifecycleMetrics.onLegacyTask to be called with '
+                    + '\'putBucketIndexesFailed\'');
                 done();
             });
         });


### PR DESCRIPTION
## Summary

Adds a dedicated metric tag (`putBucketIndexesFailed`) when the conductor's `putBucketIndexes` call returns an error. Provides the Prometheus signal that ZENKO-5285's "lifecycle index creation failing repeatedly" alert will hook into.

## Why

Today the error callback at `LifecycleConductor.js:339-345` just logs a warning and falls back to v1. There's no metric for the failure itself — only `putBucketIndexes` is emitted (before the call) which counts attempts. No way to alert on a sustained failure rate.

## Implementation

One-line change in the conductor's error path, plus a unit test that stubs `client.putBucketIndexes` to fail and asserts `LifecycleMetrics.onLegacyTask` is called with the new tag.

The new tag is cause-agnostic — operators can dig into the warn log to find the underlying reason (MongoDB 7.1's `IndexBuildKilledByOutOfDiskSpace`, duplicate-name conflict, transient infra, etc.). A future ticket can map specific Arsenal errors and emit more granular tags if needed.

## Existing tag semantics (unchanged)

- `putBucketIndexes` — counts attempts
- `putBucketIndexesFailed` (NEW) — counts failures
- Ratio = failure rate

## Related

- [BB-783](https://scality.atlassian.net/browse/BB-783) — this ticket
- [ZENKO-5286](https://scality.atlassian.net/browse/ZENKO-5286) — parent ticket that originally tracked the work ("Mongodb index creation error")
- [ZENKO-5285](https://scality.atlassian.net/browse/ZENKO-5285) — alert rule that will use the new metric
- [ARSN-588](https://scality.atlassian.net/browse/ARSN-588) — Arsenal functional test verifying the underlying error catching path ([PR #2634](https://github.com/scality/Arsenal/pull/2634))
- [ARTESCA-17683](https://scality.atlassian.net/browse/ARTESCA-17683) — set `indexBuildMinAvailableDiskSpaceMB=10000` in Artesca ([PR #5228](https://github.com/scality/artesca/pull/5228))
- Parent epic ARTESCA-16740 — Empty bucket feature

Issue: BB-783

[BB-783]: https://scality.atlassian.net/browse/BB-783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ