### PR TITLE
feat(lifecycle): emit putBucketIndexesFailed metric on index creation errors

### DIFF
--- a/extensions/lifecycle/conductor/LifecycleConductor.js
+++ b/extensions/lifecycle/conductor/LifecycleConductor.js
@@ -324,8 +324,6 @@ class LifecycleConductor {
                     return cb(null, lifecycleTaskVersions.v1);
                 }
 
-                LifecycleMetrics.onLegacyTask(log, 'putBucketIndexes');
-
                 this.activeIndexingJobs.push({
                     bucket: task.bucketName,
                     indexes: indexesForFeature.lifecycle.v2,
@@ -342,6 +340,7 @@ class LifecycleConductor {
                                 error: err,
                             });
                         }
+                        LifecycleMetrics.onLegacyTask(log, err ? 'putBucketIndexesFailed' : 'putBucketIndexes');
                         return cb(null, lifecycleTaskVersions.v1);
                     });
             });

--- a/tests/unit/lifecycle/LifecycleConductor.spec.js
+++ b/tests/unit/lifecycle/LifecycleConductor.spec.js
@@ -7,6 +7,8 @@ const { splitter } = require('arsenal').constants;
 
 const LifecycleConductor = require(
     '../../../extensions/lifecycle/conductor/LifecycleConductor');
+const { LifecycleMetrics } = require(
+    '../../../extensions/lifecycle/LifecycleMetrics');
 const {
     lifecycleTaskVersions,
     indexesForFeature,
@@ -528,6 +530,67 @@ describe('Lifecycle Conductor', () => {
                 assert.deepStrictEqual(client.receivedIdxObj, null);
                 assert.deepStrictEqual(conductor.activeIndexingJobs, []);
                 assert.deepStrictEqual(taskVersion, lifecycleTaskVersions.v1);
+                done();
+            });
+        });
+
+        it('should emit putBucketIndexesFailed metric when putBucketIndexes errors', done => {
+            const client = new BackbeatMetadataProxyMock();
+            conductor.clientManager.getBackbeatMetadataProxy = () => client;
+            conductor.activeIndexingJobsRetrieved = true;
+            conductor.activeIndexingJobs = [];
+            conductor._bucketSource = 'mongodb';
+            conductor._mongodbClient = {
+                getDiskUsage: cb => cb(null, { free: 1e12, total: 2e12 }),
+                getCollectionStats: (bucketName, _log, cb) => cb(null, {
+                    indexSizes: { _id_: 1000 },
+                }),
+            };
+            client.indexesObj = [];
+            client.putBucketIndexes = (bucket, indexes, _log, cb) =>
+                cb(new Error('mongo createIndexes failed'));
+
+            const metricsSpy = sinon.spy(LifecycleMetrics, 'onLegacyTask');
+
+            conductor._indexesGetOrCreate(getTask(true), log, (err, taskVersion) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(taskVersion, lifecycleTaskVersions.v1);
+                assert(metricsSpy.calledWith(sinon.match.any, 'putBucketIndexesFailed'),
+                    'expected LifecycleMetrics.onLegacyTask to be called with '
+                    + '\'putBucketIndexesFailed\'');
+                assert(!metricsSpy.calledWith(sinon.match.any, 'putBucketIndexes'),
+                    'expected LifecycleMetrics.onLegacyTask not to be called with '
+                    + '\'putBucketIndexes\' on the failure path');
+                done();
+            });
+        });
+
+        it('should emit putBucketIndexes metric when putBucketIndexes succeeds', done => {
+            const client = new BackbeatMetadataProxyMock();
+            conductor.clientManager.getBackbeatMetadataProxy = () => client;
+            conductor.activeIndexingJobsRetrieved = true;
+            conductor.activeIndexingJobs = [];
+            conductor._bucketSource = 'mongodb';
+            conductor._mongodbClient = {
+                getDiskUsage: cb => cb(null, { free: 1e12, total: 2e12 }),
+                getCollectionStats: (bucketName, _log, cb) => cb(null, {
+                    indexSizes: { _id_: 1000 },
+                }),
+            };
+            client.indexesObj = [];
+            client.putBucketIndexes = (bucket, indexes, _log, cb) => cb(null);
+
+            const metricsSpy = sinon.spy(LifecycleMetrics, 'onLegacyTask');
+
+            conductor._indexesGetOrCreate(getTask(true), log, (err, taskVersion) => {
+                assert.ifError(err);
+                assert.deepStrictEqual(taskVersion, lifecycleTaskVersions.v1);
+                assert(metricsSpy.calledWith(sinon.match.any, 'putBucketIndexes'),
+                    'expected LifecycleMetrics.onLegacyTask to be called with '
+                    + '\'putBucketIndexes\'');
+                assert(!metricsSpy.calledWith(sinon.match.any, 'putBucketIndexesFailed'),
+                    'expected LifecycleMetrics.onLegacyTask not to be called with '
+                    + '\'putBucketIndexesFailed\' on the success path');
                 done();
             });
         });


### PR DESCRIPTION
Replaces [#2750](https://github.com/scality/backbeat/pull/2750) (auto-closed when the branch was renamed from `improvement/ZENKO-5286/...` to `improvement/BB-783/...`).

## Summary

Adds a dedicated metric tag (`putBucketIndexesFailed`) when the conductor's `putBucketIndexes` call returns an error. Provides the Prometheus signal that [BB-784](https://scality.atlassian.net/browse/BB-784)'s Backbeat-side `LifecycleIndexCreationFailed` alert and [ZENKO-5285](https://scality.atlassian.net/browse/ZENKO-5285)'s mongo-side alert will hook into.

## Why

Today the error callback at `LifecycleConductor.js:338-345` just logs a warning and falls back to v1 — no Prometheus signal for the failure. The existing `putBucketIndexes` tag was incremented before the call and therefore counted attempts indistinguishably from successes.

## Implementation

Routes the `LifecycleMetrics.onLegacyTask` call into the callback so the status is set from the outcome:
- success → `putBucketIndexes`
- failure → `putBucketIndexesFailed`

This makes the two statuses mutually exclusive (one increment per task), so `putBucketIndexes + putBucketIndexesFailed = attempts` and `putBucketIndexesFailed / (putBucketIndexes + putBucketIndexesFailed) = failure rate`.

The new tag is cause-agnostic — operators can dig into the warn log to find the underlying reason (MongoDB 7.1's `IndexBuildKilledByOutOfDiskSpace`, duplicate-name conflict, transient infra, etc.). A future ticket can map specific Arsenal errors and emit more granular tags if needed.

Two unit tests cover the routing: success path emits only `putBucketIndexes`, failure path emits only `putBucketIndexesFailed`.

## Related

- [BB-783](https://scality.atlassian.net/browse/BB-783) — this ticket
- [BB-784](https://scality.atlassian.net/browse/BB-784) — Backbeat-side Prometheus alert wired to this metric ([PR #2753](https://github.com/scality/backbeat/pull/2753))
- [ZENKO-5286](https://scality.atlassian.net/browse/ZENKO-5286) — parent ticket that originally tracked the work (\"Mongodb index creation error\")
- [ZENKO-5285](https://scality.atlassian.net/browse/ZENKO-5285) — mongo-side alert rule ([Zenko PR #2431](https://github.com/scality/Zenko/pull/2431))
- [ARSN-588](https://scality.atlassian.net/browse/ARSN-588) — Arsenal functional test verifying the underlying error catching path ([PR #2634](https://github.com/scality/Arsenal/pull/2634))
- [ARTESCA-17683](https://scality.atlassian.net/browse/ARTESCA-17683) — set \`indexBuildMinAvailableDiskSpaceMB=10000\` in Artesca ([PR #5228](https://github.com/scality/artesca/pull/5228))
- Parent epic ARTESCA-16740 — Empty bucket feature

Issue: BB-783

[BB-784]: https://scality.atlassian.net/browse/BB-784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ZENKO-5285]: https://scality.atlassian.net/browse/ZENKO-5285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BB-783]: https://scality.atlassian.net/browse/BB-783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ