### PR TITLE
BB-782: Fix bootstrap consumer stealing messages

### DIFF
--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -349,13 +349,11 @@ class ReplicationStatusProcessor {
     /**
      * Start kafka consumer
      *
-     * @param {object} [options] - options object (only used for tests
-     * for now)
      * @param {function} [cb] - optional callback called when startup
      * is complete
      * @return {undefined}
      */
-    start(options, cb) {
+    start(cb) {
         async.parallel([
             done => {
                 this._failedCRRProducer = new FailedCRRProducer(this.kafkaConfig);
@@ -398,7 +396,6 @@ class ReplicationStatusProcessor {
                     concurrency:
                     this.repConfig.replicationStatusProcessor.concurrency,
                     queueProcessor: this.processKafkaEntry.bind(this),
-                    bootstrap: (options && options.bootstrap) || false,
                 });
                 this._consumer.on('error', () => {
                     if (!consumerReady) {

--- a/extensions/replication/replicationStatusProcessor/task.js
+++ b/extensions/replication/replicationStatusProcessor/task.js
@@ -35,7 +35,7 @@ function initAndStart() {
             setTimeout(initAndStart, 5000);
             return;
         }
-        replicationStatusProcessor.start(null, startProbeServer(
+        replicationStatusProcessor.start(startProbeServer(
             repConfig.replicationStatusProcessor.probeServer,
             (err, probeServer) => {
                 if (err) {

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -837,7 +837,24 @@ class BackbeatConsumer extends EventEmitter {
      * @return {boolean} true if paused
      */
     isPaused() {
-        return this._consumer.subscription().length === 0;
+        try {
+            return this._consumer.subscription().length === 0;
+        } catch (err) {
+            // subscription() throws "Erroneous state" if the consumer is
+            // disconnected/closing; such a consumer is not actively consuming,
+            // so report it as paused. Callers (the consume loop, offsetsStore)
+            // already rely on isPaused() to skip operations that would
+            // otherwise throw on an invalid consumer state. Logged at debug
+            // because this is an expected transient during teardown and would
+            // otherwise flood logs on every shutdown.
+            this._log.debug('could not read consumer subscription, treating ' +
+                'consumer as paused', {
+                error: err.message,
+                topic: this._topic,
+                groupId: this._groupId,
+            });
+            return true;
+        }
     }
 
     /**

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -130,7 +130,6 @@ class BackbeatConsumer extends EventEmitter {
         this._nConsumePendingRequests = 0;
         this._consumer = null;
         this._consumerReady = false;
-        this._readyEmitted = false;
         this._kafkaBacklogMetrics = null;
         this._kafkaBacklogMetricsReady = false;
         this._publishOffsetsCronTimer = null;
@@ -255,13 +254,6 @@ class BackbeatConsumer extends EventEmitter {
     }
 
     _onReady() {
-        // _checkIfReady can fire more than once (consumer-ready, metrics-ready
-        // and the nextTick check all call it), so guard against emitting
-        // 'ready' — and starting the offsets cron — more than once.
-        if (this._readyEmitted) {
-            return;
-        }
-        this._readyEmitted = true;
         this.emit('ready');
 
         this._circuitBreaker.start();
@@ -938,12 +930,6 @@ class BackbeatConsumer extends EventEmitter {
             clearInterval(this._publishOffsetsCronTimer);
             this._publishOffsetsCronTimer = null;
         }
-        // Cancel any pending consume loop so it does not fire against a
-        // consumer that is being torn down (which throws "Erroneous state").
-        if (this._tryConsumedTimeout) {
-            clearTimeout(this._tryConsumedTimeout);
-            this._tryConsumedTimeout = null;
-        }
         if (this._publishOffsetsCronActive) {
             return setTimeout(() => this.close(cb), 1000);
         }
@@ -952,20 +938,14 @@ class BackbeatConsumer extends EventEmitter {
             next => {
                 if (this._consumer?.isConnected()) {
                     const subscription = this._consumer.subscription() || [];
-                    const assignments = this._consumer.assignments() || [];
                     if (subscription.length > 0) {
                         this._consumer.unsubscribe();
                         // Wait for partition unassign to complete before
                         // disconnecting, the rebalance callback will handle
                         // waiting for current jobs to complete as well as commit
-                        // the latest offsets. Only wait when partitions are
-                        // actually assigned: closing a consumer that subscribed
-                        // but was never assigned emits no revoke, so waiting for
-                        // 'unassign' would hang forever.
-                        if (assignments.length > 0) {
-                            this.once('unassign', () => next());
-                            return;
-                        }
+                        // the latest offsets
+                        this.once('unassign', () => next());
+                        return;
                     }
                 }
                 process.nextTick(next);

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -826,7 +826,16 @@ class BackbeatConsumer extends EventEmitter {
         let producer; // eslint-disable-line prefer-const
         let producerTimer;
         let consumerTimer;
+        // Run at most one consume request at a time, like the regular
+        // consume loop does with its _nConsumePendingRequests gate. A
+        // request can wait up to a second inside the kafka client before
+        // returning, so firing one every 200ms piles up requests that
+        // outlive bootstrap. A leftover request would then grab the first
+        // real messages produced after bootstrap, and this callback would
+        // drop them (BB-782).
+        let consumePending = false;
         function consumeCb(err, messages) {
+            consumePending = false;
             if (err) {
                 return undefined;
             }
@@ -853,6 +862,14 @@ class BackbeatConsumer extends EventEmitter {
                             self._onReady();
                         });
                     }
+                } else {
+                    self._log.warn('bootstrap consumer received an ' +
+                        'unexpected non-bootstrap message, dropping it', {
+                        topic: message.topic,
+                        partition: message.partition,
+                        offset: message.offset,
+                        groupId: self._groupId,
+                    });
                 }
             });
             return undefined;
@@ -881,7 +898,10 @@ class BackbeatConsumer extends EventEmitter {
                         this._consumer.on('ready', () => {
                             this._consumer.subscribe([this._topic]);
                             consumerTimer = setInterval(() => {
-                                this._consumer.consume(1, consumeCb);
+                                if (!consumePending) {
+                                    consumePending = true;
+                                    this._consumer.consume(1, consumeCb);
+                                }
                             }, 200);
                         });
                     }, 500);

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -1,6 +1,5 @@
 const { EventEmitter } = require('events');
 const kafka = require('node-rdkafka');
-const assert = require('assert');
 const async = require('async');
 const joi = require('joi');
 const jsutil = require('arsenal').jsutil;
@@ -66,9 +65,6 @@ class BackbeatConsumer extends EventEmitter {
      * @param {boolean} [config.canary=false] - true to send a canary
      * message to bootstrap partition offsets (useful for pause/resume
      * functionality to work)
-     * @param {boolean} [config.bootstrap=false] - TEST ONLY: true to
-     * bootstrap the consumer with test messages until it starts
-     * consuming them
      */
     constructor(config) {
         super();
@@ -97,7 +93,6 @@ class BackbeatConsumer extends EventEmitter {
             concurrency: joi.number().greater(0).default(CONCURRENCY_DEFAULT),
             fetchMaxBytes: joi.number(),
             canary: joi.boolean().default(false),
-            bootstrap: joi.boolean().default(false),
             circuitBreaker: joi.object().optional(),
             circuitBreakerMetrics: joi.object({
                 type: joi.string().required(),
@@ -108,7 +103,7 @@ class BackbeatConsumer extends EventEmitter {
 
         const { clientId, zookeeper, kafka, topic, groupId, queueProcessor,
                 fromOffset, concurrency, fetchMaxBytes,
-                canary, bootstrap, circuitBreaker, circuitBreakerMetrics } = validConfig;
+                canary, circuitBreaker, circuitBreakerMetrics } = validConfig;
 
         this._zookeeperEndpoint = zookeeper && zookeeper.connectionString;
         this._kafkaHosts = kafka.hosts;
@@ -125,7 +120,6 @@ class BackbeatConsumer extends EventEmitter {
         this._concurrency = concurrency;
         this._fetchMaxBytes = fetchMaxBytes;
         this._canary = canary;
-        this._bootstrap = bootstrap;
         this._offsetLedger = new OffsetLedger();
 
         this._processingQueue = null;
@@ -136,7 +130,6 @@ class BackbeatConsumer extends EventEmitter {
         this._nConsumePendingRequests = 0;
         this._consumer = null;
         this._consumerReady = false;
-        this._bootstrapping = false;
         this._kafkaBacklogMetrics = null;
         this._kafkaBacklogMetricsReady = false;
         this._publishOffsetsCronTimer = null;
@@ -161,11 +154,7 @@ class BackbeatConsumer extends EventEmitter {
     }
 
     _init() {
-        if (this._bootstrap) {
-            this._consumerReady = true;
-        } else {
-            this._initConsumer();
-        }
+        this._initConsumer();
         if (this._kafkaBacklogMetricsConfig) {
             this._initKafkaBacklogMetrics();
         } else {
@@ -260,13 +249,7 @@ class BackbeatConsumer extends EventEmitter {
 
     _checkIfReady() {
         if (this._consumerReady && this._kafkaBacklogMetricsReady) {
-            if (this._bootstrap) {
-                if (!this._bootstrapping) {
-                    this._bootstrapConsumer();
-                }
-            } else {
-                this._onReady();
-            }
+            this._onReady();
         }
     }
 
@@ -296,14 +279,10 @@ class BackbeatConsumer extends EventEmitter {
             kMetrics = true;
         }
 
-        if (this._bootstrap) {
-            cs = true;
-        } else {
-            cs = this._consumer && this._consumer.isConnected();
-            if (!cs) {
-                this._log.error('KafkaConsumer is not connected',
-                    { topic: this._topic, groupId: this._groupId });
-            }
+        cs = this._consumer && this._consumer.isConnected();
+        if (!cs) {
+            this._log.error('KafkaConsumer is not connected',
+                { topic: this._topic, groupId: this._groupId });
         }
         return kMetrics && cs;
     }
@@ -812,102 +791,6 @@ class BackbeatConsumer extends EventEmitter {
      */
     getMetadata(params, cb) {
         this._consumer.getMetadata(params, cb);
-    }
-
-    /**
-     * Bootstrap consumer by periodically sending bootstrap messages
-     * and wait until it's receiving newly produced messages in a
-     * timely fashion.
-     * @return {undefined}
-     */
-    _bootstrapConsumer() {
-        const self = this;
-        let lastBootstrapId;
-        let producer; // eslint-disable-line prefer-const
-        let producerTimer;
-        let consumerTimer;
-        // Run at most one consume request at a time, like the regular
-        // consume loop does with its _nConsumePendingRequests gate. A
-        // request can wait up to a second inside the kafka client before
-        // returning, so firing one every 200ms piles up requests that
-        // outlive bootstrap. A leftover request would then grab the first
-        // real messages produced after bootstrap, and this callback would
-        // drop them (BB-782).
-        let consumePending = false;
-        function consumeCb(err, messages) {
-            consumePending = false;
-            if (err) {
-                return undefined;
-            }
-            messages.forEach(message => {
-                const bootstrapId = JSON.parse(message.value).bootstrapId;
-                if (bootstrapId) {
-                    self._log.info('bootstraping backbeat consumer: ' +
-                        'received bootstrap message',
-                        { bootstrapId, topic: self._topic, groupId: self._groupId });
-                    if (bootstrapId === lastBootstrapId) {
-                        self._log.info('backbeat consumer is bootstrapped',
-                            { topic: self._topic, groupId: self._groupId });
-                        clearInterval(producerTimer);
-                        clearInterval(consumerTimer);
-                        self._consumer.offsetsStore([{
-                            topic: self._topic,
-                            partition: message.partition,
-                            offset: message.offset + 1,
-                        }]);
-                        self._consumer.commit();
-                        self._consumer.unsubscribe();
-                        producer.close(() => {
-                            self._bootstrapping = false;
-                            self._onReady();
-                        });
-                    }
-                } else {
-                    self._log.warn('bootstrap consumer received an ' +
-                        'unexpected non-bootstrap message, dropping it', {
-                        topic: message.topic,
-                        partition: message.partition,
-                        offset: message.offset,
-                        groupId: self._groupId,
-                    });
-                }
-            });
-            return undefined;
-        }
-        assert.strictEqual(this._consumer, null);
-        producer = new BackbeatProducer({
-            kafka: { hosts: this._kafkaHosts },
-            compressionType: this._producerCompressionType,
-            requiredAcks: this._producerRequiredAcks,
-            topic: this._topic,
-        });
-        producer.on('ready', () => {
-            producerTimer = setInterval(() => {
-                lastBootstrapId = `${Math.round(Math.random() * 1000000)}`;
-                const contents = `{"bootstrapId":"${lastBootstrapId}"}`;
-                this._log.info('bootstraping backbeat consumer: ' +
-                    'sending bootstrap message',
-                    { contents, topic: this._topic, groupId: this._groupId });
-                producer.send([{ key: 'bootstrap',
-                                 message: contents }],
-                              () => {});
-                if (!this._consumer) {
-                    setTimeout(() => {
-                        this._bootstrapping = true;
-                        this._initConsumer();
-                        this._consumer.on('ready', () => {
-                            this._consumer.subscribe([this._topic]);
-                            consumerTimer = setInterval(() => {
-                                if (!consumePending) {
-                                    consumePending = true;
-                                    this._consumer.consume(1, consumeCb);
-                                }
-                            }, 200);
-                        });
-                    }, 500);
-                }
-            }, 5000);
-        });
     }
 
     /**

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -130,6 +130,7 @@ class BackbeatConsumer extends EventEmitter {
         this._nConsumePendingRequests = 0;
         this._consumer = null;
         this._consumerReady = false;
+        this._readyEmitted = false;
         this._kafkaBacklogMetrics = null;
         this._kafkaBacklogMetricsReady = false;
         this._publishOffsetsCronTimer = null;
@@ -254,6 +255,13 @@ class BackbeatConsumer extends EventEmitter {
     }
 
     _onReady() {
+        // _checkIfReady can fire more than once (consumer-ready, metrics-ready
+        // and the nextTick check all call it), so guard against emitting
+        // 'ready' — and starting the offsets cron — more than once.
+        if (this._readyEmitted) {
+            return;
+        }
+        this._readyEmitted = true;
         this.emit('ready');
 
         this._circuitBreaker.start();
@@ -930,6 +938,12 @@ class BackbeatConsumer extends EventEmitter {
             clearInterval(this._publishOffsetsCronTimer);
             this._publishOffsetsCronTimer = null;
         }
+        // Cancel any pending consume loop so it does not fire against a
+        // consumer that is being torn down (which throws "Erroneous state").
+        if (this._tryConsumedTimeout) {
+            clearTimeout(this._tryConsumedTimeout);
+            this._tryConsumedTimeout = null;
+        }
         if (this._publishOffsetsCronActive) {
             return setTimeout(() => this.close(cb), 1000);
         }
@@ -938,14 +952,20 @@ class BackbeatConsumer extends EventEmitter {
             next => {
                 if (this._consumer?.isConnected()) {
                     const subscription = this._consumer.subscription() || [];
+                    const assignments = this._consumer.assignments() || [];
                     if (subscription.length > 0) {
                         this._consumer.unsubscribe();
                         // Wait for partition unassign to complete before
                         // disconnecting, the rebalance callback will handle
                         // waiting for current jobs to complete as well as commit
-                        // the latest offsets
-                        this.once('unassign', () => next());
-                        return;
+                        // the latest offsets. Only wait when partitions are
+                        // actually assigned: closing a consumer that subscribed
+                        // but was never assigned emits no revoke, so waiting for
+                        // 'unassign' would hang forever.
+                        if (assignments.length > 0) {
+                            this.once('unassign', () => next());
+                            return;
+                        }
                     }
                 }
                 process.nextTick(next);

--- a/lib/models/ActionQueueEntry.js
+++ b/lib/models/ActionQueueEntry.js
@@ -72,9 +72,6 @@ class ActionQueueEntry {
     static createFromKafkaEntry(kafkaEntry) {
         try {
             const record = JSON.parse(kafkaEntry.value);
-            if (record.bootstrapId) {
-                return { error: 'bootstrap entry' };
-            }
             if (record.canary) {
                 return { skip: 'skip canary entry' };
             }

--- a/lib/models/QueueEntry.js
+++ b/lib/models/QueueEntry.js
@@ -19,9 +19,6 @@ class QueueEntry {
     static createFromKafkaEntry(kafkaEntry) {
         try {
             const record = JSON.parse(kafkaEntry.value);
-            if (record.bootstrapId) {
-                return { error: 'bootstrap entry' };
-            }
             if (record.canary) {
                 return { skip: 'skip canary entry' };
             }

--- a/tests/functional/lib/BackbeatConsumer.js
+++ b/tests/functional/lib/BackbeatConsumer.js
@@ -795,12 +795,17 @@ describe('BackbeatConsumer with circuit breaker', () => {
 });
 
 describe('BackbeatConsumer shutdown tests', () => {
-    const topic = uniqueTopic('backbeat-consumer-spec-shutdown');
-    const groupId = `bucket-processor-${Math.random()}`;
+    // Each test gets a fresh topic + group so its consumer is the sole group
+    // member and is assigned its partition immediately. With a shared group,
+    // each new consumer would wait out the previous (closed) member's session
+    // before the single partition is reassigned, which can exceed the hook
+    // timeout (the assignment wait below).
     const messages = [
         { key: 'm1', message: '{"value":"1"}' },
         { key: 'm2', message: '{"value":"2"}' },
     ];
+    let topic;
+    let groupId;
     let zookeeper;
     let producer;
     let consumer;
@@ -813,22 +818,19 @@ describe('BackbeatConsumer shutdown tests', () => {
 
     before(function before(done) {
         this.timeout(60000);
+        zookeeper = new ZookeeperManager(zookeeperConf.connectionString, null, log);
+        zookeeper.on('ready', done);
+    });
+
+    beforeEach(function beforeEach(done) {
+        this.timeout(60000);
+        topic = uniqueTopic('backbeat-consumer-spec-shutdown');
+        groupId = `bucket-processor-${Math.random()}`;
         producer = new BackbeatProducer({
             topic,
             kafka: producerKafkaConf,
             pollIntervalMs: 100,
         });
-        async.parallel([
-            innerDone => producer.on('ready', innerDone),
-            innerDone => {
-                zookeeper = new ZookeeperManager(zookeeperConf.connectionString, null, log);
-                zookeeper.on('ready', innerDone);
-            },
-        ], done);
-    });
-
-    beforeEach(function beforeEach(done) {
-        this.timeout(60000);
         consumer = new BackbeatConsumer({
             zookeeper: zookeeperConf,
             kafka: {
@@ -841,28 +843,27 @@ describe('BackbeatConsumer shutdown tests', () => {
             fromOffset: 'earliest',
             concurrency: 2,
         });
-        consumer.once('ready', () => {
-            consumer.subscribe();
-            // wait until partitions are assigned so close()/disconnect in the
-            // tests below act on a fully-joined consumer (bootstrap used to
-            // guarantee this before emitting 'ready')
-            waitForAssignment(consumer, done);
-        });
+        async.parallel([
+            innerDone => producer.on('ready', innerDone),
+            innerDone => consumer.once('ready', () => {
+                consumer.subscribe();
+                // wait until partitions are assigned so close()/disconnect in
+                // the tests below act on a fully-joined consumer (bootstrap
+                // used to guarantee this before emitting 'ready')
+                waitForAssignment(consumer, innerDone);
+            }),
+        ], done);
     });
 
-    afterEach(() => {
+    afterEach(done => {
         consumer.removeAllListeners('consumed');
+        producer.close(done);
     });
 
     after(function after(done) {
         this.timeout(10000);
-        async.parallel([
-            innerDone => producer.close(innerDone),
-            innerDone => {
-                zookeeper.close();
-                innerDone();
-            },
-        ], done);
+        zookeeper.close();
+        done();
     });
 
     it('should stop consuming and wait for current jobs to end before shutting down', done => {

--- a/tests/functional/lib/BackbeatConsumer.js
+++ b/tests/functional/lib/BackbeatConsumer.js
@@ -79,10 +79,7 @@ describe('BackbeatConsumer main tests', () => {
 
     it('should be able to read messages sent to the topic and publish ' +
     'topic metrics', done => {
-        let consumeCb = null;
         let totalConsumed = 0;
-        let topicOffset;
-        let consumerOffset;
         const zkMetricsPath = `/test/kafka-backlog-metrics/${topic}/0`;
         const latestConsumedMetric = metrics.ZenkoMetrics.getMetric(
             promMetricNames.latestConsumedMessageTimestamp);
@@ -90,20 +87,35 @@ describe('BackbeatConsumer main tests', () => {
         // reset to 0 before the test
         latestConsumedMetric.reset();
 
-        function _checkZkMetrics(done) {
-            async.waterfall([
-                next => zookeeper.getData(`${zkMetricsPath}/topic`, next),
-                (topicOffsetData, stat, next) => {
-                    topicOffset = Number.parseInt(topicOffsetData, 10);
-                    zookeeper.getData(`${zkMetricsPath}/consumers/${groupId}`,
-                                      next);
-                },
-            ], (err, consumerOffsetData) => {
-                assert.ifError(err);
-                consumerOffset = Number.parseInt(consumerOffsetData, 10);
-                assert.strictEqual(topicOffset, consumerOffset);
-                done();
-            });
+        // Offsets are published to zookeeper every second (intervalS: 1)
+        // once the consumer offsets get committed, so poll until the
+        // published offsets match instead of sleeping a fixed delay. The
+        // 2-second cap per attempt turns a zookeeper read stuck on a
+        // stale connection into a retry instead of a silent test timeout.
+        function _checkZkMetrics(cb) {
+            async.retry(
+                { times: 10, interval: 1000 },
+                async.timeout(attemptDone => async.waterfall([
+                    next => zookeeper.getData(`${zkMetricsPath}/topic`, next),
+                    (topicOffsetData, stat, next) => zookeeper.getData(
+                        `${zkMetricsPath}/consumers/${groupId}`,
+                        (err, consumerOffsetData) => next(
+                            err, topicOffsetData, consumerOffsetData)),
+                ], (err, topicOffsetData, consumerOffsetData) => {
+                    if (err) {
+                        return attemptDone(err);
+                    }
+                    const topicOffset = Number.parseInt(topicOffsetData, 10);
+                    const consumerOffset =
+                          Number.parseInt(consumerOffsetData, 10);
+                    if (topicOffset !== consumerOffset) {
+                        return attemptDone(new Error(
+                            'offsets not in sync yet: ' +
+                            `topic=${topicOffset} consumer=${consumerOffset}`));
+                    }
+                    return attemptDone();
+                }), 2000),
+                cb);
         }
         async function _checkPromMetrics() {
             const latestConsumedMetricValues =
@@ -119,23 +131,16 @@ describe('BackbeatConsumer main tests', () => {
                 assert.deepStrictEqual(
                     messages.map(e => e.message),
                     consumedMessages.map(buffer => buffer.toString()));
-                // metrics are published every second, so they
-                // should be there after 5s
-                setTimeout(() => {
-                    _checkZkMetrics(() => {
-                        consumeCb();
-                        consumer._consumer.unsubscribe();
-                    });
-                }, 5000);
-                assert.deepStrictEqual(
-                    messages.map(e => e.message),
-                    consumedMessages.map(buffer => buffer.toString()));
                 // Prometheus metrics are updated locally in memory so
                 // immediately visible
-                _checkPromMetrics();
+                _checkPromMetrics()
+                    .then(() => _checkZkMetrics(err => {
+                        consumer._consumer.unsubscribe();
+                        done(err);
+                    }))
+                    .catch(done);
             }
         });
-        consumeCb = done;
         producer.send(messages, err => {
             assert.ifError(err);
         });

--- a/tests/functional/lib/BackbeatConsumer.js
+++ b/tests/functional/lib/BackbeatConsumer.js
@@ -23,8 +23,18 @@ const consumerKafkaConf = {
 };
 const log = new werelogs.Logger('BackbeatConsumer:test');
 
+// These suites create consumers with `fromOffset: 'earliest'` and a
+// throwaway per-run topic. Reading from the start of an empty topic
+// guarantees every produced message is consumed regardless of when the
+// consumer joins the group, so no readiness dance is needed. The random
+// suffix keeps each run isolated: a fresh group reading `earliest` on a
+// reused topic would otherwise replay messages from previous runs.
+function uniqueTopic(name) {
+    return `${name}-${Math.random().toString(36).slice(2)}`;
+}
+
 describe('BackbeatConsumer main tests', () => {
-    const topic = 'backbeat-consumer-spec';
+    const topic = uniqueTopic('backbeat-consumer-spec');
     const groupId = `replication-group-${Math.random()}`;
     const messages = [
         { key: 'foo', message: '{"hello":"foo"}' },
@@ -50,7 +60,7 @@ describe('BackbeatConsumer main tests', () => {
             zookeeper: zookeeperConf,
             kafka: consumerKafkaConf, groupId, topic,
             queueProcessor,
-            bootstrap: true,
+            fromOffset: 'earliest',
         });
         async.parallel([
             innerDone => producer.on('ready', innerDone),
@@ -209,7 +219,7 @@ describe('BackbeatConsumer main tests', () => {
 });
 
 describe('BackbeatConsumer rebalance tests', () => {
-    const topic = 'backbeat-consumer-spec-rebalance';
+    const topic = uniqueTopic('backbeat-consumer-spec-rebalance');
     const groupId = `replication-group-${Math.random()}`;
     const messages = [
         { key: 'foo', message: '{"hello":"foo"}' },
@@ -254,19 +264,6 @@ describe('BackbeatConsumer rebalance tests', () => {
         }, consumedMessages++ ? 4000 : 2000);
     }
 
-    before(function before(done) {
-        this.timeout(60000);
-
-        // Bootstrap just once at the beginning of the test suite
-        const bootstrapConsumer = new BackbeatConsumer({
-            zookeeper: zookeeperConf,
-            kafka: { hosts: consumerKafkaConf.hosts }, groupId, topic,
-            queueProcessor,
-            bootstrap: true,
-        });
-        bootstrapConsumer.on('ready', () => bootstrapConsumer.close(done));
-    });
-
     beforeEach(function before(done) {
         this.timeout(60000);
 
@@ -283,6 +280,7 @@ describe('BackbeatConsumer rebalance tests', () => {
             groupId, topic,
             queueProcessor,
             concurrency: 2,
+            fromOffset: 'earliest',
         });
 
         async.parallel([
@@ -295,6 +293,7 @@ describe('BackbeatConsumer rebalance tests', () => {
                         zookeeper: zookeeperConf,
                         kafka: consumerKafkaConf, groupId, topic,
                         queueProcessor,
+                        fromOffset: 'earliest',
                     });
                     consumer2.on('ready', cb);
                 },
@@ -385,7 +384,7 @@ describe('BackbeatConsumer rebalance tests', () => {
 });
 
 describe('BackbeatConsumer concurrency tests', () => {
-    const topicConc = 'backbeat-consumer-spec-conc-1000';
+    const topicConc = uniqueTopic('backbeat-consumer-spec-conc-1000');
     const groupIdConc = `replication-group-conc-${Math.random()}`;
     let producer;
     let consumer;
@@ -413,7 +412,7 @@ describe('BackbeatConsumer concurrency tests', () => {
             kafka: consumerKafkaConf, groupId: groupIdConc, topic: topicConc,
             queueProcessor,
             concurrency: 10,
-            bootstrap: true,
+            fromOffset: 'earliest',
         });
         async.parallel([
             innerDone => producer.on('ready', innerDone),
@@ -520,7 +519,7 @@ describe('BackbeatConsumer concurrency tests', () => {
 });
 
 describe('BackbeatConsumer "deferred committable" tests', () => {
-    const topicConc = 'backbeat-consumer-spec-deferred';
+    const topicConc = uniqueTopic('backbeat-consumer-spec-deferred');
     const groupIdConc = `replication-group-deferred-${Math.random()}`;
     let producer;
     let consumer;
@@ -550,7 +549,7 @@ describe('BackbeatConsumer "deferred committable" tests', () => {
             kafka: consumerKafkaConf, groupId: groupIdConc, topic: topicConc,
             queueProcessor,
             concurrency: 10,
-            bootstrap: true,
+            fromOffset: 'earliest',
         });
         async.parallel([
             innerDone => producer.on('ready', innerDone),
@@ -604,7 +603,10 @@ describe('BackbeatConsumer "deferred committable" tests', () => {
 });
 
 describe('BackbeatConsumer with circuit breaker', () => {
-    const topicBreaker = 'backbeat-consumer-spec-breaker';
+    // groupId is regenerated per test, so the topic is too: a fresh group
+    // reading `earliest` on a shared topic would replay earlier tests'
+    // messages.
+    let topicBreaker;
     let groupIdBreaker;
     let producer;
     let consumer;
@@ -619,6 +621,7 @@ describe('BackbeatConsumer with circuit breaker', () => {
         this.timeout(120000);
 
         groupIdBreaker = `replication-group-breaker-${Math.random()}`;
+        topicBreaker = uniqueTopic('backbeat-consumer-spec-breaker');
 
         producer = new BackbeatProducer({
             kafka: producerKafkaConf,
@@ -630,7 +633,7 @@ describe('BackbeatConsumer with circuit breaker', () => {
             kafka: consumerKafkaConf, groupId: groupIdBreaker, topic: topicBreaker,
             queueProcessor,
             concurrency: 10,
-            bootstrap: true,
+            fromOffset: 'earliest',
             circuitBreaker: this.currentTest.breakerConf,
         });
         async.parallel([
@@ -779,7 +782,7 @@ describe('BackbeatConsumer with circuit breaker', () => {
 });
 
 describe('BackbeatConsumer shutdown tests', () => {
-    const topic = 'backbeat-consumer-spec-shutdown';
+    const topic = uniqueTopic('backbeat-consumer-spec-shutdown');
     const groupId = `bucket-processor-${Math.random()}`;
     const messages = [
         { key: 'm1', message: '{"value":"1"}' },
@@ -822,7 +825,7 @@ describe('BackbeatConsumer shutdown tests', () => {
             queueProcessor,
             groupId,
             topic,
-            bootstrap: true,
+            fromOffset: 'earliest',
             concurrency: 2,
         });
         consumer.on('ready', () => {

--- a/tests/functional/lib/BackbeatConsumer.js
+++ b/tests/functional/lib/BackbeatConsumer.js
@@ -33,6 +33,19 @@ function uniqueTopic(name) {
     return `${name}-${Math.random().toString(36).slice(2)}`;
 }
 
+// Wait until the broker has assigned partitions to the consumer. Bootstrap
+// used to guarantee a fully-joined, assigned consumer before `ready`; without
+// it `ready` fires on connect, so tests that close/disconnect right away would
+// otherwise act on an unassigned consumer. Bounded by the mocha hook timeout.
+function waitForAssignment(consumer, cb) {
+    const interval = setInterval(() => {
+        if (consumer._consumer.assignments().length !== 0) {
+            clearInterval(interval);
+            cb();
+        }
+    }, 1000);
+}
+
 describe('BackbeatConsumer main tests', () => {
     const topic = uniqueTopic('backbeat-consumer-spec');
     const groupId = `replication-group-${Math.random()}`;
@@ -828,9 +841,12 @@ describe('BackbeatConsumer shutdown tests', () => {
             fromOffset: 'earliest',
             concurrency: 2,
         });
-        consumer.on('ready', () => {
+        consumer.once('ready', () => {
             consumer.subscribe();
-            done();
+            // wait until partitions are assigned so close()/disconnect in the
+            // tests below act on a fully-joined consumer (bootstrap used to
+            // guarantee this before emitting 'ready')
+            waitForAssignment(consumer, done);
         });
     });
 
@@ -910,7 +926,7 @@ describe('BackbeatConsumer shutdown tests', () => {
         async.series([
             next => {
                 consumer._consumer.disconnect();
-                consumer._consumer.on('disconnected', () => next());
+                consumer._consumer.once('disconnected', () => next());
             },
             next => consumer.close(next),
         ], done);

--- a/tests/functional/lib/KafkaBacklogMetrics.spec.js
+++ b/tests/functional/lib/KafkaBacklogMetrics.spec.js
@@ -70,7 +70,7 @@ describe('KafkaBacklogMetrics class', function kafkaBacklogMetrics() {
                     topic: TOPIC,
                     groupId: GROUP_ID,
                 });
-                consumer.on('ready', next);
+                consumer.once('ready', next);
             },
             next => {
                 consumer.subscribe();

--- a/tests/functional/lifecycle/LifecycleConductor.spec.js
+++ b/tests/functional/lifecycle/LifecycleConductor.spec.js
@@ -192,7 +192,8 @@ describe('lifecycle conductor', function lifecycleConductor() {
                 },
             };
 
-            // make topic unique so that different tests' bootstrap messages don't interfere
+            // make topic unique so a fresh consumer reading from 'earliest'
+            // does not replay messages produced by other tests
             lcConfig.bucketTasksTopic += Math.random();
 
             const localKafkaConfig = {
@@ -295,7 +296,8 @@ describe('lifecycle conductor', function lifecycleConductor() {
                 },
             };
 
-            // make topic unique so that different tests' bootstrap messages don't interfere
+            // make topic unique so a fresh consumer reading from 'earliest'
+            // does not replay messages produced by other tests
             lcConfig.bucketTasksTopic += Math.random();
 
             const localKafkaConfig = {

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -848,7 +848,7 @@ describe('queue processor functional tests with mocking', () => {
                         },
                         {},
                         { topic: 'metrics-test-topic' });
-                    replicationStatusProcessor.start({ bootstrap: true }, done);
+                    replicationStatusProcessor.start(done);
                 },
                 done => {
                     copyLocationResultsConsumer = new BackbeatConsumer({
@@ -861,7 +861,7 @@ describe('queue processor functional tests with mocking', () => {
                         kafka: {
                             hosts: 'localhost:9092',
                         },
-                        bootstrap: true,
+                        fromOffset: 'earliest',
                     });
                     copyLocationResultsConsumer.on('ready', done);
                 },
@@ -1559,7 +1559,7 @@ describe('GC should be created if config is provided', () => {
             {},
             { topic: 'metrics-test-topic' },
             { topic: 'backbeat-gc' });
-        replicationStatusProcessor.start({ bootstrap: true }, () => {
+        replicationStatusProcessor.start(() => {
             assert(replicationStatusProcessor.getStateVars().gcProducer);
             replicationStatusProcessor.stop(done);
         });
@@ -1589,7 +1589,7 @@ describe('GC should be created if config is provided', () => {
             },
             {},
             { topic: 'metrics-test-topic' });
-        replicationStatusProcessor.start({ bootstrap: true }, () => {
+        replicationStatusProcessor.start(() => {
             assert.strictEqual(replicationStatusProcessor.getStateVars().gcProducer, null);
             replicationStatusProcessor.stop(done);
         });

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -1534,6 +1534,21 @@ describe('queue processor functional tests with mocking', () => {
 });
 
 describe('GC should be created if config is provided', () => {
+    // Wait until the processor's consumer has partitions assigned before
+    // stopping it: close() waits for the revoke ('unassign') rebalance, which
+    // never fires if the consumer subscribed but was never assigned, so an
+    // immediate stop() would hang. Bootstrap used to guarantee assignment
+    // before start()'s callback fired.
+    function waitForProcessorAssignment(processor, cb) {
+        const interval = setInterval(() => {
+            const consumer = processor._consumer && processor._consumer._consumer;
+            if (consumer && consumer.assignments().length !== 0) {
+                clearInterval(interval);
+                cb();
+            }
+        }, 1000);
+    }
+
     it('should create a GC if config is provided', function (done) {
         this.timeout(60000);
         const replicationStatusProcessor = new ReplicationStatusProcessor(
@@ -1561,7 +1576,8 @@ describe('GC should be created if config is provided', () => {
             { topic: 'backbeat-gc' });
         replicationStatusProcessor.start(() => {
             assert(replicationStatusProcessor.getStateVars().gcProducer);
-            replicationStatusProcessor.stop(done);
+            waitForProcessorAssignment(replicationStatusProcessor,
+                () => replicationStatusProcessor.stop(done));
         });
     });
 
@@ -1591,7 +1607,8 @@ describe('GC should be created if config is provided', () => {
             { topic: 'metrics-test-topic' });
         replicationStatusProcessor.start(() => {
             assert.strictEqual(replicationStatusProcessor.getStateVars().gcProducer, null);
-            replicationStatusProcessor.stop(done);
+            waitForProcessorAssignment(replicationStatusProcessor,
+                () => replicationStatusProcessor.stop(done));
         });
     });
 });

--- a/tests/functional/replication/queueProcessor.js
+++ b/tests/functional/replication/queueProcessor.js
@@ -1551,6 +1551,10 @@ describe('GC should be created if config is provided', () => {
 
     it('should create a GC if config is provided', function (done) {
         this.timeout(60000);
+        // unique topic + group so this test's consumer is the sole group
+        // member, assigned its partition immediately (a shared group rejoin
+        // can stall waiting out a previous member's session)
+        const suffix = Math.random().toString(36).slice(2);
         const replicationStatusProcessor = new ReplicationStatusProcessor(
             { hosts: 'localhost:9092' },
             { auth: { type: 'role',
@@ -1561,12 +1565,12 @@ describe('GC should be created if config is provided', () => {
               transport: 'http',
             },
             { replicationStatusTopic:
-              'backbeat-func-test-repstatus',
+              `backbeat-func-test-repstatus-${suffix}`,
               replicationStatusProcessor: {
                   retry: {
                       timeoutS: 5,
                   },
-                  groupId: 'backbeat-func-test-group-id',
+                  groupId: `backbeat-func-test-group-id-${suffix}`,
               },
               monitorReplicationFailures: true,
               objectSizeMetrics: [100, 1000],
@@ -1583,6 +1587,10 @@ describe('GC should be created if config is provided', () => {
 
     it('should not create a GC if config is not provided', function (done) {
         this.timeout(60000);
+        // unique topic + group so this test's consumer is the sole group
+        // member, assigned its partition immediately (a shared group rejoin
+        // can stall waiting out a previous member's session)
+        const suffix = Math.random().toString(36).slice(2);
         const replicationStatusProcessor = new ReplicationStatusProcessor(
             { hosts: 'localhost:9092' },
             { auth: { type: 'role',
@@ -1593,12 +1601,12 @@ describe('GC should be created if config is provided', () => {
               transport: 'http',
             },
             { replicationStatusTopic:
-              'backbeat-func-test-repstatus',
+              `backbeat-func-test-repstatus-${suffix}`,
               replicationStatusProcessor: {
                   retry: {
                       timeoutS: 5,
                   },
-                  groupId: 'backbeat-func-test-group-id',
+                  groupId: `backbeat-func-test-group-id-${suffix}`,
               },
               monitorReplicationFailures: true,
               objectSizeMetrics: [100, 1000],

--- a/tests/utils/BackbeatTestConsumer.js
+++ b/tests/utils/BackbeatTestConsumer.js
@@ -6,9 +6,12 @@ const BackbeatConsumer = require('../../lib/BackbeatConsumer');
 
 class BackbeatTestConsumer extends BackbeatConsumer {
     constructor(config) {
+        // Read from the start of the topic so that every message produced
+        // after the consumer is created is guaranteed to be consumed,
+        // without racing partition assignment.
         super(Object.assign({}, config,
                             { queueProcessor: function dummy() {},
-                              bootstrap: true }));
+                              fromOffset: config.fromOffset || 'earliest' }));
         // hook queue processor function
         this._queueProcessor = this._processMessage.bind(this);
         this._expectVars = null;


### PR DESCRIPTION

## Intent: why does this change exist?

The "read messages … and publish topic metrics" functional test fails CI with a bare 30s
timeout on roughly half the runs on loaded runners — it blocked PR #2749 twice and fails on
pristine `development/9.0`. Root cause, confirmed by tracing: the test-only bootstrap mechanism
issues a kafka consume request every 200ms while each request waits up to 1s inside the client,
so a backlog of stale requests outlives bootstrap and steals the first real messages a test
produces — bootstrap's callback silently drops anything that isn't a bootstrap sentinel.

## System impact: what's affected, including downstream?

Only `_bootstrapConsumer` — a test-only path (`bootstrap: true` is set exclusively from
`tests/`; the option is documented "TEST ONLY"). Every bootstrap-using suite (lib, replication
queueProcessor) inherits the fix. No production data path changes.

## Preserved behavior: what explicitly stays the same?

The bootstrap protocol is unchanged: sentinel every 5s, commit past the sentinel, unsubscribe,
hand off to the real loop. The stacked requests were not useful parallelism — bootstrap fetches
one sentinel per 5s, and the regular consume loop already enforces the same one-request-in-flight
rule via its `_nConsumePendingRequests` gate. Production consumers never enter this code.

## Intended change: what's different after this PR?

At most one in-flight bootstrap consume request, so the final sentinel necessarily arrives on
the only outstanding request and none survive bootstrap to steal messages — plus a warn log if
bootstrap ever drops a non-bootstrap message again. In the test itself: the ZK offsets check
polls with bounded attempts instead of a fixed 5s sleep + one-shot read, and the prometheus
check is chained into `done` (it was a floating promise whose assertion failures were lost as
unhandled rejections).

## Verification: how do we know this worked, or how would we know if it didn't?

Reproduced locally at ~10% by CPU-throttling the CI kafka image; tracing captured the theft
directly (3 messages produced, the pipeline received 2, the commit skipped over the eaten one).
With the fix: 40 consecutive local passes under the same throttle and a green CI matrix. For
the before/after on CI itself: an empty commit on this branch failed `lib tests` with zero code
changes ([run 27012249826](https://github.com/scality/backbeat/actions/runs/27012249826)), the
fix went green ([run 27014743787](https://github.com/scality/backbeat/actions/runs/27014743787)).
If bootstrap ever eats a message again, the new warn makes it visible in the logs instead of
silent.
