### PR TITLE
feat(lifecycle): alert when index creation fails

### DIFF
--- a/monitoring/lifecycle/alerts.test.yaml
+++ b/monitoring/lifecycle/alerts.test.yaml
@@ -466,6 +466,49 @@ tests:
         eval_time: 14m
         exp_alerts: []
 
+  - name: LifecycleIndexCreationFailed
+    interval: 1h
+    input_series:
+      - series: s3_lifecycle_legacy_tasks_total{namespace="zenko",job="artesca-data-backbeat-lifecycle-producer-headless",origin="conductor",status="putBucketIndexesFailed"}
+        values: 0x5 1x12
+      - series: s3_lifecycle_legacy_tasks_total{namespace="zenko",job="artesca-data-backbeat-lifecycle-producer-headless",origin="conductor",status="noIndex"}
+        values: 0+1x17
+    alert_rule_test:
+      - alertname: LifecycleIndexCreationFailed
+        eval_time: 4h
+        exp_alerts: []
+      - alertname: LifecycleIndexCreationFailed
+        eval_time: 6h
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              namespace: zenko
+              job: artesca-data-backbeat-lifecycle-producer-headless
+              origin: conductor
+              status: putBucketIndexesFailed
+            exp_annotations:
+              zenko_service: backbeat-lifecycle-producer
+              description: |-
+                The lifecycle producer failed to create the v2 lifecycle indexes on at least one bucket in the last 12 hours. The producer will fall back to v1 (full-scan) processing for that bucket. Check producer logs for the bucket name and the underlying MongoDB error.
+              summary: "Lifecycle index creation failure"
+      - alertname: LifecycleIndexCreationFailed
+        eval_time: 15h
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              namespace: zenko
+              job: artesca-data-backbeat-lifecycle-producer-headless
+              origin: conductor
+              status: putBucketIndexesFailed
+            exp_annotations:
+              zenko_service: backbeat-lifecycle-producer
+              description: |-
+                The lifecycle producer failed to create the v2 lifecycle indexes on at least one bucket in the last 12 hours. The producer will fall back to v1 (full-scan) processing for that bucket. Check producer logs for the bucket name and the underlying MongoDB error.
+              summary: "Lifecycle index creation failure"
+      - alertname: LifecycleIndexCreationFailed
+        eval_time: 18h
+        exp_alerts: []
+
   - name: LifecycleLatency
     interval: 10m
     input_series:

--- a/monitoring/lifecycle/alerts.yaml
+++ b/monitoring/lifecycle/alerts.yaml
@@ -82,6 +82,20 @@ groups:
         {{ ${lifecycle_latency_critical_threshold} | humanizeDuration }} ago.
       summary: "Lifecycle scan not executed in time"
 
+  - alert: LifecycleIndexCreationFailed
+    Expr: |
+      increase(s3_lifecycle_legacy_tasks_total{namespace="${namespace}", job="${job_lifecycle_producer}", status="putBucketIndexesFailed"}[12h]) > 0
+    Labels:
+     severity: warning
+    Annotations:
+      zenko_service: backbeat-lifecycle-producer
+      description: >-
+        The lifecycle producer failed to create the v2 lifecycle indexes on at
+        least one bucket in the last 12 hours. The producer will fall back to
+        v1 (full-scan) processing for that bucket. Check producer logs for the
+        bucket name and the underlying MongoDB error.
+      summary: "Lifecycle index creation failure"
+
 - name: LifecycleBucketProcessor
   rules:
 


### PR DESCRIPTION
## Summary
- Add `LifecycleIndexCreationFailed` Prometheus alert (`monitoring/lifecycle/alerts.yaml`) wired to the `s3_lifecycle_legacy_tasks_total{status="putBucketIndexesFailed"}` counter introduced by BB-783 (#2751).
- Fires on any failure in a 5m window with severity `warning` — mirrors the `CircuitBreakerError` shape: the conductor falls back to v1 full-scan, so this is recoverable but always warrants investigation (typically a disk-fill / `indexBuildMinAvailableDiskSpaceMB` refusal).
- Companion fixture added to `alerts.test.yaml`.

Part of the [Empty bucket feature epic](https://scality.atlassian.net/browse/ARTESCA-16740). A symmetric MongoDB-side createIndexes-failed alert lives in the Zenko chart under [ZENKO-5285](https://scality.atlassian.net/browse/ZENKO-5285).

Issue: BB-784

[ZENKO-5285]: https://scality.atlassian.net/browse/ZENKO-5285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ