### PR TITLE
BB-787: Restart CRR consumer stuck past drain timeout

### DIFF
--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -487,9 +487,15 @@ class QueueProcessor extends EventEmitter {
                 });
             return;
         }
+        const stuckAges = (queueState.stuckTasks || [])
+            .map(task => task.ageSeconds)
+            .filter(age => typeof age === 'number');
         this.logger.fatal(
             'consumer stuck after rebalance drain timeout, exiting for ' +
             'restart', {
+                stuckTaskCount: queueState.stuckTasks?.length,
+                oldestAgeSeconds:
+                    stuckAges.length ? Math.max(...stuckAges) : undefined,
                 queueLen: queueState.queueLen,
                 running: queueState.running,
                 exitsInWindow: budget.exitsInWindow,

--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const async = require('async');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const { EventEmitter } = require('events');
 const Redis = require('ioredis');
 const schedule = require('node-schedule');
@@ -42,6 +45,15 @@ const {
     proxyIAMPath,
     replicationBackends,
 } = require('../constants');
+
+// Budget for stuck-consumer self-exits (see _onRebalanceTimeout): allow
+// at most STUCK_EXIT_BUDGET_MAX_EXITS exits per
+// STUCK_EXIT_BUDGET_WINDOW_HOURS rolling window, so a chronic cause
+// escalates to the probe-latched alarm instead of hiding in a crash loop.
+const STUCK_EXIT_BUDGET_MAX_EXITS = 3;
+const STUCK_EXIT_BUDGET_WINDOW_HOURS = 6;
+const STUCK_EXIT_BUDGET_WINDOW_MS =
+    STUCK_EXIT_BUDGET_WINDOW_HOURS * 60 * 60 * 1000;
 
 /**
  * Labels used for Prometheus metrics
@@ -229,6 +241,14 @@ class QueueProcessor extends EventEmitter {
 
         this.logger = new Logger(
             `Backbeat:Replication:QueueProcessor:${this.site}`);
+
+        // Stuck-consumer self-exit budget file (see _onRebalanceTimeout):
+        // per-site AND per-topic, since all site/replay processors share
+        // one container /tmp and replay processors share the site name.
+        this._stuckExitBudgetFile = path.join(
+            os.tmpdir(),
+            `backbeat-qp-exit-budget-${this.site}-${this.topic}.json`);
+        this._warnIfRestartedAfterStuckExit();
 
         // global variables
         if (sourceConfig.transport === 'https') {
@@ -418,12 +438,145 @@ class QueueProcessor extends EventEmitter {
                 process.exit(1);
             }
         });
+        consumer.on('rebalance.timeout',
+            queueState => this._onRebalanceTimeout(queueState));
         consumer.on('ready', () => {
             consumerReady = true;
             const paused = options && options.paused;
             consumer.subscribe(paused);
         });
         return consumer;
+    }
+
+    /**
+     * Handle a consumer stuck past the rebalance drain timeout.
+     *
+     * S3C: supervisord only restarts a program when its process exits;
+     * nothing acts on a failed healthcheck. Crash so the supervisor
+     * rejoins us to the group and stuck in-flight tasks die instead of
+     * completing late ("ghost" writes). Hard exit, NOT
+     * process.emit('SIGTERM') as CRASH_ON_BATCH_TIMEOUT does: the
+     * SIGTERM path waits on close() -> 'unassign', which blocks on the
+     * very tasks that are stuck. On K8s the liveness probe handles this
+     * and this env var is never set. Exact match: a stray ="false"
+     * must not arm it.
+     *
+     * @param {object} queueState - processing queue state at the time of
+     * the timeout, as emitted by the consumer
+     * @return {undefined}
+     */
+    _onRebalanceTimeout(queueState) {
+        if (process.env.REPLICATION_QUEUE_PROCESSOR_CRASH_ON_REBALANCE_TIMEOUT !== 'true') {
+            this.logger.error(
+                'consumer stuck after rebalance drain timeout, self-restart ' +
+                'disabled (REPLICATION_QUEUE_PROCESSOR_CRASH_ON_REBALANCE_TIMEOUT != true); consumer ' +
+                'stays disconnected — external restart (liveness probe or ' +
+                'operator) required', {
+                    queueLen: queueState.queueLen,
+                    running: queueState.running,
+                });
+            return;
+        }
+        const budget = this._consumeStuckExitBudget();
+        if (!budget.ok) {
+            this.logger.error(
+                'stuck-consumer exit budget exhausted, staying disconnected ' +
+                'for operator intervention', {
+                    exitsInWindow: budget.exitsInWindow,
+                    windowHours: STUCK_EXIT_BUDGET_WINDOW_HOURS,
+                });
+            return;
+        }
+        this.logger.fatal(
+            'consumer stuck after rebalance drain timeout, exiting for ' +
+            'restart', {
+                queueLen: queueState.queueLen,
+                running: queueState.running,
+                exitsInWindow: budget.exitsInWindow,
+            });
+        setTimeout(() => process.exit(1), 1000);
+    }
+
+    /**
+     * Log a boot-correlation warning when this process starts after a
+     * recent stuck-consumer self-exit, so the restart and the exit that
+     * caused it can be tied together from the logs alone.
+     *
+     * @return {undefined}
+     */
+    _warnIfRestartedAfterStuckExit() {
+        const pastExits = this._readStuckExitBudget();
+        if (pastExits.length > 0) {
+            const lastExitAt = Math.max(...pastExits);
+            this.logger.warn('starting after stuck-consumer self-exit', {
+                exitsInWindow: pastExits.length,
+                lastExitAt,
+                downSeconds: Math.round((Date.now() - lastExitAt) / 1000),
+            });
+        }
+    }
+
+    /**
+     * Read the stuck-consumer self-exit budget file and return the exit
+     * timestamps still within the budget window. FAIL-OPEN: any
+     * read/parse error is treated as an empty budget, so a damaged file
+     * never blocks a restart.
+     *
+     * @return {number[]} epoch-ms timestamps of recent self-exits
+     */
+    _readStuckExitBudget() {
+        try {
+            const timestamps = JSON.parse(
+                fs.readFileSync(this._stuckExitBudgetFile, 'utf8'));
+            const now = Date.now();
+            return timestamps.filter(ts => typeof ts === 'number' &&
+                now - ts < STUCK_EXIT_BUDGET_WINDOW_MS);
+        } catch (err) {
+            if (err.code !== 'ENOENT') {
+                this.logger.warn(
+                    'could not read/persist stuck-consumer exit budget ' +
+                    'file, treating as empty (fail-open)', {
+                        op: 'read',
+                        path: this._stuckExitBudgetFile,
+                        error: err && err.message,
+                    });
+            }
+            return [];
+        }
+    }
+
+    /**
+     * Check and consume the stuck-consumer self-exit budget: at most
+     * STUCK_EXIT_BUDGET_MAX_EXITS exits per
+     * STUCK_EXIT_BUDGET_WINDOW_HOURS hours, persisted across restarts
+     * in a per-site, per-topic file under the OS temp dir. FAIL-OPEN:
+     * if the file cannot be persisted, still allow the exit (restart is
+     * the primary goal).
+     *
+     * @return {object} budget - the budget decision
+     * @return {boolean} budget.ok - true if a self-exit is allowed now
+     * @return {number} budget.exitsInWindow - exits counted in the
+     * current window, including this one when allowed
+     */
+    _consumeStuckExitBudget() {
+        const exits = this._readStuckExitBudget();
+        if (exits.length >= STUCK_EXIT_BUDGET_MAX_EXITS) {
+            return { ok: false, exitsInWindow: exits.length };
+        }
+        exits.push(Date.now());
+        try {
+            fs.writeFileSync(this._stuckExitBudgetFile,
+                JSON.stringify(exits));
+        } catch (err) {
+            this.logger.warn(
+                'could not read/persist stuck-consumer exit budget file, ' +
+                'treating as empty (fail-open)', {
+                    op: 'write',
+                    path: this._stuckExitBudgetFile,
+                    error: err && err.message,
+                });
+        }
+        return { ok: true, exitsInWindow: exits.length };
     }
 
     _setupEcho() {

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -143,6 +143,7 @@ class BackbeatConsumer extends EventEmitter {
         this._publishOffsetsCronActive = false;
         this._consumedEventTimeout = null;
         this._drainProcessQueueTimeout = null;
+        this._drainStartedAt = null;
         this._tryConsumedTimeout = null;
         // This variable is set to true when tasks have been completed
         // since the last consume, and is used to trigger a new consume
@@ -481,6 +482,9 @@ class BackbeatConsumer extends EventEmitter {
         const { topic, partition, offset } = entry;
         const consumerGroup = this._groupId;
         const taskStartTime = Date.now();
+        // stamp the entry so getInFlightTasks() can report its age
+        // eslint-disable-next-line no-param-reassign
+        entry._bbStartedAt = taskStartTime;
 
         let slow = false;
         const slowTimer = setTimeout(() => {
@@ -495,6 +499,34 @@ class BackbeatConsumer extends EventEmitter {
             const duration = Date.now() - taskStartTime;
             KafkaBacklogMetrics.onTaskProcessed(topic, partition, consumerGroup, !!err, slow, duration);
         };
+    }
+
+    /**
+     * Snapshot of the entries currently being processed, for
+     * observability (e.g. naming the tasks stuck past the rebalance
+     * drain timeout).
+     *
+     * @param {number} [limit=5] - maximum number of tasks to return
+     * @return {object[]} one item per in-flight task: { topic,
+     * partition, offset, key, ageSeconds }; key is truncated to 200
+     * chars; ageSeconds is the age since the entry was consumed (not
+     * since it was produced to the topic)
+     */
+    getInFlightTasks(limit = 5) {
+        return (this._processingQueue?.workersList() || [])
+            .slice(0, limit)
+            .map(w => {
+                const e = w.data;
+                return {
+                    topic: e.topic,
+                    partition: e.partition,
+                    offset: e.offset,
+                    key: e.key && e.key.toString().slice(0, 200),
+                    ageSeconds: e._bbStartedAt ?
+                        Math.round((Date.now() - e._bbStartedAt) / 1000) :
+                        undefined,
+                };
+            });
     }
 
     _scheduleNextTryConsume() {
@@ -659,17 +691,31 @@ class BackbeatConsumer extends EventEmitter {
                 logger.bind(this._log)('rdkafka.assign failed', { e: e.toString(), assignment });
             }
         } else if (err.code === kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS) {
-            this._log.info('rdkafka.revoke', {
+            const revokeInfo = {
                 assignment,
                 queueLen: this._processingQueue?.length(),
                 running: this._processingQueue?.running(),
-            });
+            };
+            if (this._processingQueue && !this._processingQueue.idle()) {
+                // a drain is about to begin: name the consumer and how
+                // long it has before being declared stuck
+                revokeInfo.topic = this._topic;
+                revokeInfo.groupId = this._groupId;
+                revokeInfo.drainDeadlineMs = this._maxPollIntervalMs - 1000;
+            }
+            this._log.info('rdkafka.revoke', revokeInfo);
 
             const unassign = jsutil.once(status => {
                 this._log.info(`processing queue ${status}, un-assigning`, {
                     queueLen: this._processingQueue?.length(),
                     running: this._processingQueue?.running(),
+                    topic: this._topic,
+                    groupId: this._groupId,
+                    drainDurationSeconds: this._drainStartedAt ?
+                        Math.round((Date.now() - this._drainStartedAt) / 1000) :
+                        undefined,
                 });
+                this._drainStartedAt = null;
 
                 KafkaBacklogMetrics.onRebalance(this._topic, this._groupId, status);
 
@@ -719,6 +765,7 @@ class BackbeatConsumer extends EventEmitter {
                 return;
             }
 
+            this._drainStartedAt = Date.now();
             this._processingQueue.drain = () => unassign(unassignStatus.DRAINED);
 
             // Set timeout of `max.poll.interval.ms`), to ensure we complete the rebalance
@@ -729,16 +776,22 @@ class BackbeatConsumer extends EventEmitter {
             this._drainProcessQueueTimeout = setTimeout(() => {
                 unassign(unassignStatus.TIMEOUT);
 
-                this._log.error('rdkafka.rebalance timeout: consumer stuck, disconnecting');
+                const queueLen = this._processingQueue?.length();
+                const running = this._processingQueue?.running();
+                const stuckTasks = this.getInFlightTasks();
+                this._log.error('rdkafka.rebalance timeout: consumer stuck, disconnecting', {
+                    topic: this._topic,
+                    groupId: this._groupId,
+                    queueLen,
+                    running,
+                    stuckTasks,
+                });
                 this._consumer.disconnect();
                 // Let owners decide what to do when stuck (e.g. crash on S3C, where
                 // nothing restarts a process on a failed healthcheck). disconnect()
                 // above is guarded and non-throwing, so this emit always runs.
                 // No listener => no behavior change.
-                this.emit('rebalance.timeout', {
-                    queueLen: this._processingQueue?.length(),
-                    running: this._processingQueue?.running(),
-                });
+                this.emit('rebalance.timeout', { queueLen, running, stuckTasks });
             }, this._maxPollIntervalMs - 1000); // 1 second earlier, to be within the limit
         } else {
             this._log.error('rdkafka.rebalance', { err, assignment });

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -731,6 +731,14 @@ class BackbeatConsumer extends EventEmitter {
 
                 this._log.error('rdkafka.rebalance timeout: consumer stuck, disconnecting');
                 this._consumer.disconnect();
+                // Let owners decide what to do when stuck (e.g. crash on S3C, where
+                // nothing restarts a process on a failed healthcheck). disconnect()
+                // above is guarded and non-throwing, so this emit always runs.
+                // No listener => no behavior change.
+                this.emit('rebalance.timeout', {
+                    queueLen: this._processingQueue?.length(),
+                    running: this._processingQueue?.running(),
+                });
             }, this._maxPollIntervalMs - 1000); // 1 second earlier, to be within the limit
         } else {
             this._log.error('rdkafka.rebalance', { err, assignment });

--- a/tests/functional/lib/BackbeatConsumer.js
+++ b/tests/functional/lib/BackbeatConsumer.js
@@ -361,6 +361,11 @@ describe('BackbeatConsumer rebalance tests', () => {
         assert(consumer.isReady());
         assert(consumer2.isReady());
 
+        let rebalanceTimeoutEvent = null;
+        consumer.on('rebalance.timeout', queueState => {
+            rebalanceTimeoutEvent = queueState;
+        });
+
         consumer.once('consumed.message', () => {
             // trigger rebalance during processing of first message
             consumer2.subscribe();
@@ -378,6 +383,11 @@ describe('BackbeatConsumer rebalance tests', () => {
         timer = setInterval(() => {
             if (!consumer.isReady()) {
                 assert(consumer2.isReady());
+                assert(rebalanceTimeoutEvent);
+                assert.strictEqual(typeof rebalanceTimeoutEvent.queueLen,
+                    'number');
+                assert.strictEqual(typeof rebalanceTimeoutEvent.running,
+                    'number');
                 done();
             }
         }, 1000);

--- a/tests/functional/lib/BackbeatConsumer.js
+++ b/tests/functional/lib/BackbeatConsumer.js
@@ -388,6 +388,11 @@ describe('BackbeatConsumer rebalance tests', () => {
                     'number');
                 assert.strictEqual(typeof rebalanceTimeoutEvent.running,
                     'number');
+                assert(Array.isArray(rebalanceTimeoutEvent.stuckTasks));
+                assert(rebalanceTimeoutEvent.stuckTasks.length > 0);
+                rebalanceTimeoutEvent.stuckTasks.forEach(task => {
+                    assert.strictEqual(typeof task.offset, 'number');
+                });
                 done();
             }
         }, 1000);

--- a/tests/unit/backbeatConsumer.js
+++ b/tests/unit/backbeatConsumer.js
@@ -157,6 +157,76 @@ describe('backbeatConsumer', () => {
         });
     });
 
+    describe('getInFlightTasks', () => {
+        let consumer;
+
+        beforeEach(() => {
+            consumer = new BackbeatConsumerMock({
+                kafka,
+                groupId: 'unittest-group',
+                topic: 'my-test-topic',
+            });
+        });
+
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        it('should return an empty array without a processing queue', () => {
+            assert.deepStrictEqual(consumer.getInFlightTasks(), []);
+        });
+
+        it('should map in-flight entries to their identities', () => {
+            const now = Date.now();
+            sinon.useFakeTimers({ now });
+            consumer._processingQueue = {
+                workersList: () => [{
+                    data: {
+                        topic: 'my-test-topic',
+                        partition: 1,
+                        offset: 42,
+                        key: Buffer.from(`object-key-${'x'.repeat(300)}`),
+                        _bbStartedAt: now - 30000,
+                    },
+                }, {
+                    data: {
+                        topic: 'my-test-topic',
+                        partition: 2,
+                        offset: 7,
+                    },
+                }],
+            };
+            const tasks = consumer.getInFlightTasks();
+            assert.strictEqual(tasks.length, 2);
+            assert.strictEqual(tasks[0].topic, 'my-test-topic');
+            assert.strictEqual(tasks[0].partition, 1);
+            assert.strictEqual(tasks[0].offset, 42);
+            // key is stringified and truncated to 200 chars
+            assert.strictEqual(tasks[0].key.length, 200);
+            assert(tasks[0].key.startsWith('object-key-'));
+            assert.strictEqual(tasks[0].ageSeconds, 30);
+            // entries without key or start time stay readable
+            assert.strictEqual(tasks[1].offset, 7);
+            assert.strictEqual(tasks[1].key, undefined);
+            assert.strictEqual(tasks[1].ageSeconds, undefined);
+        });
+
+        it('should cap the number of returned tasks to the limit', () => {
+            const workers = [];
+            for (let i = 0; i < 7; i++) {
+                workers.push({ data: {
+                    topic: 'my-test-topic', partition: 0, offset: i,
+                } });
+            }
+            consumer._processingQueue = { workersList: () => workers };
+            assert.strictEqual(consumer.getInFlightTasks().length, 5);
+            assert.strictEqual(consumer.getInFlightTasks(2).length, 2);
+            assert.deepStrictEqual(
+                consumer.getInFlightTasks(2).map(task => task.offset),
+                [0, 1]);
+        });
+    });
+
     describe('sequentialy consume from topic', () => {
         let consumer;
 

--- a/tests/unit/replication/QueueProcessorStuckExit.spec.js
+++ b/tests/unit/replication/QueueProcessorStuckExit.spec.js
@@ -1,0 +1,191 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const sinon = require('sinon');
+// werelogs exports a bound constructor without a .prototype: require the
+// underlying class to spy on logging across newly created instances
+const WerelogsLogger = require('werelogs/lib/Logger');
+
+const QueueProcessor =
+    require('../../../extensions/replication/queueProcessor/QueueProcessor');
+
+// unique per test run, so parallel/repeated runs do not collide on the
+// budget file in the shared OS temp dir
+const site = 'site';
+const topic = `backbeat-stuck-exit-spec-${process.pid}`;
+const budgetFile = path.join(
+    os.tmpdir(), `backbeat-qp-exit-budget-${site}-${topic}.json`);
+
+const HOUR_MS = 60 * 60 * 1000;
+
+function makeQueueProcessor() {
+    return new QueueProcessor(
+        topic,
+        { connectionString: '127.0.0.1:2181/backbeat',
+          autoCreateNamespace: false },
+        null,
+        { hosts: 'localhost:9092' },
+        { auth: { type: 'role',
+            vault: { host: 'localhost:9093',
+                port: 7777 } },
+            s3: { host: 'localhost:9094',
+                port: 7777 },
+            transport: 'http',
+        },
+        { auth: { type: 'role' },
+            bootstrapList: [{
+                site: 'site', servers: ['localhost:9095'],
+            }],
+            transport: 'http' },
+        { topic,
+          replicationStatusTopic: 'backbeat-func-test-repstatus',
+          queueProcessor: {
+              retry: {
+                  scality: { timeoutS: 5 },
+              },
+              groupId: 'backbeat-func-test-group-id',
+              mpuPartsConcurrency: 10,
+          },
+        },
+        null, // no redis in unit tests
+        { topic: 'metrics-test-topic' },
+        {},
+        {},
+        site,
+    );
+}
+
+describe('QueueProcessor stuck-consumer self-exit', () => {
+    let qp;
+    let clock;
+    let exitStub;
+    let fatalStub;
+    let errorStub;
+    let warnStub;
+    const envBackup = process.env.REPLICATION_QUEUE_PROCESSOR_CRASH_ON_REBALANCE_TIMEOUT;
+
+    beforeEach(() => {
+        fs.rmSync(budgetFile, { force: true });
+        delete process.env.REPLICATION_QUEUE_PROCESSOR_CRASH_ON_REBALANCE_TIMEOUT;
+        qp = makeQueueProcessor();
+        exitStub = sinon.stub(process, 'exit');
+        fatalStub = sinon.stub(qp.logger, 'fatal');
+        errorStub = sinon.stub(qp.logger, 'error');
+        warnStub = sinon.stub(qp.logger, 'warn');
+        clock = sinon.useFakeTimers({ now: Date.now() });
+    });
+
+    afterEach(() => {
+        sinon.restore();
+        fs.rmSync(budgetFile, { force: true });
+        if (envBackup === undefined) {
+            delete process.env.REPLICATION_QUEUE_PROCESSOR_CRASH_ON_REBALANCE_TIMEOUT;
+        } else {
+            process.env.REPLICATION_QUEUE_PROCESSOR_CRASH_ON_REBALANCE_TIMEOUT = envBackup;
+        }
+    });
+
+    it('should log fatal and exit(1) after 1s when armed and within ' +
+    'budget', () => {
+        process.env.REPLICATION_QUEUE_PROCESSOR_CRASH_ON_REBALANCE_TIMEOUT = 'true';
+        qp._onRebalanceTimeout({ queueLen: 3, running: 2 });
+        sinon.assert.calledOnceWithMatch(
+            fatalStub,
+            'consumer stuck after rebalance drain timeout, exiting for ' +
+            'restart',
+            sinon.match({ queueLen: 3, running: 2, exitsInWindow: 1 }));
+        // hard exit only fires after the 1s grace delay
+        clock.tick(999);
+        sinon.assert.notCalled(exitStub);
+        clock.tick(1);
+        sinon.assert.calledOnceWithExactly(exitStub, 1);
+        // the exit was persisted to the budget file
+        const persisted = JSON.parse(fs.readFileSync(budgetFile, 'utf8'));
+        assert.strictEqual(persisted.length, 1);
+        assert.strictEqual(typeof persisted[0], 'number');
+    });
+
+    it('should not exit and log error when env var is unset', () => {
+        qp._onRebalanceTimeout({ queueLen: 3, running: 2 });
+        sinon.assert.calledOnceWithMatch(
+            errorStub,
+            sinon.match(/self-restart disabled/),
+            sinon.match({ queueLen: 3, running: 2 }));
+        sinon.assert.notCalled(fatalStub);
+        clock.tick(2000);
+        sinon.assert.notCalled(exitStub);
+    });
+
+    it('should not exit when env var is "false" (exact match ' +
+    'required)', () => {
+        process.env.REPLICATION_QUEUE_PROCESSOR_CRASH_ON_REBALANCE_TIMEOUT = 'false';
+        qp._onRebalanceTimeout({ queueLen: 3, running: 2 });
+        sinon.assert.calledOnceWithMatch(
+            errorStub, sinon.match(/self-restart disabled/));
+        sinon.assert.notCalled(fatalStub);
+        clock.tick(2000);
+        sinon.assert.notCalled(exitStub);
+    });
+
+    it('should not exit when the exit budget is exhausted', () => {
+        process.env.REPLICATION_QUEUE_PROCESSOR_CRASH_ON_REBALANCE_TIMEOUT = 'true';
+        const now = Date.now();
+        fs.writeFileSync(budgetFile, JSON.stringify(
+            [now - (3 * HOUR_MS), now - (2 * HOUR_MS), now - HOUR_MS]));
+        qp._onRebalanceTimeout({ queueLen: 3, running: 2 });
+        sinon.assert.calledOnceWithMatch(
+            errorStub,
+            'stuck-consumer exit budget exhausted, staying disconnected ' +
+            'for operator intervention',
+            sinon.match({ exitsInWindow: 3, windowHours: 6 }));
+        sinon.assert.notCalled(fatalStub);
+        clock.tick(2000);
+        sinon.assert.notCalled(exitStub);
+    });
+
+    it('should ignore exit timestamps older than the 6h window', () => {
+        process.env.REPLICATION_QUEUE_PROCESSOR_CRASH_ON_REBALANCE_TIMEOUT = 'true';
+        const now = Date.now();
+        fs.writeFileSync(budgetFile, JSON.stringify(
+            [now - (9 * HOUR_MS), now - (8 * HOUR_MS), now - (7 * HOUR_MS)]));
+        qp._onRebalanceTimeout({ queueLen: 3, running: 2 });
+        sinon.assert.calledOnceWithMatch(
+            fatalStub, sinon.match.string,
+            sinon.match({ exitsInWindow: 1 }));
+        clock.tick(1000);
+        sinon.assert.calledOnceWithExactly(exitStub, 1);
+    });
+
+    it('should fail open (warn and still exit) on a corrupt budget ' +
+    'file', () => {
+        process.env.REPLICATION_QUEUE_PROCESSOR_CRASH_ON_REBALANCE_TIMEOUT = 'true';
+        fs.writeFileSync(budgetFile, 'not json {');
+        qp._onRebalanceTimeout({ queueLen: 3, running: 2 });
+        sinon.assert.calledWithMatch(
+            warnStub,
+            'could not read/persist stuck-consumer exit budget file, ' +
+            'treating as empty (fail-open)',
+            sinon.match({ op: 'read', path: budgetFile }));
+        sinon.assert.calledOnce(fatalStub);
+        clock.tick(1000);
+        sinon.assert.calledOnceWithExactly(exitStub, 1);
+    });
+
+    it('should warn at boot when the budget file has fresh exit ' +
+    'timestamps', () => {
+        const now = Date.now();
+        const lastExitAt = now - (5 * 60 * 1000);
+        fs.writeFileSync(budgetFile, JSON.stringify(
+            [now - HOUR_MS, lastExitAt]));
+        const protoWarn = sinon.spy(WerelogsLogger.prototype, 'warn');
+        makeQueueProcessor();
+        const call = protoWarn.getCalls().find(
+            c => c.args[0] === 'starting after stuck-consumer self-exit');
+        assert(call, 'expected boot-correlation warn to be logged');
+        assert.strictEqual(call.args[1].exitsInWindow, 2);
+        assert.strictEqual(call.args[1].lastExitAt, lastExitAt);
+        assert.strictEqual(typeof call.args[1].downSeconds, 'number');
+        assert(call.args[1].downSeconds >= 0);
+    });
+});

--- a/tests/unit/replication/QueueProcessorStuckExit.spec.js
+++ b/tests/unit/replication/QueueProcessorStuckExit.spec.js
@@ -89,12 +89,25 @@ describe('QueueProcessor stuck-consumer self-exit', () => {
     it('should log fatal and exit(1) after 1s when armed and within ' +
     'budget', () => {
         process.env.REPLICATION_QUEUE_PROCESSOR_CRASH_ON_REBALANCE_TIMEOUT = 'true';
-        qp._onRebalanceTimeout({ queueLen: 3, running: 2 });
+        qp._onRebalanceTimeout({
+            queueLen: 3,
+            running: 2,
+            stuckTasks: [
+                { topic, partition: 0, offset: 12, key: 'k1', ageSeconds: 45 },
+                { topic, partition: 1, offset: 34, key: 'k2', ageSeconds: 90 },
+            ],
+        });
         sinon.assert.calledOnceWithMatch(
             fatalStub,
             'consumer stuck after rebalance drain timeout, exiting for ' +
             'restart',
-            sinon.match({ queueLen: 3, running: 2, exitsInWindow: 1 }));
+            sinon.match({
+                stuckTaskCount: 2,
+                oldestAgeSeconds: 90,
+                queueLen: 3,
+                running: 2,
+                exitsInWindow: 1,
+            }));
         // hard exit only fires after the 1s grace delay
         clock.tick(999);
         sinon.assert.notCalled(exitStub);


### PR DESCRIPTION

## Intent: why does this change exist?

When a CRR queue processor task wedges past the rebalance drain timeout, the consumer
deliberately disconnects — the code's own comment says "so that the healthcheck will fail
and the process will get restarted". On Zenko, kubernetes does exactly that. On S3C,
supervisord only restarts processes that exit, so the worker stays down forever while its
stuck in-flight tasks can still complete late and race the partition's new owner (ghost
writes, orphaned parts). This makes the process exit on that state so supervisord's
existing autorestart brings it back into the consumer group, and kills the zombie work.

## System impact: what's affected, including downstream?

Replication queue processors only, by a two-layer gate: the lib emits a new
`rebalance.timeout` event that has no listener anywhere except QueueProcessor, and the
handler only acts when `REPLICATION_QUEUE_PROCESSOR_CRASH_ON_REBALANCE_TIMEOUT` is exactly
`"true"` — set per supervisord program by federation (scality/Federation#6929). Zenko never
sets the variable, so its probe-based restart path is untouched. Lifecycle, GC,
notification, populator, and the status processor see no behavior change.

## Preserved behavior: what explicitly stays the same?

With the variable unset, everything behaves as today — the only difference is richer
payloads on log lines that already exist (drain deadline/duration, and the identities of
the stuck tasks on the existing "consumer stuck, disconnecting" error). An exit budget
(3 per 6h per site, persisted across restarts in a per-site/per-topic tmp file, fail-open
on file errors) caps the new behavior: past the budget the processor stays disconnected and
today's exact escalation takes over — /_/live latches 500 and the platform healthcheck
alarms.

## Intended change: what's different after this PR?

On the stuck path with the gate armed: a fatal log naming the stuck objects and the budget
state, then a hard `process.exit(1)` after a 1s log-flush grace. Hard exit rather than the
`CRASH_ON_BATCH_TIMEOUT`-style SIGTERM on purpose: the graceful-stop path waits on the very
stuck tasks being escaped and can hang forever. The log story is completed by a gate-off
error ("self-restart disabled… external restart required"), a budget-exhausted error, and a
boot-correlation warning that ties each respawn back to the exit that caused it — all
visible at the default `info` log level.

## Verification: how do we know this worked, or how would we know if it didn't?

Unit: a 7-case spec for the handler (armed/unset/`"false"` gating, budget exhaustion,
stale-window pruning, corrupt-file fail-open, boot correlation) plus getInFlightTasks shape
tests. Functional: the existing stuck-rebalance test now also asserts the event fires with
the stuck-task identities; the full BackbeatConsumer functional file passes 15/15 against
the CI kafka image locally. If the mechanism ever misfires in the field, every decision
point logs which branch it took and why.
