### PR TITLE
BB-787: Exit consumer stuck past rebalance drain timeout

### DIFF
--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -731,6 +731,21 @@ class BackbeatConsumer extends EventEmitter {
 
                 this._log.error('rdkafka.rebalance timeout: consumer stuck, disconnecting');
                 this._consumer.disconnect();
+                if (process.env.CRASH_ON_REBALANCE_TIMEOUT === 'true') {
+                    // On S3C, supervisord only restarts a program when
+                    // its process exits, and nothing reacts to the
+                    // healthcheck that fails after the disconnect above, so
+                    // we exit. On K8s the liveness probe handles that state,
+                    // and this env var is never set there. Hard exit rather
+                    // than a graceful stop: the stop path would wait on the
+                    // very tasks that are stuck.
+                    this._log.fatal('consumer disconnected from queue ' +
+                        'after rebalance drain timeout, exiting process',
+                        { topic: this._topic, groupId: this._groupId });
+                    // grace period so the fatal line flushes to stdout
+                    // before the exit
+                    setTimeout(() => process.exit(1), 1000);
+                }
             }, this._maxPollIntervalMs - 1000); // 1 second earlier, to be within the limit
         } else {
             this._log.error('rdkafka.rebalance', { err, assignment });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.0.27",
+  "version": "9.0.28",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/functional/lib/BackbeatConsumer.js
+++ b/tests/functional/lib/BackbeatConsumer.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const async = require('async');
+const sinon = require('sinon');
 const werelogs = require('werelogs');
 
 const { metrics } = require('arsenal');
@@ -299,6 +300,8 @@ describe('BackbeatConsumer rebalance tests', () => {
 
     afterEach(function after(done) {
         this.timeout(10000);
+        delete process.env.CRASH_ON_REBALANCE_TIMEOUT;
+        sinon.restore();
         if (timer) {
             clearInterval(timer);
             timer = null;
@@ -356,6 +359,11 @@ describe('BackbeatConsumer rebalance tests', () => {
         assert(consumer.isReady());
         assert(consumer2.isReady());
 
+        // with the gate unset, the drain timeout must disconnect the
+        // consumer but leave the process alive; stub the exit so a
+        // gate regression cannot kill the test process
+        const exitStub = sinon.stub(process, 'exit');
+
         consumer.once('consumed.message', () => {
             // trigger rebalance during processing of first message
             consumer2.subscribe();
@@ -369,11 +377,69 @@ describe('BackbeatConsumer rebalance tests', () => {
             assert.ifError(err);
         });
 
-        // The consumer should become unhealthy eventually
+        // The consumer should become unhealthy eventually. A failed
+        // assertion inside a timer callback would surface as an
+        // unattributed exception, so report it through done() instead.
         timer = setInterval(() => {
             if (!consumer.isReady()) {
-                assert(consumer2.isReady());
-                done();
+                clearInterval(timer);
+                // a wrongly-armed exit would fire 1s after the
+                // timeout; wait past that before asserting nothing fired
+                setTimeout(() => {
+                    try {
+                        assert(consumer2.isReady(),
+                            'the healthy consumer should still be ready');
+                        sinon.assert.notCalled(exitStub);
+                        done();
+                    } catch (err) {
+                        done(err);
+                    }
+                }, 1500);
+            }
+        }, 1000);
+    }).timeout(60000);
+
+    it('should exit on rebalance timeout when CRASH_ON_REBALANCE_TIMEOUT ' +
+    'is set', done => {
+        assert(consumer.isReady());
+        assert(consumer2.isReady());
+
+        // stub the exit before arming the gate, so a real exit can
+        // never fire inside the test process
+        const exitStub = sinon.stub(process, 'exit');
+        process.env.CRASH_ON_REBALANCE_TIMEOUT = 'true';
+
+        consumer.once('consumed.message', () => {
+            // trigger rebalance during processing of first message
+            consumer2.subscribe();
+
+            // Return true to allow the consumer to "be stuck" on the message
+            return true;
+        });
+
+        consumer.subscribe();
+        producer.send([{ key: 'msg', message: 'taskStuck' }], err => {
+            assert.ifError(err);
+        });
+
+        // The consumer should become unhealthy eventually. A failed
+        // assertion inside a timer callback would surface as an
+        // unattributed exception, so report it through done() instead.
+        timer = setInterval(() => {
+            if (!consumer.isReady()) {
+                clearInterval(timer);
+                // the exit fires one second after the fatal log; give
+                // it room before asserting
+                setTimeout(() => {
+                    try {
+                        assert(consumer2.isReady(),
+                            'the healthy consumer should still be ready');
+                        sinon.assert.calledOnceWithExactly(exitStub, 1);
+                        done();
+                    } catch (err) {
+                        done(err);
+                    }
+                }, 1500);
             }
         }, 1000);
     }).timeout(60000);


### PR DESCRIPTION
Note: 1 test failing on this branch is a known and not related to this PR

On S3C nothing restarts a backbeat process whose consumer wedged past the rebalance
drain timeout: the lib disconnects it so the healthcheck fails, but supervisord only
restarts on exit — so the worker stays down, and its stuck tasks can still complete
late and write over the partition's new owner (ghost objects). This adds an env-gated
hard exit right after that disconnect, in the shared consumer so every backbeat
service is covered: when `CRASH_ON_REBALANCE_TIMEOUT === 'true'`, log a fatal and
`process.exit(1)` after a 1s log-flush grace. Same pattern as the existing
`CRASH_ON_BATCH_TIMEOUT` in LogReader.

The 1s grace leaves a window where a wedged task could wake and fire one last write.
That is benign: the next partition owner has not even finished the rebalance yet, so
its redo of the same uncommitted entry always lands later and supersedes the write.
The damaging ordering (a stale write landing after the redo) needs the stuck worker
alive minutes later, which is exactly what the exit removes.

Inert unless the env var is set: never set on Zenko/K8s (the liveness probe already
handles this state), set container-wide on S3C by scality/Federation#6929. Hard exit
rather than SIGTERM because the graceful stop path waits on the very tasks that are
stuck; strict `=== 'true'` so the var can be explicitly set to `false` to disarm.

Both endings of the drain window are pinned by functional tests against a real kafka
broker: gate unset → disconnect, process stays alive; gate armed → exit(1) fires after
the fatal. The tests stub `process.exit` before arming the gate, so the test process
can never actually die.
