### PR TITLE
BB-788: Log stuck task identities on rebalance timeout

### DIFF
--- a/extensions/replication/queueProcessor/QueueProcessor.js
+++ b/extensions/replication/queueProcessor/QueueProcessor.js
@@ -390,6 +390,9 @@ class QueueProcessor extends EventEmitter {
         const groupId =
               `${this.repConfig.queueProcessor.groupId}-${this.site}`;
         const consumer = new BackbeatConsumer({
+            // names this consumer's log lines (the default is a generic
+            // 'BackbeatConsumer' shared by every backbeat service)
+            clientId: `Backbeat:Replication:QueueProcessor:${this.site}:Consumer`,
             zookeeper: {
                 connectionString: this.zkConfig.connectionString,
             },

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -497,6 +497,26 @@ class BackbeatConsumer extends EventEmitter {
         };
     }
 
+    /**
+     * Snapshot of the entries currently being processed, for
+     * observability (e.g. naming the tasks stuck past the rebalance
+     * drain timeout). Capped at 5 tasks; the key (the object name for
+     * replication entries) is truncated to 200 chars.
+     *
+     * @return {object[]} one item per in-flight task:
+     * { topic, partition, offset, key }
+     */
+    getInFlightTasks() {
+        return (this._processingQueue?.workersList() || [])
+            .slice(0, 5)
+            .map(w => ({
+                topic: w.data.topic,
+                partition: w.data.partition,
+                offset: w.data.offset,
+                key: w.data.key && w.data.key.toString().slice(0, 200),
+            }));
+    }
+
     _scheduleNextTryConsume() {
         this._tryConsumedTimeout = setTimeout(this._tryConsume.bind(this), 1000);
     }
@@ -729,7 +749,16 @@ class BackbeatConsumer extends EventEmitter {
             this._drainProcessQueueTimeout = setTimeout(() => {
                 unassign(unassignStatus.TIMEOUT);
 
-                this._log.error('rdkafka.rebalance timeout: consumer stuck, disconnecting');
+                const queueLen = this._processingQueue?.length();
+                const running = this._processingQueue?.running();
+                const stuckTasks = this.getInFlightTasks();
+                this._log.error('rdkafka.rebalance timeout: consumer stuck, disconnecting', {
+                    topic: this._topic,
+                    groupId: this._groupId,
+                    queueLen,
+                    running,
+                    stuckTasks,
+                });
                 this._consumer.disconnect();
                 if (process.env.CRASH_ON_REBALANCE_TIMEOUT === 'true') {
                     // On S3C, supervisord only restarts a program when its

--- a/tests/unit/backbeatConsumer.js
+++ b/tests/unit/backbeatConsumer.js
@@ -157,6 +157,66 @@ describe('backbeatConsumer', () => {
         });
     });
 
+    describe('getInFlightTasks', () => {
+        let consumer;
+
+        beforeEach(() => {
+            consumer = new BackbeatConsumerMock({
+                kafka,
+                groupId: 'unittest-group',
+                topic: 'my-test-topic',
+            });
+        });
+
+        it('should return an empty array without a processing queue', () => {
+            assert.deepStrictEqual(consumer.getInFlightTasks(), []);
+        });
+
+        it('should map in-flight entries to their identities', () => {
+            consumer._processingQueue = {
+                workersList: () => [{
+                    data: {
+                        topic: 'my-test-topic',
+                        partition: 1,
+                        offset: 42,
+                        key: Buffer.from(`object-key-${'x'.repeat(300)}`),
+                    },
+                }, {
+                    data: {
+                        topic: 'my-test-topic',
+                        partition: 2,
+                        offset: 7,
+                    },
+                }],
+            };
+            const tasks = consumer.getInFlightTasks();
+            assert.strictEqual(tasks.length, 2);
+            assert.strictEqual(tasks[0].topic, 'my-test-topic');
+            assert.strictEqual(tasks[0].partition, 1);
+            assert.strictEqual(tasks[0].offset, 42);
+            // key is stringified and truncated to 200 chars
+            assert.strictEqual(tasks[0].key.length, 200);
+            assert(tasks[0].key.startsWith('object-key-'),
+                'key should keep its prefix after truncation');
+            // entries without a key stay readable
+            assert.strictEqual(tasks[1].offset, 7);
+            assert.strictEqual(tasks[1].key, undefined);
+        });
+
+        it('should cap the number of returned tasks', () => {
+            const workers = [];
+            for (let i = 0; i < 7; i++) {
+                workers.push({ data: {
+                    topic: 'my-test-topic', partition: 0, offset: i,
+                } });
+            }
+            consumer._processingQueue = { workersList: () => workers };
+            assert.deepStrictEqual(
+                consumer.getInFlightTasks().map(task => task.offset),
+                [0, 1, 2, 3, 4]);
+        });
+    });
+
     describe('sequentialy consume from topic', () => {
         let consumer;
 


### PR DESCRIPTION
## Intent: why does this change exist?

When BB-787's self-exit fires (scality/backbeat#2761), the logs say nothing about which
objects were stuck or whether the exit gate was even armed. Customer success debugging a
stuck CRR site from log files alone needs both: the identity of the wedged object, and the
difference between "this consumer will restart itself" and "this consumer is down until
someone acts".

## System impact: what's affected, including downstream?

**Replication (CRR) only — no other consumer changes behavior.** Three structural
guarantees, each grep-verifiable on this diff:

- The `rebalance.timeout` event has exactly **one listener in the repo**
  (`QueueProcessor.js`); for lifecycle, GC, notification, the populator, the status
  processor and all of Zenko, the emit is a no-op by Node EventEmitter semantics.
- `QueueProcessor.js` is loaded **only** by the replication queue/replay processor
  entrypoint (`extensions/replication/queueProcessor/task.js`) — the logger naming and the
  new CRR log lines cannot execute in any other process.
- **Zero per-message work is added** — the hot path (millions of objects/day) is untouched;
  every addition runs on the stuck path, at most once per drain timeout.

The one shared surface, stated openly: the pre-existing `'consumer stuck, disconnecting'`
error line in `lib/BackbeatConsumer.js` gains payload fields (topic, groupId, queue state,
stuck-task identities). Other consumers DO get those richer fields if **they** ever get
stuck — same line, same level, same moment, identical control flow; strictly additive JSON
on a rare incident-only error. That is an observability improvement for them, not a
behavior change.

## Preserved behavior: what explicitly stays the same?

All hot-path code is untouched — zero per-entry work added (deliberately: millions of
objects flow through these consumers). The revoke/un-assign rebalance lines are unchanged;
drain timing remains derivable from their existing timestamps. The rebalance.timeout event
gains a payload, which its only listener uses for logging.

## Intended change: what's different after this PR?

The stuck error line now names the in-flight tasks — topic, partition, offset and the
kafka key, which for replication entries is the object name, the one identity no existing
log line carries (`slow task` logs the offset but not the key). Capped at 5 tasks, keys
truncated to 200 chars. The queue processor logs an error when the timeout fires with the
gate disarmed ("self-restart disabled; consumer stays disconnected until restarted externally"), and the fatal exit
line carries queue state and site.

## Verification: how do we know this worked, or how would we know if it didn't?

Unit: getInFlightTasks shape/truncation/cap tests; the stuck-exit spec asserts the fatal
payload, the gate-off error, and exit timing across all gate states. Functional: the
existing stuck-rebalance test now asserts the event payload carries the stuck-task array
with real offsets from a genuinely wedged consumer against the CI kafka image.



