### PR TITLE
BB-788: Log stuck task identities on rebalance timeout

### DIFF
--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -19,6 +19,9 @@ const { unassignStatus } = require('./constants');
 // controls the number of messages to process in parallel
 const CONCURRENCY_DEFAULT = 1;
 const CLIENT_ID = 'BackbeatConsumer';
+// max in-flight task identities included in a log line, so the line
+// stays small at any configured concurrency
+const IN_FLIGHT_TASKS_LOG_LIMIT = 10;
 const { withTopicPrefix } = require('./util/topic');
 
 /**
@@ -497,6 +500,27 @@ class BackbeatConsumer extends EventEmitter {
         };
     }
 
+    /**
+     * Snapshot of the entries currently being processed, for
+     * observability (e.g. naming the tasks stuck past the rebalance
+     * drain timeout). Capped at IN_FLIGHT_TASKS_LOG_LIMIT tasks; a
+     * wedged task never finishes, so it is always among them.
+     *
+     * @return {object[]} one item per in-flight task:
+     * { topic, partition, offset, key }; [] when there is no
+     * processing queue
+     */
+    getInFlightTasks() {
+        return (this._processingQueue?.workersList() || [])
+            .slice(0, IN_FLIGHT_TASKS_LOG_LIMIT)
+            .map(w => ({
+                topic: w.data.topic,
+                partition: w.data.partition,
+                offset: w.data.offset,
+                key: w.data.key && w.data.key.toString(),
+            }));
+    }
+
     _scheduleNextTryConsume() {
         this._tryConsumedTimeout = setTimeout(this._tryConsume.bind(this), 1000);
     }
@@ -729,7 +753,16 @@ class BackbeatConsumer extends EventEmitter {
             this._drainProcessQueueTimeout = setTimeout(() => {
                 unassign(unassignStatus.TIMEOUT);
 
-                this._log.error('rdkafka.rebalance timeout: consumer stuck, disconnecting');
+                const queueLen = this._processingQueue?.length();
+                const running = this._processingQueue?.running();
+                const stuckTasks = this.getInFlightTasks();
+                this._log.error('rdkafka.rebalance timeout: consumer stuck, disconnecting', {
+                    topic: this._topic,
+                    groupId: this._groupId,
+                    queueLen,
+                    running,
+                    stuckTasks,
+                });
                 this._consumer.disconnect();
                 if (process.env.CRASH_ON_REBALANCE_TIMEOUT === 'true') {
                     // On S3C, supervisord only restarts a program when

--- a/tests/unit/backbeatConsumer.js
+++ b/tests/unit/backbeatConsumer.js
@@ -157,6 +157,66 @@ describe('backbeatConsumer', () => {
         });
     });
 
+    describe('getInFlightTasks', () => {
+        let consumer;
+
+        beforeEach(() => {
+            consumer = new BackbeatConsumerMock({
+                kafka,
+                groupId: 'unittest-group',
+                topic: 'my-test-topic',
+            });
+        });
+
+        it('should return an empty array without a processing queue', () => {
+            assert.deepStrictEqual(consumer.getInFlightTasks(), []);
+        });
+
+        it('should map in-flight entries to their identities', () => {
+            consumer._processingQueue = {
+                workersList: () => [{
+                    data: {
+                        topic: 'my-test-topic',
+                        partition: 1,
+                        offset: 42,
+                        key: Buffer.from(`object-key-${'x'.repeat(300)}`),
+                    },
+                }, {
+                    data: {
+                        topic: 'my-test-topic',
+                        partition: 2,
+                        offset: 7,
+                    },
+                }],
+            };
+            const tasks = consumer.getInFlightTasks();
+            assert.strictEqual(tasks.length, 2);
+            assert.strictEqual(tasks[0].topic, 'my-test-topic');
+            assert.strictEqual(tasks[0].partition, 1);
+            assert.strictEqual(tasks[0].offset, 42);
+            // the key is stringified whole, never truncated
+            assert.strictEqual(tasks[0].key,
+                `object-key-${'x'.repeat(300)}`);
+            // entries without a key keep their other fields, the key
+            // field stays undefined
+            assert.strictEqual(tasks[1].offset, 7);
+            assert.strictEqual(tasks[1].key, undefined);
+        });
+
+        it('should cap the number of returned tasks', () => {
+            const workers = [];
+            for (let i = 0; i < 12; i++) {
+                workers.push({ data: {
+                    topic: 'my-test-topic', partition: 0, offset: i,
+                } });
+            }
+            consumer._processingQueue = { workersList: () => workers };
+            assert.deepStrictEqual(
+                consumer.getInFlightTasks().map(task => task.offset),
+                [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        });
+    });
+
     describe('sequentialy consume from topic', () => {
         let consumer;
 


### PR DESCRIPTION
Note: 1 test failing on this branch is a known and not related to this PR

When the rebalance drain timeout fires, the stuck-consumer error line now says what the
consumer was stuck on: queue depth, running count, and the kafka coordinates + message
key of up to 10 in-flight tasks. Keys are logged whole (their size is already bounded
by arsenal's objectKeyByteLimit). The cap of 10 equals the default consumer
concurrency, so the line can list a full default in-flight set but never grows past
~11KB worst case; the list is oldest-first, so the wedged tasks always lead it, and
anything beyond ten would be the newest, least suspicious entries. Runs once, in the
drain-timeout path only — zero per-message work. Stacked on #2761.

A real line, captured from the functional suite (single line in the logs, wrapped here):

```json
{"name":"BackbeatConsumer","time":1781182870950,
 "topic":"backbeat-consumer-spec-shutdown","groupId":"bucket-processor-0.274398999",
 "queueLen":0,"running":1,
 "stuckTasks":[{"topic":"backbeat-consumer-spec-shutdown","partition":0,"offset":142,"key":"key"}],
 "level":"error","message":"rdkafka.rebalance timeout: consumer stuck, disconnecting",
 "hostname":"...","pid":76103}
```

On a CRR processor the same line carries `topic: backbeat-replication`,
`groupId: backbeat-replication-group-<site>` (configured groupId + site), and
`key: <bucket>/<object-key>` — the key the populator sets when publishing the entry
(`ReplicationQueuePopulator.js`). The key names the wedged object, partition/offset let
you fetch the exact message back from kafka, and grepping the processor log for the key
shows how far the task got.

Ten is also sufficient because nothing beyond it is lost: `running` minus the listed
tasks says how many more were in flight, and the remainder is recoverable two ways --
dump the partition from the lowest listed offset with kafka tools (every message key
names its object), or just wait: the next partition owner re-runs every uncommitted
entry and logs each one as it goes.
