### PR TITLE
Drop redundant stuck-task logging and stabilize topic-metrics test

### DIFF
--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -478,13 +478,16 @@ class BackbeatConsumer extends EventEmitter {
      * @returns {function} - callback function to be called when task has been processed
      */
     _startProcessingTask(entry) {
-        const { topic, partition, offset } = entry;
+        const { topic, partition, offset, key } = entry;
         const consumerGroup = this._groupId;
         const taskStartTime = Date.now();
 
         let slow = false;
         const slowTimer = setTimeout(() => {
-            this._log.warn('slow task', { topic, partition, consumerGroup, offset });
+            this._log.warn('slow task', {
+                topic, partition, consumerGroup, offset,
+                key: key?.toString(),
+            });
             slow = true;
             KafkaBacklogMetrics.onSlowTask(topic, partition, consumerGroup);
         }, this._maxPollIntervalMs);
@@ -729,7 +732,12 @@ class BackbeatConsumer extends EventEmitter {
             this._drainProcessQueueTimeout = setTimeout(() => {
                 unassign(unassignStatus.TIMEOUT);
 
-                this._log.error('rdkafka.rebalance timeout: consumer stuck, disconnecting');
+                this._log.error('rdkafka.rebalance timeout: consumer stuck, disconnecting', {
+                    topic: this._topic,
+                    groupId: this._groupId,
+                    queueLen: this._processingQueue.length(),
+                    running: this._processingQueue.running(),
+                });
                 this._consumer.disconnect();
                 if (process.env.CRASH_ON_REBALANCE_TIMEOUT === 'true') {
                     // On S3C, supervisord only restarts a program when

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -19,9 +19,6 @@ const { unassignStatus } = require('./constants');
 // controls the number of messages to process in parallel
 const CONCURRENCY_DEFAULT = 1;
 const CLIENT_ID = 'BackbeatConsumer';
-// max in-flight task identities included in a log line, so the line
-// stays small at any configured concurrency
-const IN_FLIGHT_TASKS_LOG_LIMIT = 10;
 const { withTopicPrefix } = require('./util/topic');
 
 /**
@@ -500,27 +497,6 @@ class BackbeatConsumer extends EventEmitter {
         };
     }
 
-    /**
-     * Snapshot of the entries currently being processed, for
-     * observability (e.g. naming the tasks stuck past the rebalance
-     * drain timeout). Capped at IN_FLIGHT_TASKS_LOG_LIMIT tasks; a
-     * wedged task never finishes, so it is always among them.
-     *
-     * @return {object[]} one item per in-flight task:
-     * { topic, partition, offset, key }; [] when there is no
-     * processing queue
-     */
-    getInFlightTasks() {
-        return (this._processingQueue?.workersList() || [])
-            .slice(0, IN_FLIGHT_TASKS_LOG_LIMIT)
-            .map(w => ({
-                topic: w.data.topic,
-                partition: w.data.partition,
-                offset: w.data.offset,
-                key: w.data.key && w.data.key.toString(),
-            }));
-    }
-
     _scheduleNextTryConsume() {
         this._tryConsumedTimeout = setTimeout(this._tryConsume.bind(this), 1000);
     }
@@ -753,16 +729,7 @@ class BackbeatConsumer extends EventEmitter {
             this._drainProcessQueueTimeout = setTimeout(() => {
                 unassign(unassignStatus.TIMEOUT);
 
-                const queueLen = this._processingQueue?.length();
-                const running = this._processingQueue?.running();
-                const stuckTasks = this.getInFlightTasks();
-                this._log.error('rdkafka.rebalance timeout: consumer stuck, disconnecting', {
-                    topic: this._topic,
-                    groupId: this._groupId,
-                    queueLen,
-                    running,
-                    stuckTasks,
-                });
+                this._log.error('rdkafka.rebalance timeout: consumer stuck, disconnecting');
                 this._consumer.disconnect();
                 if (process.env.CRASH_ON_REBALANCE_TIMEOUT === 'true') {
                     // On S3C, supervisord only restarts a program when

--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -848,37 +848,47 @@ class BackbeatConsumer extends EventEmitter {
         let lastBootstrapId;
         let producer; // eslint-disable-line prefer-const
         let producerTimer;
-        let consumerTimer;
-        function consumeCb(err, messages) {
-            if (err) {
-                return undefined;
+        let bootstrapped = false;
+        function consumeOnce() {
+            if (bootstrapped) {
+                return;
             }
-            messages.forEach(message => {
-                const bootstrapId = JSON.parse(message.value).bootstrapId;
-                if (bootstrapId) {
-                    self._log.info('bootstraping backbeat consumer: ' +
-                        'received bootstrap message',
-                        { bootstrapId, topic: self._topic, groupId: self._groupId });
-                    if (bootstrapId === lastBootstrapId) {
-                        self._log.info('backbeat consumer is bootstrapped',
-                            { topic: self._topic, groupId: self._groupId });
-                        clearInterval(producerTimer);
-                        clearInterval(consumerTimer);
-                        self._consumer.offsetsStore([{
-                            topic: self._topic,
-                            partition: message.partition,
-                            offset: message.offset + 1,
-                        }]);
-                        self._consumer.commit();
-                        self._consumer.unsubscribe();
-                        producer.close(() => {
-                            self._bootstrapping = false;
-                            self._onReady();
-                        });
-                    }
+            self._consumer.consume(1, (err, messages) => {
+                if (bootstrapped) {
+                    return;
+                }
+                if (!err) {
+                    messages.forEach(message => {
+                        const bootstrapId =
+                              JSON.parse(message.value).bootstrapId;
+                        if (bootstrapId) {
+                            self._log.info('bootstraping backbeat consumer: ' +
+                                'received bootstrap message',
+                                { bootstrapId, topic: self._topic, groupId: self._groupId });
+                            if (bootstrapId === lastBootstrapId) {
+                                self._log.info('backbeat consumer is bootstrapped',
+                                    { topic: self._topic, groupId: self._groupId });
+                                bootstrapped = true;
+                                clearInterval(producerTimer);
+                                self._consumer.offsetsStore([{
+                                    topic: self._topic,
+                                    partition: message.partition,
+                                    offset: message.offset + 1,
+                                }]);
+                                self._consumer.commit();
+                                self._consumer.unsubscribe();
+                                producer.close(() => {
+                                    self._bootstrapping = false;
+                                    self._onReady();
+                                });
+                            }
+                        }
+                    });
+                }
+                if (!bootstrapped) {
+                    setTimeout(consumeOnce, 200);
                 }
             });
-            return undefined;
         }
         assert.strictEqual(this._consumer, null);
         producer = new BackbeatProducer({
@@ -903,9 +913,7 @@ class BackbeatConsumer extends EventEmitter {
                         this._initConsumer();
                         this._consumer.on('ready', () => {
                             this._consumer.subscribe([this._topic]);
-                            consumerTimer = setInterval(() => {
-                                this._consumer.consume(1, consumeCb);
-                            }, 200);
+                            consumeOnce();
                         });
                     }, 500);
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.0.28",
+  "version": "9.0.29",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/backbeatConsumer.js
+++ b/tests/unit/backbeatConsumer.js
@@ -157,66 +157,6 @@ describe('backbeatConsumer', () => {
         });
     });
 
-    describe('getInFlightTasks', () => {
-        let consumer;
-
-        beforeEach(() => {
-            consumer = new BackbeatConsumerMock({
-                kafka,
-                groupId: 'unittest-group',
-                topic: 'my-test-topic',
-            });
-        });
-
-        it('should return an empty array without a processing queue', () => {
-            assert.deepStrictEqual(consumer.getInFlightTasks(), []);
-        });
-
-        it('should map in-flight entries to their identities', () => {
-            consumer._processingQueue = {
-                workersList: () => [{
-                    data: {
-                        topic: 'my-test-topic',
-                        partition: 1,
-                        offset: 42,
-                        key: Buffer.from(`object-key-${'x'.repeat(300)}`),
-                    },
-                }, {
-                    data: {
-                        topic: 'my-test-topic',
-                        partition: 2,
-                        offset: 7,
-                    },
-                }],
-            };
-            const tasks = consumer.getInFlightTasks();
-            assert.strictEqual(tasks.length, 2);
-            assert.strictEqual(tasks[0].topic, 'my-test-topic');
-            assert.strictEqual(tasks[0].partition, 1);
-            assert.strictEqual(tasks[0].offset, 42);
-            // the key is stringified whole, never truncated
-            assert.strictEqual(tasks[0].key,
-                `object-key-${'x'.repeat(300)}`);
-            // entries without a key keep their other fields, the key
-            // field stays undefined
-            assert.strictEqual(tasks[1].offset, 7);
-            assert.strictEqual(tasks[1].key, undefined);
-        });
-
-        it('should cap the number of returned tasks', () => {
-            const workers = [];
-            for (let i = 0; i < 12; i++) {
-                workers.push({ data: {
-                    topic: 'my-test-topic', partition: 0, offset: i,
-                } });
-            }
-            consumer._processingQueue = { workersList: () => workers };
-            assert.deepStrictEqual(
-                consumer.getInFlightTasks().map(task => task.offset),
-                [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-        });
-    });
-
     describe('sequentialy consume from topic', () => {
         let consumer;
 


### PR DESCRIPTION
This PR removes the stuck-task snapshot added in BB-788. getInFlightTasks() was reading w.data.topic/partition/offset off async.queue's workers, but the processing queue is now a TaskScheduler that pushes contexts shaped as { entry }, so the field accesses threw and the rdkafka.rebalance timeout: consumer stuck, disconnecting log never carried the identities it was meant to surface. Investigation showed the snapshot was redundant anyway: the per-task slow task warning in _startProcessingTask fires at maxPollIntervalMs and the rebalance drain timeout fires at maxPollIntervalMs - 1000, with the consumer paused during draining, so every in-flight task at timeout has already been logged individually with topic, partition, consumerGroup and offset.

The only field the snapshot carried that slow task did not was the message key, which is now added to the slow-task log. The rebalance-timeout error keeps the cheap queueLen and running reads from the TaskScheduler so operators can still distinguish "wedged on running work" from "backed up in the queue" at the moment of disconnection. TaskScheduler stays agnostic of the kafka entry shape. No new public surface was added.

The PR also stabilizes the "publish topic metrics" functional test, which summed debounced consumed event counts to exactly messages.length and flaked under CI timing. It now checks the queueProcessor's own consumedMessages array, guarded by a flag so the assertion block runs once.

Issue: BB-789