### PR TITLE
feat(lifecycle): support Days=0 expiration (current, noncurrent, abort-MPU)

### DIFF
--- a/extensions/lifecycle/util/RulesReducer.js
+++ b/extensions/lifecycle/util/RulesReducer.js
@@ -142,8 +142,7 @@ class RulesReducer {
         let storageClass;
 
         if (r.Expiration) {
-            // NOTE: Expiration Days cannot be 0.
-            if (r.Expiration.Days) {
+            if (r.Expiration.Days !== undefined) {
                 days = this._decrementExpirationDay(r.Expiration.Days);
             } else if (r.Expiration.Date) {
                 if (r.Expiration.Date <= this._currentDate) {
@@ -200,8 +199,8 @@ class RulesReducer {
         let storageClass;
 
         if (r.NoncurrentVersionExpiration) {
-            // 'NoncurrentDays' for NoncurrentVersionExpiration action is a positive integer
-            if (r.NoncurrentVersionExpiration.NoncurrentDays) {
+            // 'NoncurrentDays' for NoncurrentVersionExpiration action is a nonnegative integer
+            if (r.NoncurrentVersionExpiration.NoncurrentDays !== undefined) {
                 days = this._decrementExpirationDay(r.NoncurrentVersionExpiration.NoncurrentDays);
             }
         }
@@ -246,7 +245,7 @@ class RulesReducer {
         // NOTE: When you specify the Days tag, Amazon S3 automatically performs ExpiredObjectDeleteMarker
         // cleanup when the delete markers are old enough to satisfy the age criteria.
         if (r.Expiration) {
-            if (r.Expiration.Days) {
+            if (r.Expiration.Days !== undefined) {
                 days = this._decrementExpirationDay(r.Expiration.Days);
             } else if (r.Expiration.Date) {
                 if (r.Expiration.Date <= this._currentDate) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.5.0-preview.1",
+  "version": "9.5.0-preview.2",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/lifecycle/RulesReducer.spec.js
+++ b/tests/unit/lifecycle/RulesReducer.spec.js
@@ -143,6 +143,29 @@ describe('RulesReducer with versioning Disabled', () => {
         assert.deepStrictEqual(result, expected);
     });
 
+    it('with Expiration rule using Days set to 0', () => {
+        const currentDate = Date.now();
+        const prefix = '';
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 0 },
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{
+                prefix: '',
+                days: 0,
+            }]
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
     it('with Expiration rule using Days and prefix', () => {
         const currentDate = Date.now();
         const prefix = 'pre';

--- a/tests/unit/lifecycle/RulesReducerWithVersion.spec.js
+++ b/tests/unit/lifecycle/RulesReducerWithVersion.spec.js
@@ -121,6 +121,28 @@ describe('RulesReducer with versioning Enabled', () => {
         assert.deepStrictEqual(result, expected);
     });
 
+    it('with Expiration rule using Days set to 0', () => {
+        const currentDate = Date.now();
+        const prefix = '';
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 0 },
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            currents: [{ prefix: '', days: 0 }],
+            nonCurrents: [],
+            orphans: [{ prefix: '', days: 0 }],
+        };
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        assert.deepStrictEqual(result, expected);
+    });
+
     it('with Expiration rule using Days and prefix', () => {
         const currentDate = Date.now();
         const prefix = 'pre';
@@ -454,6 +476,30 @@ describe('RulesReducer with versioning Enabled', () => {
             nonCurrents: [{
                 prefix: '',
                 days: 2,
+            }],
+            orphans: [],
+        };
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with NoncurrentVersionExpiration rule using NoncurrentDays set to 0', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                NoncurrentVersionExpiration: { NoncurrentDays: 0 },
+                ID: '0',
+                Prefix: '',
+                Status: 'Enabled',
+            },
+        ];
+        const rulesReducer = new RulesReducer(versioningStatus, currentDate, bucketLCRules, options);
+        const result = rulesReducer.toListings();
+
+        const expected = {
+            currents: [],
+            nonCurrents: [{
+                prefix: '',
+                days: 0,
             }],
             orphans: [],
         };

--- a/tests/unit/lifecycle/rules.spec.js
+++ b/tests/unit/lifecycle/rules.spec.js
@@ -318,6 +318,31 @@ describe('rulesToParams with versioning Disabled', () => {
         assert.deepStrictEqual(result, expected);
     });
 
+    it('with Expiration rule using Days set to 0 (no BeforeDate, lists all)', () => {
+        const currentDate = Date.now();
+        const prefix = '';
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 0 },
+                ID: '123',
+                Prefix: prefix,
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: prefix,
+               MaxKeys: MAX_KEYS,
+            },
+            listType: 'current',
+            remainings: []
+        };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
     it('with Expiration rule using Days and prefix', () => {
         const currentDate = Date.now();
         const prefix = 'pre';

--- a/tests/unit/lifecycle/rulesWithVersion.spec.js
+++ b/tests/unit/lifecycle/rulesWithVersion.spec.js
@@ -262,6 +262,33 @@ describe('rulesToParams with versioning Enabled', () => {
         assert.deepStrictEqual(result, expected);
     });
 
+    it('with Expiration rule using Days set to 0 (no BeforeDate, lists all)', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                Expiration: { Days: 0 },
+                ID: '123',
+                Prefix: '',
+                Status: 'Enabled',
+            }
+        ];
+        const expected = {
+            params: {
+               Bucket: bucketName,
+               Prefix: '',
+               MaxKeys: MAX_KEYS,
+            },
+            listType: 'current',
+            remainings: [{
+                listType: 'orphan',
+                prefix: '',
+            }]
+        };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
     it('with Expiration rule using Days', () => {
         const currentDate = Date.now();
         const prefix = '';
@@ -712,6 +739,31 @@ describe('rulesToParams with versioning Enabled', () => {
             {
                 NoncurrentVersionTransitions: [{ NoncurrentDays: 0, StorageClass: locationName }],
                 ID: '456',
+                Prefix: '',
+                Status: 'Enabled',
+            }
+        ];
+
+        const expected = {
+            params: {
+                Bucket: bucketName,
+                Prefix: '',
+                MaxKeys: MAX_KEYS,
+            },
+            listType: 'noncurrent',
+            remainings: []
+        };
+
+        const result = rulesToParams(versioningStatus, currentDate, bucketLCRules, bucketData, options);
+        assert.deepStrictEqual(result, expected);
+    });
+
+    it('with NoncurrentVersionExpiration rule using NoncurrentDays set to 0 (no BeforeDate)', () => {
+        const currentDate = Date.now();
+        const bucketLCRules = [
+            {
+                NoncurrentVersionExpiration: { NoncurrentDays: 0 },
+                ID: '123',
                 Prefix: '',
                 Status: 'Enabled',
             }


### PR DESCRIPTION
## Summary

Support an explicit lifecycle expiration rule with `Days=0` (previously the minimum was 1) as the unambiguous "empty this bucket" intent — for current `Expiration.Days`, `NoncurrentVersionExpiration.NoncurrentDays`, and orphan delete-marker expiration.

The only backbeat code that dropped `Days=0` was the V2 listing optimizer (`RulesReducer`), which used truthy `if (r.Expiration.Days)` gates. These are switched to `!== undefined`. `days=0` then yields a listing with no `BeforeDate` (lists all objects) — the same internal state a past-dated `Expiration.Date` already produces. Per-object eligibility checks (`LifecycleTask` / `LifecycleTaskV2`) already handle `0`.

`AbortIncompleteMultipartUpload.DaysAfterInitiation=0` needs no backbeat change: MPUs are listed via `listMultipartUploads` (not the reducer), and the per-object check already supports `0`.

## Dependencies

This change is **self-contained** — the reducer reads the already-stored `Days` value and never calls arsenal's lifecycle parser, so backbeat needs no arsenal change. The earlier arsenal-bump commit has been **dropped**; this PR inherits `development/9.5`'s arsenal pin (`8.4.7`) with no version jump.

End-to-end, `Days=0` still requires the *storage* side to accept and persist a 0-day rule — arsenal **ARSN-597** (relaxed day-based validators, now on the 8.5 line) as consumed by cloudserver **CLDSRV-928**. That's a runtime/rollout ordering, not a build dependency of this PR.

## Notes

- `Days=0` deliberately diverges from AWS S3 (which requires ≥ 1); that divergence is what makes it a safe explicit intent signal.

Issue: BB-791
