### PR TITLE
Process master entry on ObjectRestore:Retry

### DIFF
--- a/extensions/lifecycle/LifecycleQueuePopulator.js
+++ b/extensions/lifecycle/LifecycleQueuePopulator.js
@@ -283,8 +283,10 @@ class LifecycleQueuePopulator extends QueuePopulatorExtension {
         }
 
         // if entry is a versioned object and is the master entry, skip task as
-        // the non-master entry will be processed
-        if (this._isVersionedObject(value) && isMasterKey(entry.key)) {
+        // the non-master entry will be processed. The retrigger restore flow
+        // (originOp 's3:ObjectRestore:Retry') only updates the master entry, so
+        // the master event is the only one we will ever get — do not skip it.
+        if (this._isVersionedObject(value) && isMasterKey(entry.key) && operation !== 's3:ObjectRestore:Retry') {
             this.log.trace('skip processing of object master entry');
             return;
         }

--- a/tests/unit/lifecycle/LifecycleQueuePopulator.spec.js
+++ b/tests/unit/lifecycle/LifecycleQueuePopulator.spec.js
@@ -374,6 +374,82 @@ describe('LifecycleQueuePopulator', () => {
                 assert(!kafkaAdjustSendStub.calledOnce);
                 assert(!kafkaSendStub.calledOnce);
             });
+
+            it('should process master entry on s3:ObjectRestore:Retry even when isNull is set', () => {
+                const objMd = {
+                    'md-model-version': 2,
+                    'owner-display-name': 'Bart',
+                    'owner-id': '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be',
+                    'x-amz-storage-class': 'dmf-v1',
+                    'content-length': 542,
+                    'content-type': 'text/plain',
+                    'last-modified': '2017-07-13T02:44:25.515Z',
+                    'content-md5': '01064f35c238bd2b785e34508c3d27f4',
+                    'key': 'object',
+                    'location': [],
+                    'isDeleteMarker': false,
+                    'isNull': true,
+                    'versionId': '98500086134471999999RG001  0',
+                    'archive': {
+                        archiveInfo: {
+                            archiveId: '04425717-a65c-4e8a-95e1-fa1d902d9d9f',
+                            archiveVersion: 7504504064263669,
+                        },
+                        restoreRequestedAt: '2017-07-11T02:44:25.515Z',
+                        restoreRequestedDays: 3,
+                    },
+                    'dataStoreName': 'dmf-v1',
+                    'originOp': 's3:ObjectRestore:Retry',
+                };
+                const entry = {
+                    type: 'put',
+                    bucket: 'lc-queue-populator-test-bucket',
+                    key: 'object',
+                    value: JSON.stringify(objMd),
+                };
+
+                lcqp._handleRestoreOp(entry);
+
+                assert(kafkaSendStub.calledOnce);
+            });
+
+            it('should still skip master entry on s3:ObjectRestore:Post when isNull is set', () => {
+                const objMd = {
+                    'md-model-version': 2,
+                    'owner-display-name': 'Bart',
+                    'owner-id': '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be',
+                    'x-amz-storage-class': 'dmf-v1',
+                    'content-length': 542,
+                    'content-type': 'text/plain',
+                    'last-modified': '2017-07-13T02:44:25.515Z',
+                    'content-md5': '01064f35c238bd2b785e34508c3d27f4',
+                    'key': 'object',
+                    'location': [],
+                    'isDeleteMarker': false,
+                    'isNull': true,
+                    'versionId': '98500086134471999999RG001  0',
+                    'archive': {
+                        archiveInfo: {
+                            archiveId: '04425717-a65c-4e8a-95e1-fa1d902d9d9f',
+                            archiveVersion: 7504504064263669,
+                        },
+                        restoreRequestedAt: '2017-07-11T02:44:25.515Z',
+                        restoreRequestedDays: 3,
+                    },
+                    'dataStoreName': 'dmf-v1',
+                    'originOp': 's3:ObjectRestore:Post',
+                };
+                const entry = {
+                    type: 'put',
+                    bucket: 'lc-queue-populator-test-bucket',
+                    key: 'object',
+                    value: JSON.stringify(objMd),
+                };
+
+                lcqp._handleRestoreOp(entry);
+
+                assert(!kafkaSendStub.called);
+            });
         });
     });
 


### PR DESCRIPTION
For null-version objects (master entry with versionId and isNull: true, typical of buckets that have had versioning Suspended at any point), a requeueRestore Kafka message without objectVersion updates the master metadata as expected but never produces a cold-restore-req message: the lifecycle queue populator's master-skip rule drops the resulting oplog event, and the retry never reaches DMF.

The skip rule was designed for the normal restore flow (s3:ObjectRestore:Post), where the populator receives events on both the master and the version entry and must dedup. The retrigger restore flow (s3:ObjectRestore:Retry) only updates the master entry, so the master event is the only event the populator will ever get for that retry.

This PR exempts s3:ObjectRestore:Retry from the master-skip rule. The normal s3:ObjectRestore:Post path is unchanged.

The current workaround is to pass the encoded internal VersionId returned by head-object in objectVersion, which routes the update through the version-entry path and avoids the skip rule. That requires the caller to know an internal versionId on objects that are otherwise non-versioned from the API's perspective. With this fix, omitting objectVersion works as expected on null-version objects, matching what the S3 API surface implies.

Issue: BB-794