### PR TITLE
Bump package.json to 9.5.0-preview.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.4.0",
+  "version": "9.5.0-preview.1",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Bump backbeat version to `9.5.0-preview.1` so the `development/9.5` branch — which carries the CRR-multiple-destinations work from #2743 — can be consumed by Zenko #2378 for integration testing.

Issue: BB-762