### PR TITLE
improvement: commit + log + metric on task failure in GC and lifecycle cold-archive

### DIFF
--- a/extensions/gc/GarbageCollectorMetrics.js
+++ b/extensions/gc/GarbageCollectorMetrics.js
@@ -23,6 +23,14 @@ const gcDuration = ZenkoMetrics.createHistogram({
     buckets: [0.2, 0.1, 0.5, 2.5, 10, 50],
 });
 
+const gcFailed = ZenkoMetrics.createCounter({
+    name: 's3_gc_failed_total',
+    help: 'Total number of GC tasks that failed permanently after retries ' +
+        'were exhausted or on a non-retryable error. Offset is committed to ' +
+        'avoid ledger leaks; the underlying operation is not retried.',
+    labelNames: [GC_LABEL_ORIGIN, GC_LABEL_LOCATION],
+});
+
 class GarbageCollectorMetrics {
     static handleError(log, err, method) {
         if (log) {
@@ -51,6 +59,17 @@ class GarbageCollectorMetrics {
             }, duration / 1000);
         } catch (err) {
             GarbageCollectorMetrics.handleError(log, err, 'GarbageCollectorMetrics.onGcComplete');
+        }
+    }
+
+    static onGcFailed(log, process, location) {
+        try {
+            gcFailed.inc({
+                [GC_LABEL_ORIGIN]: process,
+                [GC_LABEL_LOCATION]: location,
+            });
+        } catch (err) {
+            GarbageCollectorMetrics.handleError(log, err, 'GarbageCollectorMetrics.onGcFailed');
         }
     }
 }

--- a/extensions/gc/tasks/GarbageCollectorTask.js
+++ b/extensions/gc/tasks/GarbageCollectorTask.js
@@ -203,7 +203,20 @@ class GarbageCollectorTask extends BackbeatTask {
             actionFunc: cb => this._executeDeleteDataOnce(entry, log, cb),
             shouldRetryFunc: err => err.retryable,
             log,
-        }, done);
+        }, err => {
+            if (err) {
+                const ruleType = entry.getContextAttribute('ruleType');
+                log.error('task failed permanently after retries, committing offset', {
+                    method: 'GarbageCollectorTask._executeDeleteData',
+                    error: err.message,
+                    locations: entry.getAttribute('target.locations'),
+                    ...entry.getLogInfo(),
+                });
+                GarbageCollectorMetrics.onGcFailed(log, ruleType,
+                    entry.getAttribute('source.storageClass'));
+            }
+            return done(err);
+        });
     }
 
     _deleteArchivedSourceDataOnce(entry, log, done) {
@@ -250,6 +263,11 @@ class GarbageCollectorTask extends BackbeatTask {
                     }
 
                     if (err) {
+                        // Stash the parts on the entry so the outer
+                        // retry-wrapper's failure log (in
+                        // _deleteArchivedSourceData) can surface them for ops
+                        // to reclaim manually if the delete never succeeds.
+                        entry.setAttribute('target.locations', locations);
                         log.error('an error occurred on batchDelete backbeat route',
                             Object.assign({
                                 method: 'GarbageCollectorTask._deleteArchivedSourceData',
@@ -289,17 +307,7 @@ class GarbageCollectorTask extends BackbeatTask {
                     next(err);
                 });
             },
-        ], err => {
-            if (err) {
-                // if error occurs, do not commit offset unless the error is ObjNotFound
-                // because it means the object has been deleted by other means and we don't need to retry
-                    if (err.name === 'ObjNotFound' || err.name === 'NoSuchBucket') {
-                        return done(err, { committable: true });
-                }
-                return done(err, { committable: false });
-            }
-            return done();
-        });
+        ], err => done(err));
     }
 
     _deleteArchivedSourceData(entry, log, done) {
@@ -310,7 +318,19 @@ class GarbageCollectorTask extends BackbeatTask {
             actionFunc: cb => this._deleteArchivedSourceDataOnce(entry, log, cb),
             shouldRetryFunc: err => err.retryable,
             log,
-        }, done);
+        }, err => {
+            if (err && err.name !== 'ObjNotFound' && err.name !== 'NoSuchBucket') {
+                log.error('task failed permanently after retries, committing offset', {
+                    method: 'GarbageCollectorTask._deleteArchivedSourceData',
+                    error: err.message,
+                    locations: entry.getAttribute('target.locations'),
+                    ...entry.getLogInfo(),
+                });
+                GarbageCollectorMetrics.onGcFailed(log, 'archive',
+                    entry.getAttribute('target.oldLocation'));
+            }
+            return done(err);
+        });
     }
 
     /**

--- a/extensions/lifecycle/LifecycleMetrics.js
+++ b/extensions/lifecycle/LifecycleMetrics.js
@@ -194,6 +194,15 @@ const lifecycleKafkaPublish = {
     }),
 };
 
+const lifecycleFailed = ZenkoMetrics.createCounter({
+    name: 's3_lifecycle_failed_total',
+    help: 'Total number of lifecycle tasks that failed permanently after ' +
+        'retries were exhausted or on a non-retryable error. Offset is ' +
+        'committed to avoid ledger leaks; the underlying operation is not ' +
+        'retried.',
+    labelNames: [LIFECYCLE_LABEL_ORIGIN, LIFECYCLE_LABEL_TYPE, LIFECYCLE_LABEL_LOCATION],
+});
+
 class LifecycleMetrics {
     static handleError(log, err, method, params = {}) {
         if (log) {
@@ -419,6 +428,20 @@ class LifecycleMetrics {
         } catch (err) {
             LifecycleMetrics.handleError(log, err, 'LifecycleMetrics.onKafkaPublish', {
                 op, process, count, kafkaErr,
+            });
+        }
+    }
+
+    static onLifecycleFailed(log, process, type, location) {
+        try {
+            lifecycleFailed.inc({
+                [LIFECYCLE_LABEL_ORIGIN]: process,
+                [LIFECYCLE_LABEL_TYPE]: type,
+                [LIFECYCLE_LABEL_LOCATION]: location,
+            });
+        } catch (err) {
+            LifecycleMetrics.handleError(log, err, 'LifecycleMetrics.onLifecycleFailed', {
+                process, type, location,
             });
         }
     }

--- a/extensions/lifecycle/objectProcessor/LifecycleObjectTransitionProcessor.js
+++ b/extensions/lifecycle/objectProcessor/LifecycleObjectTransitionProcessor.js
@@ -3,6 +3,7 @@ const assert = require('assert');
 const async = require('async');
 
 const ColdStorageStatusQueueEntry = require('../../../lib/models/ColdStorageStatusQueueEntry');
+const { LifecycleMetrics } = require('../LifecycleMetrics');
 const LifecycleObjectProcessor = require('./LifecycleObjectProcessor');
 const LifecycleUpdateExpirationTask = require('../tasks/LifecycleUpdateExpirationTask');
 const LifecycleUpdateTransitionTask = require('../tasks/LifecycleUpdateTransitionTask');
@@ -200,7 +201,20 @@ class LifecycleObjectTransitionProcessor extends LifecycleObjectProcessor {
             actionFunc: done => task.processEntry(coldLocation, entry, done),
             shouldRetryFunc: err => err.retryable,
             log: this._log,
-        }, done);
+        }, err => {
+            if (err) {
+                this._log.error('task failed permanently after retries, committing offset', {
+                    method: 'LifecycleObjectTransitionProcessor.processColdStorageStatusEntry',
+                    error: err.message,
+                    op: entry.op,
+                    coldLocation,
+                    ...entry.getLogInfo(),
+                });
+                LifecycleMetrics.onLifecycleFailed(this._log, this.getProcessorType(),
+                    entry.op, coldLocation);
+            }
+            return done(err);
+        });
     }
 
     getStateVars() {

--- a/extensions/lifecycle/tasks/LifecycleColdStatusArchiveTask.js
+++ b/extensions/lifecycle/tasks/LifecycleColdStatusArchiveTask.js
@@ -137,8 +137,7 @@ class LifecycleColdStatusArchiveTask extends LifecycleUpdateTransitionTask {
             },
         ], err => {
             if (err && !(err instanceof SkipMdUpdateError)) {
-                // if error occurs, do not commit offset
-                return done(err, { committable: false });
+                return done(err);
             }
             return done();
         });

--- a/tests/unit/gc/GarbageCollectorTask.spec.js
+++ b/tests/unit/gc/GarbageCollectorTask.spec.js
@@ -4,6 +4,7 @@ const sinon = require('sinon');
 const { ObjectMD } = require('arsenal').models;
 
 const GarbageCollectorTask = require('../../../extensions/gc/tasks/GarbageCollectorTask');
+const { GarbageCollectorMetrics } = require('../../../extensions/gc/GarbageCollectorMetrics');
 const ActionQueueEntry = require('../../../lib/models/ActionQueueEntry');
 
 const {
@@ -47,6 +48,7 @@ describe('GarbageCollectorTask', () => {
             consumer: {
                 retry: {
                     maxRetries: 3,
+                    backoff: { min: 10, max: 20, factor: 1, jitter: 0 },
                 },
             },
         };
@@ -141,8 +143,9 @@ describe('GarbageCollectorTask', () => {
         });
     });
 
-    it('should not delete archived location info if gc failed', done => {
+    it('should commit and record a failure metric if gc failed', done => {
         backbeatClient.batchDeleteResponse = { error: { statusCode: 500 }, res: null };
+        const onGcFailedSpy = sinon.spy(GarbageCollectorMetrics, 'onGcFailed');
 
         const entry = ActionQueueEntry.create('deleteArchivedSourceData')
               .addContext({
@@ -169,7 +172,10 @@ describe('GarbageCollectorTask', () => {
 
         gcTask.processActionEntry(entry, (err, commitInfo) => {
             assert.strictEqual(err.statusCode, 500);
-            assert.deepStrictEqual(commitInfo, { committable: false });
+            assert.strictEqual(commitInfo, undefined);
+            assert.strictEqual(onGcFailedSpy.callCount, 1);
+            assert.deepStrictEqual(onGcFailedSpy.firstCall.args.slice(1),
+                ['archive', 'old-location']);
             assert.strictEqual(backbeatMetadataProxyClient.getReceivedMd(), null);
 
             const objMD = backbeatMetadataProxyClient.mdObj;
@@ -177,12 +183,14 @@ describe('GarbageCollectorTask', () => {
             assert.strictEqual(objMD.getDataStoreName(), 'old-location');
             assert.strictEqual(objMD.getAmzStorageClass(), 'old-location');
             assert.strictEqual(objMD.getTransitionInProgress(), true);
+            onGcFailedSpy.restore();
             done();
         });
     });
 
     it('should retry delete archived source data if gc failed with retryable error', done => {
         backbeatClient.batchDeleteResponse = { error: { statusCode: 500, retryable: true }, res: null };
+        const onGcFailedSpy = sinon.spy(GarbageCollectorMetrics, 'onGcFailed');
 
         const entry = ActionQueueEntry.create('deleteArchivedSourceData')
               .addContext({
@@ -212,13 +220,17 @@ describe('GarbageCollectorTask', () => {
         gcTask.processActionEntry(entry, (err, commitInfo) => {
             assert.strictEqual(batchDeleteDataSpy.callCount, 4);
             assert.strictEqual(err.statusCode, 500);
-            assert.deepStrictEqual(commitInfo, { committable: false });
+            assert.strictEqual(commitInfo, undefined);
+            assert.strictEqual(onGcFailedSpy.callCount, 1);
+            assert.deepStrictEqual(onGcFailedSpy.firstCall.args.slice(1),
+                ['archive', 'old-location']);
             batchDeleteDataSpy.restore();
+            onGcFailedSpy.restore();
             done();
         });
     });
 
-    it('should send committable error when object is not found', done => {
+    it('should commit without retry when object is not found', done => {
         backbeatMetadataProxyClient.error = { statusCode: 404, name: 'ObjNotFound' };
 
         const entry = ActionQueueEntry.create('deleteArchivedSourceData')
@@ -242,12 +254,12 @@ describe('GarbageCollectorTask', () => {
 
         gcTask.processActionEntry(entry, (err, commitInfo) => {
             assert.strictEqual(err.statusCode, 404);
-            assert.deepStrictEqual(commitInfo, { committable: true });
+            assert.strictEqual(commitInfo, undefined);
             done();
         });
     });
 
-    it('should send committable error when bucket is not found', done => {
+    it('should commit without retry when bucket is not found', done => {
         backbeatMetadataProxyClient.error = { statusCode: 404, name: 'NoSuchBucket' };
 
         const entry = ActionQueueEntry.create('deleteArchivedSourceData')
@@ -271,7 +283,7 @@ describe('GarbageCollectorTask', () => {
 
         gcTask.processActionEntry(entry, (err, commitInfo) => {
             assert.strictEqual(err.statusCode, 404);
-            assert.deepStrictEqual(commitInfo, { committable: true });
+            assert.strictEqual(commitInfo, undefined);
             done();
         });
     });
@@ -326,6 +338,7 @@ describe('GarbageCollectorTask', () => {
 
     it('should retry delete data if gc failed with retryable error', done => {
         backbeatClient.batchDeleteResponse = { error: { statusCode: 500, retryable: true }, res: null };
+        const onGcFailedSpy = sinon.spy(GarbageCollectorMetrics, 'onGcFailed');
 
         const entry = ActionQueueEntry.create('deleteData')
             .addContext({
@@ -336,6 +349,11 @@ describe('GarbageCollectorTask', () => {
                 versionId: version,
             })
             .setAttribute('serviceName', 'lifecycle-expiration')
+            .setAttribute('source', {
+                bucket,
+                objectKey: key,
+                storageClass: 'sourceStorageClass',
+            })
             .setAttribute('target', {
                 bucket,
                 key: version,
@@ -360,7 +378,11 @@ describe('GarbageCollectorTask', () => {
         gcTask.processActionEntry(entry, err => {
             assert.strictEqual(batchDeleteDataSpy.callCount, 4);
             assert.strictEqual(err.statusCode, 500);
+            assert.strictEqual(onGcFailedSpy.callCount, 1);
+            assert.deepStrictEqual(onGcFailedSpy.firstCall.args.slice(1),
+                ['expiration', 'sourceStorageClass']);
             batchDeleteDataSpy.restore();
+            onGcFailedSpy.restore();
             done();
         });
     });

--- a/tests/unit/lifecycle/LifecycleColdStatusArchiveTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleColdStatusArchiveTask.spec.js
@@ -125,6 +125,25 @@ describe('LifecycleColdStatusArchiveTask', () => {
         });
     });
 
+    it('should propagate the error without setting committable when metadata update fails', done => {
+        const putError = new Error('metadata service down');
+        putError.retryable = false;
+        sinon.stub(backbeatMetadataProxyClient, 'putMetadata').yields(putError);
+
+        const entry = ColdStorageStatusQueueEntry.createFromKafkaEntry({ value: message });
+        mdObj.setLocation(loc)
+            .setDataStoreName('us-east-1')
+            .setAmzStorageClass('us-east-1')
+            .setArchive(null);
+        backbeatMetadataProxyClient.setMdObj(mdObj);
+
+        archiveTask.processEntry(coldLocation, entry, (err, commitInfo) => {
+            assert.strictEqual(err, putError);
+            assert.strictEqual(commitInfo, undefined);
+            done();
+        });
+    });
+
     it('should send kafka entry to delete orphan cold object when source object was deleted', done => {
         const entry = ColdStorageStatusQueueEntry.createFromKafkaEntry({ value: message });
 

--- a/tests/unit/lifecycle/LifecycleObjectTransitionProcessor.spec.js
+++ b/tests/unit/lifecycle/LifecycleObjectTransitionProcessor.spec.js
@@ -1,7 +1,13 @@
 const assert = require('assert');
+const sinon = require('sinon');
 const config = require('../../config.json');
+const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
 const LifecycleObjectTransitionProcessor =
     require('../../../extensions/lifecycle/objectProcessor/LifecycleObjectTransitionProcessor');
+const LifecycleColdStatusArchiveTask =
+    require('../../../extensions/lifecycle/tasks/LifecycleColdStatusArchiveTask');
+const { LifecycleMetrics } =
+    require('../../../extensions/lifecycle/LifecycleMetrics');
 
 describe('LifecycleObjectTransitionProcessor', () => {
     let objectProcessor;
@@ -29,6 +35,74 @@ describe('LifecycleObjectTransitionProcessor', () => {
             assert.ifError(err);
             assert(objectProcessor._gcProducer, 'gcProducer should be set');
             done();
+        });
+    });
+
+    describe('processColdStorageStatusEntry failure metric', () => {
+        const kafkaEntry = {
+            topic: `${config.extensions.lifecycle.coldStorageStatusTopicPrefix}glacier`,
+            value: Buffer.from(JSON.stringify({
+                op: 'archive',
+                bucketName: 'testBucket',
+                objectKey: 'testObj',
+                objectVersion: 'testversion',
+                accountId: '834789881858',
+                archiveInfo: { archiveId: 'x', archiveVersion: 1 },
+                requestId: 'r1',
+            })),
+        };
+
+        beforeEach(() => {
+            // Fast retry config so the test doesn't burn seconds on backoff.
+            objectProcessor.retryWrapper = new BackbeatTask({
+                maxRetries: 1,
+                backoff: { min: 10, max: 20, factor: 1, jitter: 0 },
+            });
+        });
+
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        it('should fire onLifecycleFailed when the task exhausts retries', done => {
+            const err = new Error('backend outage');
+            err.retryable = true;
+            sinon.stub(LifecycleColdStatusArchiveTask.prototype, 'processEntry').yields(err);
+            const spy = sinon.spy(LifecycleMetrics, 'onLifecycleFailed');
+
+            objectProcessor.processColdStorageStatusEntry(kafkaEntry, cbErr => {
+                assert.strictEqual(cbErr, err);
+                assert.strictEqual(spy.callCount, 1);
+                assert.deepStrictEqual(spy.firstCall.args.slice(1),
+                    ['transition-processor', 'archive', 'glacier']);
+                done();
+            });
+        });
+
+        it('should fire onLifecycleFailed when the task returns a non-retryable error', done => {
+            const err = new Error('bad state');
+            // No err.retryable set -> shouldRetryFunc returns undefined -> immediate give-up
+            sinon.stub(LifecycleColdStatusArchiveTask.prototype, 'processEntry').yields(err);
+            const spy = sinon.spy(LifecycleMetrics, 'onLifecycleFailed');
+
+            objectProcessor.processColdStorageStatusEntry(kafkaEntry, cbErr => {
+                assert.strictEqual(cbErr, err);
+                assert.strictEqual(spy.callCount, 1);
+                assert.deepStrictEqual(spy.firstCall.args.slice(1),
+                    ['transition-processor', 'archive', 'glacier']);
+                done();
+            });
+        });
+
+        it('should not fire onLifecycleFailed when the task succeeds', done => {
+            sinon.stub(LifecycleColdStatusArchiveTask.prototype, 'processEntry').yields();
+            const spy = sinon.spy(LifecycleMetrics, 'onLifecycleFailed');
+
+            objectProcessor.processColdStorageStatusEntry(kafkaEntry, cbErr => {
+                assert.ifError(cbErr);
+                assert.strictEqual(spy.callCount, 0);
+                done();
+            });
         });
     });
 });


### PR DESCRIPTION
**TL;DR** — Three task error paths returned `{ committable: false }` after their retry budget was exhausted without ever calling `onEntryCommittable`. The offset never advanced past those entries, they lingered in the `OffsetLedger`, and with the BB-777 rebalance-wait-for-drain fix now merged this turns every rebalance that catches one into a forced pod restart. This PR flips those sites to commit on final failure, emits a structured error log at the point of drop (including the individual data-store parts so ops can reclaim manually), and adds a per-extension counter that can be queried from Prometheus.

## What "final failure" means here

All three sites are wrapped by a `BackbeatTask.retry`-style helper with a ~5 minute budget and exponential backoff — they only reach the poison-pill path once retries are exhausted or the error is flagged non-retryable. Realistic triggers include:

- a warm cluster / metadata service / vault outage lasting longer than the retry budget
- non-retryable backend errors (`AccessDenied` after a role rotation, `Conflict` on `putMetadata`, `InvalidRequest`)
- the lifecycle orphan-cleanup path failing to publish because the cold producer can't reach its target topic
- `arsenal.errors.InternalError` when the vault-derived client can't be obtained

## Why not "kafka will redeliver"

That was the intent behind `committable: false`, but it doesn't work: Kafka only redelivers on the next assignment (rebalance / restart), and neither path benefits from an upstream cron. The cold-status message is a one-shot notification from the cold backend; the GC `deleteArchivedSourceData` entry is published exactly once by the archive task in fire-and-forget mode. On top of that, `LifecycleTask` explicitly skips objects with `transitionInProgress=true` on later bucket scans, so the regular pipeline won't pick a stuck object back up either. Effectively the current behavior is "hold the offset forever, ledger grows, and next rebalance forces a pod restart."

## What this PR does

For each of the three sites:

1. Stop returning `{ committable: false }` — just call `done(err)` so the consumer commits the offset like it would for any other completed task.
2. At the outer retry-wrapper's completion callback (i.e. the point where the retry gave up), emit an error-level log with the entry info, the error message, and the individual data-store parts / locations the task was trying to delete (so ops has enough to reclaim stuck data manually).
3. Increment a new counter recording the failure so operators can query it from Prometheus:
   - `s3_gc_failed_total{origin, location}` for GC
   - `s3_lifecycle_failed_total{origin, type, location}` for lifecycle

The log + metric live at the retry-wrapper's completion callback (not inside the task's own error handler) so they fire exactly once per final give-up, not once per attempt.

Sites covered:

- `GarbageCollectorTask._deleteArchivedSourceData` — the archive-side warm-copy cleanup. Parts come from `objMD.getLocation()` inside the async.waterfall; stashed on the entry via `entry.setAttribute('target.locations', ...)` so the outer failure log can surface them.
- `GarbageCollectorTask._executeDeleteData` — the hot transition / restore-expiration paths. Already committed silently on failure (no poison-pill), but had no log or metric. Parts are already on the entry.
- `LifecycleObjectTransitionProcessor.processColdStorageStatusEntry` — the cold-status archive handler. No parts concept (this task manipulates metadata + enqueues GC); log fires without a parts field. Uses `this.getProcessorType()` for the metric label rather than a hard-coded string.

For GC, the pre-existing `ObjNotFound` / `NoSuchBucket` carveout (return with commit, no retry) is simplified from `done(err, { committable: true })` to `done(err)` — same semantics, less noise.

## What this PR does not do

- No dashboards or alerts. The metric is a primitive for ad-hoc extraction on platforms where the ledger leak is observed; dashboards and alert rules are a follow-up.
- No retry topic, dead-letter topic, or sweeper. That's a separate design conversation. The consequence of this PR is that permanent failures are now visible as an error log + a metric datapoint rather than a silent ledger leak, but the underlying operation is not retried automatically.
- Does not change the behavior of Pattern A callers (`ReplicateObject`, `MultipleBackendTask`, `CopyLocationTask`, `LifecycleUpdateTransitionTask`) that use `committable: false` correctly with a producer-callback `onEntryCommittable`.

Issue: BB-772
