### PR TITLE
Bump arsenal to 8.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@scality/cloudserverclient": "^1.0.8",
     "@smithy/node-http-handler": "^3.3.3",
     "JSONStream": "^1.3.5",
-    "arsenal": "git+https://github.com/scality/arsenal#8.5.2",
+    "arsenal": "git+https://github.com/scality/arsenal#8.5.6",
     "async": "^2.3.0",
     "backo": "^1.1.0",
     "breakbeat": "scality/breakbeat#v1.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.5.0-preview.3",
+  "version": "9.5.0-preview.4",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/functional/ingestion/MongoQueueProcessor.js
+++ b/tests/functional/ingestion/MongoQueueProcessor.js
@@ -833,7 +833,7 @@ describe('MongoQueueProcessor', function mqp() {
                 title: ' with lifecycle configuration',
                 patchBucketInfo: (bucketInfo, next) => next(null, {
                     ...bucketInfo,
-                    lifecycleConfiguration: new LifecycleConfiguration(null, { replicationEndpoints: [] }),
+                    lifecycleConfiguration: new LifecycleConfiguration(null, null, { replicationEndpoints: [] }),
                 }),
                 options: { doesNotNeedOpogUpdate: true, versionId: VERSION_ID },
             },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5465,9 +5465,9 @@ arraybuffer.prototype.slice@^1.0.4:
   optionalDependencies:
     ioctl "^2.0.2"
 
-"arsenal@git+https://github.com/scality/arsenal#8.5.2":
-  version "8.5.2"
-  resolved "git+https://github.com/scality/arsenal#cd9ddfca043b522c9199a0edbf23a73dbc7973fd"
+"arsenal@git+https://github.com/scality/arsenal#8.5.6":
+  version "8.5.6"
+  resolved "git+https://github.com/scality/arsenal#0db557930c7d13204167188a7503e6e00d154df5"
   dependencies:
     "@aws-sdk/client-kms" "^3.975.0"
     "@aws-sdk/client-s3" "^3.975.0"
@@ -5506,7 +5506,7 @@ arraybuffer.prototype.slice@^1.0.4:
     simple-glob "^0.2.0"
     socket.io "^4.8.0"
     socket.io-client "^4.8.0"
-    sproxydclient "github:scality/sproxydclient#8.1.0"
+    sproxydclient "github:scality/sproxydclient#8.2.1"
     utf8 "^3.0.0"
     uuid "^10.0.0"
     werelogs scality/werelogs#8.2.4
@@ -10514,6 +10514,14 @@ sprintf-js@~1.0.2:
 "sproxydclient@github:scality/sproxydclient#8.1.0":
   version "8.1.0"
   resolved "https://codeload.github.com/scality/sproxydclient/tar.gz/8f26d4e256780aa85c5a6b7f9a358773d22f3193"
+  dependencies:
+    async "^3.2.6"
+    httpagent "github:scality/httpagent#1.1.0"
+    werelogs scality/werelogs#8.2.0
+
+"sproxydclient@github:scality/sproxydclient#8.2.1":
+  version "8.2.1"
+  resolved "https://codeload.github.com/scality/sproxydclient/tar.gz/501829f5521787e7e946de6792f5806ffa6ec437"
   dependencies:
     async "^3.2.6"
     httpagent "github:scality/httpagent#1.1.0"


### PR DESCRIPTION
## Summary

Bump backbeat's arsenal dependency `8.5.2 → 8.5.6`.

This pulls in the `getApplicableRules` fix from **ARSN-597**: day-based lifecycle actions with `Days=0` now survive rule selection (the guard changed from a truthy `if (rule.Expiration.Days)` to `!== undefined`). Without it, the **v1 lifecycle task path** drops `Days=0` rules at `getApplicableRules` and never expires the objects — so the "empty this bucket" (`Days=0`) feature (BB-791) is incomplete on v1.

Same 8.5.x line as the current pin, so a low-risk forward bump. Also bumps the package version to `9.5.0-preview.4`.

Issue: BB-791