### PR TITLE
Downgrade node-rdkafka to 3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "minimatch": "^10.0.1",
     "mongodb": "^6.11.0",
     "node-forge": "^1.3.1",
-    "node-rdkafka": "^3.6.0",
+    "node-rdkafka": "3.0.1",
     "node-rdkafka-prometheus": "^1.0.0",
     "node-schedule": "^2.1.1",
     "node-zookeeper-client": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.4.0",
+  "version": "9.4.1",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9147,10 +9147,10 @@ nan@^2.14.0, nan@^2.18.0, nan@^2.3.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.23.1.tgz#6f86a31dd87e3d1eb77512bf4b9e14c8aded3975"
   integrity sha512-r7bBUGKzlqk8oPBDYxt6Z0aEdF1G1rwlMcLk8LCOMbOzf0mG+JUfUzG4fIMWwHWP0iyaLWEQZJmtB7nOHEm/qw==
 
-nan@^2.24.0:
-  version "2.26.2"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.26.2.tgz#2e5e25764224c737b9897790b57c3294d4dcee9c"
-  integrity sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==
+nan@^2.19.0:
+  version "2.28.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.28.0.tgz#126717fd359d5a03d3edf7c44e6ce9b707fb57f5"
+  integrity sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==
 
 napi-macros@~2.0.0:
   version "2.0.0"
@@ -9285,13 +9285,13 @@ node-rdkafka-prometheus@^1.0.0:
     "@log4js-node/log4js-api" "^1.0.0"
     prom-client "^12.0.0"
 
-node-rdkafka@^3.6.0:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-3.6.1.tgz#164357f08ff23a4722e89bfb3b2b09481c1e8cc1"
-  integrity sha512-sfpTbrT35429cs0RE8Yb9avGX9BiRRvpV7aweQsghKTjtrVZP3jBrKOPItWXAqHb8doyh3SkuGuUVBLgig1SRg==
+node-rdkafka@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-3.0.1.tgz#c536d7702d971535b41099acc1baf89706a5d1ba"
+  integrity sha512-USTFu7ylRj+fEiGz0hA92GWSqmX/hu/xSTqtgmInPPmh5zKhjauTciRjDEG3yK5m6yChwyHKQTIgmr56DfhiaQ==
   dependencies:
     bindings "^1.3.1"
-    nan "^2.24.0"
+    nan "^2.19.0"
 
 node-releases@^2.0.27:
   version "2.0.27"


### PR DESCRIPTION
Downgrades `node-rdkafka` from `^3.6.0` to exactly `3.0.1`.

## Why

librdkafka >= 2.5.0 cannot consume messages stored in the legacy v0/v1 MessageSet format: when the FetchResponse uses a flexible version (v12+), the legacy reader parses the Key/Value length prefixes as compact varints instead of fixed int32, so every message is delivered with **NULL key and value** (plus `Unsupported Message(Set) MagicByte` errors). Reported upstream with a fix: confluentinc/librdkafka#5549 / confluentinc/librdkafka#5550.

S3C federation pins `log.message.format.version=0.10.2.2` on the backbeat-queue brokers, so **all** messages are stored/served in the legacy v1 format: since #2728 (node-rdkafka `^3.6.0` / librdkafka 2.12.0), backbeat cannot process any kafka entry on S3C — every entry fails with `malformed JSON in kafka entry — Cannot read properties of null (reading 'bootstrapId')` and replication stays `PENDING`. This currently blocks the S3C 10 component bump (scality/Federation#6993).

## Why 3.0.1

- Newest node-rdkafka release bundling librdkafka **2.3.0** — the exact librdkafka backbeat ran until 9.3.x (no release ever bundled the last-good 2.4.x; 3.1.0 jumps to the broken 2.5.0).
- 3.0.0 is 2.18.0 (the pre-#2728 lockfile resolution) with only EOL Node versions dropped; 3.0.1 adds one additive OAuthBearer API. Binding-side changes up to 3.6.1 are not relevant to backbeat (TS typings, cooperative rebalance — unused, we pin eager `range,roundrobin` — Node 23/24 support).
- All app-side fixes from #2728 (bootstrap chained-setTimeout, `partition.assignment.strategy` pin) are kept.
- Verified against a Kafka 3.9.1 broker configured with `log.message.format.version=0.10.2.2`: 3.0.1 consumes legacy v1 topics with intact key/value; 3.1.0+ does not.

**The pin must not be raised past 3.0.1** until node-rdkafka bundles a librdkafka release containing the fix from confluentinc/librdkafka#5550. Note: Node >= 24 support will require node-rdkafka >= 3.6.1 (nan bump), so the re-bump must precede or accompany any Node 24 migration.

Issue: BB-806
