### PR TITLE
handle orphans on processQueueEntryRetryFull

### DIFF
--- a/extensions/replication/tasks/ReplicateObject.js
+++ b/extensions/replication/tasks/ReplicateObject.js
@@ -1018,7 +1018,17 @@ class ReplicateObject extends BackbeatTask {
             next => this._getAndPutData(sourceEntry, destEntry, log, next),
             (destLocations, conflict, next) => {
                 destEntry.setLocation(destLocations);
-                return this._putMetadata(destEntry, false, conflict, log, next);
+                return this._putMetadata(destEntry, false, conflict, log, err => {
+                    if (err) {
+                        log.warn('putMetadata failed during full retry, cleaning up orphan data', {
+                            method: 'ReplicateObject._processQueueEntryRetryFull',
+                            entry: destEntry.getLogInfo(),
+                            error: err.message,
+                        });
+                        return this._deleteOrphans(destEntry, destLocations, log, () => next(err));
+                    }
+                    return next();
+                });
             },
         ], err => this._handleReplicationOutcome(
             err, sourceEntry, destEntry, kafkaEntry, log, done));

--- a/tests/unit/replication/ReplicateObject.spec.js
+++ b/tests/unit/replication/ReplicateObject.spec.js
@@ -461,6 +461,26 @@ describe('ReplicateObject', () => {
         });
     });
 
+    it('_processQueueEntryRetryFull should delete orphans on putMetadata errors', done => {
+        const writtenLocations = [{ key: 'data-key', dataStoreName: 'file' }];
+        const sourceEntry = QueueEntry.createFromKafkaEntry(replicationEntry);
+        const destEntry = makeDestEntry();
+        sinon.stub(task, '_publishReplicationStatus').returns();
+        sinon.stub(task, '_deleteOrphans').callsFake((entry, locations, log, cb) => cb());
+        sinon.stub(task, '_getAndPutData').callsFake((src, dest, log, cb) =>
+            cb(null, writtenLocations, undefined));
+        sinon.stub(task, '_putMetadata').callsFake((entry, mdOnly, conflict, log, cb) =>
+            cb(new MicroVersionIdAlreadyStoredException({ message: 'collision' })));
+
+        task._processQueueEntryRetryFull(sourceEntry, destEntry, {}, fakeLogger, err => {
+            assert.ifError(err);
+            sinon.assert.calledOnce(task._deleteOrphans);
+            sinon.assert.calledWith(task._deleteOrphans,
+                destEntry, writtenLocations, sinon.match.any, sinon.match.any);
+            done();
+        });
+    });
+
     describe('_publishReplicationStatus', () => {
         const ObjectQueueEntry =
             require('../../../lib/models/ObjectQueueEntry');


### PR DESCRIPTION
Issue: BB-802

This fixes a small risk that was raised during crr cascade code reviews : When calling putMetadata after having written data, if putMetadata errors out, there is a situation where we don't delete the orphan data.
This risk is not even fully related to crr cascade, as the bug could also happen before.