### PR TITLE
Add async/await migration guidance for Claude and code reviews

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,7 @@ When reviewing a PR, analyze the changes against these criteria:
 | Area | What to check |
 |------|---------------|
 | Async error handling | Uncaught promise rejections, missing error callbacks, swallowed errors in streams. Double callbacks in try/catch blocks (callback called in try then again in catch) |
-| Async/await usage | New or modified code should use async/await instead of callbacks when possible. When code is migrated from callbacks to async/await, verify: no leftover callback or next params, no mixed callback + promise patterns, proper try/catch around awaited calls, errors are re-thrown or handled (not silently swallowed). Watch for the anti-pattern: `try { cb(); } catch(err) { cb(err); }` where an exception after the first `cb()` triggers a second call |
+| Async/await usage | New or modified code should use async/await instead of callbacks (see [Async/await migration suggestions](#asyncawait-migration-suggestions) below for when to suggest migrating). When code is migrated from callbacks to async/await, verify: no leftover callback or next params, no mixed callback + promise patterns, proper try/catch around awaited calls, errors are re-thrown or handled (not silently swallowed), `return await` rather than returning a bare promise, no `forEach` with async callbacks (use `for...of` or `Promise.all`), callers updated or backward compatibility kept via `util.callbackify`. Watch for the anti-pattern: `try { cb(); } catch(err) { cb(err); }` where an exception after the first `cb()` triggers a second call |
 | Kafka consumer/producer | Correct topic configuration, proper offset commits, consumer group handling, message serialization. Verify `onEntryCommittable` is always reachable. Check circuit breaker thresholds when adding new downstream topics |
 | Stream handling | Backpressure, proper cleanup on error, no leaked file descriptors, correct pipe chains |
 | Dependency pinning | Git-based deps (arsenal, vaultclient, bucketclient, werelogs, breakbeat, httpagent) must pin to a tag, not a branch |
@@ -20,3 +20,14 @@ When reviewing a PR, analyze the changes against these criteria:
 | Extension architecture | Changes respect the pluggable extension pattern, no cross-extension coupling |
 | Security | Command injection, prototype pollution, unsafe deserialization, credential exposure in config/env vars, OWASP-relevant issues for Node.js |
 | Breaking changes | Anything that changes public APIs, Kafka message formats, inter-service contracts, or oplog/change stream projections |
+
+## Async/await migration suggestions
+
+Backbeat is migrating from callbacks and the `async` library to async/await, per the [Scality migration guide](https://scality.atlassian.net/wiki/spaces/OS/pages/3523346468/2025-10-30+-+Async+Await+migration) and its **migrate when you touch** rule: functions a PR significantly changes get migrated in that PR; untouched or lightly-touched code is left alone. Apply judgement:
+
+- If the PR significantly reworks a function (signature, rewritten logic, most of its body) and it remains callback-based, suggest migrating it to async/await — in a dedicated commit if large.
+- For class methods, consider the whole hierarchy (e.g. `MultipleBackendTask extends ReplicateObject extends BackbeatTask`): making a method async changes its contract for every subclass, so a suggestion must cover overrides and `super` calls together — and flag partial migrations where a base method became async but overrides or `super` callers still use callbacks.
+- Flag new callback-style functions (last parameter named `cb`, `callback`, `done`, `next`) and new uses of the `async` library: new code must use async/await. Exception: `async` utilities with concurrency limits (`async.eachLimit`, `async.queue`) that raw Promises cannot easily replicate.
+- Do **not** suggest migration for minor edits inside a large callback-based function, callback shapes imposed by external APIs (node-rdkafka event handlers, stream/event-emitter callbacks, Mocha hooks), or test-only changes.
+- When new code consumes a callback-only dependency, suggest `util.promisify` (bind object methods) over hand-rolled `new Promise`.
+- At most one migration suggestion per function, phrased as a suggestion, not a blocker.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,5 +10,16 @@ This is a **Node.js asynchronous queue and job manager** for Scality's S3C and A
 - Management API and routes (`lib/api/`)
 - Configuration management with Joi validation (`lib/Config.js`)
 - Git-based internal deps: arsenal, vaultclient, bucketclient, werelogs, breakbeat, httpagent
-- CommonJS modules with callback-based async patterns
+- CommonJS modules; legacy code is callback-based, migrating to async/await (see below)
 - Mocha + Sinon test suites (`tests/unit/`, `tests/functional/`, `tests/behavior/`)
+
+## Async code style
+
+The codebase is migrating from callbacks and the `async` library to async/await, per the [Scality migration guide](https://scality.atlassian.net/wiki/spaces/OS/pages/3523346468/2025-10-30+-+Async+Await+migration):
+
+- New functions use async/await — no callback parameters, no new uses of the `async` library (except utilities with concurrency limits, e.g. `async.eachLimit`).
+- **Migrate when you touch**: a function you significantly change (signature, rewritten logic, substantial edits) gets migrated as part of the change; minor edits do not require migration. Keep large migrations in a dedicated commit.
+- Class methods migrate hierarchy-wide: making a method async changes its contract for every subclass (e.g. `MultipleBackendTask extends ReplicateObject extends BackbeatTask`) — migrate overrides and `super` calls together with the base method.
+- Wrap callback-based dependencies (node-rdkafka, arsenal, bucketclient, ...) with `util.promisify` (bind object methods) rather than hand-rolled `new Promise`; use native Promise APIs where available.
+- If out-of-scope callers still pass callbacks, keep backward compatibility with `util.callbackify` or a continuation callback; never invoke the callback inside a `try/catch` — exceptions it throws would be swallowed.
+- `return await` rather than returning a bare promise; a function with nothing to await should not be `async`; never `forEach` with async callbacks — use `for...of` or `Promise.all(array.map(...))`.


### PR DESCRIPTION
Encode the "migrate when you touch" rule from the [Scality async/await migration guide](https://scality.atlassian.net/wiki/spaces/OS/pages/3523346468/2025-10-30+-+Async+Await+migration) into the repo's Claude guidance:

- `CLAUDE.md`: new **Async code style** section — new code uses async/await, significantly-changed functions get migrated (in a dedicated commit when large), `util.promisify`/`util.callbackify` at callback-API boundaries, and the main pitfalls (`return await`, no async `forEach`, never invoke a callback inside `try/catch`). Also fixes the repo summary line that described callback style as the convention.
- `.github/copilot-instructions.md`: new **Async/await migration suggestions** section telling the CI review when to suggest a migration (PR substantially reworks a callback-based function, new callback-style functions) and when to stay silent (minor edits, callback shapes imposed by external APIs such as node-rdkafka event handlers, test-only changes), capped at one suggestion per function. The existing verification row gains the same pitfall checks.

Issue: BB-805