### PR TITLE
Guard LogConsumer against offsetsStore failures during rebalance

### DIFF
--- a/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
+++ b/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
@@ -314,14 +314,36 @@ class LogConsumer extends EventEmitter {
             });
             return;
         }
-        this._consumer.offsetsStore(this._topicPartition);
+        const topicPartition = this._topicPartition;
+        this._topicPartition = null;
+        // only store offsets while connected; skipped offsets are
+        // re-consumed by the next partition owner.
+        if (!this._consumer.isConnected()) {
+            this._log.info('Skipping offsets store', {
+                method: 'LogConsumer.storeOffsets',
+                reason: 'consumer not connected',
+                topicPartition,
+                consumerGroupId: this._consumerGroupId,
+            });
+            return;
+        }
+        try {
+            this._consumer.offsetsStore(topicPartition);
+        } catch (e) {
+            this._log.error('offsetsStore failed', {
+                method: 'LogConsumer.storeOffsets',
+                error: e.toString(),
+                topicPartition,
+                consumerGroupId: this._consumerGroupId,
+            });
+            return;
+        }
         this._log.info('Offsets stored', {
             method: 'LogConsumer.storeOffsets',
             consumerGroupId: this._consumerGroupId,
-            topicPartition: this._topicPartition,
+            topicPartition,
         });
         this._pendingCommit = true;
-        this._topicPartition = null;
     }
 
     _hasUnprocessedMessages() {

--- a/tests/unit/lib/queuePopulator/kafkaLogConsumer/LogConsumer.js
+++ b/tests/unit/lib/queuePopulator/kafkaLogConsumer/LogConsumer.js
@@ -55,6 +55,7 @@ describe('LogConsumer', () => {
         logConsumer = new LogConsumer(kafkaConfig, logger);
         logConsumer._consumer = {
             offsetsStore: () => null,
+            isConnected: () => true,
         };
     });
 
@@ -258,11 +259,35 @@ describe('LogConsumer', () => {
             const offsetsStore = sinon.stub(logConsumer._consumer, 'offsetsStore').returns(null);
             logConsumer._topicPartition = [{ topic: 'oplog-topic', partition: 0, offset: 5 }];
             logConsumer._pendingCommit = false;
-            
+
             logConsumer.storeOffsets();
-            
+
             assert.strictEqual(logConsumer._pendingCommit, true);
             sinon.assert.calledOnce(offsetsStore);
+        });
+
+        it('should not call offsetsStore when consumer is not connected', () => {
+            const offsetsStore = sinon.stub(logConsumer._consumer, 'offsetsStore').returns(null);
+            sinon.stub(logConsumer._consumer, 'isConnected').returns(false);
+            logConsumer._topicPartition = [{ topic: 'oplog-topic', partition: 0, offset: 5 }];
+
+            logConsumer.storeOffsets();
+
+            sinon.assert.notCalled(offsetsStore);
+            assert.strictEqual(logConsumer._topicPartition, null);
+            assert.strictEqual(logConsumer._pendingCommit, false);
+        });
+
+        it('should not crash nor set pendingCommit when offsetsStore throws', () => {
+            const offsetsStore = sinon.stub(logConsumer._consumer, 'offsetsStore')
+                .throws(new Error('Local: Erroneous state'));
+            logConsumer._topicPartition = [{ topic: 'oplog-topic', partition: 0, offset: 5 }];
+
+            assert.doesNotThrow(() => logConsumer.storeOffsets());
+
+            sinon.assert.calledOnce(offsetsStore);
+            assert.strictEqual(logConsumer._topicPartition, null);
+            assert.strictEqual(logConsumer._pendingCommit, false);
         });
     });
 


### PR DESCRIPTION
The queue populator's Kafka `LogConsumer.storeOffsets()` called `offsetsStore()` unguarded. When a rebalance or shutdown revokes partitions between batch processing and offset storage, the call throws `LibrdKafkaError: Local: Erroneous state`, which escapes as an unhandled exception and kills the process. The pod exits without a clean consumer-group leave, so its session lingers and the delayed rebalance hits surviving pods at arbitrary points — seeding the drain stalls that freeze oplog consumption (replication entries, bucket notifications). Observed twice in one Zenko end2end run ([run 29589236290 attempt 1](https://github.com/scality/Zenko/actions/runs/29589236290/attempts/1)).

This ports the protection BackbeatConsumer has had since BB-758 (#2731) to the LogConsumer: skip the store when the consumer is not connected, and log instead of crashing if the call still throws. Offsets not stored are simply re-consumed by whichever consumer owns the partitions next — the populator pipeline is at-least-once and tolerates duplicates. In both cases the processed batch is released (`_topicPartition` cleared) so consumption never wedges on a batch whose offsets can no longer be stored, and `_pendingCommit` is only raised when a store actually happened.

Note that #2731 was the defense-in-depth layer of BB-758, behind the structural rebalance fixes #2739 (BB-776) and #2740 (BB-777); the LogConsumer's structural analog (`_drainAndUnassign`/`_onOffsetCommit` drain deadlock) and the replication status consumer's missing `fromOffset` are intentionally out of scope here, tracked separately.

Issue: BB-823