### PR TITLE
Use literal seconds for lifecycle alert threshold defaults

### DIFF
--- a/monitoring/lifecycle/alerts.yaml
+++ b/monitoring/lifecycle/alerts.yaml
@@ -21,16 +21,16 @@ x-inputs:
   type: constant
 - name: lifecycle_latency_warning_threshold
   type: config
-  value: 24*60*60 # 24h, in seconds
+  value: 86400 # 24h, in seconds
 - name: lifecycle_latency_critical_threshold
   type: config
-  value: 36*60*60 # 36h, in seconds
+  value: 129600 # 36h, in seconds
 - name: lifecycle_conductor_scan_warning_threshold
   type: config
-  value: 10*60 # 10m, in seconds
+  value: 600 # 10m, in seconds
 - name: lifecycle_conductor_scan_critical_threshold
   type: config
-  value: 30*60 # 30m, in seconds
+  value: 1800 # 30m, in seconds
 
 groups:
 - name: LifecycleProducer

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.5.0-preview.6",
+  "version": "9.5.0-preview.7",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The lifecycle alert threshold `x-inputs` used arithmetic defaults (`10*60`, `24*60*60`, ...). Arithmetic is valid inside the PromQL expressions, but the same values are interpolated into the Go-template `description` annotations of the `LifecycleLateScan` and `LifecycleStalledScan` alerts, and Go templates have no `*` operator: when the consumer leaves an input unset, the rendered annotation (`{{ 10*60 | humanizeDuration }}`) fails to parse with `unexpected "*" in operand`. prometheus-operator then rejects the rule group and aborts the entire Prometheus config sync — all alerting silently dies, and any ServiceMonitor reconciled afterwards is never scraped.

This is the root cause of the deterministic `end2end-pra` (PRA nominal case) and Kafka Cleaner CTST failures on every Zenko branch bumping backbeat >= 9.5.0-preview.2 (scality/Zenko#2461, scality/Zenko#2447, scality/Zenko#2451): zenko-operator v1.8.13 only binds the latency thresholds, so the conductor-scan inputs introduced by BB-740 fall back to their raw defaults.

The alerts CI workflow does not catch this because it always supplies its own threshold values instead of rendering the file defaults.

Using literal seconds keeps the PromQL semantics identical and renders valid annotations (`{{ 600 | humanizeDuration }}` → "10 minutes").

Issue: BB-824