### PR TITLE
BB-828 Restore Kerberos GSSAPI support in the image

### DIFF
--- a/.github/scripts/check_image_kerberos_support.sh
+++ b/.github/scripts/check_image_kerberos_support.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Image test: verify a backbeat image is Kerberos-capable.
+#
+# Checks inside the given image:
+#   1. node-rdkafka compiled with sasl_gssapi;
+#   2. kinit present (used to obtain tickets);
+#   3. Cyrus SASL GSSAPI plugin present (loaded at connect time).
+#
+# Usage: check_image_kerberos_support.sh <image-ref>
+set -euo pipefail
+
+IMAGE="$1"
+
+echo "checking Kerberos support in ${IMAGE}"
+docker run --rm --entrypoint /bin/bash "${IMAGE}" -c '
+    set -e
+    node -e "
+        const f = require(\"node-rdkafka\").features;
+        console.log(\"node-rdkafka features: \" + f.join(\", \"));
+        process.exit(f.includes(\"sasl_gssapi\") ? 0 : 1);
+    "
+    command -v kinit
+    ls /usr/lib/*/sasl2/ | grep -i gssapi
+'
+echo "OK: ${IMAGE} is Kerberos-capable"

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -46,7 +46,12 @@ jobs:
           tags: ghcr.io/${{ github.repository }}:${{ github.sha }}-federation
           cache-from: type=gha,scope=federation
           cache-to: type=gha,scope=federation,mode=max
-        
+
+      - name: Check Kerberos support in built images
+        run: |
+          .github/scripts/check_image_kerberos_support.sh ghcr.io/${{ github.repository }}:${{ github.sha }}
+          .github/scripts/check_image_kerberos_support.sh ghcr.io/${{ github.repository }}:${{ github.sha }}-federation
+
       - name: Install Oras
         run: |
           curl -L https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz | \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM node:${NODE_VERSION} AS builder
 
 WORKDIR /usr/src/app
 
+# libsasl2-dev is required at build time for node-rdkafka to compile
+# librdkafka with SASL GSSAPI (Kerberos) support.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -20,7 +22,8 @@ RUN apt-get update \
         libssl-dev \
         libreadline-dev \
         libffi-dev \
-        libzstd-dev
+        libzstd-dev \
+        libsasl2-dev
 
 ENV DOCKERIZE_VERSION=v0.6.1
 
@@ -37,10 +40,15 @@ RUN yarn install --ignore-engines --frozen-lockfile --production --network-concu
 ################################################################################
 FROM node:${NODE_VERSION}
 
+# Kerberos runtime for Kafka destinations: kinit (krb5-user), libsasl2, and
+# the Cyrus SASL GSSAPI plugin, loaded dynamically by librdkafka.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         jq \
+        krb5-user \
+        libsasl2-2 \
+        libsasl2-modules-gssapi-mit \
         openssl \
         tini \
     && rm -rf /var/lib/apt/lists/*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.0.29",
+  "version": "9.0.30",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The image convergence dropped libsasl2-dev from the build stage and the Kerberos runtime packages from the final image, so node-rdkafka compiles librdkafka without sasl_gssapi and Kerberos notification destinations fail at connect. Restore the packages and add CI checks on both images so GSSAPI support cannot silently regress again.


[We added some tests in integration for this](https://github.com/scality/Integration/pull/1459)
Passing integration build with this new backbeat: https://github.com/scality/Integration/actions/runs/30070161868/job/89409177612


Regression introduced in: https://github.com/scality/backbeat/pull/2600