### PR TITLE
BB-830: fix notification config write race that silently drops events

### DIFF
--- a/extensions/notification/configManager/ZookeeperConfigManager.js
+++ b/extensions/notification/configManager/ZookeeperConfigManager.js
@@ -9,6 +9,11 @@ const BaseConfigManager = require('./BaseConfigManager');
 const safeJsonParse = require('../../../lib/util/safeJsonParse');
 const constants = require('../constants');
 
+// bounded retry with backoff for config writes to zookeeper, so a transient
+// failure does not drop the configuration
+const CONFIG_WRITE_MAX_ATTEMPTS = 5;
+const CONFIG_WRITE_RETRY_BASE_MS = 200;
+
 const paramsJoi = joi.object({
     zkClient: joi.object().optional(),
     zkConfig: joi.object().when('zkClient', {
@@ -64,7 +69,15 @@ class ZookeeperConfigManager extends BaseConfigManager  {
             bucket,
             config,
         });
-        this._setBucketNotifConfig(bucket, JSON.stringify(config), err => {
+        const data = JSON.stringify(config);
+        // retry with backoff; the write is idempotent so retrying is safe
+        return async.retry({
+            times: CONFIG_WRITE_MAX_ATTEMPTS,
+            interval: retryCount =>
+                CONFIG_WRITE_RETRY_BASE_MS * (2 ** (retryCount - 1)),
+        },
+        next => this._setBucketNotifConfig(bucket, data, next),
+        err => {
             if (err) {
                 this._emitter.emit('error', err, 'setConfigListener');
             }
@@ -208,21 +221,29 @@ class ZookeeperConfigManager extends BaseConfigManager  {
             bucket,
             zkPath,
         });
-        return async.waterfall([
-            next => this._checkNodeExists(zkPath, next),
-            (exists, next) => {
-                if (!exists) {
-                    return this._createBucketNotifConfigNode(bucket,
-                        err => next(err));
-                }
-                return next();
-            },
-            next => this._zkClient.setData(zkPath, Buffer.from(data), -1, next),
-        ], err => {
+        // idempotent create-or-update of the bucket's config node
+        return this._writeBucketNotifConfigNode(zkPath, bucket, data, err => {
             if (err) {
-                this.log.error('error saving config', { method, zkPath, data });
+                this.log.error('error saving config', { method, zkPath, data, error: err });
             }
             return this._callbackHandler(cb, err);
+        });
+    }
+
+    _writeBucketNotifConfigNode(zkPath, bucket, data, cb) {
+        // forward only the error, not setData's stat result
+        return this._zkClient.setData(zkPath, Buffer.from(data), -1, err => {
+            if (err && err.name === 'NO_NODE') {
+                // create the node if it does not exist yet, then write again
+                return this._createBucketNotifConfigNode(bucket, createErr => {
+                    if (createErr) {
+                        return cb(createErr);
+                    }
+                    return this._zkClient.setData(zkPath, Buffer.from(data),
+                        -1, retryErr => cb(retryErr));
+                });
+            }
+            return cb(err);
         });
     }
 

--- a/tests/unit/notification/configManager/ZookeeperConfigManager.spec.js
+++ b/tests/unit/notification/configManager/ZookeeperConfigManager.spec.js
@@ -216,6 +216,59 @@ describe('ZookeeperConfigManager', () => {
         });
     });
 
+    describe('_setBucketNotifConfig resilience', () => {
+        afterEach(() => {
+            sinon.restore();
+            zk._resetState();
+        });
+
+        it('should create the node and persist the config when it does not exist yet', done => {
+            const manager = new ZookeeperConfigManager(params);
+            const bucket = 'freshBucket';
+            const config = getTestConfigValue(bucket);
+            const node = `/${zkConfigParentNode}/${bucket}`;
+            async.series([
+                next => managerInit(manager, next),
+                next => manager._setBucketNotifConfig(
+                    bucket, JSON.stringify(config), err => {
+                        assert.ifError(err);
+                        return next();
+                    }),
+                next => zkClient.getData(node, undefined, (err, data) => {
+                    assert.ifError(err);
+                    assert.strictEqual(
+                        JSON.parse(data.toString()).bucket, bucket);
+                    return next();
+                }),
+            ], done);
+        });
+
+        it('should retry the config write on a transient failure', done => {
+            const manager = new ZookeeperConfigManager(params);
+            const bucket = 'retryBucket';
+            const config = getTestConfigValue(bucket);
+            const node = `/${zkConfigParentNode}/${bucket}`;
+            managerInit(manager, () => {
+                const transient = new Error('transient zookeeper error');
+                const stub = sinon.stub(manager, '_setBucketNotifConfig');
+                stub.onCall(0).callsFake((b, d, cb) => cb(transient));
+                stub.onCall(1).callsFake((b, d, cb) => cb(transient));
+                stub.callThrough();
+                // setConfig triggers the listener retry
+                manager.setConfig(bucket, config);
+                setTimeout(() => {
+                    assert.strictEqual(stub.callCount, 3);
+                    zkClient.getData(node, undefined, (err, data) => {
+                        assert.ifError(err);
+                        assert.strictEqual(
+                            JSON.parse(data.toString()).bucket, bucket);
+                        return done();
+                    });
+                }, 2000);
+            });
+        });
+    });
+
     describe('setup', () => {
         it('should setup zookeeper client when it\'s not provided', done => {
             const manager = new ZookeeperConfigManager({


### PR DESCRIPTION
Bucket notification events could be silently and permanently lost for a bucket whenever the one-time write of its notification configuration to Zookeeper lost a race and failed, because the delivery path treats a missing configuration as "nothing to deliver" and drops every event for that bucket without a trace. This change makes that configuration write resilient so a transient failure no longer strands a bucket's notifications, and surfaces the previously silent drop in the logs. The race was found through intermittent failures of the bucket-notification end-to-end suite in CI (BB-830).