### PR TITLE
Fix the queue populator LogConsumer drain deadlock on rebalance

### DIFF
--- a/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
+++ b/lib/queuePopulator/KafkaLogConsumer/LogConsumer.js
@@ -11,6 +11,8 @@ const EVENTS = {
     UNASSIGNED: 'unassigned',
 };
 
+const DRAIN_TIMEOUT_MS = 30000;
+
 class LogConsumer extends EventEmitter {
 
     /**
@@ -29,7 +31,6 @@ class LogConsumer extends EventEmitter {
         this._topic = topic;
         this._consumerGroupId = consumerGroupId;
         this._topicPartition = null;
-        this._pendingCommit = false;
         this._log = logger;
         this._consumer = null;
     }
@@ -102,10 +103,6 @@ class LogConsumer extends EventEmitter {
                 groupId: this._consumerGroupId,
             });
             return undefined;
-        }
-        this._pendingCommit = false;
-        if (!this._hasUnprocessedMessages()) {
-            this.emit(EVENTS.DRAINED);
         }
         this._log.debug('Offsets committed', {
             method: 'LogConsumer._onOffsetCommit',
@@ -187,8 +184,8 @@ class LogConsumer extends EventEmitter {
     }
 
     /**
-     * Waits for all messages to be processed before unassigning
-     * the partitions from the consumer
+     * Waits for the in-flight batch to be processed, then commits
+     * stored offsets and unassigns the partitions from the consumer
      * @returns {void}
      */
     _drainAndUnassign() {
@@ -200,10 +197,11 @@ class LogConsumer extends EventEmitter {
             clearTimeout(drainTimeout);
             drainTimeout = null;
             KafkaBacklogMetrics.onRebalance(this._topic, this._consumerGroupId, status);
+            this._commitStoredOffsets();
             this._unassignPartitions();
         });
 
-        if (!this._hasUnprocessedMessages() && !this._pendingCommit) {
+        if (!this._hasUnprocessedMessages()) {
             return unassign(unassignStatus.IDLE);
         }
 
@@ -211,15 +209,39 @@ class LogConsumer extends EventEmitter {
 
         drainTimeout = setTimeout(() => {
             unassign(unassignStatus.TIMEOUT);
-            this._log.error('Timeout waiting for messages to be processed', {
+            this._log.error('Timeout waiting for the batch to be processed: ' +
+                'consumer stuck, disconnecting', {
                 method: 'LogConsumer._drainAndUnassign',
                 topic: this._topic,
                 consumerGroupId: this._consumerGroupId,
             });
+            // disconnect so the healthcheck fails and the process
+            // gets restarted
             this._consumer.disconnect();
-        }, this._maxPollIntervalMs - 1000);
+        }, Math.min(DRAIN_TIMEOUT_MS, this._maxPollIntervalMs - 1000));
 
         return undefined;
+    }
+
+    /**
+     * Best-effort commit of the stored offsets before releasing the
+     * partitions; uncommitted offsets are re-consumed by the next
+     * partition owner
+     * @returns {void}
+     */
+    _commitStoredOffsets() {
+        try {
+            this._consumer.commit();
+        } catch (e) {
+            const logger = this._consumer.isConnected() &&
+                e.code !== kafka.CODES.ERRORS.ERR__STATE ? this._log.error : this._log.info;
+            logger.bind(this._log)('rdkafka.commit failed', {
+                method: 'LogConsumer._commitStoredOffsets',
+                error: e.toString(),
+                topic: this._topic,
+                consumerGroupId: this._consumerGroupId,
+            });
+        }
     }
 
     /**
@@ -306,44 +328,44 @@ class LogConsumer extends EventEmitter {
      * @returns {undefined}
      */
     storeOffsets() {
-        if (!this._hasUnprocessedMessages()) {
+        if (this._hasUnprocessedMessages()) {
+            const topicPartition = this._topicPartition;
+            this._topicPartition = null;
+            // only store offsets while connected; skipped offsets are
+            // re-consumed by the next partition owner.
+            if (!this._consumer.isConnected()) {
+                this._log.info('Skipping offsets store', {
+                    method: 'LogConsumer.storeOffsets',
+                    reason: 'consumer not connected',
+                    topicPartition,
+                    consumerGroupId: this._consumerGroupId,
+                });
+            } else {
+                try {
+                    this._consumer.offsetsStore(topicPartition);
+                    this._log.info('Offsets stored', {
+                        method: 'LogConsumer.storeOffsets',
+                        consumerGroupId: this._consumerGroupId,
+                        topicPartition,
+                    });
+                } catch (e) {
+                    this._log.error('offsetsStore failed', {
+                        method: 'LogConsumer.storeOffsets',
+                        error: e.toString(),
+                        topicPartition,
+                        consumerGroupId: this._consumerGroupId,
+                    });
+                }
+            }
+        } else {
             this._log.debug('No offsets to store', {
                 method: 'LogConsumer.storeOffsets',
                 topic: this._topic,
                 consumerGroupId: this._consumerGroupId,
             });
-            return;
         }
-        const topicPartition = this._topicPartition;
-        this._topicPartition = null;
-        // only store offsets while connected; skipped offsets are
-        // re-consumed by the next partition owner.
-        if (!this._consumer.isConnected()) {
-            this._log.info('Skipping offsets store', {
-                method: 'LogConsumer.storeOffsets',
-                reason: 'consumer not connected',
-                topicPartition,
-                consumerGroupId: this._consumerGroupId,
-            });
-            return;
-        }
-        try {
-            this._consumer.offsetsStore(topicPartition);
-        } catch (e) {
-            this._log.error('offsetsStore failed', {
-                method: 'LogConsumer.storeOffsets',
-                error: e.toString(),
-                topicPartition,
-                consumerGroupId: this._consumerGroupId,
-            });
-            return;
-        }
-        this._log.info('Offsets stored', {
-            method: 'LogConsumer.storeOffsets',
-            consumerGroupId: this._consumerGroupId,
-            topicPartition,
-        });
-        this._pendingCommit = true;
+        // batch fully processed: release any pending drain
+        this.emit(EVENTS.DRAINED);
     }
 
     _hasUnprocessedMessages() {

--- a/tests/functional/lib/queuePopulator/LogConsumer.js
+++ b/tests/functional/lib/queuePopulator/LogConsumer.js
@@ -1,0 +1,266 @@
+const assert = require('assert');
+const async = require('async');
+const werelogs = require('werelogs');
+
+const BackbeatProducer = require('../../../../lib/BackbeatProducer');
+const LogConsumer =
+    require('../../../../lib/queuePopulator/KafkaLogConsumer/LogConsumer');
+
+const producerKafkaConf = {
+    hosts: process.env.KAFKA_TEST_HOSTS || 'localhost:9092',
+};
+const log = new werelogs.Logger('LogConsumer:test');
+
+const changeStreamDocument = {
+    ns: {
+        db: 'metadata',
+        coll: 'example-bucket',
+    },
+    documentKey: {
+        _id: 'example-key',
+    },
+    operationType: 'insert',
+    clusterTime: {
+        $timestamp: {
+            t: 1701270357,
+            i: 1,
+        },
+    },
+    fullDocument: {
+        value: {
+            field: 'value',
+        },
+    },
+};
+
+const messages = [
+    { key: 'foo', message: JSON.stringify(changeStreamDocument) },
+    { key: 'bar', message: JSON.stringify(changeStreamDocument) },
+    { key: 'qux', message: JSON.stringify(changeStreamDocument) },
+];
+
+describe('LogConsumer rebalance tests', () => {
+    const topic = 'backbeat-log-consumer-spec-rebalance';
+    let groupId;
+    let producer;
+    let consumer;
+    let consumer2;
+    let pollers = [];
+    // last offsets stored by the auto-storing poller, per partition
+    let lastStored;
+
+    // group joins and rebalance callbacks are only serviced during
+    // consume() polls: emulate the LogReader's batch loop, including
+    // storing the offsets once a batch is processed (autoStore)
+    function startPolling(logConsumer, autoStore) {
+        const timer = setInterval(() => {
+            logConsumer.readRecords({ limit: messages.length }, (err, res) => {
+                if (res && res.log) {
+                    res.log.on('data', () => {});
+                    res.log.on('error', () => {});
+                }
+                if (autoStore && logConsumer._hasUnprocessedMessages()) {
+                    logConsumer._topicPartition.forEach(tp => {
+                        lastStored.set(tp.partition, { ...tp });
+                    });
+                    logConsumer.storeOffsets();
+                }
+            });
+        }, 300);
+        pollers.push(timer);
+    }
+
+    function waitFor(predicate, timeoutMs, description, cb) {
+        const deadline = Date.now() + timeoutMs;
+        const check = () => {
+            if (predicate()) {
+                return cb();
+            }
+            if (Date.now() > deadline) {
+                return cb(new Error(`timed out waiting for ${description}`));
+            }
+            return setTimeout(check, 200);
+        };
+        check();
+    }
+
+    beforeEach(function beforeEach(done) {
+        this.timeout(60000);
+        groupId = `log-consumer-group-${Math.random()}`;
+        consumer2 = null;
+        lastStored = new Map();
+        producer = new BackbeatProducer({
+            kafka: producerKafkaConf, topic,
+            pollIntervalMs: 100,
+            compressionType: 'none',
+        });
+        async.series([
+            next => producer.on('ready', next),
+            next => producer.send(messages, next),
+        ], done);
+    });
+
+    afterEach(function afterEach(done) {
+        this.timeout(60000);
+        // keep the pollers running while closing: the leave-group
+        // rebalance is only delivered through consume() polls
+        async.parallel([
+            next => producer.close(next),
+            next => (consumer ? consumer.close(next) : next()),
+            next => (consumer2 ? consumer2.close(next) : next()),
+        ], () => {
+            pollers.forEach(clearInterval);
+            pollers = [];
+            consumer = null;
+            consumer2 = null;
+            done();
+        });
+    });
+
+    function setupConsumer(autoStore, cb) {
+        consumer = new LogConsumer({
+            hosts: producerKafkaConf.hosts,
+            topic,
+            consumerGroupId: groupId,
+            maxPollIntervalMs: 45000,
+        }, log);
+        async.series([
+            next => consumer.setup(next),
+            next => {
+                startPolling(consumer, autoStore);
+                if (autoStore) {
+                    return waitFor(() => lastStored.size > 0, 30000,
+                        'a batch to be consumed and stored', next);
+                }
+                return waitFor(() => consumer._hasUnprocessedMessages(),
+                    30000, 'a batch to be consumed', next);
+            },
+        ], cb);
+    }
+
+    it('should commit stored offsets, release partitions promptly on ' +
+    'rebalance and keep consuming', function testPromptRelease(done) {
+        this.timeout(60000);
+        async.series([
+            next => setupConsumer(true, next),
+            next => {
+                // pre-fix, the revoke below would stall for
+                // maxPollIntervalMs - 1000 = 44s waiting for a commit
+                // callback that librdkafka only delivers after
+                // unassign: the 15s cap proves the drain no longer
+                // gates on it
+                const unassignDeadline = setTimeout(() => {
+                    next(new Error('partitions were not released within ' +
+                        '15s of the rebalance'));
+                }, 15000);
+                consumer.once('unassigned', () => {
+                    clearTimeout(unassignDeadline);
+                    next();
+                });
+                consumer2 = new LogConsumer({
+                    hosts: producerKafkaConf.hosts,
+                    topic,
+                    consumerGroupId: groupId,
+                }, log);
+                consumer2.setup(() => startPolling(consumer2, true));
+            },
+            next => {
+                assert.strictEqual(consumer._consumer.isConnected(), true,
+                    'consumer should stay connected after releasing ' +
+                    'partitions');
+                consumer._consumer.committed(
+                    [...lastStored.values()].map(tp =>
+                        ({ topic: tp.topic, partition: tp.partition })),
+                    10000, (err, committed) => {
+                        if (err) {
+                            return next(err);
+                        }
+                        lastStored.forEach(stored => {
+                            const part = committed.find(
+                                c => c.partition === stored.partition);
+                            assert(part, 'no committed offset for ' +
+                                `partition ${stored.partition}`);
+                            assert.strictEqual(part.offset, stored.offset,
+                                'committed offset should match the last ' +
+                                'stored offset after the rebalance');
+                        });
+                        return next();
+                    });
+            },
+            next => {
+                // no zombie: once the second consumer leaves, the
+                // first must take the partitions back and consume again
+                consumer2.close(() => {
+                    consumer2 = null;
+                    waitFor(() => consumer._consumer.assignments().length > 0,
+                        30000, 'partitions to be re-assigned', next);
+                });
+            },
+            next => {
+                const storedBefore = [...lastStored.values()]
+                    .reduce((sum, tp) => sum + tp.offset, 0);
+                producer.send([messages[0]], err => {
+                    if (err) {
+                        return next(err);
+                    }
+                    return waitFor(() => [...lastStored.values()]
+                        .reduce((sum, tp) => sum + tp.offset, 0)
+                            > storedBefore,
+                        30000, 'a batch to be consumed after the rebalance',
+                        next);
+                });
+            },
+        ], done);
+    });
+
+    it('should time out and disconnect when the in-flight batch never ' +
+    'completes', function testDrainTimeout(done) {
+        this.timeout(150000);
+        // LogConsumer pauses its polls while a batch is in flight, so
+        // a broker revoke normally only reaches it through the very
+        // poll that captured the batch. Reproduce that timing by
+        // polling the raw consumer (the genuine librdkafka delivery
+        // path, bypassing only the batch guard) while the batch is
+        // never stored: the drain can then only end by timeout.
+        // maxPollIntervalMs cannot go below session.timeout.ms (45s),
+        // so the drain times out at the 30s DRAIN_TIMEOUT_MS cap.
+        let revokedAt;
+        async.series([
+            next => setupConsumer(false, next),
+            next => {
+                const rawPoller = setInterval(
+                    () => consumer._consumer.consume(1, () => {}), 300);
+                pollers.push(rawPoller);
+                revokedAt = Date.now();
+                const unassignDeadline = setTimeout(() => {
+                    next(new Error('drain timeout did not fire'));
+                }, 50000);
+                consumer.once('unassigned', () => {
+                    clearTimeout(unassignDeadline);
+                    next();
+                });
+                consumer2 = new LogConsumer({
+                    hosts: producerKafkaConf.hosts,
+                    topic,
+                    consumerGroupId: groupId,
+                }, log);
+                consumer2.setup(() => startPolling(consumer2, true));
+            },
+            next => {
+                const elapsed = Date.now() - revokedAt;
+                assert(elapsed >= 25000,
+                    `unassign fired after ${elapsed}ms, expected the 30s ` +
+                    'drain timeout');
+                // completing the batch after the forced release must be
+                // harmless (offsets skipped, batch redelivered), and it
+                // lets the disconnect's own final revoke drain instantly
+                // instead of waiting out a second timeout
+                consumer.storeOffsets();
+                // the timeout path deliberately disconnects so the
+                // healthcheck fails and the process gets restarted
+                waitFor(() => !consumer._consumer.isConnected(), 60000,
+                    'the consumer to disconnect', next);
+            },
+        ], done);
+    });
+});

--- a/tests/unit/lib/queuePopulator/kafkaLogConsumer/LogConsumer.js
+++ b/tests/unit/lib/queuePopulator/kafkaLogConsumer/LogConsumer.js
@@ -211,14 +211,21 @@ describe('LogConsumer', () => {
     });
 
     describe('storeOffsets', () => {
+        let drained;
+
+        beforeEach(() => {
+            drained = sinon.spy();
+            logConsumer.on('drained', drained);
+        });
+
         it('should not call offsetsStore when topicPartition is undefined', () => {
             const offsetsStore = sinon.stub(logConsumer._consumer, 'offsetsStore').returns(null);
             logConsumer._topicPartition = undefined;
-            
+
             logConsumer.storeOffsets();
-            
+
             sinon.assert.notCalled(offsetsStore);
-            assert.strictEqual(logConsumer._pendingCommit, false);
+            sinon.assert.calledOnce(drained);
         });
 
         it('should not store offsets if topicPartition is empty array', () => {
@@ -226,17 +233,18 @@ describe('LogConsumer', () => {
             logConsumer._topicPartition = [];
             logConsumer.storeOffsets();
             assert(offsetsStore.notCalled);
-            assert.strictEqual(logConsumer._pendingCommit, false);
+            sinon.assert.calledOnce(drained);
         });
 
-        it('should reset topicPartition after storing offsets', () => {
+        it('should reset topicPartition and emit drained after storing offsets', () => {
             const offsetsStore = sinon.stub(logConsumer._consumer, 'offsetsStore').returns(null);
             const topicPartition = [{ topic: 'oplog-topic', partition: 0, offset: 1 }];
             logConsumer._topicPartition = topicPartition;
             logConsumer.storeOffsets();
             assert(offsetsStore.calledWithMatch(topicPartition));
             assert.strictEqual(logConsumer._topicPartition, null);
-            assert.strictEqual(logConsumer._pendingCommit, true);
+            sinon.assert.calledOnce(drained);
+            assert(offsetsStore.calledBefore(drained));
         });
 
         it('should store multiple partition offsets correctly', () => {
@@ -248,25 +256,15 @@ describe('LogConsumer', () => {
             ];
             logConsumer._topicPartition = topicPartition;
             logConsumer.storeOffsets();
-            
+
             sinon.assert.calledOnce(offsetsStore);
             sinon.assert.calledWith(offsetsStore, topicPartition);
             assert.strictEqual(logConsumer._topicPartition, null);
-            assert.strictEqual(logConsumer._pendingCommit, true);
+            sinon.assert.calledOnce(drained);
         });
 
-        it('should set pendingCommit to true when storing offsets', () => {
-            const offsetsStore = sinon.stub(logConsumer._consumer, 'offsetsStore').returns(null);
-            logConsumer._topicPartition = [{ topic: 'oplog-topic', partition: 0, offset: 5 }];
-            logConsumer._pendingCommit = false;
-
-            logConsumer.storeOffsets();
-
-            assert.strictEqual(logConsumer._pendingCommit, true);
-            sinon.assert.calledOnce(offsetsStore);
-        });
-
-        it('should not call offsetsStore when consumer is not connected', () => {
+        it('should not call offsetsStore but still emit drained when consumer ' +
+        'is not connected', () => {
             const offsetsStore = sinon.stub(logConsumer._consumer, 'offsetsStore').returns(null);
             sinon.stub(logConsumer._consumer, 'isConnected').returns(false);
             logConsumer._topicPartition = [{ topic: 'oplog-topic', partition: 0, offset: 5 }];
@@ -275,10 +273,10 @@ describe('LogConsumer', () => {
 
             sinon.assert.notCalled(offsetsStore);
             assert.strictEqual(logConsumer._topicPartition, null);
-            assert.strictEqual(logConsumer._pendingCommit, false);
+            sinon.assert.calledOnce(drained);
         });
 
-        it('should not crash nor set pendingCommit when offsetsStore throws', () => {
+        it('should not crash and still emit drained when offsetsStore throws', () => {
             const offsetsStore = sinon.stub(logConsumer._consumer, 'offsetsStore')
                 .throws(new Error('Local: Erroneous state'));
             logConsumer._topicPartition = [{ topic: 'oplog-topic', partition: 0, offset: 5 }];
@@ -287,7 +285,7 @@ describe('LogConsumer', () => {
 
             sinon.assert.calledOnce(offsetsStore);
             assert.strictEqual(logConsumer._topicPartition, null);
-            assert.strictEqual(logConsumer._pendingCommit, false);
+            sinon.assert.calledOnce(drained);
         });
     });
 
@@ -299,44 +297,52 @@ describe('LogConsumer', () => {
     });
 
     describe('_onOffsetCommit', () => {
-        it('should not log error and not change pendingCommit on NO_OFFSET error', () => {
+        let drained;
+
+        beforeEach(() => {
+            drained = sinon.spy();
+            logConsumer.on('drained', drained);
+        });
+
+        it('should not log error on NO_OFFSET error', () => {
             const logErrorSpy = sinon.spy(logConsumer._log, 'error');
             const logDebugSpy = sinon.spy(logConsumer._log, 'debug');
-            logConsumer._pendingCommit = true;
-            
+
             const result = logConsumer._onOffsetCommit({ code: kafka.CODES.ERRORS.ERR__NO_OFFSET }, null);
-            
+
             sinon.assert.notCalled(logErrorSpy);
             sinon.assert.notCalled(logDebugSpy);
-            assert.strictEqual(logConsumer._pendingCommit, true);
+            sinon.assert.notCalled(drained);
             assert.strictEqual(result, undefined);
         });
 
-        it('should log error and not change pendingCommit on non-NO_OFFSET errors', () => {
+        it('should log error on non-NO_OFFSET errors', () => {
             const logErrorSpy = sinon.spy(logConsumer._log, 'error');
             const logDebugSpy = sinon.spy(logConsumer._log, 'debug');
             const error = { code: kafka.CODES.ERRORS.ERR__UNKNOWN_TOPIC };
             const topicPartitions = [{ topic: 'test-topic', partition: 1, offset: 5 }];
-            logConsumer._pendingCommit = true;
-            
+
             const result = logConsumer._onOffsetCommit(error, topicPartitions);
-            
+
             sinon.assert.calledOnce(logErrorSpy);
             sinon.assert.notCalled(logDebugSpy);
-            assert.strictEqual(logConsumer._pendingCommit, true);
+            sinon.assert.notCalled(drained);
             assert.strictEqual(result, undefined);
         });
 
-        it('should set pendingCommit to false on successful commit', () => {
+        it('should log at debug level on successful commit', () => {
+            const logErrorSpy = sinon.spy(logConsumer._log, 'error');
+            const logDebugSpy = sinon.spy(logConsumer._log, 'debug');
             const topicPartitions = [
                 { topic: 'oplog-topic', partition: 0, offset: 10 },
                 { topic: 'oplog-topic', partition: 1, offset: 20 }
             ];
-            logConsumer._pendingCommit = true;
-            
+
             const result = logConsumer._onOffsetCommit(null, topicPartitions);
-            
-            assert.strictEqual(logConsumer._pendingCommit, false);
+
+            sinon.assert.notCalled(logErrorSpy);
+            sinon.assert.calledOnce(logDebugSpy);
+            sinon.assert.notCalled(drained);
             assert.strictEqual(result, undefined);
         });
     });
@@ -374,15 +380,16 @@ describe('LogConsumer', () => {
                 clock.restore();
             });
 
-            it('should immediately unassign when no pending messages or commits', async () => {
+            it('should commit and immediately unassign when no batch is in flight', async () => {
                 const unassignStub = sinon.stub();
+                const commitStub = sinon.stub();
                 const assignment = [{ topic: 'test-topic', partition: 0 }];
                 logConsumer._consumer = {
                     unassign: unassignStub,
+                    commit: commitStub,
                     isConnected: () => true,
                 };
                 logConsumer._topicPartition = [];
-                logConsumer._pendingCommit = false;
 
                 let unassignHandler;
                 const unassignPromise = new Promise(resolve => { unassignHandler = resolve; });
@@ -394,19 +401,22 @@ describe('LogConsumer', () => {
 
                 void await unassignPromise;
 
+                sinon.assert.calledOnce(commitStub);
                 sinon.assert.calledOnce(unassignStub);
+                assert(commitStub.calledBefore(unassignStub));
             });
 
-            it('should wait for pending messages to be processed and committed before unassigning', async () => {
+            it('should wait for the in-flight batch before committing and unassigning', async () => {
                 const unassignStub = sinon.stub();
                 const commitStub = sinon.stub();
+                const offsetsStoreStub = sinon.stub();
                 logConsumer._consumer = {
                     unassign: unassignStub,
                     commit: commitStub,
+                    offsetsStore: offsetsStoreStub,
                     isConnected: () => true,
                 };
                 logConsumer._topicPartition = [{ topic: 'test', partition: 0, offset: 1 }];
-                logConsumer._pendingCommit = false;
 
                 let unassignHandler;
                 const unassignPromise = new Promise(resolve => { unassignHandler = resolve; });
@@ -415,38 +425,59 @@ describe('LogConsumer', () => {
 
                 logConsumer._onRebalance({ code: kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS }, []);
 
-                // First tick - should not unassign yet due to pending messages
+                // should not unassign while the batch is in flight
                 clock.tick(1000);
                 sinon.assert.notCalled(unassignStub);
 
-                // Simulate processing completion and commit
-                logConsumer._topicPartition = null;
-                logConsumer._pendingCommit = true;
-
-                // Second tick - should not unassign yet due to pending commit
-                clock.tick(1000);
-                sinon.assert.notCalled(unassignStub);
-
-                // Simulate successful commit by emitting drained event
-                logConsumer._pendingCommit = false;
-                logConsumer.emit('drained');
+                // batch processing completes: offsets are stored, which
+                // releases the drain
+                logConsumer.storeOffsets();
 
                 void await unassignPromise;
 
+                sinon.assert.calledOnce(offsetsStoreStub);
+                sinon.assert.calledOnce(commitStub);
+                sinon.assert.calledOnce(unassignStub);
+                assert(offsetsStoreStub.calledBefore(commitStub));
+                assert(commitStub.calledBefore(unassignStub));
+            });
+
+            it('should unassign even when the commit throws', async () => {
+                const unassignStub = sinon.stub();
+                const commitStub = sinon.stub().throws(new Error('Local: Erroneous state'));
+                logConsumer._consumer = {
+                    unassign: unassignStub,
+                    commit: commitStub,
+                    isConnected: () => true,
+                };
+                logConsumer._topicPartition = [];
+
+                let unassignHandler;
+                const unassignPromise = new Promise(resolve => { unassignHandler = resolve; });
+
+                logConsumer.once('unassigned', unassignHandler);
+
+                logConsumer._onRebalance({ code: kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS }, []);
+                clock.tick(1000);
+
+                void await unassignPromise;
+
+                sinon.assert.calledOnce(commitStub);
                 sinon.assert.calledOnce(unassignStub);
             });
 
             it('should disconnect consumer on timeout', async () => {
                 const disconnectStub = sinon.stub();
                 const unassignStub = sinon.stub();
+                const commitStub = sinon.stub();
                 logConsumer._consumer = {
                     disconnect: disconnectStub,
                     unassign: unassignStub,
+                    commit: commitStub,
                     isConnected: () => true,
                 };
                 logConsumer._maxPollIntervalMs = 5000;
                 logConsumer._topicPartition = [{ topic: 'test', partition: 0, offset: 1 }];
-                logConsumer._pendingCommit = false;
 
                 let unassignHandler;
                 const unassignPromise = new Promise(resolve => { unassignHandler = resolve; });
@@ -457,6 +488,40 @@ describe('LogConsumer', () => {
 
                 // Advance time to trigger timeout (maxPollIntervalMs - 1000)
                 clock.tick(4000);
+
+                void await unassignPromise;
+
+                sinon.assert.calledOnce(unassignStub);
+                sinon.assert.calledOnce(disconnectStub);
+            });
+
+            it('should cap the drain timeout at 30 seconds', async () => {
+                const disconnectStub = sinon.stub();
+                const unassignStub = sinon.stub();
+                const commitStub = sinon.stub();
+                logConsumer._consumer = {
+                    disconnect: disconnectStub,
+                    unassign: unassignStub,
+                    commit: commitStub,
+                    isConnected: () => true,
+                };
+                logConsumer._maxPollIntervalMs = 300000;
+                logConsumer._topicPartition = [{ topic: 'test', partition: 0, offset: 1 }];
+
+                let unassignHandler;
+                const unassignPromise = new Promise(resolve => { unassignHandler = resolve; });
+
+                logConsumer.once('unassigned', unassignHandler);
+
+                logConsumer._onRebalance({ code: kafka.CODES.ERRORS.ERR__REVOKE_PARTITIONS }, []);
+
+                // just below the cap: still waiting for the batch
+                clock.tick(29000);
+                sinon.assert.notCalled(unassignStub);
+
+                // past the 30s cap: unassign fires, not at
+                // maxPollIntervalMs - 1000
+                clock.tick(2000);
 
                 void await unassignPromise;
 


### PR DESCRIPTION
### The problem

When a consumer group rebalances (typically because a backbeat pod restarts during a rolling update), every consumer must release its partitions before the group can resume. The queue populator's LogConsumer refused to release until its last stored offsets were **committed** — but librdkafka cannot complete a commit while the rebalance is waiting for the release, and it commits the stored offsets itself as part of releasing anyway. The consumer was waiting on something that can only happen after the wait ends.

So whenever a rebalance arrived within the ~5 seconds following a batch:

- the consumer held its partitions for 299s (`maxPollIntervalMs − 1000`). The whole group waits for its slowest member, so the entire oplog pipeline — replication entries, bucket notifications, lifecycle — froze for ~5 minutes;
- when the wait timed out, it disconnected the consumer and nothing ever reconnected: the pod consumed nothing at all until the liveness probe restarted it;
- pod shutdown goes through the same wait, so stopping a pod could overrun the 30s kubernetes grace period, get SIGKILLed, and leave a stale group member behind — which is exactly what triggers the next unlucky rebalance.

### Impact on Zenko CI

This was the single largest source of CTST end2end flakiness over the past two months: the two Replication scenarios (object stuck `PENDING` past the test timeout while the populator was frozen or dead) failed **49 of 257 runs across 20 branches**, and the Bucket notifications filter scenario (events delivered ~5 minutes late, after all 4 in-test retries) failed **7 runs** — each red job costing a full ~4h end2end attempt. Traced examples: [run 29589236290 attempt 1](https://github.com/scality/Zenko/actions/runs/29589236290/attempts/1) (populator frozen 15:38:20→15:43:19, then dead until the liveness restart) and [run 29082783060 attempt 1](https://github.com/scality/Zenko/actions/runs/29082783060/attempts/1) (all 4 retries' notifications delivered in one batch, 44s after the last retry gave up). Merging this should remove both flake clusters.

### The fix

Same approach as BackbeatConsumer's rebalance handling (#2731 / #2739 / #2740):

- on rebalance, wait only for the batch currently being processed (a few seconds at most), not for a commit acknowledgment: `storeOffsets()` now signals batch completion directly, and the `_pendingCommit` flag is removed;
- commit the stored offsets right before releasing the partitions, best-effort: if the commit cannot go through, librdkafka commits stored offsets during the release anyway, and at worst the next partition owner re-consumes a few records — the populator is at-least-once by design;
- cap the wait at 30s (was 299s) and keep the deliberate disconnect when it expires: a batch stuck that long means the populator is wedged, and a healthcheck-driven restart is the intended recovery.

A new functional suite (`tests/functional/lib/queuePopulator/LogConsumer.js`, runs under `ft_test:lib`) exercises a real two-consumer rebalance against kafka: partitions released within seconds of the revoke, committed offsets on the broker matching the stored ones, the consumer still alive and consuming once the group settles, and the timeout/disconnect path.

Issue: BB-825