### PR TITLE
Consume the replication status topic from the earliest offset

### DIFF
--- a/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
+++ b/extensions/replication/replicationStatusProcessor/ReplicationStatusProcessor.js
@@ -347,6 +347,29 @@ class ReplicationStatusProcessor {
     }
 
     /**
+     * Build the options of the status topic consumer
+     * @param {Object} [options] - options object as given to start()
+     * @return {Object} consumer options
+     */
+    _getConsumerOptions(options) {
+        return {
+            kafka: {
+                hosts: this.kafkaConfig.hosts,
+                site: this.kafkaConfig.site,
+                compressionType: this.kafkaConfig.compressionType,
+                requiredAcks: this.kafkaConfig.requiredAcks,
+            },
+            topic: this.repConfig.replicationStatusTopic,
+            groupId: this.repConfig.replicationStatusProcessor.groupId,
+            concurrency: this.repConfig.replicationStatusProcessor.concurrency,
+            maxQueued: this.repConfig.replicationStatusProcessor.maxQueued,
+            queueProcessor: this.processKafkaEntry.bind(this),
+            bootstrap: (options && options.bootstrap) || false,
+            fromOffset: 'earliest',
+        };
+    }
+
+    /**
      * Start kafka consumer
      *
      * @param {object} [options] - options object (only used for tests
@@ -386,20 +409,8 @@ class ReplicationStatusProcessor {
             },
             done => {
                 let consumerReady = false;
-                this._consumer = new BackbeatConsumer({
-                    kafka: {
-                        hosts: this.kafkaConfig.hosts,
-                        site: this.kafkaConfig.site,
-                        compressionType: this.kafkaConfig.compressionType,
-                        requiredAcks: this.kafkaConfig.requiredAcks,
-                    },
-                    topic: this.repConfig.replicationStatusTopic,
-                    groupId: this.repConfig.replicationStatusProcessor.groupId,
-                    concurrency: this.repConfig.replicationStatusProcessor.concurrency,
-                    maxQueued: this.repConfig.replicationStatusProcessor.maxQueued,
-                    queueProcessor: this.processKafkaEntry.bind(this),
-                    bootstrap: (options && options.bootstrap) || false,
-                });
+                this._consumer = new BackbeatConsumer(
+                    this._getConsumerOptions(options));
                 this._consumer.on('error', () => {
                     if (!consumerReady) {
                         this.logger.fatal('error starting a backbeat consumer');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.4.1",
+  "version": "9.4.2",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/functional/lib/BackbeatConsumer.js
+++ b/tests/functional/lib/BackbeatConsumer.js
@@ -257,7 +257,7 @@ describe('BackbeatConsumer rebalance tests', () => {
         // Bootstrap just once at the beginning of the test suite
         const bootstrapConsumer = new BackbeatConsumer({
             zookeeper: zookeeperConf,
-            kafka: { hosts: consumerKafkaConf.hosts }, groupId, topic,
+            kafka: consumerKafkaConf, groupId, topic,
             queueProcessor,
             bootstrap: true,
         });
@@ -1273,4 +1273,103 @@ describe('BackbeatConsumer shutdown tests', () => {
             },
         ], done);
     }).timeout(60000);
+});
+
+describe('BackbeatConsumer fromOffset tests', () => {
+    const topic = 'backbeat-consumer-spec-from-offset';
+    let producer;
+    let consumer;
+    let consumedMessages;
+
+    function queueProcessor(message, cb) {
+        consumedMessages.push(message.value.toString());
+        process.nextTick(cb);
+    }
+
+    function waitFor(predicate, timeoutMs, description, cb) {
+        const deadline = Date.now() + timeoutMs;
+        const check = () => {
+            if (predicate()) {
+                return cb();
+            }
+            if (Date.now() > deadline) {
+                return cb(new Error(`timed out waiting for ${description}`));
+            }
+            return setTimeout(check, 200);
+        };
+        check();
+    }
+
+    function startConsumer(cb) {
+        consumer = new BackbeatConsumer({
+            clientId: 'BackbeatConsumer-fromOffset',
+            zookeeper: zookeeperConf,
+            kafka: consumerKafkaConf,
+            groupId: `from-offset-group-${Math.random()}`,
+            topic,
+            fromOffset: 'earliest',
+            queueProcessor,
+            concurrency: 2,
+        });
+        consumer.on('ready', () => {
+            consumer.subscribe();
+            cb();
+        });
+    }
+
+    before(function before(done) {
+        this.timeout(60000);
+        // settle the topic once (bootstrap canary produced and
+        // consumed) so per-test consumers join an established topic;
+        // per-test groups stay fresh so their partitions have no
+        // committed offset
+        const bootstrapConsumer = new BackbeatConsumer({
+            zookeeper: zookeeperConf,
+            kafka: consumerKafkaConf,
+            groupId: `from-offset-bootstrap-${Math.random()}`,
+            topic,
+            queueProcessor,
+            bootstrap: true,
+        });
+        bootstrapConsumer.on('ready', () => bootstrapConsumer.close(done));
+    });
+
+    beforeEach(function beforeEach(done) {
+        this.timeout(60000);
+        consumedMessages = [];
+        producer = new BackbeatProducer({
+            kafka: producerKafkaConf, topic,
+            pollIntervalMs: 100,
+        });
+        producer.on('ready', done);
+    });
+
+    afterEach(function afterEach(done) {
+        this.timeout(90000);
+        async.parallel([
+            innerDone => producer.close(innerDone),
+            innerDone => (consumer ? consumer.close(innerDone) : innerDone()),
+        ], err => {
+            consumer = null;
+            done(err);
+        });
+    });
+
+    it('should consume messages produced before the group existed with ' +
+    'fromOffset earliest', function testEarliest(done) {
+        this.timeout(120000);
+        const marker = `marker-earliest-${Math.random()}`;
+        async.series([
+            next => producer.send([{ key: 'k', message: marker }], next),
+            // without fromOffset 'earliest', the client default
+            // ('latest') would position past this pre-existing
+            // message and never deliver it
+            next => startConsumer(next),
+            // wide budget: a consumer group's first join can take a
+            // session timeout (45s) to settle when a rebalance hits
+            // its joining window
+            next => waitFor(() => consumedMessages.includes(marker), 75000,
+                'the pre-existing message to be consumed', next),
+        ], done);
+    });
 });

--- a/tests/unit/replication/ReplicationStatusProcessor.js
+++ b/tests/unit/replication/ReplicationStatusProcessor.js
@@ -130,4 +130,34 @@ describe('ReplicationStatusProcessor', () => {
             ]);
         });
     });
+    describe('::_getConsumerOptions', () => {
+        it('should consume the status topic from the earliest offset', () => {
+            const replicationStatusProcessor = new ReplicationStatusProcessor(
+                { hosts: 'localhost:9092' },
+                {
+                    auth: {},
+                    s3: {},
+                    transport: 'http',
+                },
+                {
+                    replicationStatusTopic: 'backbeat-replication-status',
+                    replicationStatusProcessor: {
+                        groupId: 'backbeat-replication-status-group',
+                        concurrency: 10,
+                        maxQueued: 1000,
+                    },
+                    objectSizeMetrics: [100, 1000],
+                },
+                {});
+            const consumerOptions =
+                replicationStatusProcessor._getConsumerOptions({});
+
+            assert.strictEqual(consumerOptions.fromOffset, 'earliest');
+            assert.strictEqual(consumerOptions.topic,
+                'backbeat-replication-status');
+            assert.strictEqual(consumerOptions.groupId,
+                'backbeat-replication-status-group');
+            assert.strictEqual(consumerOptions.bootstrap, false);
+        });
+    });
 });


### PR DESCRIPTION
### The problem

The replication status processor consumes the `backbeat-replication-status` topic and writes each replication's outcome back to the source object's metadata (COMPLETED/FAILED per site); FAILED entries also feed the failed-CRR listing so the object can be retried.

Its Kafka consumer never specified where to start reading when a partition has **no saved position** (no committed offset). In that case the client default applies: start at the **end** of the log, skipping whatever is already there. That default is never noticed in normal operation, because the group commits as it consumes and always finds its saved position. But it turns one specific race into permanent data loss:

1. the status processor restarts (rolling update, crash) — for a few seconds the consumer group has no member;
2. during that gap, a status message is produced onto a partition that never had a saved position (typically its first message ever — common on fresh deployments where every partition starts empty);
3. the new pod comes up, finds no saved position for that partition, starts at the end of the log — **after** the message.

Nobody ever reads that status, and nothing re-sends it: the data processor produced it, got its delivery acknowledgment, and moved on. The object's metadata says `PENDING` forever, and since the failure never reached the failed-CRR listing, it cannot even be retried.

### Impact on Zenko CI

This is the second half of the top CTST Replication flake, alongside the populator freeze fixed by #2787. In [run 29589236290 attempt 1](https://github.com/scality/Zenko/actions/runs/29589236290/attempts/1): the status-processor pod was rolled at 15:37:36; the FAILED status for the test's object landed on partition 4, offset 0 — first message ever on that partition — at 15:38:36, during the member gap; the replacement pod joined at 15:38:57 and started at offset 1. The "Re-replicate objects that failed to replicate" scenario (23 of 257 runs failed over two months) then waited its full 500s for a FAILED status that no longer existed anywhere — no test timeout can save this case, which is what makes it the *unrecoverable* variant of the flake.

The two fixes are complementary: #2787 removes the freezes and zombie pods that cause most of the red runs — and most of the restarts that open these gaps in the first place; this PR ensures that when a restart does happen (deploys never stop), a status produced during the gap is processed late instead of never. Together they should close out the Replication cluster (49 of 257 runs). Outside CI, the same race exists on any production rolling update, with the same silent consequence.

### The fix

Set `fromOffset: 'earliest'` on the status consumer: with no saved position, read the partition from the beginning. Steady state is unchanged (a saved position always wins over this setting), and the oplog LogConsumer already pins `earliest` for the same reason. In the worst case — a group that lost all its saved positions, e.g. after sitting empty past the offset retention — the consumer replays what the topic still retains (bounded by topic retention, broker default 7 days), and `UpdateReplicationStatus` re-reads the object's current metadata and skips anything already in a final state, so a replay mostly heals stuck-PENDING objects at the cost of temporary consumer lag.

The consumer options move to a `_getConsumerOptions()` method so a unit test can pin the option on this component, and two functional tests pin the semantics against a real kafka: an `'earliest'` consumer picks up a message produced before its group existed, and a default-configured consumer provably skips it — the exact loss mode this PR removes.

Issue: BB-826