### PR TITLE
Retry stale service-credential 403s on the internal backbeat routes

### DIFF
--- a/extensions/replication/tasks/MultipleBackendTask.js
+++ b/extensions/replication/tasks/MultipleBackendTask.js
@@ -1283,8 +1283,7 @@ class MultipleBackendTask extends ReplicateObject {
         if (err.BadRole || err.name === 'BadRole' ||
             (err.origin === 'source' &&
              (err.NoSuchEntity || err.name === 'NoSuchEntity' ||
-              err.AccessDenied || err.name === 'AccessDenied' ||
-              err.InvalidAccessKeyId || err.name === 'InvalidAccessKeyId'))) {
+              err.AccessDenied || err.name === 'AccessDenied'))) {
             log.error('replication failed permanently for object, ' +
                       'processing skipped',
                 { failMethod: err.method,

--- a/lib/BackbeatMetadataProxy.js
+++ b/lib/BackbeatMetadataProxy.js
@@ -7,6 +7,7 @@ const RoleCredentials = require('./credentials/RoleCredentials');
 const { getAccountCredentials } = require('./credentials/AccountCredentials');
 const { http: HttpAgent } = require('httpagent');
 const { lifecycleListing: { NON_CURRENT_TYPE, CURRENT_TYPE, ORPHAN_DM_TYPE } } = require('./constants');
+const { retryOnStaleCredentials } = require('./util/staleCredentialError');
 const { 
     BackbeatRoutesClient,
     GetBucketIndexesCommand,
@@ -71,7 +72,7 @@ class BackbeatMetadataProxy extends BackbeatTask {
                          versionId: params.versionId },
             actionFunc: done =>
                 this._putMetadataOnce(params, log, done),
-            shouldRetryFunc: err => err.retryable,
+            shouldRetryFunc: retryOnStaleCredentials(),
             log,
         }, cb);
     }
@@ -127,7 +128,7 @@ class BackbeatMetadataProxy extends BackbeatTask {
                 objectKey: params.objectKey
             },
             actionFunc: done => this._headLocationOnce(params, log, done),
-            shouldRetryFunc: err => err.retryable,
+            shouldRetryFunc: retryOnStaleCredentials(),
             log,
         }, cb);
     }
@@ -190,7 +191,7 @@ class BackbeatMetadataProxy extends BackbeatTask {
                          objectKey: params.objectKey,
                          versionId: params.versionId },
             actionFunc: done => this._getMetadataOnce(params, log, done),
-            shouldRetryFunc: err => err.retryable,
+            shouldRetryFunc: retryOnStaleCredentials(),
             log,
         }, cb);
     }

--- a/lib/util/staleCredentialError.js
+++ b/lib/util/staleCredentialError.js
@@ -1,0 +1,45 @@
+/**
+ * Helpers for retrying failures caused by a stale service credential.
+ *
+ * Backbeat and cloudserver both cache their service-account credentials at
+ * process start, so a credential rotation leaves the two disagreeing until
+ * both have restarted, and cloudserver rejects the key it does not know with
+ * a 403. Smithy classifies a 403 as non-retryable (see isRetryableMiddleware),
+ * which is right for a customer endpoint but drops the entry on the internal
+ * routes, where a later attempt may well be served by an already-updated pod.
+ */
+
+const MAX_STALE_CREDENTIAL_RETRIES = 5;
+
+/**
+ * Check if an error denotes a stale service credential
+ * @param {Error} err - The error object
+ * @returns {boolean} True if the access key is unknown or its secret mismatched
+ */
+function isStaleCredentialError(err) {
+    const code = err && (err.name || err.code);
+    return code === 'InvalidAccessKeyId' || code === 'SignatureDoesNotMatch';
+}
+
+/**
+ * Build a shouldRetryFunc for BackbeatTask.retry() that keeps the usual
+ * err.retryable behaviour and additionally retries a bounded number of
+ * stale-credential failures.
+ *
+ * The returned function is stateful: build one per retry() call so that the
+ * budget applies to a single logical operation.
+ *
+ * @param {number} [maxRetries] - maximum stale-credential retries
+ * @returns {function} predicate suitable for retry()'s shouldRetryFunc
+ */
+function retryOnStaleCredentials(maxRetries = MAX_STALE_CREDENTIAL_RETRIES) {
+    let attempts = 0;
+    return err => err.retryable ||
+        (isStaleCredentialError(err) && attempts++ < maxRetries);
+}
+
+module.exports = {
+    MAX_STALE_CREDENTIAL_RETRIES,
+    isStaleCredentialError,
+    retryOnStaleCredentials,
+};

--- a/tests/unit/lib/BackbeatMetadataProxy.spec.js
+++ b/tests/unit/lib/BackbeatMetadataProxy.spec.js
@@ -1,0 +1,193 @@
+const assert = require('assert');
+const sinon = require('sinon');
+const BackOff = require('backo');
+
+const BackbeatMetadataProxy = require('../../../lib/BackbeatMetadataProxy');
+const {
+    MAX_STALE_CREDENTIAL_RETRIES,
+    isStaleCredentialError,
+    retryOnStaleCredentials,
+} = require('../../../lib/util/staleCredentialError');
+
+// max.poll.interval.ms defaults to 300s: a correlated skew window must not let
+// a single entry hold a concurrency slot anywhere near that long
+const MAX_POLL_INTERVAL_MS = 300000;
+
+const log = {
+    trace: () => {},
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    getSerializedUids: () => 'test-uid',
+    end: () => log,
+};
+
+const authConfig = { type: 'account', account: 'bart' };
+
+const mdParams = {
+    bucket: 'source-bucket',
+    objectKey: 'key',
+    versionId: '0123456789',
+};
+
+function makeError(name, retryable = false) {
+    const err = new Error(name);
+    err.name = name;
+    err.retryable = retryable;
+    return err;
+}
+
+function newProxy() {
+    return new BackbeatMetadataProxy('http://localhost:8000', authConfig);
+}
+
+describe('BackbeatMetadataProxy', () => {
+    let proxy;
+
+    beforeEach(() => {
+        proxy = newProxy();
+        // keep the retry delays out of the wall clock; the real backoff is
+        // asserted separately below
+        proxy.retryParams.backoff = { min: 1, max: 5, jitter: 0, factor: 1 };
+    });
+
+    afterEach(() => sinon.restore());
+
+    describe('stale service-credential retries', () => {
+        it('should retry a stale-credential 403 and succeed once a fresh endpoint answers', done => {
+            const send = sinon.stub().resolves({ Body: '{}' });
+            send.onCall(0).rejects(makeError('InvalidAccessKeyId'));
+            send.onCall(1).rejects(makeError('InvalidAccessKeyId'));
+            proxy.setBackbeatClient({ send });
+
+            proxy.getMetadata(mdParams, log, (err, data) => {
+                assert.ifError(err);
+                assert.strictEqual(send.callCount, 3);
+                assert.deepStrictEqual(data, { Body: '{}' });
+                return done();
+            });
+        });
+
+        it('should retry a SignatureDoesNotMatch failure', done => {
+            const send = sinon.stub().resolves({ Body: '{}' });
+            send.onCall(0).rejects(makeError('SignatureDoesNotMatch'));
+            proxy.setBackbeatClient({ send });
+
+            proxy.getMetadata(mdParams, log, err => {
+                assert.ifError(err);
+                assert.strictEqual(send.callCount, 2);
+                return done();
+            });
+        });
+
+        it('should give up once the stale-credential budget is exhausted', done => {
+            const send = sinon.stub().rejects(makeError('InvalidAccessKeyId'));
+            proxy.setBackbeatClient({ send });
+
+            proxy.getMetadata(mdParams, log, err => {
+                assert(err);
+                assert.strictEqual(err.name, 'InvalidAccessKeyId');
+                assert.strictEqual(send.callCount,
+                    MAX_STALE_CREDENTIAL_RETRIES + 1);
+                return done();
+            });
+        });
+
+        it('should not retry an AccessDenied failure', done => {
+            const send = sinon.stub().rejects(makeError('AccessDenied'));
+            proxy.setBackbeatClient({ send });
+
+            proxy.getMetadata(mdParams, log, err => {
+                assert(err);
+                assert.strictEqual(err.name, 'AccessDenied');
+                assert.strictEqual(send.callCount, 1);
+                return done();
+            });
+        });
+
+        it('should not retry an unrelated non-retryable failure', done => {
+            const send = sinon.stub().rejects(makeError('MethodNotAllowed'));
+            proxy.setBackbeatClient({ send });
+
+            proxy.getMetadata(mdParams, log, err => {
+                assert(err);
+                assert.strictEqual(send.callCount, 1);
+                return done();
+            });
+        });
+
+        it('should still retry an error flagged retryable by the client', done => {
+            const send = sinon.stub().resolves({ Body: '{}' });
+            send.onCall(0).rejects(makeError('InternalError', true));
+            proxy.setBackbeatClient({ send });
+
+            proxy.getMetadata(mdParams, log, err => {
+                assert.ifError(err);
+                assert.strictEqual(send.callCount, 2);
+                return done();
+            });
+        });
+
+        it('should retry putMetadata with the same metadata blob', done => {
+            const mdBlob = Buffer.from('{"md-model-version":2}');
+            const send = sinon.stub().resolves({});
+            send.onCall(0).rejects(makeError('InvalidAccessKeyId'));
+            proxy.setBackbeatClient({ send });
+
+            proxy.putMetadata({ ...mdParams, mdBlob }, log, err => {
+                assert.ifError(err);
+                assert.strictEqual(send.callCount, 2);
+                const bodies = send.getCalls().map(c => c.args[0].input.Body);
+                assert.deepStrictEqual(bodies, [mdBlob, mdBlob]);
+                return done();
+            });
+        });
+
+        it('should retry headLocation', done => {
+            const send = sinon.stub().resolves({});
+            send.onCall(0).rejects(makeError('InvalidAccessKeyId'));
+            proxy.setBackbeatClient({ send });
+
+            const params = {
+                ...mdParams,
+                locations: [{ dataStoreName: 'us-east-1', key: 'key' }],
+            };
+            proxy.headLocation(params, log, err => {
+                assert.ifError(err);
+                assert.strictEqual(send.callCount, 2);
+                return done();
+            });
+        });
+
+        it('should keep the default retry budget far below max.poll.interval.ms', () => {
+            const backoff = new BackOff(newProxy().retryParams.backoff);
+            let totalMs = 0;
+            for (let i = 0; i < MAX_STALE_CREDENTIAL_RETRIES; i++) {
+                totalMs += backoff.duration();
+            }
+            assert(totalMs < MAX_POLL_INTERVAL_MS / 10,
+                `stale-credential retries may span ${totalMs}ms`);
+        });
+    });
+});
+
+describe('staleCredentialError', () => {
+    it('should recognise stale-credential failures only', () => {
+        assert(isStaleCredentialError({ name: 'InvalidAccessKeyId' }));
+        assert(isStaleCredentialError({ code: 'SignatureDoesNotMatch' }));
+        assert(!isStaleCredentialError({ name: 'AccessDenied' }));
+        assert(!isStaleCredentialError({ name: 'NoSuchEntity' }));
+        assert(!isStaleCredentialError(undefined));
+    });
+
+    it('should give each predicate its own budget', () => {
+        const err = makeError('InvalidAccessKeyId');
+        const first = retryOnStaleCredentials(1);
+        const second = retryOnStaleCredentials(1);
+
+        assert.strictEqual(first(err), true);
+        assert.strictEqual(first(err), false);
+        assert.strictEqual(second(err), true);
+    });
+});

--- a/tests/unit/replication/MultipleBackendTask.js
+++ b/tests/unit/replication/MultipleBackendTask.js
@@ -710,4 +710,43 @@ describe('MultipleBackendTask', function test() {
             });
         });
     });
+
+    describe('::_handleReplicationOutcome', () => {
+        function makeSourceError(name) {
+            const err = new Error(name);
+            err.name = name;
+            err.origin = 'source';
+            return err;
+        }
+
+        beforeEach(() => {
+            sinon.stub(task, '_publishReplicationStatus').returns();
+        });
+
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        it('should publish FAILED and defer the commit for a stale-credential 403', done => {
+            task._handleReplicationOutcome(makeSourceError('InvalidAccessKeyId'),
+                sourceEntry, replicationEntry, fakeLogger, (err, completionArgs) => {
+                    assert.ifError(err);
+                    assert.deepStrictEqual(completionArgs, { committable: false });
+                    assert(task._publishReplicationStatus.calledOnce);
+                    assert.strictEqual(
+                        task._publishReplicationStatus.firstCall.args[1], 'FAILED');
+                    return done();
+                });
+        });
+
+        it('should skip a source AccessDenied without publishing a status', done => {
+            task._handleReplicationOutcome(makeSourceError('AccessDenied'),
+                sourceEntry, replicationEntry, fakeLogger, (err, completionArgs) => {
+                    assert.ifError(err);
+                    assert.strictEqual(completionArgs, undefined);
+                    assert(task._publishReplicationStatus.notCalled);
+                    return done();
+                });
+        });
+    });
 });


### PR DESCRIPTION
## Problem

Artesca regenerates builtin service-account keys on every overlay write (PSVAPI-134). Backbeat and cloudserver each snapshot authdata at process start and neither reloads it, so during the rolling restarts that follow a rotation cloudserver returns `403 InvalidAccessKeyId` on internal calls.

Smithy classifies a 403 as non-retryable (`lib/clients/utils.js`), every retry wrapper gates on `err.retryable`, and `BackbeatConsumer` commits the offset regardless — so a replication-status entry is destroyed outright. The failure lands in `_refreshSourceEntry`, upstream of every FAILED bookkeeping step, so the object keeps its `PENDING` status, never enters the failed-CRR sorted set, and is invisible to crrRetry.

A census on the ticket (10 CTST runs, 100 rejected requests, 8 skew episodes) found 95 % of these are cloudserver-stale — so a retry in backbeat can succeed — and that staleness is a per-request property: internal-cloudserver runs 4 replicas to backbeat's 1 and rolls a pod at a time, so a later attempt can be served by an already-updated pod. One backbeat pod was observed both failing and succeeding within the same second.

## Changes

**`lib/util/staleCredentialError.js`** (new) — `isStaleCredentialError()` matching `InvalidAccessKeyId` and `SignatureDoesNotMatch`, and `retryOnStaleCredentials()`, a stateful predicate that preserves the existing `err.retryable` behaviour and adds a bounded number of stale-credential retries. `AccessDenied` is deliberately excluded: on an internal route it is the existing signal for a misconfigured source role (`lib/util/replicationPermissionError.js`) and must keep failing fast.

**`lib/BackbeatMetadataProxy.js`** — the three source-metadata calls (`getMetadata`, `putMetadata`, `headLocation`) use that predicate. A fresh one per `retry()` call, so the budget applies to a single logical operation.

**`extensions/replication/tasks/MultipleBackendTask.js`** — `_handleReplicationOutcome` listed `InvalidAccessKeyId` as a permanent failure and returned a bare `done()`, committing the offset with no status published. `ReplicateObject` already omits it and publishes FAILED with `committable: false`; the subclass now matches, so an entry whose retries are exhausted stays visible to crrRetry.

## Notes for review

- **Timing.** The proxy calls `super()` with no retryParams, so it uses the defaults (`min: 1000, factor: 1.5`): attempts at 1 s, 2.5 s, 4.75 s, 8.1 s, 13.2 s — ~13 s total, ~20x under `max.poll.interval.ms` (300 s). This matters because the failure is correlated across all `concurrency: 10` slots during a skew window. A unit test guards the property.
- **The backend-specific budgets are not reachable.** The `60000` ms backoff / `900 s` timeout picked in `ReplicateObject.js:67-71` belongs to the task instances and only governs retries those tasks start themselves. `MultipleBackendTask._refreshSourceEntry` calls the proxy directly, so a stale-credential retry runs on the proxy's own params regardless of destination type.
- **`committable: false` defers the commit, it does not withhold it** — `_publishReplicationStatus` calls `onEntryCommittable` in the producer callback whether the produce succeeded or not, and this is already the path taken by every COMPLETED and FAILED outcome. No new stall mode; the change removes a special case that bypassed the normal path.
- No change to `isRetryableMiddleware`, so a customer-destination 403 stays permanent by construction. The four call sites that opt in only ever talk to the internal endpoint.

## Deliberately out of scope

- The 24 % of census rejections that arrived on the ordinary S3 route (`GetBucketReplication` in `_setupRolesOnce`) are not retried. With the second commit they become visible FAILED entries rather than silent losses.
- The ~5 % backbeat-stale direction still needs a pod restart; an `operatorBackend` credential reload would close it.
- What the *status* processor should do when retries are exhausted — collides with BB-772's commit-on-poison-pill decision.
- Backports: 9.2 can take the same patch; 9.1 is on aws-sdk v2 and needs a variant.

Issue: BB-832