### PR TITLE
Consume from the earliest offset where a lost message is unrecoverable

### DIFF
--- a/extensions/gc/GarbageCollector.js
+++ b/extensions/gc/GarbageCollector.js
@@ -121,14 +121,11 @@ class GarbageCollector extends EventEmitter {
     }
 
     /**
-     * Start kafka consumer. Emits a 'ready' event when
-     * consumer is ready.
-     *
-     * @return {undefined}
+     * Build the options of the garbage collector topic consumer
+     * @return {Object} consumer options
      */
-    start() {
-        let consumerReady = false;
-        this._consumer = new BackbeatConsumer({
+    _getConsumerOptions() {
+        return {
             kafka: {
                 hosts: this._kafkaConfig.hosts,
                 site: this._kafkaConfig.site,
@@ -143,7 +140,19 @@ class GarbageCollector extends EventEmitter {
             // sent to the gc don't have a key anyways)
             orderByFunc: null,
             queueProcessor: this.processKafkaEntry.bind(this),
-        });
+            fromOffset: 'earliest',
+        };
+    }
+
+    /**
+     * Start kafka consumer. Emits a 'ready' event when
+     * consumer is ready.
+     *
+     * @return {undefined}
+     */
+    start() {
+        let consumerReady = false;
+        this._consumer = new BackbeatConsumer(this._getConsumerOptions());
         this._consumer.on('error', () => {
             if (!consumerReady) {
                 this._logger.error('garbage collector failed to start the ' +

--- a/extensions/lifecycle/objectProcessor/LifecycleObjectTransitionProcessor.js
+++ b/extensions/lifecycle/objectProcessor/LifecycleObjectTransitionProcessor.js
@@ -99,6 +99,8 @@ class LifecycleObjectTransitionProcessor extends LifecycleObjectProcessor {
     getConsumerParams() {
         const consumerParams = super.getConsumerParams(this._lcConfig.transitionTasksTopic);
 
+        consumerParams[this._lcConfig.transitionTasksTopic].fromOffset = 'earliest';
+
         const locations = require('../../../conf/locationConfig.json') || {};
 
         this._lcConfig.coldStorageTopics.forEach(topic => {
@@ -133,6 +135,7 @@ class LifecycleObjectTransitionProcessor extends LifecycleObjectProcessor {
                 maxQueued: this._processConfig.maxQueued,
                 queueProcessor: this.processColdStorageStatusEntry.bind(this),
                 circuitBreaker,
+                fromOffset: 'earliest',
             };
         });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.5.0-preview.8",
+  "version": "9.5.0-preview.9",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/gc/GarbageCollector.spec.js
+++ b/tests/unit/gc/GarbageCollector.spec.js
@@ -64,6 +64,10 @@ describe('garbage collector', function garbageCollector() {
     after(() => {
         httpServer.close();
     });
+    it('should consume the gc topic from the earliest offset', () => {
+        assert.strictEqual(gc._getConsumerOptions().fromOffset, 'earliest');
+    });
+
     it('should skip unsupported action type', done => {
         expectBatchDeleteLocations = null;
         const action = ActionQueueEntry.create('foo');

--- a/tests/unit/lifecycle/LifecycleObjectExpirationProcessor.spec.js
+++ b/tests/unit/lifecycle/LifecycleObjectExpirationProcessor.spec.js
@@ -16,6 +16,14 @@ describe('LifecycleObjectExpirationProcessor', () => {
         );
     });
 
+    it('should not pin fromOffset on the object tasks topic', () => {
+        const consumerParams = objectProcessor.getConsumerParams();
+        assert.strictEqual(
+            consumerParams[config.extensions.lifecycle.objectTasksTopic].fromOffset,
+            undefined,
+        );
+    });
+
     it('should contain object tasks topic in consumer params', () => {
         const consumerParams = objectProcessor.getConsumerParams();
         assert.deepStrictEqual(Object.keys(consumerParams), [config.extensions.lifecycle.objectTasksTopic]);

--- a/tests/unit/lifecycle/LifecycleObjectTransitionProcessor.spec.js
+++ b/tests/unit/lifecycle/LifecycleObjectTransitionProcessor.spec.js
@@ -21,6 +21,26 @@ describe('LifecycleObjectTransitionProcessor', () => {
         );
     });
 
+    it('should consume the transition tasks topic from the earliest offset', () => {
+        const consumerParams = objectProcessor.getConsumerParams();
+        assert.strictEqual(
+            consumerParams[config.extensions.lifecycle.transitionTasksTopic].fromOffset,
+            'earliest'
+        );
+    });
+
+    it('should consume the cold status topics from the earliest offset', () => {
+        const coldTopic = `${config.extensions.lifecycle.coldStorageStatusTopicPrefix}location-dmf-v1`;
+        const coldProcessor = new LifecycleObjectTransitionProcessor(
+            config.zookeeper,
+            config.kafka,
+            { ...config.extensions.lifecycle, coldStorageTopics: [coldTopic] },
+            config.s3,
+        );
+        const consumerParams = coldProcessor.getConsumerParams();
+        assert.strictEqual(consumerParams[coldTopic].fromOffset, 'earliest');
+    });
+
     it('should contain transition tasks topic in consumer params', () => {
         const consumerParams = objectProcessor.getConsumerParams();
         assert.deepStrictEqual(Object.keys(consumerParams), [config.extensions.lifecycle.transitionTasksTopic]);


### PR DESCRIPTION
Pins `fromOffset: 'earliest'` on the three consumers where a message produced during a consumer group gap is permanently lost **and** the group is service-wide rather than created per site or per destination:

| Topic | Consumer |
| --- | --- |
| `backbeat-lifecycle-transition-tasks` | transition processor |
| `cold-status-<location>` | transition processor, per location |
| gc topic | `GarbageCollector` |

Four consumers deliberately stay on the default: the lifecycle object (expiration) tasks topic (self-healing via the conductor's re-enumeration), the notification internal topic and the data-mover topic (both use a per-instance group id on a shared topic, so a new destination or location would replay the full retention window), and the replication topic itself (replay cost needs its own decision). A unit test pins the expiration exclusion so it is not "fixed" by accident.

The per-consumer rationale — why each loss is or is not recoverable, and the replay-safety analysis behind each decision — is in BB-831.

### Validation

On a 30-run census with an earlier build of this fix, the Azure Archive location CRUD scenario went from 8/20 runs failing (40 %) to 1/30 (3.3 %), and no skip of this kind appears in any of the dumps inspected. Pre-fix, cold-status messages produced but never consumed ran at 15–34 % across two censuses, concentrated in the rollout window and absent outside it, and the mechanism was traced end to end in every case examined — all of them cold-status. Caveats: an unrelated fix touching cold transitions landed between censuses, and the validated build's consumer set is wider than what this PR now pins, so the attribution rests on the traced mechanism rather than on the rate alone.

### Implementation note

The gc consumer options move into `_getConsumerOptions()` for unit coverage, following #2788. Generic `fromOffset` semantics are already covered by the functional tests #2788 added to the `BackbeatConsumer` suite.

Issue: BB-831