### PR TITLE
Accept object-valued value and overheadFields in kafka entries

### DIFF
--- a/lib/models/QueueEntry.js
+++ b/lib/models/QueueEntry.js
@@ -5,6 +5,26 @@ const BucketQueueEntry = require('./BucketQueueEntry');
 const BucketMdQueueEntry = require('./BucketMdQueueEntry');
 const DeleteOpQueueEntry = require('./DeleteOpQueueEntry');
 
+/**
+ * Decode a nested field of a kafka entry, which producers may send either
+ * as a JSON string or as an already-decoded object.
+ *
+ * @param {string|object} field - JSON string or decoded object
+ * @return {object} the decoded field
+ * @throws {Error} if the field is neither a JSON string nor an object; the
+ *   caller turns this into a "malformed JSON in kafka entry" error
+ */
+function decodeField(field) {
+    if (typeof field === 'string') {
+        return JSON.parse(field);
+    }
+    if (typeof field === 'object') {
+        return field;
+    }
+    throw new Error(
+        `expected a JSON string or an object, got ${typeof field}`);
+}
+
 class QueueEntry {
 
     /**
@@ -27,14 +47,14 @@ class QueueEntry {
             }
             let entry;
             if (record.type === 'del') {
-                const overheadFields = record.overheadFields && JSON.parse(record.overheadFields);
+                const overheadFields = record.overheadFields && decodeField(record.overheadFields);
                 entry = new DeleteOpQueueEntry(record.bucket, record.key, overheadFields);
             } else if (record.bucket === usersBucket) {
                 // BucketQueueEntry class just handles puts of keys
                 // to usersBucket
                 entry = new BucketQueueEntry(record.key, record.value);
             } else if (record.value) {
-                const metadataVal = JSON.parse(record.value);
+                const metadataVal = decodeField(record.value);
                 if (metadataVal.mdBucketModelVersion) {
                     // it's bucket metadata
                     entry = new BucketMdQueueEntry(record.key, metadataVal);

--- a/tests/unit/lib/models/ObjectQueueEntry.spec.js
+++ b/tests/unit/lib/models/ObjectQueueEntry.spec.js
@@ -384,5 +384,22 @@ describe('ObjectQueueEntry', () => {
             assert.strictEqual(entry.getKey(), 'key');
             assert.deepStrictEqual(entry.getOverheadField('foo'), 'bar');
         });
+
+        it('should create a DeleteOpQueueEntry with object overhead fields',
+        () => {
+            const entry = QueueEntry.createFromKafkaEntry({
+                value: JSON.stringify({
+                    type: 'del',
+                    bucket: 'bucket',
+                    key: 'key',
+                    overheadFields: { foo: 'bar' },
+                }),
+            });
+
+            assert(entry instanceof DeleteOpQueueEntry);
+            assert.strictEqual(entry.getBucket(), 'bucket');
+            assert.strictEqual(entry.getKey(), 'key');
+            assert.deepStrictEqual(entry.getOverheadField('foo'), 'bar');
+        });
     });
 });

--- a/tests/unit/lib/models/QueueEntry.spec.js
+++ b/tests/unit/lib/models/QueueEntry.spec.js
@@ -71,4 +71,54 @@ describe('QueueEntry helper class', () => {
             assert.strictEqual(completed1.getReplicationStatus(), 'COMPLETED');
         });
     });
+
+    describe('nested field decoding', () => {
+        function withDecodedValue(kafkaEntry) {
+            const record = JSON.parse(kafkaEntry.value);
+            record.value = JSON.parse(record.value);
+            return { ...kafkaEntry, value: JSON.stringify(record) };
+        }
+
+        it('should accept an object as the entry value', () => {
+            const fromString = QueueEntry.createFromKafkaEntry(replicationEntry);
+            const fromObject = QueueEntry.createFromKafkaEntry(
+                withDecodedValue(replicationEntry));
+
+            assert.strictEqual(fromObject.error, undefined);
+            assert.deepStrictEqual(fromObject.getValue(), fromString.getValue());
+            assert.strictEqual(fromObject.getBucket(), fromString.getBucket());
+            assert.strictEqual(fromObject.getObjectKey(),
+                               fromString.getObjectKey());
+        });
+
+        it('should report a malformed value string', () => {
+            const entry = QueueEntry.createFromKafkaEntry({
+                value: JSON.stringify({
+                    type: 'put',
+                    bucket: 'bucket',
+                    key: 'key',
+                    value: 'not json',
+                }),
+            });
+
+            assert.strictEqual(entry.error.message,
+                               'malformed JSON in kafka entry');
+        });
+
+        it('should reject a value that is neither a string nor an object',
+        () => {
+            const entry = QueueEntry.createFromKafkaEntry({
+                value: JSON.stringify({
+                    type: 'put',
+                    bucket: 'bucket',
+                    key: 'key',
+                    value: 42,
+                }),
+            });
+
+            assert.strictEqual(entry.error.message,
+                               'malformed JSON in kafka entry');
+            assert.match(entry.error.description, /got number/);
+        });
+    });
 });

--- a/tests/unit/lib/models/QueueEntry.spec.js
+++ b/tests/unit/lib/models/QueueEntry.spec.js
@@ -2,9 +2,8 @@
 
 const assert = require('assert');
 
-const QueueEntry =
-          require('../../../lib/models/QueueEntry');
-const { replicationEntry } = require('../../utils/kafkaEntries');
+const QueueEntry = require('../../../../lib/models/QueueEntry');
+const { replicationEntry } = require('../../../utils/kafkaEntries');
 
 describe('QueueEntry helper class', () => {
     describe('built from Kafka queue entry', () => {


### PR DESCRIPTION
`createFromKafkaEntry` parses the kafka message body and then parses the nested `value` — and, for `del` entries, `overheadFields` — a second time, so producers have to send them as JSON text.

The D/R metadata stream is built by a MongoDB change-stream pipeline ([ZKOP-562]), which cannot serialise a document to a string: there is no `$toJson`, and `$convert` rejects documents. Manufacturing one for the consumer to parse straight back would mean either `$function` (per-document server-side JS on a production secondary, inside a change-stream pipeline) or a custom Kafka Connect SMT shipped in the kafka-connect image.

The string requirement only exists because every producer so far builds entries in JavaScript — `ListRecordStream` does `value: JSON.stringify(objectMd)` on the oplog path, and S3C ingestion stringifies upstream. Nothing consumes the string form; it is parsed on receipt.

So decode these fields only when they are strings, and pass objects through. That is a superset of the existing format: producers that stringify take the identical path, so ingestion is unaffected.

The first commit moves the `QueueEntry` spec to `tests/unit/lib/models/`, next to the model it tests.

Issue: BB-847

[ZKOP-562]: https://scality.atlassian.net/browse/ZKOP-562