### PR TITLE
Consume the ingestion topic from the earliest offset

### DIFF
--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -147,6 +147,7 @@ class MongoQueueProcessor {
                 },
                 concurrency: this.mongoProcessorConfig.concurrency,
                 maxQueued: this.mongoProcessorConfig.maxQueued,
+                fromOffset: 'earliest',
             });
             this._consumer.on('error', () => {
                 MongoProcessorMetrics.onIngestionKafkaConsume('error');

--- a/tests/unit/mongoProcessor/MongoQueueProcessor.spec.js
+++ b/tests/unit/mongoProcessor/MongoQueueProcessor.spec.js
@@ -1,9 +1,12 @@
 const assert = require('assert');
+const sinon = require('sinon');
 
 const MongoQueueProcessor =
     require('../../../extensions/mongoProcessor/MongoQueueProcessor');
 const ObjectQueueEntry =
     require('../../../lib/models/ObjectQueueEntry');
+const BackbeatConsumer = require('../../../lib/BackbeatConsumer');
+const Config = require('../../../lib/Config');
 
 function _makeProcessor(bootstrapList) {
     const proc = Object.create(MongoQueueProcessor.prototype);
@@ -232,5 +235,41 @@ describe('MongoQueueProcessor._updateReplicationInfo', () => {
         assert.strictEqual(bySite['cloud-b'].destination, undefined);
         assert.strictEqual(bySite['cloud-b'].role, undefined);
         assert.strictEqual(bySite['cloud-b'].status, 'PENDING');
+    });
+});
+
+describe('MongoQueueProcessor.start', () => {
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    function startProcessor() {
+        sinon.stub(BackbeatConsumer.prototype, '_init');
+        sinon.stub(Config, 'getBootstrapList').returns([]);
+        sinon.stub(Config, 'on');
+
+        const proc = _makeProcessor([]);
+        proc.logger = { info: () => {}, error: () => {}, fatal: () => {} };
+        proc.kafkaConfig = { hosts: 'localhost:9092' };
+        proc.mongoProcessorConfig = {
+            topic: 'backbeat-ingestion',
+            groupId: 'backbeat-ingestion-group',
+            concurrency: 5,
+        };
+        proc._setupMetricsClients = cb => cb();
+        proc._mongoClient = { setup: cb => cb() };
+
+        proc.start();
+
+        return proc;
+    }
+
+    it('starts the consumer at the earliest offset', done => {
+        const proc = startProcessor();
+
+        setImmediate(() => {
+            assert.strictEqual(proc._consumer._fromOffset, 'earliest');
+            done();
+        });
     });
 });


### PR DESCRIPTION
`MongoQueueProcessor` did not set `fromOffset`, so it inherited librdkafka's default `latest`: a message produced onto a partition with no committed offset while the group had no member — a rolling update, a crash-restart — is skipped forever once the replacement consumer resolves its start position.

BB-831 swept this defect class and left this consumer unpinned, as having "no known permanent-loss path". That does not hold. `LogReader` persists its own log position in Zookeeper and advances it after publishing a batch, and the ingestion snapshot phase runs once at source creation — so nothing re-reads that stretch of the raft log, and a skipped message means the object metadata is never ingested.

Pinned unconditionally rather than behind a D/R mode, since the D/R metadata sink reuses this processor and loses entries the same way. The permanent-loss argument, the group geometry and the replay-safety analysis are on BB-848.

The consumer options move into `_getConsumerOptions()` for unit coverage, following #2788.

Issue: BB-848