### PR TITLE
Skip the rebalance-sensitive consumer tests on 9.5

### DIFF
--- a/tests/functional/lib/BackbeatConsumer.js
+++ b/tests/functional/lib/BackbeatConsumer.js
@@ -572,7 +572,10 @@ describe('BackbeatConsumer rebalance during batch processing', () => {
     }).timeout(60000);
 });
 
-describe('BackbeatConsumer ledger drain on rebalance', () => {
+// Skipped on 9.5: these tests were written against librdkafka 2.12 and fail
+// 40-80% of the time on the 2.3.0 pinned by BB-806, which 9.5 keeps. Unskip on
+// 9.6, which carries the librdkafka upgrade (BB-849).
+describe.skip('BackbeatConsumer ledger drain on rebalance', () => {
     const topic = 'backbeat-consumer-spec-ledger-drain';
     const groupId = `replication-group-ledger-drain-${Math.random()}`;
     let producer;
@@ -1275,7 +1278,8 @@ describe('BackbeatConsumer shutdown tests', () => {
     }).timeout(60000);
 });
 
-describe('BackbeatConsumer fromOffset tests', () => {
+// Skipped on 9.5 for the same reason as the ledger drain tests above (BB-849).
+describe.skip('BackbeatConsumer fromOffset tests', () => {
     const topic = 'backbeat-consumer-spec-from-offset';
     let producer;
     let consumer;


### PR DESCRIPTION
The `ledger drain on rebalance` and `fromOffset` consumer tests were written against librdkafka 2.12 and do not hold on the 2.3.0 that BB-806 pinned and that 9.5 keeps.

A controlled A/B on CI, 25 runs per arm over the full `lib` suite, isolates the cause — the first two arms differ only in `package.json` and `yarn.lock`:

| tree | librdkafka | jobs failed |
|---|---|---|
| 17 Jul (`c16e5ddb`) | 2.3.0 | 10/25 = 40% |
| 17 Jul (`d7f3303d`) | 2.12.0 | 0/25 |
| HEAD (`52b9510f`) | 2.3.0 | 20/25 = 80% |
| HEAD + librdkafka 2.12 | 2.12.0 | 0/25 |
| **HEAD + this change** | **2.3.0** | **0/25** |

The librdkafka upgrade lands on 9.6 instead — S3C-11389 raises Federation's message-format pin, which removes the constraint that forced the downgrade in the first place. So this skips the two describes on 9.5 rather than touching the dependency.

Two things worth knowing for later:

- The skip cascades into 9.6, so the unskip has to land together with the upgrade there.
- The `concurrency` and `rebalance` describes are deliberately left enabled. They accounted for failures in 2 of the 25 pre-skip runs, so 9.5 may still see occasional flakiness from them.

Issue: BB-849
