### PR TITLE
Upgrade node-rdkafka to 3.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "minimatch": "^10.0.1",
     "mongodb": "^6.11.0",
     "node-forge": "^1.3.1",
-    "node-rdkafka": "3.0.1",
+    "node-rdkafka": "3.6.1",
     "node-rdkafka-prometheus": "^1.0.0",
     "node-schedule": "^2.1.1",
     "node-zookeeper-client": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.5.1",
+  "version": "9.5.2",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9176,7 +9176,7 @@ nan@^2.14.0, nan@^2.18.0, nan@^2.3.2:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.23.1.tgz#6f86a31dd87e3d1eb77512bf4b9e14c8aded3975"
   integrity sha512-r7bBUGKzlqk8oPBDYxt6Z0aEdF1G1rwlMcLk8LCOMbOzf0mG+JUfUzG4fIMWwHWP0iyaLWEQZJmtB7nOHEm/qw==
 
-nan@^2.19.0:
+nan@^2.24.0:
   version "2.28.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.28.0.tgz#126717fd359d5a03d3edf7c44e6ce9b707fb57f5"
   integrity sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==
@@ -9314,13 +9314,13 @@ node-rdkafka-prometheus@^1.0.0:
     "@log4js-node/log4js-api" "^1.0.0"
     prom-client "^12.0.0"
 
-node-rdkafka@3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-3.0.1.tgz#c536d7702d971535b41099acc1baf89706a5d1ba"
-  integrity sha512-USTFu7ylRj+fEiGz0hA92GWSqmX/hu/xSTqtgmInPPmh5zKhjauTciRjDEG3yK5m6yChwyHKQTIgmr56DfhiaQ==
+node-rdkafka@3.6.1:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/node-rdkafka/-/node-rdkafka-3.6.1.tgz#164357f08ff23a4722e89bfb3b2b09481c1e8cc1"
+  integrity sha512-sfpTbrT35429cs0RE8Yb9avGX9BiRRvpV7aweQsghKTjtrVZP3jBrKOPItWXAqHb8doyh3SkuGuUVBLgig1SRg==
   dependencies:
     bindings "^1.3.1"
-    nan "^2.19.0"
+    nan "^2.24.0"
 
 node-releases@^2.0.27:
   version "2.0.27"


### PR DESCRIPTION
Pin node-rdkafka to 3.6.1 exactly (librdkafka 2.12.0), replacing the 3.0.1 / librdkafka 2.3.0 from BB-806. S3C-11389 raises Federation's message-format pin, which removes the legacy v0/v1 MessageSet constraint that forced that downgrade.

Measured on CI over 25 runs per arm of the full `lib` suite: 20/25 jobs fail on librdkafka 2.3.0, and 0/25 on 2.12.0.

The pin stays exact rather than a caret — `^2.12.0` previously resolved forward from node-rdkafka 2.12.0 to 2.18.0, which changed the bundled librdkafka from 1.7.0 to 2.3.0 with no review.

Issue: BB-852
