### PR TITLE
Bump cloudserver client to 1.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@aws-sdk/client-s3": "^3.921.0",
     "@aws-sdk/client-sts": "^3.921.0",
     "@aws-sdk/credential-providers": "^3.921.0",
-    "@scality/cloudserverclient": "^1.0.9",
+    "@scality/cloudserverclient": "^1.0.12",
     "@smithy/node-http-handler": "^3.3.3",
     "JSONStream": "^1.3.5",
     "arsenal": "git+https://github.com/scality/arsenal#8.5.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.5.0",
+  "version": "9.5.1",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/functional/replication/streamedCopy.spec.js
+++ b/tests/functional/replication/streamedCopy.spec.js
@@ -142,8 +142,12 @@ class S3Mock {
             const expectedUrls = ['putobject', 'putpart'].map(
                 op => `/_/backbeat/multiplebackenddata/${constants.bucket}` +
                     `/${constants.objectKey}?operation=${op}`)
-                  .concat([`/_/backbeat/data/${constants.bucket}/${constants.objectKey}?v2=`]);
-            assert(expectedUrls.includes(req.url));
+                  .concat([
+                      `/_/backbeat/data/${constants.bucket}/${constants.objectKey}` +
+                      `?v2=&versionId=${constants.versionId}`,
+                  ]);
+            assert(expectedUrls.includes(req.url),
+                `Unexpected PUT URL: ${req.url}, expected one of: ${JSON.stringify(expectedUrls)}`);
             const chunks = [];
             req.on('data', chunk => {
                 if (this.testScenario === 'abortPut') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3233,10 +3233,10 @@
   resolved "https://registry.yarnpkg.com/@rtsao/scc/-/scc-1.1.0.tgz#927dd2fae9bc3361403ac2c7a00c32ddce9ad7e8"
   integrity sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==
 
-"@scality/cloudserverclient@^1.0.9":
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@scality/cloudserverclient/-/cloudserverclient-1.0.9.tgz#0a333e39436e1f1e74279c3b5a11645be1fffbc1"
-  integrity sha512-ZGqH4G535opDAEP2PxdYDFG7kjZ/eBrzP3ZmO49goFVjRhyDCZ1gT0Pask3/wZcyysZ2Au1qylorZSLPiZmB2A==
+"@scality/cloudserverclient@^1.0.12":
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/@scality/cloudserverclient/-/cloudserverclient-1.0.12.tgz#cbef36fb65b9cb9f7235d6d7dec291a535cd8dd2"
+  integrity sha512-A85ki+dQSdBt7C9pGxTA2NXRbg74azZ2LV/dBWf2A5soQFYXabDAnKQl/4+hnar8OAbIZ8XFoJjqqQzRZ4mGhg==
   dependencies:
     "@aws-sdk/client-s3" "^3.1009.0"
     "@aws-sdk/middleware-expect-continue" "^3.972.8"


### PR DESCRIPTION
Issue: BB-856

This will modify putData : send versionID through query params instead of the headers which will allow cloudserver to properly fetch the requested version id