### PR TITLE
BB-786: trigger cold transition from oplog

### DIFF
--- a/extensions/gc/tasks/GarbageCollectorTask.js
+++ b/extensions/gc/tasks/GarbageCollectorTask.js
@@ -264,10 +264,15 @@ class GarbageCollectorTask extends BackbeatTask {
                     version,
                 });
 
+                // A direct transition (requested in the PUT request itself, rather than by a
+                // lifecycle rule) already declares the cold storage class in the metadata: use
+                // a dedicated originOp so that consumers can tell both apart.
+                const isDirect = objMD.getAmzStorageClass() === newLocation;
+
                 objMD.setLocation()
                     .setDataStoreName(newLocation)
                     .setAmzStorageClass(newLocation)
-                    .setOriginOp('s3:LifecycleTransition')
+                    .setOriginOp(isDirect ? 's3:LifecycleTransition:Direct' : 's3:LifecycleTransition')
                     .setTransitionInProgress(false)
                     .setUserMetadata({
                         'x-amz-meta-scal-s3-transition-attempt': undefined,

--- a/extensions/lifecycle/LifecycleQueuePopulator.js
+++ b/extensions/lifecycle/LifecycleQueuePopulator.js
@@ -20,6 +20,7 @@ const {
     coldStorageRestoreAdjustTopicPrefix,
     coldStorageRestoreTopicPrefix,
     coldStorageGCTopicPrefix,
+    coldStorageArchiveTopicPrefix,
 } = config.extensions.lifecycle;
 const BackbeatProducer = require('../../lib/BackbeatProducer');
 const locations = require('../../conf/locationConfig.json') || {};
@@ -99,6 +100,7 @@ class LifecycleQueuePopulator extends QueuePopulatorExtension {
                     next => this._setupProducer(`${coldStorageRestoreAdjustTopicPrefix}${location}`, next),
                     next => this._setupProducer(`${coldStorageRestoreTopicPrefix}${location}`, next),
                     next => this._setupProducer(`${coldStorageGCTopicPrefix}${location}`, next),
+                    next => this._setupProducer(`${coldStorageArchiveTopicPrefix}${location}`, next),
                 ], done);
             }, cb);
         } else {
@@ -238,6 +240,143 @@ class LifecycleQueuePopulator extends QueuePopulatorExtension {
         return new Date(date.$date || date);
     }
 
+    _isColdLocation(locationName) {
+        return !!(locationName && this.locationConfigs[locationName]
+            && this.locationConfigs[locationName].isCold);
+    }
+
+    /**
+     * Handle a "direct-to-cold" transition: cloudserver has written the object data to a hot
+     * location, but the user requested a cold storage class in the PUT request. Cloudserver
+     * flags the object as "transition in progress", and it is up to the queue populator to
+     * trigger the archival, as there is no lifecycle rule (nor lifecycle scan) involved.
+     *
+     * The message published here is strictly the same as the one the lifecycle bucket processor
+     * publishes (c.f. ReplicationAPI.sendDataMoverAction), so that the whole downstream pipeline
+     * (Sorbet, cold status processor, garbage collector) is reused unchanged.
+     *
+     * @param {Object} entry - The record log entry from metadata.
+     * @return {undefined}
+     */
+    _handleTransitionOp(entry) {
+        // accountId is mandatory in the message, for Sorbet to assume the bucket owner's role
+        if (!this.vaultClientWrapper) {
+            return;
+        }
+
+        if (entry.type !== 'put' ||
+            entry.key.startsWith(mpuBucketPrefix)) {
+            return;
+        }
+
+        const value = JSON.parse(entry.value);
+
+        // Only object creation may declare a cold storage class, and the requeue of a failed
+        // transition asks for a new attempt. Any other originOp is written by backbeat itself:
+        // excluding them ensures we never re-trigger on our own metadata updates.
+        if (!['s3:ObjectCreated:Put',
+            's3:ObjectCreated:CompleteMultipartUpload',
+            's3:ObjectCreated:Copy',
+            's3:LifecycleTransition:Retry'].includes(value.originOp)) {
+            return;
+        }
+
+        // Set by cloudserver on a direct-to-cold PUT, and kept set until the transition
+        // completes: this is the marker distinguishing a pending transition from a plain PUT.
+        if (!value['x-amz-scal-transition-in-progress']) {
+            return;
+        }
+
+        const coldLocation = value['x-amz-storage-class'];
+        if (!this._isColdLocation(coldLocation)) {
+            return;
+        }
+
+        // The data is already in the cold location: the transition has completed.
+        if (this._isColdLocation(value.dataStoreName)) {
+            return;
+        }
+
+        // Note: the check is on archiveInfo rather than on archive, so that a pending
+        // deferred restore does not prevent the transition from being triggered.
+        if (value.archive && value.archive.archiveInfo) {
+            return;
+        }
+
+        // if entry is a versioned object and is the master entry, skip task as
+        // the non-master entry will be processed
+        if (this._isVersionedObject(value) && isMasterKey(entry.key)) {
+            this.log.trace('skip processing of object master entry');
+            return;
+        }
+
+        let attempt;
+        const rawAttempt = value['x-amz-meta-scal-s3-transition-attempt'];
+        if (rawAttempt) {
+            attempt = Number.parseInt(rawAttempt, 10);
+        }
+
+        const ownerId = value['owner-id'];
+        this.vaultClientWrapper.getAccountId(ownerId, (err, accountId) => {
+            if (err) {
+                this.log.error('unable to get account', {
+                    method: 'LifecycleQueuePopulator._handleTransitionOp',
+                    ownerId,
+                    err,
+                });
+                return;
+            }
+
+            this.log.trace(
+                'publishing object transition entry',
+                { bucket: entry.bucket, key: entry.key, version: value.versionId, coldLocation },
+            );
+
+            const topic = `${coldStorageArchiveTopicPrefix}${coldLocation}`;
+            const key = `${entry.bucket}/${entry.key}`;
+
+            let version;
+            if (value.versionId) {
+                version = encode(value.versionId);
+            }
+
+            const transitionTime = this._parseDate(
+                value['x-amz-scal-transition-time'] || value['last-modified']);
+            const message = JSON.stringify({
+                accountId,
+                bucketName: entry.bucket,
+                objectKey: value.key,
+                objectVersion: version,
+                requestId: uuid(),
+                size: value['content-length'],
+                eTag: value['content-md5'],
+                try: attempt,
+                transitionTime: transitionTime.toISOString(),
+            });
+
+            const producer = this._producers[topic];
+            if (producer) {
+                LifecycleMetrics.onLifecycleTriggered(this.log, 'queuePopulator', 'archive',
+                    coldLocation, Date.now() - transitionTime.getTime());
+
+                const kafkaEntry = { key: encodeURIComponent(key), message };
+                producer.send([kafkaEntry], err => {
+                    LifecycleMetrics.onKafkaPublish(this.log, 'ColdStorageArchiveTopic', 'queuePopulator', err, 1);
+                    if (err) {
+                        this.log.error('error publishing object transition request entry', {
+                            error: err,
+                            method: 'LifecycleQueuePopulator._handleTransitionOp',
+                        });
+                    }
+                });
+            } else {
+                this.log.error(`producer not available for location ${coldLocation}`, {
+                    method: 'LifecycleQueuePopulator._handleTransitionOp',
+                });
+            }
+        });
+    }
+
     _handleRestoreOp(entry) {
         if (!this.vaultClientWrapper) {
             return;
@@ -279,6 +418,18 @@ class LifecycleQueuePopulator extends QueuePopulatorExtension {
 
         if (!value.archive || !value.archive.restoreRequestedAt ||
             !value.archive.restoreRequestedDays) {
+            return;
+        }
+
+        // The object is not archived yet: there is nothing to restore. This may happen when a
+        // restore is requested on an object whose transition is still in progress, in which
+        // case the restore is deferred until the transition completes.
+        if (!value.archive.archiveInfo) {
+            this.log.debug('object not archived yet, skipping restore request', {
+                method: 'LifecycleQueuePopulator._handleRestoreOp',
+                bucket: entry.bucket,
+                key: entry.key,
+            });
             return;
         }
 
@@ -504,6 +655,7 @@ class LifecycleQueuePopulator extends QueuePopulatorExtension {
         }
 
         this._handleRestoreOp(entry);
+        this._handleTransitionOp(entry);
 
         if (this.extConfig.conductor.bucketSource !== 'zookeeper') {
             this.log.debug('bucket source is not zookeeper, skipping entry', {

--- a/extensions/lifecycle/tasks/LifecycleColdStatusArchiveTask.js
+++ b/extensions/lifecycle/tasks/LifecycleColdStatusArchiveTask.js
@@ -112,10 +112,15 @@ class LifecycleColdStatusArchiveTask extends LifecycleUpdateTransitionTask {
                 objectMD.setOriginOp('s3:LifecycleTransition:SetArchive');
 
                 if (skipLocationDeletion) {
+                    // A direct transition (requested in the PUT request itself, rather than by a
+                    // lifecycle rule) already declares the cold storage class in the metadata:
+                    // use a dedicated originOp so that consumers can tell both apart.
+                    const isDirect = objectMD.getAmzStorageClass() === coldLocation;
+
                     objectMD.setDataStoreName(coldLocation)
                         .setAmzStorageClass(coldLocation)
                         .setTransitionInProgress(false)
-                        .setOriginOp('s3:LifecycleTransition')
+                        .setOriginOp(isDirect ? 's3:LifecycleTransition:Direct' : 's3:LifecycleTransition')
                         .setUserMetadata({
                             'x-amz-meta-scal-s3-transition-attempt': undefined,
                         });

--- a/extensions/lifecycle/tasks/LifecycleResetTransitionInProgressTask.js
+++ b/extensions/lifecycle/tasks/LifecycleResetTransitionInProgressTask.js
@@ -1,6 +1,10 @@
 'use strict';
 
 const { LifecycleRequeueTask } = require('./LifecycleRequeueTask');
+const locationsConfig = require('../../../conf/locationConfig.json') || {};
+
+const isColdLocation = locationName => !!(locationName && locationsConfig[locationName]
+    && locationsConfig[locationName].isCold);
 
 class LifecycleResetTransitionInProgressTask extends LifecycleRequeueTask {
     /**
@@ -18,11 +22,30 @@ class LifecycleResetTransitionInProgressTask extends LifecycleRequeueTask {
             return false;
         }
         md.setOriginOp('s3:LifecycleTransition:Retry');
-        md.setTransitionInProgress(false);
+        // For a direct transition, the "transition in progress" flag is what the queue populator
+        // keys on to retry the archival: clearing it would both hide this update from the
+        // populator and, since shouldSkipObject() bails when the flag is unset, prevent any
+        // further requeue. There is no lifecycle scan to re-pick these objects, so the flag must
+        // stay set until the transition actually completes.
+        if (!this._isDirectTransition(md)) {
+            md.setTransitionInProgress(false);
+        }
         md.setUserMetadata({
             'x-amz-meta-scal-s3-transition-attempt': try_,
         });
         return true;
+    }
+
+    /**
+     * Whether the object transition was requested directly in the PUT request (as opposed to
+     * being triggered by a lifecycle rule): in that case the requested cold storage class is
+     * declared in the object metadata, while the data still lies in a hot location.
+     *
+     * @param {ObjectMD} md - object metadata
+     * @return {boolean} true if this is a pending direct transition
+     */
+    _isDirectTransition(md) {
+        return isColdLocation(md.getAmzStorageClass()) && !isColdLocation(md.getDataStoreName());
     }
 
     shouldSkipObject(md, expectedEtag, log) {

--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -23,6 +23,8 @@ const errorTransitionInProgress = errors.InternalError.
     customizeDescription('transition is currently in progress');
 const errorTransitionColdObject = errors.InternalError.
     customizeDescription('transitioning a cold object is forbidden');
+const errorTransitionDeclaredColdObject = errors.InternalError.
+    customizeDescription('transitioning an object declared as cold is forbidden');
 const errorObjectTemporarilyRestored = errors.InternalError.
     customizeDescription('object temporarily restored');
 const errorReplicationInProgress = errors.InternalError.
@@ -1236,6 +1238,14 @@ class LifecycleTask extends BackbeatTask {
                 // We do not transition cold objects
                 if (isObjectCold) {
                     return next(errorTransitionColdObject);
+                }
+                // The object storage class was set to a cold location in the PUT request: the
+                // transition is triggered directly by the queue populator, and lifecycle rules
+                // must never manage such objects.
+                const declaredStorageClass = objectMD.getAmzStorageClass();
+                if (declaredStorageClass && locationsConfig[declaredStorageClass]
+                    && locationsConfig[declaredStorageClass].isCold) {
+                    return next(errorTransitionDeclaredColdObject);
                 }
                 // If transition is in progress, do not re-publish entry
                 // to data-mover or cold-archive topic.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.0.30",
+  "version": "9.0.31",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/gc/GarbageCollectorTask.spec.js
+++ b/tests/unit/gc/GarbageCollectorTask.spec.js
@@ -97,10 +97,47 @@ describe('GarbageCollectorTask', () => {
             assert.strictEqual(updatedMD.getDataStoreName(), 'new-location');
             assert.strictEqual(updatedMD.getAmzStorageClass(), 'new-location');
             assert.strictEqual(updatedMD.getTransitionInProgress(), false);
+            assert.strictEqual(updatedMD.getOriginOp(), 's3:LifecycleTransition');
             done();
         });
     });
 
+    it('should set the direct transition origin op if the new location was requested', done => {
+        backbeatClient.batchDeleteResponse = { error: null, res: null };
+
+        const entry = ActionQueueEntry.create('deleteArchivedSourceData')
+              .addContext({
+                  origin: 'lifecycle',
+                  ruleType: 'archive',
+                  bucketName: bucket,
+                  objectKey: key,
+                  versionId: version,
+              })
+              .setAttribute('serviceName', 'lifecycle-transition')
+              .setAttribute('target.oldLocation', 'old-location')
+              .setAttribute('target.newLocation', 'new-location')
+              .setAttribute('target.bucket', bucket)
+              .setAttribute('target.key', version)
+              .setAttribute('target.version', key)
+              .setAttribute('target.accountId', accountId)
+              .setAttribute('target.owner', owner);
+
+        mdObj.setLocation(loc)
+            .setDataStoreName('old-location')
+            .setAmzStorageClass('new-location')
+            .setTransitionInProgress(true);
+        backbeatMetadataProxyClient.setMdObj(mdObj);
+
+        gcTask.processActionEntry(entry, err => {
+            assert.ifError(err);
+
+            const updatedMD = backbeatMetadataProxyClient.mdObj;
+            assert.strictEqual(updatedMD.getDataStoreName(), 'new-location');
+            assert.strictEqual(updatedMD.getTransitionInProgress(), false);
+            assert.strictEqual(updatedMD.getOriginOp(), 's3:LifecycleTransition:Direct');
+            done();
+        });
+    });
 
     it('should delete archived location info if gc failed with 404', done => {
         backbeatClient.batchDeleteResponse = { error: { statusCode: 404 }, res: null };

--- a/tests/unit/lifecycle/LifecycleColdStatusArchiveTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleColdStatusArchiveTask.spec.js
@@ -117,10 +117,31 @@ describe('LifecycleColdStatusArchiveTask', () => {
             assert.strictEqual(gcEntry, null);
             assert.strictEqual(updatedMD.dataStoreName, 'cold');
             assert.strictEqual(updatedMD['x-amz-storage-class'], 'cold');
+            assert.strictEqual(updatedMD.originOp, 's3:LifecycleTransition');
             assert.deepStrictEqual(updatedMD.archive.archiveInfo, {
                 archiveId: 'da80b6dc-280d-4dce-83b5-d5b40276e321',
                 archiveVersion: 5166759712787974,
             });
+            done();
+        });
+    });
+
+    it('should set the direct transition origin op if the cold class was requested', done => {
+        backbeatClient.batchDeleteResponse = { error: { statusCode: 404 }, res: null };
+
+        const entry = ColdStorageStatusQueueEntry.createFromKafkaEntry({ value: message });
+        mdObj.setLocation()
+            .setDataStoreName('us-east-1')
+            .setAmzStorageClass(coldLocation)
+            .setArchive(null);
+        backbeatMetadataProxyClient.setMdObj(mdObj);
+
+        archiveTask.processEntry(coldLocation, entry, err => {
+            assert.ifError(err);
+
+            const updatedMD = backbeatMetadataProxyClient.getReceivedMd();
+            assert.strictEqual(updatedMD.dataStoreName, 'cold');
+            assert.strictEqual(updatedMD.originOp, 's3:LifecycleTransition:Direct');
             done();
         });
     });

--- a/tests/unit/lifecycle/LifecycleQueuePopulator.spec.js
+++ b/tests/unit/lifecycle/LifecycleQueuePopulator.spec.js
@@ -7,7 +7,8 @@ const config = require('../../../lib/Config');
 const {
     coldStorageRestoreAdjustTopicPrefix,
     coldStorageRestoreTopicPrefix,
-    coldStorageGCTopicPrefix
+    coldStorageGCTopicPrefix,
+    coldStorageArchiveTopicPrefix
 } = config.extensions.lifecycle;
 
 const LifecycleQueuePopulator = require('../../../extensions/lifecycle/LifecycleQueuePopulator');
@@ -78,6 +79,10 @@ const templateEntry = {
     'versionId': '98500086134471999999RG001  0',
     'isNFS': true,
     'archive': {
+        archiveInfo: {
+            archiveId: '04425717-a65c-4e8a-95e1-fa1d902d9d9f',
+            archiveVersion: 7504504064263669,
+        },
         restoreRequestedAt: Date.now(),
         restoreRequestedDays: 1,
     },
@@ -131,16 +136,17 @@ describe('LifecycleQueuePopulator', () => {
                 done();
             });
         });
-        it('should have three producers per cold location', done => {
+        it('should have four producers per cold location', done => {
             lcqp.locationConfigs = Object.assign({}, locationConfigs, coldLocationConfigs);
             lcqp.setupProducers(() => {
                 const producers = Object.keys(lcqp._producers);
                 const coldLocations = Object.keys(coldLocationConfigs);
-                assert.strictEqual(producers.length, coldLocations.length * 3);
+                assert.strictEqual(producers.length, coldLocations.length * 4);
                 coldLocations.forEach(loc => {
                     assert(producers.includes(`${coldStorageRestoreAdjustTopicPrefix}${loc}`));
                     assert(producers.includes(`${coldStorageRestoreTopicPrefix}${loc}`));
                     assert(producers.includes(`${coldStorageGCTopicPrefix}${loc}`));
+                    assert(producers.includes(`${coldStorageArchiveTopicPrefix}${loc}`));
                 });
                 done();
             });
@@ -190,6 +196,20 @@ describe('LifecycleQueuePopulator', () => {
                 lcqp._handleRestoreOp(entry);
                 assert.strictEqual(getAccountIdStub.calledOnce, !params.ignore);
             });
+        });
+
+        it('should ignore an object which is not archived yet', () => {
+            const getAccountIdStub = sinon.stub().yields(null,
+                '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be');
+            lcqp.vaultClientWrapper = {
+                getAccountId: getAccountIdStub,
+            };
+            const entry = getKafkaEntry('s3:ObjectRestore:Post');
+            const value = JSON.parse(entry.value);
+            delete value.archive.archiveInfo;
+            entry.value = JSON.stringify(value);
+            lcqp._handleRestoreOp(entry);
+            assert(!getAccountIdStub.called);
         });
 
         describe('restore requests', () => {
@@ -377,6 +397,220 @@ describe('LifecycleQueuePopulator', () => {
         });
     });
 
+    describe(':_handleTransitionOp', () => {
+        const accountId = '79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be';
+        const versionId = '98500086134471999999RG001  0';
+        const archiveTopic = `${coldStorageArchiveTopicPrefix}dmf-v1`;
+
+        let lcqp;
+        let getAccountIdStub;
+        let kafkaSendStub;
+
+        function getTransitionEntry(overrides) {
+            const value = Object.assign({
+                'md-model-version': 2,
+                'owner-display-name': 'Bart',
+                'owner-id': accountId,
+                'content-length': 542,
+                'content-type': 'text/plain',
+                'last-modified': '2017-07-13T02:44:25.519Z',
+                'content-md5': '01064f35c238bd2b785e34508c3d27f4',
+                'x-amz-storage-class': 'dmf-v1',
+                'x-amz-scal-transition-in-progress': true,
+                'x-amz-scal-transition-time': '2017-07-13T02:44:20.000Z',
+                'key': 'hosts',
+                'location': [],
+                'isDeleteMarker': false,
+                'isNull': false,
+                versionId,
+                'dataStoreName': 'us-east-1',
+                'originOp': 's3:ObjectCreated:Put',
+            }, overrides);
+            // allow overrides to remove a field by passing `undefined`
+            Object.keys(value).forEach(k => {
+                if (value[k] === undefined) {
+                    delete value[k];
+                }
+            });
+            return {
+                type: 'put',
+                bucket: 'lc-queue-populator-test-bucket',
+                key: `hosts\x00${versionId}`,
+                value: JSON.stringify(value),
+            };
+        }
+
+        beforeEach(() => {
+            lcqp = new LifecycleQueuePopulator(params);
+            lcqp.locationConfigs = Object.assign({}, coldLocationConfigs, locationConfigs);
+            getAccountIdStub = sinon.stub().yields(null, accountId);
+            lcqp.vaultClientWrapper = {
+                getAccountId: getAccountIdStub,
+            };
+            kafkaSendStub = sinon.stub().yields();
+            lcqp._producers[archiveTopic] = {
+                send: kafkaSendStub,
+            };
+        });
+
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        [
+            { originOp: 's3:ObjectCreated:Put', ignore: false },
+            { originOp: 's3:ObjectCreated:CompleteMultipartUpload', ignore: false },
+            { originOp: 's3:ObjectCreated:Copy', ignore: false },
+            { originOp: 's3:LifecycleTransition:Retry', ignore: false },
+            { originOp: 's3:LifecycleTransition:Start', ignore: true },
+            { originOp: 's3:LifecycleTransition:SetArchive', ignore: true },
+            { originOp: 's3:LifecycleTransition:Direct', ignore: true },
+            { originOp: 's3:LifecycleTransition', ignore: true },
+            { originOp: 's3:ObjectRestore:Post', ignore: true },
+        ].forEach(({ originOp, ignore }) => {
+            const outcome = ignore ? 'ignore' : 'consider';
+            it(`should ${outcome} ${originOp} event`, () => {
+                lcqp._handleTransitionOp(getTransitionEntry({ originOp }));
+                assert.strictEqual(kafkaSendStub.calledOnce, !ignore);
+            });
+        });
+
+        it('should publish an archive request matching the bucket processor message', () => {
+            lcqp._handleTransitionOp(getTransitionEntry());
+
+            assert(kafkaSendStub.calledOnce);
+            const kafkaEntry = kafkaSendStub.args[0][0][0];
+            assert.strictEqual(kafkaEntry.key,
+                encodeURIComponent(`lc-queue-populator-test-bucket/hosts\x00${versionId}`));
+
+            const message = JSON.parse(kafkaEntry.message);
+            assert.deepStrictEqual(message, {
+                accountId,
+                bucketName: 'lc-queue-populator-test-bucket',
+                objectKey: 'hosts',
+                objectVersion: encode(versionId),
+                requestId: message.requestId,
+                size: 542,
+                eTag: '01064f35c238bd2b785e34508c3d27f4',
+                transitionTime: '2017-07-13T02:44:20.000Z',
+            });
+            assert(message.requestId);
+        });
+
+        it('should fall back on last-modified when no transition time is set', () => {
+            lcqp._handleTransitionOp(getTransitionEntry({
+                'x-amz-scal-transition-time': undefined,
+            }));
+
+            assert(kafkaSendStub.calledOnce);
+            const message = JSON.parse(kafkaSendStub.args[0][0][0].message);
+            assert.strictEqual(message.transitionTime, '2017-07-13T02:44:25.519Z');
+        });
+
+        it('should publish the transition attempt count', () => {
+            lcqp._handleTransitionOp(getTransitionEntry({
+                'originOp': 's3:LifecycleTransition:Retry',
+                'x-amz-meta-scal-s3-transition-attempt': '3',
+            }));
+
+            assert(kafkaSendStub.calledOnce);
+            const message = JSON.parse(kafkaSendStub.args[0][0][0].message);
+            assert.strictEqual(message.try, 3);
+        });
+
+        it('should not set objectVersion for a non-versioned object', () => {
+            const entry = getTransitionEntry({ versionId: undefined });
+            entry.key = 'hosts';
+            lcqp._handleTransitionOp(entry);
+
+            assert(kafkaSendStub.calledOnce);
+            const message = JSON.parse(kafkaSendStub.args[0][0][0].message);
+            assert.strictEqual(message.objectVersion, undefined);
+        });
+
+        [
+            {
+                desc: 'transition is not in progress',
+                overrides: { 'x-amz-scal-transition-in-progress': undefined },
+            },
+            {
+                desc: 'the storage class is not cold',
+                overrides: { 'x-amz-storage-class': 'us-east-2' },
+            },
+            {
+                desc: 'the object has no storage class',
+                overrides: { 'x-amz-storage-class': undefined },
+            },
+            {
+                desc: 'the data is already in the cold location',
+                overrides: { dataStoreName: 'dmf-v1' },
+            },
+            {
+                desc: 'the object is already archived',
+                overrides: {
+                    archive: {
+                        archiveInfo: {
+                            archiveId: '04425717-a65c-4e8a-95e1-fa1d902d9d9f',
+                            archiveVersion: 7504504064263669,
+                        },
+                    },
+                },
+            },
+        ].forEach(({ desc, overrides }) => {
+            it(`should not publish when ${desc}`, () => {
+                lcqp._handleTransitionOp(getTransitionEntry(overrides));
+                assert(!getAccountIdStub.called);
+                assert(!kafkaSendStub.called);
+            });
+        });
+
+        it('should publish when a deferred restore is pending', () => {
+            lcqp._handleTransitionOp(getTransitionEntry({
+                archive: { restoreRequestedAt: '2017-07-13T02:44:25.519Z', restoreRequestedDays: 1 },
+            }));
+            assert(kafkaSendStub.calledOnce);
+        });
+
+        it('should skip the master key of a versioned object', () => {
+            const entry = getTransitionEntry();
+            entry.key = 'hosts';
+            lcqp._handleTransitionOp(entry);
+            assert(!kafkaSendStub.called);
+        });
+
+        it('should skip mpu shadow bucket entries', () => {
+            const entry = getTransitionEntry();
+            entry.key = `mpuShadowBucket${entry.key}`;
+            lcqp._handleTransitionOp(entry);
+            assert(!kafkaSendStub.called);
+        });
+
+        it('should skip delete operations', () => {
+            const entry = getTransitionEntry();
+            entry.type = 'delete';
+            lcqp._handleTransitionOp(entry);
+            assert(!kafkaSendStub.called);
+        });
+
+        it('should do nothing without a vault client', () => {
+            lcqp.vaultClientWrapper = null;
+            lcqp._handleTransitionOp(getTransitionEntry());
+            assert(!kafkaSendStub.called);
+        });
+
+        it('should not publish when the account cannot be resolved', () => {
+            getAccountIdStub.yields(errors.InternalError);
+            lcqp._handleTransitionOp(getTransitionEntry());
+            assert(!kafkaSendStub.called);
+        });
+
+        it('should not throw when no producer is available', () => {
+            delete lcqp._producers[archiveTopic];
+            lcqp._handleTransitionOp(getTransitionEntry());
+            assert(getAccountIdStub.calledOnce);
+        });
+    });
+
     describe(':filter', () => {
         const bucketMD = {
             name: 'lc-queue-populator-test-bucket',
@@ -408,6 +642,12 @@ describe('LifecycleQueuePopulator', () => {
                 value: JSON.stringify(templateEntry),
             });
             assert(handleDeleteStub.calledOnce);
+        });
+
+        it('should call _handleTransitionOp on put message', () => {
+            const handleTransitionStub = sinon.stub(lcqp, '_handleTransitionOp').returns();
+            lcqp.filter(getKafkaEntry('s3:ObjectCreated:Put'));
+            assert(handleTransitionStub.calledOnce);
         });
 
         it('should not update zookeeper when bucketSource is mongodb (default)', () => {

--- a/tests/unit/lifecycle/LifecycleResetTransitionInProgressTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleResetTransitionInProgressTask.spec.js
@@ -38,6 +38,18 @@ describe('LifecycleResetTransitionInProgressTask', () => {
         .setUserMetadata({
             'x-amz-meta-scal-s3-transition-attempt': 11,
         });
+    // "direct" transition: the cold storage class was requested in the PUT request, and the
+    // data still lies in the hot location
+    const objectDirectTransitioning = new ObjectMD()
+        .setContentMd5('etag1')
+        .setTransitionInProgress(true)
+        .setAmzStorageClass('location-dmf-v1')
+        .setDataStoreName('us-east-1');
+    const objectDirectTransitioned = new ObjectMD()
+        .setContentMd5('etag1')
+        .setTransitionInProgress(true)
+        .setAmzStorageClass('location-dmf-v1')
+        .setDataStoreName('location-dmf-v1');
 
     beforeEach(() => {
         backbeatMetadataProxyClient = new BackbeatMetadataProxyMock();
@@ -81,6 +93,33 @@ describe('LifecycleResetTransitionInProgressTask', () => {
 
     it('should reset transition in progress flag', done => {
         backbeatMetadataProxyClient.setMdObj(objectTransitioning);
+        task.processActionEntry(actionEntry, err => {
+            assert.ifError(err);
+
+            const md = backbeatMetadataProxyClient.mdObj;
+            assert.ok(!md.getTransitionInProgress());
+
+            done();
+        });
+    });
+
+    it('should keep transition in progress flag for a direct transition', done => {
+        backbeatMetadataProxyClient.setMdObj(objectDirectTransitioning);
+        task.processActionEntry(actionEntry, err => {
+            assert.ifError(err);
+
+            const md = backbeatMetadataProxyClient.mdObj;
+            assert.ok(md.getTransitionInProgress());
+            assert.strictEqual(md.getOriginOp(), 's3:LifecycleTransition:Retry');
+            const umd = JSON.parse(md.getUserMetadata());
+            assert.strictEqual(umd['x-amz-meta-scal-s3-transition-attempt'], 12);
+
+            done();
+        });
+    });
+
+    it('should reset transition in progress flag once the object is in the cold location', done => {
+        backbeatMetadataProxyClient.setMdObj(objectDirectTransitioned);
         task.processActionEntry(actionEntry, err => {
             assert.ifError(err);
 

--- a/tests/unit/lifecycle/LifecycleTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleTask.spec.js
@@ -8,6 +8,7 @@ const { ValidLifecycleRules } = require('arsenal').models;
 
 const LifecycleTask = require(
     '../../../extensions/lifecycle/tasks/LifecycleTask');
+const ReplicationAPI = require('../../../extensions/replication/ReplicationAPI');
 const fakeLogger = require('../../utils/fakeLogger');
 const { timeOptions } = require('../../functional/lifecycle/configObjects');
 
@@ -2370,6 +2371,67 @@ describe('lifecycle task helper methods', () => {
             lifecycleTask._getTransitionActionEntry(testParams, mockObjectMD, fakeLogger, (err, entry) => {
                 assert.deepStrictEqual(err, expectedError);
                 assert.strictEqual(entry, undefined);
+                done();
+            });
+        });
+    });
+
+    describe('_applyTransitionRule', () => {
+        const testParams = {
+            bucket: 'test-bucket',
+            owner: 'test-owner',
+            objectKey: 'test-key',
+            site: 'us-east-2',
+            transitionTime: Date.now(),
+        };
+
+        let lifecycleTask;
+
+        beforeEach(() => {
+            lifecycleTask = new LifecycleTask(lp);
+            lifecycleTask.pausedLocations = new Set();
+            lifecycleTask.circuitBreakers = { tripped: () => false };
+        });
+
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        function stubObjectMD(overrides) {
+            const objectMD = Object.assign({
+                getReplicationStatus: () => 'COMPLETED',
+                getDataStoreName: () => 'us-east-1',
+                getAmzStorageClass: () => 'us-east-1',
+                getTransitionInProgress: () => false,
+                getArchive: () => undefined,
+                setTransitionInProgress: () => {},
+                setOriginOp: () => {},
+                getSerialized: () => '{}',
+            }, overrides);
+            sinon.stub(lifecycleTask, '_getObjectMD').yields(null, objectMD);
+        }
+
+        it('should not transition an object declared as cold', done => {
+            stubObjectMD({ getAmzStorageClass: () => 'location-dmf-v1' });
+            const getEntryStub = sinon.stub(lifecycleTask, '_getTransitionActionEntry');
+
+            lifecycleTask._applyTransitionRule(testParams, fakeLogger, err => {
+                assert.strictEqual(err.description,
+                    'transitioning an object declared as cold is forbidden');
+                assert(!getEntryStub.called);
+                done();
+            });
+        });
+
+        it('should transition an object with a hot storage class', done => {
+            stubObjectMD();
+            const getEntryStub = sinon.stub(lifecycleTask, '_getTransitionActionEntry').yields(null, {});
+            sinon.stub(ReplicationAPI, 'sendDataMoverAction').yields();
+            sinon.stub(lifecycleTask, '_putObjectMD').yields();
+
+            lifecycleTask._applyTransitionRule(testParams, fakeLogger, err => {
+                assert.ifError(err);
+                assert(getEntryStub.calledOnce);
                 done();
             });
         });


### PR DESCRIPTION
## Context

Support "direct-to-cold" transitions: an object uploaded with a cold storage class must end up archived in that cold location, without waiting for a lifecycle rule.

Cloudserver (CLDSRV, out of scope here) stores the data in the hot location on such a PUT, and records the requested cold class in `x-amz-storage-class` together with the transition-in-progress flag — while keeping the ordinary create origin op, so bucket notifications still fire.

## Changes

- **`LifecycleQueuePopulator`**: new `_handleTransitionOp`, called from `filter()`, detects these objects from the MongoDB oplog and publishes the cold archive request on `cold-archive-req-<location>`, reusing the exact message shape of `ReplicationAPI.sendDataMoverAction`. The whole downstream pipeline (Sorbet -> cold status topic -> `LifecycleColdStatusArchiveTask` -> GC) is unchanged. A fourth producer per cold location is set up for the archive topic. The populator is strictly publish-only and never writes object metadata.

  The discriminator only accepts origin ops that backbeat itself never writes, so a transition is never re-triggered by its own metadata updates; objects already holding `archive.archiveInfo` are excluded, while a pending deferred restore is not.
- **`LifecycleResetTransitionInProgressTask`**: keep the transition-in-progress flag set when requeuing a direct transition, since that flag (together with the cold storage class) is precisely what identifies the object as pending — clearing it would hide the object from the populator and break the retry loop after a single attempt.
- **`LifecycleTask`**: a bucket lifecycle rule must not transition an object which is already declared as cold.
- **`GarbageCollectorTask` / `LifecycleColdStatusArchiveTask`**: the metadata update completing the transition is stamped with a distinct `s3:LifecycleTransition:Direct` origin op when the object already declared the target cold class, so consumers can tell a direct transition from a lifecycle-driven one.

Unit tests added for all five files.

Issue: BB-786
