### PR TITLE
Never garbage-collect data on an isCRR location

### DIFF
--- a/extensions/gc/tasks/GarbageCollectorTask.js
+++ b/extensions/gc/tasks/GarbageCollectorTask.js
@@ -6,6 +6,7 @@ const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
 const { BatchDeleteCommand } = require('@scality/cloudserverclient');
 const { GarbageCollectorMetrics } = require('../GarbageCollectorMetrics');
 const { TRANSITION_ATTEMPT_MD } = require('../../../lib/util/transitionAttempt');
+const locationsConfig = require('../../../conf/locationConfig.json') || {};
 /** @typedef { import('../GarbageCollector.js') } GarbageCollector */
 
 class GarbageCollectorTask extends BackbeatTask {
@@ -143,6 +144,18 @@ class GarbageCollectorTask extends BackbeatTask {
     _executeDeleteDataOnce(entry, log, done) {
         const { locations } = entry.getAttribute('target');
         const ruleType = entry.getContextAttribute('ruleType');
+        // The service can only delete local data: data on a CRR location lives on
+        // the remote site, out of reach. Getting one here means a bug upstream.
+        const { dataStoreName } = locations[0] || {};
+        if (locationsConfig[dataStoreName]?.isCRR) {
+            log.warn('refusing to delete data on a CRR location', {
+                method: 'GarbageCollectorTask._executeDeleteDataOnce',
+                dataStoreName,
+                ruleType,
+                ...entry.getLogInfo(),
+            });
+            return process.nextTick(done);
+        }
         const params = {
             Locations: locations.map(location => ({
                 key: location.key,
@@ -160,7 +173,7 @@ class GarbageCollectorTask extends BackbeatTask {
             }),
         };
 
-        this._batchDeleteData(params, entry, log, err => {
+        return this._batchDeleteData(params, entry, log, err => {
             // ruleType can be either `transition` or `restore` (for restore-expiration)
             GarbageCollectorMetrics.onS3Request(log, 'batchdelete', ruleType, err);
             entry.setEnd(err);

--- a/extensions/lifecycle/tasks/LifecycleUpdateTransitionTask.js
+++ b/extensions/lifecycle/tasks/LifecycleUpdateTransitionTask.js
@@ -10,6 +10,7 @@ const {
     TRANSITION_ATTEMPT_MD,
     getTransitionAttempt,
 } = require('../../../lib/util/transitionAttempt');
+const locationsConfig = require('../../../conf/locationConfig.json') || {};
 /** @typedef { import('../objectProcessor/LifecycleObjectProcessor.js') } LifecycleObjectProcessor */
 
 class LifecycleUpdateTransitionTask extends BackbeatTask {
@@ -114,6 +115,19 @@ class LifecycleUpdateTransitionTask extends BackbeatTask {
 
     _garbageCollectLocation(entry, locations, log, done) {
         const { bucket, key, version, eTag, accountId, owner } = this.getTargetAttribute(entry);
+        // Data on a CRR location means this was pull replication, not a
+        // transition: the source is the remote site, and must not be removed.
+        const { dataStoreName } = locations[0] || {};
+        if (locationsConfig[dataStoreName]?.isCRR) {
+            log.info('skipping garbage collection of data on a CRR location', {
+                method: 'LifecycleUpdateTransitionTask._garbageCollectLocation',
+                bucket,
+                objectKey: key,
+                versionId: version,
+                dataStoreName,
+            });
+            return process.nextTick(done);
+        }
         const gcEntry = ActionQueueEntry.create('deleteData')
               .addContext({
                   origin: 'lifecycle',

--- a/tests/unit/gc/GarbageCollectorTask.spec.js
+++ b/tests/unit/gc/GarbageCollectorTask.spec.js
@@ -424,4 +424,111 @@ describe('GarbageCollectorTask', () => {
         });
     });
 
+    describe('with CRR locations', () => {
+        let log;
+
+        function createDeleteDataEntry(locations) {
+            return ActionQueueEntry.create('deleteData')
+                .addContext({
+                    origin: 'lifecycle',
+                    ruleType: 'transition',
+                    bucketName: bucket,
+                    objectKey: key,
+                    versionId: version,
+                })
+                .setAttribute('serviceName', 'lifecycle-transition')
+                .setAttribute('source', {
+                    bucket,
+                    objectKey: key,
+                    storageClass: 'sourceStorageClass',
+                })
+                .setAttribute('target', {
+                    bucket,
+                    key: version,
+                    version: key,
+                    accountId,
+                    owner,
+                    locations,
+                });
+        }
+
+        const crrLocation = {
+            key: 'crrKey',
+            dataStoreName: 'location-crr-source',
+            size: 10,
+            dataStoreVersionId: 'crrVersionId',
+        };
+        const regularLocation = {
+            key: 'locationKey',
+            dataStoreName: 'us-east-1',
+            size: 20,
+            dataStoreVersionId: 'dataStoreVersionId',
+        };
+
+        beforeEach(() => {
+            log = {
+                info: sinon.spy(),
+                warn: sinon.spy(),
+                debug: sinon.spy(),
+                error: sinon.spy(),
+                getSerializedUids: () => 'uids',
+            };
+            log.end = () => log;
+            gcTask.logger = { newRequestLogger: () => log };
+            backbeatClient.batchDeleteResponse = { error: null, res: null };
+        });
+
+        it('should not delete anything and warn when all locations are on a ' +
+        'CRR location', done => {
+            const entry = createDeleteDataEntry([crrLocation]);
+            const batchDeleteDataSpy = sinon.spy(gcTask, '_batchDeleteData');
+            const onGcCompletedSpy = sinon.spy(GarbageCollectorMetrics, 'onGcCompleted');
+
+            gcTask.processActionEntry(entry, err => {
+                assert.ifError(err);
+                assert.strictEqual(batchDeleteDataSpy.callCount, 0);
+                assert.strictEqual(backbeatClient.times.batchDeleteResponse, 0);
+                assert.strictEqual(onGcCompletedSpy.callCount, 0);
+                assert.strictEqual(log.warn.callCount, 1);
+                assert.strictEqual(
+                    log.warn.firstCall.args[1].dataStoreName,
+                    'location-crr-source');
+                batchDeleteDataSpy.restore();
+                onGcCompletedSpy.restore();
+                done();
+            });
+        });
+
+        it('should not delete anything for a multipart object on a CRR ' +
+        'location', done => {
+            const secondCrrLocation = Object.assign({}, crrLocation, { key: 'crrKey2' });
+            const entry = createDeleteDataEntry([crrLocation, secondCrrLocation]);
+            const batchDeleteDataSpy = sinon.spy(gcTask, '_batchDeleteData');
+
+            gcTask.processActionEntry(entry, err => {
+                assert.ifError(err);
+                assert.strictEqual(batchDeleteDataSpy.callCount, 0);
+                assert.strictEqual(log.warn.callCount, 1);
+                batchDeleteDataSpy.restore();
+                done();
+            });
+        });
+
+        it('should delete all locations and not warn when none is on a CRR ' +
+        'location', done => {
+            const entry = createDeleteDataEntry([regularLocation]);
+            const batchDeleteDataSpy = sinon.spy(gcTask, '_batchDeleteData');
+
+            gcTask.processActionEntry(entry, err => {
+                assert.ifError(err);
+                assert.strictEqual(batchDeleteDataSpy.callCount, 1);
+                assert.deepStrictEqual(
+                    batchDeleteDataSpy.firstCall.args[0].Locations,
+                    [regularLocation]);
+                assert.strictEqual(log.warn.callCount, 0);
+                batchDeleteDataSpy.restore();
+                done();
+            });
+        });
+    });
 });

--- a/tests/unit/lifecycle/LifecycleUpdateTransitionTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleUpdateTransitionTask.spec.js
@@ -148,6 +148,48 @@ describe('LifecycleUpdateTransitionTask', () => {
         });
     });
 
+    it('should update metadata but not GC the from-location when it is a CRR ' +
+    'location', done => {
+        const crrLocation = [Object.assign({}, oldLocation[0],
+            { dataStoreName: 'location-crr-source' })];
+        mdObj.setLocation(crrLocation);
+        task.processActionEntry(actionEntry, err => {
+            assert.ifError(err);
+            const receivedMd = backbeatMetadataProxyClient.getReceivedMd();
+            assert.deepStrictEqual(receivedMd.location, newLocation);
+            assert.strictEqual(gcProducer.getReceivedEntry(), null);
+            done();
+        });
+    });
+
+    it('should not GC anything for a multipart object on a CRR location', done => {
+        const crrPart = Object.assign({}, oldLocation[0],
+            { key: 'crrKey', dataStoreName: 'location-crr-source' });
+        const secondCrrPart = Object.assign({}, crrPart, { key: 'crrKey2', start: 10 });
+        mdObj.setLocation([crrPart, secondCrrPart]);
+        task.processActionEntry(actionEntry, err => {
+            assert.ifError(err);
+            assert.strictEqual(gcProducer.getReceivedEntry(), null);
+            done();
+        });
+    });
+
+    it('should still GC the new location on rollback even if the ' +
+    'from-location is a CRR location', done => {
+        mdObj.setLocation([Object.assign({}, oldLocation[0],
+            { dataStoreName: 'location-crr-source' })]);
+        actionEntry.setAttribute('target.eTag',
+                                 '"6713e7cf89b6b16d5abf11d1fabac587"');
+        task.processActionEntry(actionEntry, err => {
+            assert.ifError(err);
+            assert.strictEqual(backbeatMetadataProxyClient.getReceivedMd(), null);
+            const receivedGcEntry = gcProducer.getReceivedEntry();
+            assert.deepStrictEqual(
+                receivedGcEntry.getAttribute('target.locations'), newLocation);
+            done();
+        });
+    });
+
     it('should reset transition-in-progress flag when transition fails', done => {
         actionEntry.setError(errors.InternalError);
         task.processActionEntry(actionEntry, err => {


### PR DESCRIPTION
Data living on an `isCRR` location is production data owned by a remote site. We may read it (that is the whole point of localizing a clean room object), but we must never delete it. That is a general rule keyed on the location type, not a clean room conditional and not behind a config flag.

It needs to hold at two independent points, one commit each.

**BB-813 - do not trigger the GC.** The copy engine reuses the lifecycle transition pipeline: `CopyLocationTask` copies the data locally, then `LifecycleUpdateTransitionTask` merges the new location into the metadata and publishes a `deleteData` action for the old one. Against an `isCRR` source that would wipe the remote production copy, so unlike a transition, the localization merge leaves the from-location alone and publishes nothing. This also gives us replay safety for duplicate copy actions: the second merge supersedes the first and collects its copy, which is only safe because the first never touched the remote source.

**BB-818 - guard the GC service.** The same rule applied where data actually gets deleted, whatever published the action. The service only has data to delete, and it has no way to delete data living on a remote location. Getting such an action is a bug upstream, hence the warning rather than silence, but there is nothing to do about it here beyond skipping it. No completion metric is emitted for a delete that did not happen.

Both check the location of the data being collected rather than the object storage class, because the two can disagree. If the object changes while the copy is in flight - the queue populator captures its `eTag` and `lastModified`, and the merge re-reads metadata later - the copy is discarded and we collect the local data we just wrote. Metadata was never updated at that point, so the storage class still names the `isCRR` location while the data to collect is local. Keying on the storage class would skip that collection and leak the local copy, which nothing else would ever pick up since metadata still points at the remote data.

Issue: BB-813
Issue: BB-818