### PR TITLE
Pull replication of objects still on the source location

### DIFF
--- a/conf/locationConfig.json
+++ b/conf/locationConfig.json
@@ -42,5 +42,12 @@
     "legacyAwsBehavior": false,
     "isCold": true,
     "details": {}
+  },
+  "location-crr-source": {
+    "type": "scality",
+    "objectId": "location-crr-source",
+    "legacyAwsBehavior": false,
+    "isCRR": true,
+    "details": {}
   }
 }

--- a/extensions/gc/tasks/GarbageCollectorTask.js
+++ b/extensions/gc/tasks/GarbageCollectorTask.js
@@ -5,6 +5,7 @@ const { ObjectMD } = require('arsenal').models;
 const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
 const { BatchDeleteCommand } = require('@scality/cloudserverclient');
 const { GarbageCollectorMetrics } = require('../GarbageCollectorMetrics');
+const { TRANSITION_ATTEMPT_MD } = require('../../../lib/util/transitionAttempt');
 /** @typedef { import('../GarbageCollector.js') } GarbageCollector */
 
 class GarbageCollectorTask extends BackbeatTask {
@@ -294,7 +295,7 @@ class GarbageCollectorTask extends BackbeatTask {
                     .setAmzStorageClass(newLocation)
                     .setTransitionInProgress(false)
                     .setOriginOp(isDirectToCold ? 's3:LifecycleTransition:Direct' : 's3:LifecycleTransition')
-                    .setUserMetadata({ 'x-amz-meta-scal-s3-transition-attempt': undefined });
+                    .setUserMetadata({ [TRANSITION_ATTEMPT_MD]: undefined });
                 this._putMetadata(entry, objMD, log, err => {
                     GarbageCollectorMetrics.onS3Request(log, 'putMetadata', 'archive', err);
                     if (!err) {

--- a/extensions/lifecycle/LifecycleMetrics.js
+++ b/extensions/lifecycle/LifecycleMetrics.js
@@ -12,6 +12,9 @@ const LIFECYCLE_LABEL_CONDUCTOR_SCAN_ID = 'conductor_scan_id';
 
 const LIFECYCLE_MARKER_METRICS_LOCATION = '-delete-marker-';
 
+const TRANSITION_TYPE = 'transition';
+const PULL_REPLICATION = 'pullReplication';
+
 // Keep per-scan series long enough for scraping and debugging recent overlap,
 // but remove them from prom-client after a configurable retention interval.
 // We intentionally do not cap the number of tracked scan IDs: if overlapping
@@ -447,9 +450,21 @@ class LifecycleMetrics {
     }
 }
 
+/**
+ * Metrics type of a copyLocation action.
+ * @param {ActionQueueEntry} actionEntry - copyLocation action
+ * @return {string} metrics type
+ */
+function getCopyLocationMetricsType(actionEntry) {
+    return actionEntry.getAttribute('metrics.origin') === PULL_REPLICATION ?
+        PULL_REPLICATION : TRANSITION_TYPE;
+}
+
 module.exports = {
     DEFAULT_SCAN_METRIC_RETENTION_S,
     LifecycleMetrics,
     LIFECYCLE_MARKER_METRICS_LOCATION,
+    PULL_REPLICATION,
+    getCopyLocationMetricsType,
     resetLifecycleScanMetricCleanupTimers,
 };

--- a/extensions/lifecycle/objectProcessor/LifecycleObjectTransitionProcessor.js
+++ b/extensions/lifecycle/objectProcessor/LifecycleObjectTransitionProcessor.js
@@ -1,6 +1,7 @@
 'use strict';
 const assert = require('assert');
 const async = require('async');
+const { errors } = require('arsenal');
 
 const ColdStorageStatusQueueEntry = require('../../../lib/models/ColdStorageStatusQueueEntry');
 const { LifecycleMetrics } = require('../LifecycleMetrics');
@@ -14,6 +15,9 @@ const { updateCircuitBreakerConfigForImplicitOutputQueue } = require('../../../l
 const { LifecycleRetriggerRestoreTask } = require('../tasks/LifecycleRetriggerRestoreTask');
 const BackbeatProducer = require('../../../lib/BackbeatProducer');
 const GarbageCollectorProducer = require('../../gc/GarbageCollectorProducer');
+const VaultClientWrapper = require('../../utils/VaultClientWrapper');
+const { AccountIdCache } = require('../../utils/AccountIdCache');
+const { authTypeAssumeRole } = require('../../../lib/constants');
 
 class LifecycleObjectTransitionProcessor extends LifecycleObjectProcessor {
 
@@ -44,9 +48,68 @@ class LifecycleObjectTransitionProcessor extends LifecycleObjectProcessor {
      * @param {Number} s3Config.port - s3 endpoint port
      * @param {String} [transport="http"] - transport method ("http"
      *  or "https")
+     * @param {Object} [vaultAdminConfig] - vault admin endpoint, used to
+     *  resolve canonical ids into account ids
      */
-    constructor(zkConfig, kafkaConfig, lcConfig, s3Config, transport = 'http') {
+    constructor(zkConfig, kafkaConfig, lcConfig, s3Config, transport = 'http',
+        vaultAdminConfig = undefined) {
         super(zkConfig, kafkaConfig, lcConfig, s3Config, transport);
+
+        const authConfig = this.getAuthConfig(this._lcConfig);
+        if (authConfig.type === authTypeAssumeRole) {
+            this.vaultClientWrapper = new VaultClientWrapper(
+                `lifecycle:${this.getProcessorType()}`,
+                vaultAdminConfig,
+                authConfig,
+                this._log,
+            );
+            this._accountIdCache = new AccountIdCache(
+                this._processConfig.concurrency);
+        }
+    }
+
+    /**
+     * Resolve the account id of a canonical id. Actions published by the
+     * lifecycle conductor already carry the account id; those published by the
+     * queue populator (pull replication) only know the canonical id.
+     * @param {String} ownerId - canonical id of the object owner
+     * @param {Logger} log - logger instance
+     * @param {Function} cb - callback: cb(err, accountId)
+     * @return {undefined}
+     */
+    getAccountId(ownerId, log, cb) {
+        if (!this.vaultClientWrapper) {
+            log.debug('skipping: not assume role auth type');
+            return process.nextTick(cb);
+        }
+
+        // A cached miss must fail like a fresh lookup would: `isKnown()` is also
+        // true for misses, and `get()` would then hand back `undefined`.
+        if (this._accountIdCache.isMiss(ownerId)) {
+            log.error('canonical id does not exist (cached)', { ownerId });
+            return process.nextTick(cb, errors.NoSuchEntity);
+        }
+
+        if (this._accountIdCache.has(ownerId)) {
+            return process.nextTick(cb, null, this._accountIdCache.get(ownerId));
+        }
+
+        return this.vaultClientWrapper.getAccountId(ownerId, (err, accountId) => {
+            if (err) {
+                if (err.NoSuchEntity) {
+                    log.error('canonical id does not exist', { error: err, ownerId });
+                    this._accountIdCache.miss(ownerId);
+                } else {
+                    log.error('could not get account id', { error: err, ownerId });
+                }
+                return cb(err);
+            }
+
+            this._accountIdCache.set(ownerId, accountId);
+            this._accountIdCache.expireOldest();
+
+            return cb(null, accountId);
+        });
     }
 
     /**
@@ -56,6 +119,7 @@ class LifecycleObjectTransitionProcessor extends LifecycleObjectProcessor {
      * @return {undefined}
      */
     start(done) {
+        this.vaultClientWrapper?.init();
         async.waterfall([
             next => super.start(next),
             next => {
@@ -226,7 +290,12 @@ class LifecycleObjectTransitionProcessor extends LifecycleObjectProcessor {
             ...super.getStateVars(),
             coldProducer: this._coldProducer,
             gcProducer: this._gcProducer,
+            getAccountId: this.getAccountId.bind(this),
         };
+    }
+
+    isReady() {
+        return super.isReady() && (!this.vaultClientWrapper || this.vaultClientWrapper.tempCredentialsReady());
     }
 }
 

--- a/extensions/lifecycle/objectProcessor/task.js
+++ b/extensions/lifecycle/objectProcessor/task.js
@@ -32,7 +32,7 @@ let objectProcessor;
 switch (process.env.LIFECYCLE_OBJECT_PROCESSOR_TYPE) {
     case 'transition':
         objectProcessor = new LifecycleObjectTransitionProcessor(
-            zkConfig, kafkaConfig, lcConfig, s3Config, transport);
+            zkConfig, kafkaConfig, lcConfig, s3Config, transport, config.vaultAdmin);
         break;
     case 'expiration': // fallthrough
     default:

--- a/extensions/lifecycle/tasks/LifecycleColdStatusArchiveTask.js
+++ b/extensions/lifecycle/tasks/LifecycleColdStatusArchiveTask.js
@@ -4,6 +4,7 @@ const ObjectMDArchive = require('arsenal').models.ObjectMDArchive;
 const ActionQueueEntry = require('../../../lib/models/ActionQueueEntry');
 const LifecycleUpdateTransitionTask = require('./LifecycleUpdateTransitionTask');
 const { LifecycleMetrics } = require('../LifecycleMetrics');
+const { TRANSITION_ATTEMPT_MD } = require('../../../lib/util/transitionAttempt');
 
 class SkipMdUpdateError extends Error {}
 
@@ -119,7 +120,7 @@ class LifecycleColdStatusArchiveTask extends LifecycleUpdateTransitionTask {
                         .setAmzStorageClass(coldLocation)
                         .setTransitionInProgress(false)
                         .setOriginOp(isDirectToCold ? 's3:LifecycleTransition:Direct' : 's3:LifecycleTransition')
-                        .setUserMetadata({ 'x-amz-meta-scal-s3-transition-attempt': undefined });
+                        .setUserMetadata({ [TRANSITION_ATTEMPT_MD]: undefined });
                 }
 
                 this._putMetadata(entry, objectMD, log, err => {

--- a/extensions/lifecycle/tasks/LifecycleResetTransitionInProgressTask.js
+++ b/extensions/lifecycle/tasks/LifecycleResetTransitionInProgressTask.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { LifecycleRequeueTask } = require('./LifecycleRequeueTask');
+const { TRANSITION_ATTEMPT_MD } = require('../../../lib/util/transitionAttempt');
 const locationsConfig = require('../../../conf/locationConfig.json') || {};
 
 class LifecycleResetTransitionInProgressTask extends LifecycleRequeueTask {
@@ -23,9 +24,7 @@ class LifecycleResetTransitionInProgressTask extends LifecycleRequeueTask {
             // Keep the flag as the queue populator keys on it to trigger the next attempt
             md.setTransitionInProgress(false);
         }
-        md.setUserMetadata({
-            'x-amz-meta-scal-s3-transition-attempt': try_,
-        });
+        md.setUserMetadata({ [TRANSITION_ATTEMPT_MD]: try_ });
         return true;
     }
 

--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -24,6 +24,7 @@ const ReplicationAPI = require('../../replication/ReplicationAPI');
 const { LifecycleMetrics, LIFECYCLE_MARKER_METRICS_LOCATION } = require('../LifecycleMetrics');
 const locationsConfig = require('../../../conf/locationConfig.json') || {};
 const { rulesSupportTransition } = require('../util/rules');
+const { getTransitionAttempt } = require('../../../lib/util/transitionAttempt');
 const { stampTraceHeaders } = require('arsenal/build/lib/tracing').kafka;
 const { decode } = versioning.VersionID;
 
@@ -1178,15 +1179,7 @@ class LifecycleTask extends BackbeatTask {
     }
 
     _getTransitionActionEntry(params, objectMD, log, cb) {
-        let attempt;
-        const umd = objectMD.getUserMetadata();
-        if (umd) {
-            const parsed = JSON.parse(umd);
-            const rawAttempt = parsed['x-amz-meta-scal-s3-transition-attempt'];
-            if (rawAttempt) {
-                attempt = Number.parseInt(rawAttempt, 10);
-            }
-        }
+        const attempt = getTransitionAttempt(objectMD);
 
         const entry = ReplicationAPI.createCopyLocationAction({
             bucketName: params.bucket,

--- a/extensions/lifecycle/tasks/LifecycleUpdateTransitionTask.js
+++ b/extensions/lifecycle/tasks/LifecycleUpdateTransitionTask.js
@@ -6,6 +6,10 @@ const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
 const ActionQueueEntry = require('../../../lib/models/ActionQueueEntry');
 const ObjectMD = require('arsenal').models.ObjectMD;
 const { LifecycleMetrics } = require('../LifecycleMetrics');
+const {
+    TRANSITION_ATTEMPT_MD,
+    getTransitionAttempt,
+} = require('../../../lib/util/transitionAttempt');
 /** @typedef { import('../objectProcessor/LifecycleObjectProcessor.js') } LifecycleObjectProcessor */
 
 class LifecycleUpdateTransitionTask extends BackbeatTask {
@@ -71,9 +75,7 @@ class LifecycleUpdateTransitionTask extends BackbeatTask {
             .setDataStoreName(newLocationName)
             .setAmzStorageClass(newLocationName)
             .setOriginOp('s3:LifecycleTransition')
-            .setUserMetadata({
-                'x-amz-meta-scal-s3-transition-attempt': undefined,
-            })
+            .setUserMetadata({ [TRANSITION_ATTEMPT_MD]: undefined })
             .setTransitionInProgress(false);
     }
 
@@ -232,20 +234,10 @@ class LifecycleUpdateTransitionTask extends BackbeatTask {
                 next(err, objMD);
             }),
             (objMD, next) => {
-                const userMDStr = objMD.getUserMetadata() || '{}';
-                const userMD = JSON.parse(userMDStr);
-
-                let tryCount = userMD['x-amz-meta-scal-s3-transition-attempt'];
-                if (tryCount === undefined) {
-                    tryCount = 1;
-                } else {
-                    tryCount = parseInt(tryCount, 10) + 1;
-                }
+                const tryCount = (getTransitionAttempt(objMD) || 0) + 1;
 
                 objMD.setTransitionInProgress(false)
-                    .setUserMetadata({
-                        'x-amz-meta-scal-s3-transition-attempt': tryCount,
-                    });
+                    .setUserMetadata({ [TRANSITION_ATTEMPT_MD]: tryCount });
 
                 return this._putMetadata(entry, objMD, log, next);
             },

--- a/extensions/lifecycle/tasks/LifecycleUpdateTransitionTask.js
+++ b/extensions/lifecycle/tasks/LifecycleUpdateTransitionTask.js
@@ -5,7 +5,7 @@ const errors = require('arsenal').errors;
 const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
 const ActionQueueEntry = require('../../../lib/models/ActionQueueEntry');
 const ObjectMD = require('arsenal').models.ObjectMD;
-const { LifecycleMetrics } = require('../LifecycleMetrics');
+const { LifecycleMetrics, getCopyLocationMetricsType } = require('../LifecycleMetrics');
 const {
     TRANSITION_ATTEMPT_MD,
     getTransitionAttempt,
@@ -202,7 +202,7 @@ class LifecycleUpdateTransitionTask extends BackbeatTask {
                     const transitionTime = entry.getAttribute('metrics.transitionTime') ||
                         objMD.getTransitionTime();
                     const locationName = entry.getAttribute('toLocation');
-                    LifecycleMetrics.onLifecycleCompleted(log, 'transition',
+                    LifecycleMetrics.onLifecycleCompleted(log, getCopyLocationMetricsType(entry),
                         locationName, Date.now() - Date.parse(transitionTime));
                     next(err);
                 });

--- a/extensions/lifecycle/tasks/LifecycleUpdateTransitionTask.js
+++ b/extensions/lifecycle/tasks/LifecycleUpdateTransitionTask.js
@@ -245,6 +245,42 @@ class LifecycleUpdateTransitionTask extends BackbeatTask {
     }
 
     /**
+     * Actions published by the lifecycle conductor carry the account id; those
+     * published by the queue populator (pull replication) only know the object
+     * owner's canonical id. Resolve it once, up-front, so the rest of the task
+     * -and the garbage collection entry it emits- can use `target.accountId`
+     * as usual.
+     * @param {ActionQueueEntry} entry - action entry to execute
+     * @param {Logger} log - logger instance
+     * @param {Function} cb - callback function
+     * @return {undefined}
+     */
+    _resolveAccountId(entry, log, cb) {
+        const { accountId, owner } = this.getTargetAttribute(entry);
+        if (accountId) {
+            return process.nextTick(cb);
+        }
+
+        if (!owner) {
+            // Nothing to resolve from: carry on all the same, and let whatever
+            // needs the account id fail on its own, if anything does.
+            log.error('cannot resolve account id: entry has no account id nor owner');
+            return process.nextTick(cb);
+        }
+
+        log.debug('no account id in entry, resolving from canonical id', { owner });
+        return this.getAccountId(owner, log, (err, resolvedAccountId) => {
+            if (err) {
+                return cb(err);
+            }
+            if (resolvedAccountId) {
+                entry.setAttribute('target.accountId', resolvedAccountId);
+            }
+            return cb();
+        });
+    }
+
+    /**
      *
      * @param {ActionQueueEntry} entry - action entry to execute
      * @param {Function} done - callback funtion
@@ -260,11 +296,18 @@ class LifecycleUpdateTransitionTask extends BackbeatTask {
             lastModified: 'target.lastModified',
         });
         log.addDefaultFields(entry.getLogInfo());
-        if (entry.getStatus() === 'success') {
-            return this.handleSuccessfullTransition(entry, log, done);
-        }
 
-        return this.handleFailedTransition(entry, log, done);
+        return this._resolveAccountId(entry, log, err => {
+            if (err) {
+                return done(err);
+            }
+
+            if (entry.getStatus() === 'success') {
+                return this.handleSuccessfullTransition(entry, log, done);
+            }
+
+            return this.handleFailedTransition(entry, log, done);
+        });
     }
 }
 

--- a/extensions/replication/ReplicationMetric.js
+++ b/extensions/replication/ReplicationMetric.js
@@ -1,4 +1,5 @@
 const { Logger } = require('werelogs');
+const { PULL_REPLICATION } = require('../lifecycle/LifecycleMetrics');
 
 const MetricsModel = require('../../lib/models/MetricsModel');
 
@@ -46,11 +47,6 @@ class ReplicationMetric {
         return this;
     }
 
-    _isLifecycleAction() {
-        const { origin } = this._entry.getContext();
-        return origin !== undefined && origin === 'lifecycle';
-    }
-
     _createProducerMessage() {
         const { bucket, key, version } = this._entry.getAttribute('target');
         const metricsModel = new MetricsModel()
@@ -65,8 +61,9 @@ class ReplicationMetric {
     }
 
     publish() {
-        // Lifecycle metrics not yet implemented.
-        if (this._isLifecycleAction()) {
+        // Metrics API/routes only support CRR
+        const { origin } = this._entry.getContext();
+        if (['lifecycle', PULL_REPLICATION].includes(origin)) {
             return undefined;
         }
         if (!this._producer) {

--- a/extensions/replication/ReplicationMetrics.js
+++ b/extensions/replication/ReplicationMetrics.js
@@ -83,17 +83,18 @@ class ReplicationMetrics extends ZenkoMetrics {
         const fromLocationType = _getReplicationEndpointType(fromLocation);
         const toLocationType = _getReplicationEndpointType(toLocation);
 
-        replicationQueuedTotal.inc({
+        const labels = {
             origin: originLabel,
             fromLocation, fromLocationType,
-            toLocation, toLocationType, partition,
-        });
+            toLocation, toLocationType,
+            // Empty when queued by the populator, which batches its publishes
+            // and only learns their partition much later.
+            partition: partition ?? '',
+        };
 
-        replicationQueuedBytes.inc({
-            origin: originLabel,
-            fromLocation, fromLocationType,
-            toLocation, toLocationType, partition,
-        }, Number.parseInt(contentLength, 10));
+        replicationQueuedTotal.inc(labels);
+
+        replicationQueuedBytes.inc(labels, Number.parseInt(contentLength, 10));
     }
 
     static onReplicationProcessed(originLabel, fromLocation, toLocation,

--- a/extensions/replication/ReplicationQueuePopulator.js
+++ b/extensions/replication/ReplicationQueuePopulator.js
@@ -5,12 +5,14 @@ const QueuePopulatorExtension =
           require('../../lib/queuePopulator/QueuePopulatorExtension');
 const ObjectQueueEntry = require('../../lib/models/ObjectQueueEntry');
 const ReplicationAPI = require('./ReplicationAPI');
-const { LifecycleMetrics, PULL_REPLICATION_TYPE } = require('../lifecycle/LifecycleMetrics');
+const ReplicationMetrics = require('./ReplicationMetrics');
+const { LifecycleMetrics, PULL_REPLICATION } = require('../lifecycle/LifecycleMetrics');
 const config = require('../../lib/Config');
 const locationsConfig = require('../../conf/locationConfig.json') || {};
 const safeJsonParse = require('../../lib/util/safeJsonParse');
 const { getTransitionAttempt } = require('../../lib/util/transitionAttempt');
 const { traceHeadersFromEntry } = require('arsenal/build/lib/tracing').kafka;
+const { replicationDirections } = require('./constants');
 
 class ReplicationQueuePopulator extends QueuePopulatorExtension {
     constructor(params) {
@@ -118,14 +120,12 @@ class ReplicationQueuePopulator extends QueuePopulatorExtension {
                 this._incrementMetrics(backend.site, bytes);
             });
 
-        // TODO: replication specific metrics go here
-        this.metricsHandler.bytes(
-            entry.logReader.getMetricLabels(),
-            bytes
-        );
-        this.metricsHandler.objects(
-            entry.logReader.getMetricLabels()
-        );
+        const metricLabels = {
+            ...entry.logReader.getMetricLabels(),
+            direction: replicationDirections.push,
+        };
+        this.metricsHandler.bytes(metricLabels, bytes);
+        this.metricsHandler.objects(metricLabels);
 
         const publishedEntry = Object.assign({}, entry);
         delete publishedEntry.logReader;
@@ -218,6 +218,18 @@ class ReplicationQueuePopulator extends QueuePopulatorExtension {
                      action.toKafkaMessage(),
                      undefined,
                      traceHeadersFromEntry(value));
+
+        // Counterpart of the bytes the data mover reports once the copy
+        // completed, to measure the pull replication backlog.
+        ReplicationMetrics.onReplicationQueued(PULL_REPLICATION,
+            queueEntry.getDataStoreName(), targetLocation, contentLength);
+
+        const metricLabels = {
+            ...entry.logReader.getMetricLabels(),
+            direction: replicationDirections.pull,
+        };
+        this.metricsHandler.bytes(metricLabels, contentLength);
+        this.metricsHandler.objects(metricLabels);
     }
 
     /**

--- a/extensions/replication/ReplicationQueuePopulator.js
+++ b/extensions/replication/ReplicationQueuePopulator.js
@@ -1,11 +1,15 @@
 const { isMasterKey } = require('arsenal').versioning;
-const { usersBucket, mpuBucketPrefix } = require('arsenal').constants;
+const { usersBucket, mpuBucketPrefix, externalBackends } = require('arsenal').constants;
 
 const QueuePopulatorExtension =
           require('../../lib/queuePopulator/QueuePopulatorExtension');
 const ObjectQueueEntry = require('../../lib/models/ObjectQueueEntry');
+const ReplicationAPI = require('./ReplicationAPI');
+const { LifecycleMetrics, PULL_REPLICATION_TYPE } = require('../lifecycle/LifecycleMetrics');
+const config = require('../../lib/Config');
 const locationsConfig = require('../../conf/locationConfig.json') || {};
 const safeJsonParse = require('../../lib/util/safeJsonParse');
+const { getTransitionAttempt } = require('../../lib/util/transitionAttempt');
 const { traceHeadersFromEntry } = require('arsenal/build/lib/tracing').kafka;
 
 class ReplicationQueuePopulator extends QueuePopulatorExtension {
@@ -13,6 +17,14 @@ class ReplicationQueuePopulator extends QueuePopulatorExtension {
         super(params);
         this.repConfig = params.config;
         this.metricsHandler = params.metricsHandler;
+        this.transitionTasksTopic = config.extensions?.lifecycle?.transitionTasksTopic;
+
+        // Where the data is fetched to when the object metadata does not name a
+        // usable target. Any location will do, as long as it can hold the data.
+        this.defaultLocalLocation = ['us-east-1', ...Object.keys(locationsConfig)].find(name => {
+            const loc = locationsConfig[name];
+            return loc && !loc.isCold && !loc.isCRR && !loc.isTransient && !externalBackends[loc.type];
+        });
     }
 
     filter(entry) {
@@ -73,19 +85,24 @@ class ReplicationQueuePopulator extends QueuePopulatorExtension {
         if (sanityCheckRes) {
             return;
         }
+        const locationConfig = locationsConfig[queueEntry.getDataStoreName()] || {};
         // Allow a non-versioned object if being replicated from an NFS bucket.
         // Or if the master key is of a non versioned object
         if (!this._entryCanBeReplicated(queueEntry)) {
             return;
         }
+        // Data still on the source location has to be fetched first. This is
+        // unrelated to replicationInfo, which tracks replication of a *local*
+        // object to remote sites, hence the check before any of its conditions.
+        if (locationConfig.isCRR && this.transitionTasksTopic) {
+            this._publishPullReplicationAction(entry, queueEntry, value);
+            return;
+        }
         if (queueEntry.getReplicationStatus() !== 'PENDING') {
             return;
         }
-        const dataStoreName = queueEntry.getDataStoreName();
-        const isObjectCold = dataStoreName && locationsConfig[dataStoreName]
-            && locationsConfig[dataStoreName].isCold;
         // We do not replicate cold objects.
-        if (isObjectCold) {
+        if (locationConfig.isCold) {
             return;
         }
 
@@ -122,6 +139,125 @@ class ReplicationQueuePopulator extends QueuePopulatorExtension {
                      JSON.stringify(publishedEntry),
                      undefined,
                      traceHeaders);
+    }
+
+    /**
+     * Queue a copyLocation action for an object whose data still lives on the
+     * source location: the data mover copies it over, and the transition
+     * processor merges the new location into the object metadata.
+     *
+     * Duplicates are expected (and harmless): the same object may show up
+     * several times in the oplog, and the copy is idempotent.
+     *
+     * @param {Object} entry - raw metadata log entry
+     * @param {ObjectQueueEntry} queueEntry - parsed entry
+     * @param {Object} value - parsed entry metadata
+     * @return {undefined}
+     */
+    _publishPullReplicationAction(entry, queueEntry, value) {
+        if (queueEntry.getIsDeleteMarker()) {
+            return;
+        }
+
+        // Fail if the object is not empty, but has no location to pull data from
+        const contentLength = queueEntry.getContentLength();
+        const locations = queueEntry.getLocation();
+        if (!locations?.length && contentLength > 0) {
+            this.log.error('non-empty object without location, skipping pull replication', {
+                method: 'ReplicationQueuePopulator._publishPullReplicationAction',
+                ...queueEntry.getLogInfo(),
+                dataStoreName: queueEntry.getDataStoreName(),
+                contentLength,
+            });
+            return;
+        }
+
+        const bucket = queueEntry.getBucket();
+        const objectKey = queueEntry.getObjectKey();
+        const targetLocation = this._getPullReplicationTarget(queueEntry, locations);
+        if (!targetLocation) {
+            return;
+        }
+        const transitionTime = new Date(entry.overheadFields?.commitTimestamp ?? Date.now());
+        const action = ReplicationAPI.createCopyLocationAction({
+            bucketName: bucket,
+            objectKey,
+            owner: queueEntry.getOwnerId(),
+            versionId: queueEntry.getEncodedVersionId() || 'null',
+            eTag: `"${queueEntry.getContentMd5()}"`,
+            lastModified: queueEntry.getLastModified(),
+            toLocation: targetLocation,
+            originLabel: PULL_REPLICATION,
+            fromLocation: queueEntry.getDataStoreName(),
+            contentLength,
+            resultsTopic: this.transitionTasksTopic,
+            transitionTime: transitionTime.toISOString(),
+            attempt: getTransitionAttempt(queueEntry),
+        });
+        // 'transition' is what the lifecycle transition processor dispatches
+        // on to pick up the copyLocation result.
+        action.addContext({
+            origin: PULL_REPLICATION,
+            ruleType: 'transition',
+            bucketName: bucket,
+            objectKey,
+            versionId: value.versionId,
+        });
+        action.setAttribute('source', {
+            bucket,
+            objectKey,
+            storageClass: queueEntry.getDataStoreName(),
+        });
+
+        LifecycleMetrics.onLifecycleTriggered(this.log, 'queuePopulator',
+            PULL_REPLICATION, targetLocation, Date.now() - transitionTime.getTime());
+
+        this.log.trace('publishing pull replication entry', { entry: queueEntry.getLogInfo() });
+        this.publish(ReplicationAPI.getDataMoverTopic(),
+                     `${bucket}/${objectKey}`,
+                     action.toKafkaMessage(),
+                     undefined,
+                     traceHeadersFromEntry(value));
+    }
+
+    /**
+     * Local location the object data must be copied to.
+     *
+     * The metadata may not name a usable target, typically if that location
+     * was deleted/renamed since. This is not recoverable here, but copying
+     * the data anywhere local beats leaving it on the source forever.
+     *
+     * The locations may also be missing altogether, which could be the case
+     * for empty objects where there is no actual data to copy: only metadata
+     * to update to mark the transition as complete.
+     *
+     * @param {ObjectQueueEntry} queueEntry - parsed entry
+     * @param {Object[]} [locations] - object data locations
+     * @return {String|undefined} target location, undefined if there is none
+     */
+    _getPullReplicationTarget(queueEntry, locations) {
+        const { targetLocation } = locations?.[0] ?? {};
+        if (locationsConfig[targetLocation]) {
+            return targetLocation;
+        }
+
+        if (!this.defaultLocalLocation) {
+            this.log.error('invalid target location and no local location ' +
+                'to fall back to, skipping pull replication', {
+                method: 'ReplicationQueuePopulator._getPullReplicationTarget',
+                ...queueEntry.getLogInfo(),
+                targetLocation,
+            });
+            return undefined;
+        }
+
+        this.log.warn('invalid target location in object metadata', {
+            method: 'ReplicationQueuePopulator._getPullReplicationTarget',
+            ...queueEntry.getLogInfo(),
+            targetLocation,
+            fallbackLocation: this.defaultLocalLocation,
+        });
+        return this.defaultLocalLocation;
     }
 
     /**

--- a/extensions/replication/constants.js
+++ b/extensions/replication/constants.js
@@ -35,6 +35,10 @@ const constants = {
         failedCRR: testIsOn ? 'test:bb:crr:failed' : 'bb:crr:failed',
     },
     replicationBackends: ['aws_s3', 'azure', 'gcp'],
+    replicationDirections: {
+        push: 'push',
+        pull: 'pull',
+    },
     replicationStages: {
         sourceDataRead: 'ReplicationSourceDataRead',
         destinationDataWrite: 'ReplicationDestinationDataWrite',

--- a/extensions/replication/tasks/CopyLocationTask.js
+++ b/extensions/replication/tasks/CopyLocationTask.js
@@ -16,7 +16,7 @@ const {
     MultipleBackendAbortMPUCommand,
     addContentLengthMiddleware,
 } = require('@scality/cloudserverclient');
-const { LifecycleMetrics } = require('../../lifecycle/LifecycleMetrics');
+const { LifecycleMetrics, getCopyLocationMetricsType } = require('../../lifecycle/LifecycleMetrics');
 const ReplicationMetric = require('../ReplicationMetric');
 const ReplicationMetrics = require('../ReplicationMetrics');
 const { isRetryableMiddleware, TIMEOUT_MS } = require('../../../lib/clients/utils');
@@ -138,7 +138,7 @@ class CopyLocationTask extends BackbeatTask {
 
                 const transitionTime = actionEntry.getAttribute('metrics.transitionTime') ||
                     objMD.getTransitionTime();
-                LifecycleMetrics.onLifecycleStarted(log, 'transition',
+                LifecycleMetrics.onLifecycleStarted(log, getCopyLocationMetricsType(actionEntry),
                     actionEntry.getAttribute('toLocation'),
                     startTime - Date.parse(transitionTime));
 

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -132,17 +132,6 @@ class Config extends EventEmitter {
                 parsedConfig.internalCertFilePaths);
         }
 
-        // Overwrite extension configs if configured
-        // We can specify the list of extensions that should be handled by this
-        // instance of the queuePopulator
-        const configuredExtensions = process.env.BACKBEAT_QUEUEPOPULATOR_EXTENSIONS;
-        if (configuredExtensions) {
-            const allowedExtensions = configuredExtensions.split(',');
-            const filteredExtensions = Object.entries(parsedConfig.extensions)
-                .filter(entry => allowedExtensions.includes(entry[0]));
-            parsedConfig.extensions = Object.fromEntries(filteredExtensions);
-        }
-
         // config is validated, safe to assign directly to the config object
         Object.assign(this, parsedConfig);
 

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -62,16 +62,21 @@ const messageMetrics = ZenkoMetrics.createCounter({
     labelNames: [...metricLabels, 'publishStatus'],
 });
 
+// Which way the data is moving: 'push' out to a remote site, or 'pull' in from
+// a source cluster. Not to be confused with 'origin', which names the
+// extensions loaded in the populator and is the same for both.
+const DIRECTION_LABEL = 'direction';
+
 const objectMetrics = ZenkoMetrics.createCounter({
     name: 's3_replication_populator_objects_total',
     help: 'Total objects queued for replication',
-    labelNames: metricLabels,
+    labelNames: [...metricLabels, DIRECTION_LABEL],
 });
 
 const byteMetrics = ZenkoMetrics.createCounter({
     name: 's3_replication_populator_bytes_total',
     help: 'Total number of bytes queued for replication not including metadata',
-    labelNames: metricLabels,
+    labelNames: [...metricLabels, DIRECTION_LABEL],
 });
 
 const notificationEvent = ZenkoMetrics.createCounter({

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -165,7 +165,7 @@ class QueuePopulator {
         this.mConfig = mConfig;
         this.rConfig = rConfig;
         this.vConfig = vConfig;
-        this.extConfigs = extConfigs;
+        this.extConfigs = QueuePopulator._filterConfiguredExtensions(extConfigs);
 
         this.log = new Logger('Backbeat:QueuePopulator');
 
@@ -182,6 +182,21 @@ class QueuePopulator {
         this._loadedExtensions = [];
 
         this._circuitBreaker = new CircuitBreaker(qpConfig.circuitBreaker);
+    }
+
+    /**
+     * Return the extensions this populator instance runs.
+     * @param {Object} extConfigs - configuration of every configured extension
+     * @return {Object} configuration of the extensions to run here
+     */
+    static _filterConfiguredExtensions(extConfigs) {
+        const configured = process.env.BACKBEAT_QUEUEPOPULATOR_EXTENSIONS;
+        if (!configured) {
+            return extConfigs;
+        }
+        const names = configured.split(',');
+        return Object.fromEntries(
+            Object.entries(extConfigs).filter(([name]) => names.includes(name)));
     }
 
     /**

--- a/lib/util/transitionAttempt.js
+++ b/lib/util/transitionAttempt.js
@@ -1,0 +1,20 @@
+// Kept in the user metadata so it survives across processes: the transition
+// processor bumps it on failure, and clears it once the object reached its new
+// location.
+const TRANSITION_ATTEMPT_MD = 'x-amz-meta-scal-s3-transition-attempt';
+
+/**
+ * Read the transition attempt count of an object.
+ * @param {ObjectMD} objMD - object metadata
+ * @return {Number|undefined} attempt count, or undefined if the object was
+ * never transitioned
+ */
+function getTransitionAttempt(objMD) {
+    const attempt = Number.parseInt(objMD.getValue()[TRANSITION_ATTEMPT_MD], 10);
+    return Number.isInteger(attempt) ? attempt : undefined;
+}
+
+module.exports = {
+    TRANSITION_ATTEMPT_MD,
+    getTransitionAttempt,
+};

--- a/tests/unit/QueuePopulator.spec.js
+++ b/tests/unit/QueuePopulator.spec.js
@@ -377,4 +377,35 @@ describe('QueuePopulator', () => {
             });
         });
     });
+
+    describe('configured extensions', () => {
+        const extConfigs = { replication: {}, lifecycle: {}, notification: {} };
+
+        function buildPopulator() {
+            return new QueuePopulator({}, {}, { logSource: 'bucketd' },
+                null, null, null, null, extConfigs);
+        }
+
+        afterEach(() => {
+            delete process.env.BACKBEAT_QUEUEPOPULATOR_EXTENSIONS;
+        });
+
+        it('should run every extension by default', () => {
+            assert.deepStrictEqual(Object.keys(buildPopulator().extConfigs),
+                ['replication', 'lifecycle', 'notification']);
+        });
+
+        it('should only run the extensions it is configured with', () => {
+            process.env.BACKBEAT_QUEUEPOPULATOR_EXTENSIONS = 'replication';
+            assert.deepStrictEqual(Object.keys(buildPopulator().extConfigs),
+                ['replication']);
+        });
+
+        it('should leave the configuration of the other extensions alone', () => {
+            process.env.BACKBEAT_QUEUEPOPULATOR_EXTENSIONS = 'replication';
+            buildPopulator();
+            assert.deepStrictEqual(Object.keys(extConfigs),
+                ['replication', 'lifecycle', 'notification']);
+        });
+    });
 });

--- a/tests/unit/ReplicationMetric.js
+++ b/tests/unit/ReplicationMetric.js
@@ -56,27 +56,13 @@ describe('ReplicationMetric', () => {
             .forEach(key => assert.strictEqual(data[key], mock[key]));
     });
 
-    it('::_isLifecycleAction should return false by default', () => {
-        metric.withEntry(entry);
-        assert.strictEqual(metric._isLifecycleAction(), false);
-    });
-
-    it('::_isLifecycleAction should return true when origin is lifecycle',
-        () => {
-            entry.setAttribute('contextInfo', {
-                origin: 'lifecycle',
-            });
+    ['lifecycle', 'pullReplication'].forEach(origin => {
+        it(`::publish should not send data to topic for a ${origin} action`, () => {
+            entry.setAttribute('contextInfo', { origin });
             metric.withEntry(entry);
-            assert.strictEqual(metric._isLifecycleAction(), true);
+            metric.publish();
+            assert.strictEqual(sentMessages.length, 0);
         });
-
-    it('::publish should not send data to topic if lifecycle task', () => {
-        entry.setAttribute('contextInfo', {
-            origin: 'lifecycle',
-        });
-        metric.withEntry(entry);
-        metric.publish();
-        assert.strictEqual(sentMessages.length, 0);
     });
 
     it('::publish should not send data to topic if metrics are disabled',

--- a/tests/unit/lifecycle/CircuitBreakerGroup.spec.js
+++ b/tests/unit/lifecycle/CircuitBreakerGroup.spec.js
@@ -436,6 +436,11 @@ describe('extractBucketProcessorCircuitBreakerConfigs', () => {
                                     '${location}',
                                     'location-dmf-v1',
                                 ),
+                                formatProbeConfig(
+                                    topicSpecificLocationTemplateProbe,
+                                    '${location}',
+                                    'location-crr-source',
+                                ),
                             ],
                         },
                         global: [],
@@ -492,6 +497,11 @@ describe('extractBucketProcessorCircuitBreakerConfigs', () => {
                                     topicSpecificLocationTemplateProbe,
                                     '${location}',
                                     'location-dmf-v1',
+                                ),
+                                formatProbeConfig(
+                                    topicSpecificLocationTemplateProbe,
+                                    '${location}',
+                                    'location-crr-source',
                                 ),
                             ],
                         },

--- a/tests/unit/lifecycle/LifecycleMetrics.spec.js
+++ b/tests/unit/lifecycle/LifecycleMetrics.spec.js
@@ -2,8 +2,10 @@ const assert = require('assert');
 const sinon = require('sinon');
 const {
     LifecycleMetrics,
+    getCopyLocationMetricsType,
     resetLifecycleScanMetricCleanupTimers,
 } = require('../../../extensions/lifecycle/LifecycleMetrics');
+const ActionQueueEntry = require('../../../lib/models/ActionQueueEntry');
 const { ZenkoMetrics } = require('arsenal').metrics;
 
 describe('LifecycleMetrics', () => {
@@ -18,6 +20,23 @@ describe('LifecycleMetrics', () => {
     afterEach(() => {
         resetLifecycleScanMetricCleanupTimers();
         sinon.restore();
+    });
+
+    describe('getCopyLocationMetricsType', () => {
+        [
+            ['pullReplication', 'pullReplication'],
+            ['lifecycle', 'transition'],
+            [undefined, 'transition'],
+        ].forEach(([origin, expected]) => {
+            it(`should report ${origin} actions as ${expected}`, () => {
+                const entry = ActionQueueEntry.create('copyLocation');
+                if (origin !== undefined) {
+                    entry.setAttribute('metrics', { origin });
+                }
+
+                assert.strictEqual(getCopyLocationMetricsType(entry), expected);
+            });
+        });
     });
 
     describe('error handling', () => {

--- a/tests/unit/lifecycle/LifecycleObjectTransitionProcessor.spec.js
+++ b/tests/unit/lifecycle/LifecycleObjectTransitionProcessor.spec.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const sinon = require('sinon');
+const { errors } = require('arsenal');
 const config = require('../../config.json');
 const BackbeatTask = require('../../../lib/tasks/BackbeatTask');
 const LifecycleObjectTransitionProcessor =
@@ -123,6 +124,100 @@ describe('LifecycleObjectTransitionProcessor', () => {
                 assert.strictEqual(spy.callCount, 0);
                 done();
             });
+        });
+    });
+
+    describe('getAccountId', () => {
+        const ownerId = 'canonical-id-1';
+        const accountId = '834789881858';
+        let processor;
+        let log;
+
+        beforeEach(() => {
+            processor = new LifecycleObjectTransitionProcessor(
+                config.zookeeper,
+                config.kafka,
+                {
+                    ...config.extensions.lifecycle,
+                    transitionProcessor: {
+                        ...config.extensions.lifecycle.transitionProcessor,
+                        auth: { type: 'assumeRole', roleName: 'role' },
+                    },
+                },
+                config.s3,
+                config.transport,
+                { host: 'localhost', port: 8600 },
+            );
+            log = { debug: () => {}, error: () => {} };
+        });
+
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        it('should skip the lookup when auth type is not assume role', done => {
+            assert.strictEqual(objectProcessor.vaultClientWrapper, undefined);
+            objectProcessor.getAccountId(ownerId, log, (err, id) => {
+                assert.ifError(err);
+                assert.strictEqual(id, undefined);
+                done();
+            });
+        });
+
+        it('should resolve through vault and cache the result', done => {
+            const stub = sinon.stub(processor.vaultClientWrapper, 'getAccountId')
+                .yields(null, accountId);
+
+            processor.getAccountId(ownerId, log, (err, id) => {
+                assert.ifError(err);
+                assert.strictEqual(id, accountId);
+                assert.strictEqual(stub.callCount, 1);
+
+                processor.getAccountId(ownerId, log, (err2, id2) => {
+                    assert.ifError(err2);
+                    assert.strictEqual(id2, accountId);
+                    assert.strictEqual(stub.callCount, 1);
+                    done();
+                });
+            });
+        });
+
+        it('should fail on a cached miss instead of returning no account id', done => {
+            const stub = sinon.stub(processor.vaultClientWrapper, 'getAccountId')
+                .yields(errors.NoSuchEntity);
+
+            processor.getAccountId(ownerId, log, err => {
+                assert(err.NoSuchEntity);
+                assert.strictEqual(stub.callCount, 1);
+
+                // the miss is cached, but must still surface as an error
+                processor.getAccountId(ownerId, log, (err2, id2) => {
+                    assert(err2.NoSuchEntity);
+                    assert.strictEqual(id2, undefined);
+                    assert.strictEqual(stub.callCount, 1);
+                    done();
+                });
+            });
+        });
+
+        it('should propagate other vault errors without caching them', done => {
+            const stub = sinon.stub(processor.vaultClientWrapper, 'getAccountId')
+                .yields(errors.InternalError);
+
+            processor.getAccountId(ownerId, log, err => {
+                assert(err.InternalError);
+
+                processor.getAccountId(ownerId, log, err2 => {
+                    assert(err2.InternalError);
+                    assert.strictEqual(stub.callCount, 2);
+                    done();
+                });
+            });
+        });
+
+        it('should not hold readiness back without assume role auth', () => {
+            objectProcessor._consumers = { isReady: () => true };
+            assert.strictEqual(objectProcessor.isReady(), true);
         });
     });
 });

--- a/tests/unit/lifecycle/LifecycleTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleTask.spec.js
@@ -2375,7 +2375,7 @@ describe('lifecycle task helper methods', () => {
                 getDataStoreName: () => 'local-site',
                 getDataStoreVersionId: () => 'version-123',
                 getContentLength: () => 1024,
-                getUserMetadata: () => null,
+                getValue: () => ({}),
             };
 
             sinon.stub(lifecycleTask, '_canUnconditionallyGarbageCollect').returns(true);
@@ -2416,7 +2416,7 @@ describe('lifecycle task helper methods', () => {
                 getDataStoreName: () => 'local-site',
                 getDataStoreVersionId: () => 'version-123',
                 getContentLength: () => 1024,
-                getUserMetadata: () => JSON.stringify({
+                getValue: () => ({
                     'x-amz-meta-scal-s3-transition-attempt': '3'
                 }),
             };
@@ -2435,7 +2435,7 @@ describe('lifecycle task helper methods', () => {
                 getDataStoreName: () => 'aws-location',
                 getDataStoreVersionId: () => null,
                 getContentLength: () => 2048,
-                getUserMetadata: () => null,
+                getValue: () => ({}),
                 getLocation: () => [{ name: 'aws-location', dataStoreVersionId: null }],
             };
 
@@ -2457,7 +2457,7 @@ describe('lifecycle task helper methods', () => {
                 getDataStoreName: () => 'aws-location',
                 getDataStoreVersionId: () => null,
                 getContentLength: () => 2048,
-                getUserMetadata: () => null,
+                getValue: () => ({}),
                 getLocation: () => [{ name: 'aws-location', dataStoreVersionId: null }],
             };
 

--- a/tests/unit/lifecycle/LifecycleUpdateTransitionTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleUpdateTransitionTask.spec.js
@@ -169,4 +169,47 @@ describe('LifecycleUpdateTransitionTask', () => {
             done();
         });
     });
+
+    // pull replication actions are published by the queue populator,
+    // which only knows the object owner's canonical id
+    describe('account id resolution', () => {
+        it('should not look up the account id when the entry has one', done => {
+            actionEntry.setAttribute('target.accountId', '000000000042');
+            actionEntry.setAttribute('target.owner', 'some-canonical-id');
+            task.processActionEntry(actionEntry, err => {
+                assert.ifError(err);
+                assert.strictEqual(objectProcessor.accountIdLookups, 0);
+                done();
+            });
+        });
+
+        it('should resolve the account id from the owner canonical id', done => {
+            objectProcessor.setAccountId('some-canonical-id', '000000000042');
+            actionEntry.setAttribute('target.owner', 'some-canonical-id');
+            task.processActionEntry(actionEntry, err => {
+                assert.ifError(err);
+                assert.strictEqual(objectProcessor.accountIdLookups, 1);
+                assert.strictEqual(
+                    actionEntry.getAttribute('target.accountId'),
+                    '000000000042');
+                // the garbage collection entry must not resolve it again
+                const receivedGcEntry = gcProducer.getReceivedEntry();
+                assert.strictEqual(
+                    receivedGcEntry.getAttribute('target.accountId'),
+                    '000000000042');
+                done();
+            });
+        });
+
+        it('should fail the entry when the account id cannot be resolved',
+        done => {
+            actionEntry.setAttribute('target.owner', 'unknown-canonical-id');
+            task.processActionEntry(actionEntry, err => {
+                assert(err);
+                assert.strictEqual(
+                    backbeatMetadataProxyClient.getReceivedMd(), null);
+                done();
+            });
+        });
+    });
 });

--- a/tests/unit/mocks.js
+++ b/tests/unit/mocks.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { errors } = require('arsenal');
 const { ObjectMD } = require('arsenal').models;
 
 class GarbageCollectorProducerMock {
@@ -157,6 +158,21 @@ class ProcessorMock {
         this.coldProducer = coldProducer;
         this._gcConfig = gcConfig;
         this.logger = logger;
+        this.accountIds = {};
+        this.accountIdLookups = 0;
+    }
+
+    setAccountId(ownerId, accountId) {
+        this.accountIds[ownerId] = accountId;
+    }
+
+    getAccountId(ownerId, log, cb) {
+        this.accountIdLookups += 1;
+        const accountId = this.accountIds[ownerId];
+        if (!accountId) {
+            return process.nextTick(cb, errors.NoSuchEntity);
+        }
+        return process.nextTick(cb, null, accountId);
     }
 
     getStateVars() {
@@ -170,6 +186,7 @@ class ProcessorMock {
             getBackbeatClient: () => this.backbeatClient,
             getBackbeatMetadataProxy: () => this.backbeatMetadataProxy,
             getS3Client: () => this.s3Client,
+            getAccountId: this.getAccountId.bind(this),
         };
     }
 }

--- a/tests/unit/replication/ReplicationQueuePopulator.spec.js
+++ b/tests/unit/replication/ReplicationQueuePopulator.spec.js
@@ -6,6 +6,7 @@ const { encode } = require('arsenal').versioning.VersionID;
 const ReplicationQueuePopulator =
     require('../../../extensions/replication/ReplicationQueuePopulator');
 const ReplicationAPI = require('../../../extensions/replication/ReplicationAPI');
+const ReplicationMetrics = require('../../../extensions/replication/ReplicationMetrics');
 const { LifecycleMetrics } =
     require('../../../extensions/lifecycle/LifecycleMetrics');
 const config = require('../../../lib/Config');
@@ -240,14 +241,15 @@ describe('replication queue populator', () => {
 
         rqp._filterKeyOp(entry);
 
+        const expectedLabels = { ...labels, direction: 'push' };
         sinon.assert.calledOnceWithExactly(
             params.metricsHandler.bytes,
-            labels,
+            expectedLabels,
             128
         );
         sinon.assert.calledOnceWithExactly(
             params.metricsHandler.objects,
-            labels
+            expectedLabels
         );
     });
 
@@ -419,6 +421,7 @@ describe('replication queue populator: pull replication', () => {
     let params;
     let rqp;
     let triggeredMetric;
+    let queuedMetric;
 
     function makeValue(overrides = {}) {
         return JSON.stringify({
@@ -462,6 +465,7 @@ describe('replication queue populator: pull replication', () => {
         };
         rqp = new RecordingQueuePopulatorMock(params);
         triggeredMetric = sinon.stub(LifecycleMetrics, 'onLifecycleTriggered');
+        queuedMetric = sinon.stub(ReplicationMetrics, 'onReplicationQueued');
     });
 
     afterEach(() => {
@@ -510,7 +514,29 @@ describe('replication queue populator: pull replication', () => {
         sinon.assert.calledOnceWithExactly(triggeredMetric, rqp.log,
             'queuePopulator', 'pullReplication', TARGET_LOCATION,
             sinon.match.number);
-        sinon.assert.notCalled(params.metricsHandler.objects);
+    });
+
+    it('should count the object on the populator metrics as pulled', () => {
+        rqp._filterKeyOp(makeEntry(makeValue()));
+
+        const expectedLabels = { ...labels, direction: 'pull' };
+        sinon.assert.calledOnceWithExactly(params.metricsHandler.objects,
+            expectedLabels);
+        sinon.assert.calledOnceWithExactly(params.metricsHandler.bytes,
+            expectedLabels, 128);
+    });
+
+    it('should report the object as queued for pull replication', () => {
+        rqp._filterKeyOp(makeEntry(makeValue()));
+
+        sinon.assert.calledOnceWithExactly(queuedMetric, 'pullReplication',
+            CRR_LOCATION, TARGET_LOCATION, 128);
+    });
+
+    it('should not report an object it skipped as queued', () => {
+        rqp._filterKeyOp(makeEntry(makeValue({ isDeleteMarker: true })));
+
+        sinon.assert.notCalled(queuedMetric);
     });
 
     // pull replication is about where the data lives, forward replication is

--- a/tests/unit/replication/ReplicationQueuePopulator.spec.js
+++ b/tests/unit/replication/ReplicationQueuePopulator.spec.js
@@ -1,8 +1,14 @@
 const assert = require('assert');
 const sinon = require('sinon');
 
+const { encode } = require('arsenal').versioning.VersionID;
+
 const ReplicationQueuePopulator =
     require('../../../extensions/replication/ReplicationQueuePopulator');
+const ReplicationAPI = require('../../../extensions/replication/ReplicationAPI');
+const { LifecycleMetrics } =
+    require('../../../extensions/lifecycle/LifecycleMetrics');
+const config = require('../../../lib/Config');
 
 const fakeLogger = require('../../utils/fakeLogger');
 
@@ -380,5 +386,372 @@ describe('replication queue populator', () => {
 
         assert.doesNotThrow(() => rqp._filterKeyOp(entry));
         assert.deepStrictEqual(rqp.getState(), {});
+    });
+});
+
+/**
+ * Records every published message, whatever the topic, so pull replication
+ * entries (data mover topic) can be inspected.
+ * @class
+ */
+class RecordingQueuePopulatorMock extends ReplicationQueuePopulator {
+    constructor(params) {
+        super(params);
+
+        this.published = [];
+    }
+
+    publish(topic, key, message) {
+        this.published.push({ topic, key, message });
+    }
+}
+
+describe('replication queue populator: pull replication', () => {
+    const CRR_LOCATION = 'location-crr-source';
+    // location named in the object metadata by the rewrite pipeline
+    const TARGET_LOCATION = 'us-east-2';
+    // default local location: used when the target is unusable
+    const LOCAL_LOCATION = 'us-east-1';
+    const RESULTS_TOPIC = config.extensions.lifecycle.transitionTasksTopic;
+    const VERSION_ID = '98477724999464999999RG001  1.30.12';
+    const VERSIONED_KEY = `a-test-key\u0000${VERSION_ID}`;
+
+    let params;
+    let rqp;
+    let triggeredMetric;
+
+    function makeValue(overrides = {}) {
+        return JSON.stringify({
+            ...kafkaValue,
+            dataStoreName: CRR_LOCATION,
+            location: [{
+                key: 'some-data-key',
+                size: 128,
+                start: 0,
+                dataStoreName: CRR_LOCATION,
+                dataStoreETag: '1:d41d8cd98f00b204e9800118ecf8427e',
+                bucket: 'test-bucket-source',
+                role: 'arn:aws:iam::123456789012:role/source-read',
+                targetLocation: TARGET_LOCATION,
+            }],
+            ...overrides,
+        });
+    }
+
+    function makeEntry(value, key = VERSIONED_KEY) {
+        return {
+            type: 'put',
+            bucket: 'test-bucket-source',
+            key,
+            value,
+            overheadFields: { commitTimestamp: '2024-05-06T10:11:12.000Z' },
+            logReader: { getMetricLabels: stubMetricLabels() },
+        };
+    }
+
+    beforeEach(() => {
+        params = {
+            config: {
+                topic: TOPIC,
+            },
+            logger: fakeLogger,
+            metricsHandler: {
+                bytes: sinon.spy(),
+                objects: sinon.spy(),
+            },
+        };
+        rqp = new RecordingQueuePopulatorMock(params);
+        triggeredMetric = sinon.stub(LifecycleMetrics, 'onLifecycleTriggered');
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('should publish a copyLocation action for an object still on the source', () => {
+        rqp._filterKeyOp(makeEntry(makeValue()));
+
+        assert.strictEqual(rqp.published.length, 1);
+        const [{ topic, key, message }] = rqp.published;
+        assert.strictEqual(topic, ReplicationAPI.getDataMoverTopic());
+        assert.strictEqual(key, 'test-bucket-source/a-test-key');
+
+        const action = JSON.parse(message);
+        assert.strictEqual(action.action, 'copyLocation');
+        assert.strictEqual(action.toLocation, TARGET_LOCATION);
+        assert.strictEqual(action.resultsTopic, RESULTS_TOPIC);
+        assert.strictEqual(action.contextInfo.ruleType, 'transition');
+        assert.strictEqual(action.contextInfo.origin, 'pullReplication');
+        assert.strictEqual(action.metrics.origin, 'pullReplication');
+        assert.deepStrictEqual(action.target, {
+            owner: kafkaValue['owner-id'],
+            bucket: 'test-bucket-source',
+            key: 'a-test-key',
+            version: encode(VERSION_ID),
+            eTag: `"${kafkaValue['content-md5']}"`,
+            lastModified: kafkaValue['last-modified'],
+        });
+        // resolved by the transition processor, not by the populator
+        assert.strictEqual(action.target.accountId, undefined);
+        assert.deepStrictEqual(action.source, {
+            bucket: 'test-bucket-source',
+            objectKey: 'a-test-key',
+            storageClass: CRR_LOCATION,
+        });
+        assert.strictEqual(action.metrics.fromLocation, CRR_LOCATION);
+        assert.strictEqual(action.metrics.contentLength, 128);
+        assert.strictEqual(action.metrics.transitionTime,
+            '2024-05-06T10:11:12.000Z');
+    });
+
+    it('should report the transition as triggered', () => {
+        rqp._filterKeyOp(makeEntry(makeValue()));
+
+        sinon.assert.calledOnceWithExactly(triggeredMetric, rqp.log,
+            'queuePopulator', 'pullReplication', TARGET_LOCATION,
+            sinon.match.number);
+        sinon.assert.notCalled(params.metricsHandler.objects);
+    });
+
+    // pull replication is about where the data lives, forward replication is
+    // about where it has been copied to: the two are independent.
+    ['PENDING', 'COMPLETED', 'FAILED'].forEach(status => {
+        it(`should publish regardless of replication status ${status}`, () => {
+            const value = makeValue({
+                replicationInfo: { ...repInfo, status },
+            });
+            rqp._filterKeyOp(makeEntry(value));
+
+            assert.strictEqual(rqp.published.length, 1);
+        });
+    });
+
+    it('should publish when there is no replication configured', () => {
+        const value = makeValue({ replicationInfo: null });
+        rqp._filterKeyOp(makeEntry(value));
+
+        assert.strictEqual(rqp.published.length, 1);
+    });
+
+    it('should propagate the transition attempt count', () => {
+        const value = makeValue({
+            'x-amz-meta-scal-s3-transition-attempt': '3',
+        });
+        rqp._filterKeyOp(makeEntry(value));
+
+        assert.strictEqual(rqp.published.length, 1);
+        const action = JSON.parse(rqp.published[0].message);
+        assert.strictEqual(action.target.attempt, 3);
+    });
+
+    it('should not set an attempt count for a first copy', () => {
+        rqp._filterKeyOp(makeEntry(makeValue()));
+
+        const action = JSON.parse(rqp.published[0].message);
+        assert.strictEqual(action.target.attempt, undefined);
+    });
+
+    it('should skip master keys', () => {
+        rqp._filterKeyOp(makeEntry(makeValue(), 'a-test-key'));
+
+        assert.strictEqual(rqp.published.length, 0);
+    });
+
+    // A null version is the only entry for the object, so nothing else would
+    // ever pull it. Both shapes are reached with the 'null' version id.
+    [
+        ['a standalone null master', { versionId: undefined }],
+        ['a suspended null version', { isNull: true }],
+    ].forEach(([desc, overrides]) => {
+        it(`should pull ${desc}`, () => {
+            const value = makeValue(overrides);
+            rqp._filterKeyOp(makeEntry(value, 'a-test-key'));
+
+            assert.strictEqual(rqp.published.length, 1);
+            assert.strictEqual(rqp.published[0].topic, ReplicationAPI.getDataMoverTopic());
+            const action = JSON.parse(rqp.published[0].message);
+            assert.strictEqual(action.target.version, 'null');
+        });
+    });
+
+    it('should skip delete markers', () => {
+        const value = makeValue({ isDeleteMarker: true, location: null });
+        rqp._filterKeyOp(makeEntry(value));
+
+        assert.strictEqual(rqp.published.length, 0);
+    });
+
+    // an object to localize should carry a location, whatever its size
+    it('should pull empty objects, and report the missing location', () => {
+        const warnSpy = sinon.spy(rqp.log, 'warn');
+        const value = makeValue({
+            'location': null,
+            'content-length': 0,
+        });
+        rqp._filterKeyOp(makeEntry(value));
+
+        assert.strictEqual(rqp.published.length, 1);
+        assert.strictEqual(rqp.published[0].topic, ReplicationAPI.getDataMoverTopic());
+        const action = JSON.parse(rqp.published[0].message);
+        assert.strictEqual(action.toLocation, LOCAL_LOCATION);
+        assert.strictEqual(action.metrics.contentLength, 0);
+        sinon.assert.calledOnce(warnSpy);
+    });
+
+    it('should skip and report non-empty objects without location', () => {
+        const errorSpy = sinon.spy(rqp.log, 'error');
+        const value = makeValue({ location: null });
+        rqp._filterKeyOp(makeEntry(value));
+
+        assert.strictEqual(rqp.published.length, 0);
+        sinon.assert.calledOnce(errorSpy);
+    });
+
+    // partial oplog projections (change stream `update` events) may not carry
+    // the location: they cannot be pulled, and behave as before.
+    it('should not pull entries with no dataStoreName', () => {
+        const value = makeValue({ dataStoreName: undefined });
+        rqp._filterKeyOp(makeEntry(value));
+
+        sinon.assert.notCalled(triggeredMetric);
+        assert.strictEqual(
+            rqp.published.filter(
+                p => p.topic === ReplicationAPI.getDataMoverTopic()).length,
+            0);
+    });
+
+    it('should not pull objects on a regular location', () => {
+        const value = makeValue({ dataStoreName: LOCAL_LOCATION });
+        rqp._filterKeyOp(makeEntry(value));
+
+        assert.strictEqual(rqp.published.length, 1);
+        assert.strictEqual(rqp.published[0].topic, TOPIC);
+        sinon.assert.notCalled(triggeredMetric);
+    });
+
+    it('should not pull anything when lifecycle is not configured', () => {
+        sinon.replace(config, 'extensions', {
+            ...config.extensions,
+            lifecycle: undefined,
+        });
+        const populator = new RecordingQueuePopulatorMock(params);
+
+        populator._filterKeyOp(makeEntry(makeValue()));
+
+        assert.strictEqual(
+            populator.published.filter(
+                p => p.topic === ReplicationAPI.getDataMoverTopic()).length,
+            0);
+        sinon.assert.notCalled(triggeredMetric);
+    });
+
+    // the target may have been deleted since the metadata was written, and
+    // objects written before the pipeline named one carry no target at all
+    [
+        ['an unknown target', 'a-deleted-location'],
+        ['no target', undefined],
+    ].forEach(([desc, targetLocation]) => {
+        it(`should pull to the default location with ${desc}`, () => {
+            const warnSpy = sinon.spy(rqp.log, 'warn');
+            const value = makeValue({
+                location: [{
+                    key: 'some-data-key',
+                    size: 128,
+                    start: 0,
+                    dataStoreName: CRR_LOCATION,
+                    dataStoreETag: '1:d41d8cd98f00b204e9800118ecf8427e',
+                    targetLocation,
+                }],
+            });
+            rqp._filterKeyOp(makeEntry(value));
+
+            assert.strictEqual(rqp.published.length, 1);
+            const action = JSON.parse(rqp.published[0].message);
+            assert.strictEqual(action.toLocation, LOCAL_LOCATION);
+            sinon.assert.calledOnce(warnSpy);
+        });
+    });
+
+    it('should not pull anywhere when the config has no local location', () => {
+        // no location in the config can hold a local copy of the data
+        rqp.defaultLocalLocation = undefined;
+        const value = makeValue({
+            location: [{
+                key: 'some-data-key',
+                size: 128,
+                start: 0,
+                dataStoreName: CRR_LOCATION,
+                dataStoreETag: '1:d41d8cd98f00b204e9800118ecf8427e',
+                targetLocation: 'a-deleted-location',
+            }],
+        });
+        rqp._filterKeyOp(makeEntry(value));
+
+        assert.strictEqual(rqp.published.length, 0);
+        sinon.assert.notCalled(triggeredMetric);
+        sinon.assert.notCalled(queuedMetric);
+        sinon.assert.notCalled(params.metricsHandler.objects);
+    });
+
+    it('should skip pull replication when there is no local location', () => {
+        sinon.stub(rqp, '_getPullReplicationTarget').returns(undefined);
+        rqp._filterKeyOp(makeEntry(makeValue()));
+
+        assert.strictEqual(rqp.published.length, 0);
+        sinon.assert.notCalled(triggeredMetric);
+    });
+});
+
+describe('replication queue populator: default local location', () => {
+    // the populator module holds this very object
+    const locationsConfig = require('../../../conf/locationConfig.json');
+
+    function defaultLocalLocation() {
+        return new ReplicationQueuePopulator({
+            config: { topic: TOPIC },
+            logger: fakeLogger,
+        }).defaultLocalLocation;
+    }
+
+    afterEach(() => sinon.restore());
+
+    it('should pick us-east-1 from the shipped configuration', () => {
+        assert.strictEqual(defaultLocalLocation(), 'us-east-1');
+    });
+
+    it('should prefer us-east-1 over the other usable locations', () => {
+        sinon.stub(locationsConfig, 'wontwork-location').value({ type: 'file' });
+
+        assert.strictEqual(defaultLocalLocation(), 'us-east-1');
+    });
+
+    it('should pick the first usable location when us-east-1 is not defined', () => {
+        sinon.stub(locationsConfig, 'us-east-1').value(undefined);
+        sinon.stub(locationsConfig, 'us-east-2').value({ type: 'file' });
+        sinon.stub(locationsConfig, 'wontwork-location').value({ type: 'file' });
+
+        assert.strictEqual(defaultLocalLocation(), 'us-east-2');
+    });
+
+    [
+        ['cold', { type: 'tlp', isCold: true }],
+        ['CRR', { type: 'scality', isCRR: true }],
+        ['transient', { type: 'file', isTransient: true }],
+        ['an external backend', { type: 'aws_s3' }],
+    ].forEach(([desc, details]) => {
+        it(`should not pick a location which is ${desc}`, () => {
+            sinon.stub(locationsConfig, 'us-east-1').value(details);
+            sinon.stub(locationsConfig, 'us-east-2').value({ type: 'file' });
+
+            assert.strictEqual(defaultLocalLocation(), 'us-east-2');
+        });
+    });
+
+    // other specs add locations to the shared configuration, so rule them all out
+    it('should find no location when none can hold a local copy', () => {
+        Object.keys(locationsConfig).forEach(
+            name => sinon.stub(locationsConfig, name).value({ type: 'aws_s3' }));
+
+        assert.strictEqual(defaultLocalLocation(), undefined);
     });
 });


### PR DESCRIPTION
Objects are created locally but their metadata still points at the source cluster: the data itself has not been copied over yet. Something has to notice them and ask for it to be pulled in.

The queue populator is the natural place for that, since bootstrap, re-bootstrap and streamed updates all go through the same oplog. When an object lands on a location flagged `isCRR`, publish a `copyLocation` action and let the existing data mover/transition workflow do the actual copy. No activation switch: the flag on the location is the trigger. It is skipped without lifecycle -S3C runs replication without it- as there would be nothing to merge the copy into the object metadata.

This is unrelated to `replicationInfo`, which tracks replication of a *local* object to remote sites, hence the check before any of its conditions.

The destination comes from the object metadata, where the source-side rewrite stamps it next to the bucket and role the copy already needs. If it names a location we do not know, we fall back to the first local one and print a : copying the data elsewhere beats leaving it on the source forever.

The populator only knows the object owner's canonical id, and a Vault lookup per entry would throttle it, so the account id is resolved by the transition processor instead, once per action and only when missing.

Pull replication reuses the transition pipeline, but remains a separate workflow to report on and to troubleshoot, so it gets its own metrics type. It is also counted as queued on the replication metrics: without it a growing backlog would be indistinguishable from an idle cluster.

### Along the way

- the transition attempt metadata key was open-coded in five places across lifecycle and gc, one of which would throw on user metadata that does not parse
- `BACKBEAT_QUEUEPOPULATOR_EXTENSIONS` was applied by dropping the other extensions from the configuration, so anything reading their settings got nothing in the populator processes

Issue: BB-814