### PR TITLE
Skip non-localized entries in replication and lifecycle

### DIFF
--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -34,6 +34,8 @@ const errorTransitionColdObject = errors.InternalError.
     customizeDescription('transitioning a cold object is forbidden');
 const errorTransitionDeclaredColdObject = errors.InternalError.
     customizeDescription('transitioning an object declared as cold is forbidden');
+const errorTransitionObjectOnSource = errors.InternalError.
+    customizeDescription('transitioning an object still on the source location is forbidden');
 const errorObjectTemporarilyRestored = errors.InternalError.
     customizeDescription('object temporarily restored');
 const errorReplicationInProgress = errors.InternalError.
@@ -1265,16 +1267,20 @@ class LifecycleTask extends BackbeatTask {
                     return next(errorReplicationInProgress);
                 }
                 const dataStoreName = objectMD.getDataStoreName();
-                const isObjectCold = dataStoreName && locationsConfig[dataStoreName]
-                    && locationsConfig[dataStoreName].isCold;
+                const locationConfig = (dataStoreName && locationsConfig[dataStoreName]) || {};
                 // We do not transition cold objects
-                if (isObjectCold) {
+                if (locationConfig.isCold) {
                     return next(errorTransitionColdObject);
                 }
                 // Skip direct-to-cold objects, whose transition is triggered by the queue
                 // populator and require the transition in progress flag to be set
                 if (locationsConfig[objectMD.getAmzStorageClass()]?.isCold) {
                     return next(errorTransitionDeclaredColdObject);
+                }
+                // Data still on the source location: data has not been pulled yet, so cannot
+                // transition at this point.
+                if (locationConfig.isCRR) {
+                    return next(errorTransitionObjectOnSource);
                 }
                 // If transition is in progress, do not re-publish entry
                 // to data-mover or cold-archive topic.

--- a/tests/unit/lifecycle/LifecycleTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleTask.spec.js
@@ -11,8 +11,8 @@ const LifecycleTask = require(
 const LifecycleTaskV2 = require(
     '../../../extensions/lifecycle/tasks/LifecycleTaskV2');
 const ActionQueueEntry = require('../../../lib/models/ActionQueueEntry');
-const { LifecycleMetrics } = require('../../../extensions/lifecycle/LifecycleMetrics');
 const ReplicationAPI = require('../../../extensions/replication/ReplicationAPI');
+const { LifecycleMetrics } = require('../../../extensions/lifecycle/LifecycleMetrics');
 const fakeLogger = require('../../utils/fakeLogger');
 const { withActiveSpan } = require('../../utils/withActiveSpan');
 const { timeOptions } = require('../../functional/lifecycle/configObjects');
@@ -2475,61 +2475,99 @@ describe('lifecycle task helper methods', () => {
     });
 
     describe('_applyTransitionRule', () => {
+        const CRR_LOCATION = 'location-crr-source';
         const testParams = {
             bucket: 'test-bucket',
             owner: 'test-owner',
             objectKey: 'test-key',
-            site: 'us-east-2',
+            versionId: 'test-version-id',
+            eTag: '"test-etag"',
+            lastModified: '2023-01-01T00:00:00.000Z',
+            site: 'test-site',
+            accountId: 'test-account-id',
             transitionTime: Date.now(),
+            bucketData: {
+                target: {
+                    bucket: 'test-bucket',
+                    owner: 'test-owner',
+                    accountId: 'test-account-id',
+                },
+            },
         };
 
         let lifecycleTask;
+        let objectMD;
+        let sendDataMoverAction;
+        let putObjectMD;
+
+        function setupObjectMD(overrides) {
+            objectMD = Object.assign({
+                getReplicationStatus: () => 'COMPLETED',
+                getDataStoreName: () => 'us-east-1',
+                getAmzStorageClass: () => 'us-east-1',
+                getDataStoreVersionId: () => 'version-123',
+                getTransitionInProgress: () => false,
+                getArchive: () => undefined,
+                getContentLength: () => 1024,
+                getUserMetadata: () => null,
+                getValue: () => ({}),
+                setTransitionInProgress: sinon.spy(),
+                setOriginOp: sinon.spy(),
+                getSerialized: () => '{}',
+            }, overrides);
+            sinon.stub(lifecycleTask, '_getObjectMD')
+                .callsFake((params, log, cb) => cb(null, objectMD));
+        }
 
         beforeEach(() => {
             lifecycleTask = new LifecycleTask(lp);
             lifecycleTask.pausedLocations = new Set();
             lifecycleTask.circuitBreakers = { tripped: () => false };
+            lifecycleTask.producer = {};
+            lifecycleTask.transitionTasksTopic = 'test-transition-topic';
+            sendDataMoverAction = sinon.stub(
+                ReplicationAPI, 'sendDataMoverAction')
+                .callsFake((producer, entry, log, cb) => cb());
+            putObjectMD = sinon.stub(lifecycleTask, '_putObjectMD')
+                .callsFake((params, log, cb) => cb());
         });
-
-        afterEach(() => {
-            sinon.restore();
-        });
-
-        function stubObjectMD(overrides) {
-            const objectMD = Object.assign({
-                getReplicationStatus: () => 'COMPLETED',
-                getDataStoreName: () => 'us-east-1',
-                getAmzStorageClass: () => 'us-east-1',
-                getTransitionInProgress: () => false,
-                getArchive: () => undefined,
-                setTransitionInProgress: () => {},
-                setOriginOp: () => {},
-                getSerialized: () => '{}',
-            }, overrides);
-            sinon.stub(lifecycleTask, '_getObjectMD').yields(null, objectMD);
-        }
 
         it('should not transition an object declared as cold', done => {
-            stubObjectMD({ getAmzStorageClass: () => 'location-dmf-v1' });
+            setupObjectMD({ getAmzStorageClass: () => 'location-dmf-v1' });
             const getEntryStub = sinon.stub(lifecycleTask, '_getTransitionActionEntry');
 
             lifecycleTask._applyTransitionRule(testParams, fakeLogger, err => {
                 assert.strictEqual(err.description,
                     'transitioning an object declared as cold is forbidden');
-                assert(!getEntryStub.called);
+                sinon.assert.notCalled(getEntryStub);
+                sinon.assert.notCalled(sendDataMoverAction);
+                sinon.assert.notCalled(putObjectMD);
                 done();
             });
         });
 
-        it('should transition an object with a hot storage class', done => {
-            stubObjectMD();
-            const getEntryStub = sinon.stub(lifecycleTask, '_getTransitionActionEntry').yields(null, {});
-            sinon.stub(ReplicationAPI, 'sendDataMoverAction').yields();
-            sinon.stub(lifecycleTask, '_putObjectMD').yields();
+        it('should not transition an object still on the source location',
+        done => {
+            setupObjectMD({ getDataStoreName: () => CRR_LOCATION });
+
+            lifecycleTask._applyTransitionRule(testParams, fakeLogger, err => {
+                assert.strictEqual(err.description,
+                    'transitioning an object still on the source location is forbidden');
+                sinon.assert.notCalled(sendDataMoverAction);
+                sinon.assert.notCalled(objectMD.setTransitionInProgress);
+                sinon.assert.notCalled(putObjectMD);
+                done();
+            });
+        });
+
+        it('should transition an object on a regular location', done => {
+            setupObjectMD();
 
             lifecycleTask._applyTransitionRule(testParams, fakeLogger, err => {
                 assert.ifError(err);
-                assert(getEntryStub.calledOnce);
+                sinon.assert.calledOnce(sendDataMoverAction);
+                sinon.assert.calledOnce(objectMD.setTransitionInProgress);
+                sinon.assert.calledOnce(putObjectMD);
                 done();
             });
         });


### PR DESCRIPTION
In a clean room, an object's metadata is local but its data still lives on the source cluster: `dataStoreName` points at an `isCRR` location. Such a version has nothing local to offer, so the existing workflows must leave it alone until localization has rewritten the metadata.

BB-814 already diverted those entries in the replication populator to localization, but only when localization was configured. Otherwise they fell through and got replicated, which would copy a location the target cannot read. They are now skipped in both cases. Nothing is lost: the localization merge produces a new oplog entry with the real location, and replication picks it up then.

Lifecycle transitions get the same treatment. Localization is the only valid transition out of an `isCRR` location and it is driven by its own path, not by lifecycle rules, so a transition rule matching such a version is skipped and the version re-evaluated on a later scan.

`LifecycleTaskV2` only calls `_applyTransitionRule`, it does not override it, so the single check covers both tasks.

Tested with the replication and lifecycle unit suites; the populator specs cover the disabled-localization and `PENDING` cases, and the new `_applyTransitionRule` specs assert no data-mover action and no `transitionInProgress` for an `isCRR` object, with a regular location as positive control.

Issue: BB-816