### PR TITLE
Add a D/R mode to the mongo-processor

### DIFF
--- a/extensions/mongoProcessor/MongoProcessorConfigValidator.js
+++ b/extensions/mongoProcessor/MongoProcessorConfigValidator.js
@@ -1,5 +1,6 @@
 const joi = require('joi');
-const { retryParamsJoi, probeServerJoi, logJoiOptional } = require('../../lib/config/configItems.joi');
+const { retryParamsJoi, probeServerJoi, logJoiOptional, mongoJoi } =
+    require('../../lib/config/configItems.joi');
 const { extensionConfigValidator } = require('../../lib/config/extensionConfigValidator');
 
 const { MAX_QUEUED_DEFAULT }  = require('../../lib/constants').backbeatConsumer;
@@ -7,6 +8,7 @@ const { MAX_QUEUED_DEFAULT }  = require('../../lib/constants').backbeatConsumer;
 const joiSchema = joi.object({
     topic: joi.string().required(),
     groupId: joi.string().required(),
+    mongodb: mongoJoi,
     retry: retryParamsJoi,
     concurrency: joi.number().greater(0).default(1),
     maxQueued: joi.number().greater(0).default(MAX_QUEUED_DEFAULT),

--- a/extensions/mongoProcessor/MongoProcessorConfigValidator.js
+++ b/extensions/mongoProcessor/MongoProcessorConfigValidator.js
@@ -1,6 +1,6 @@
 const joi = require('joi');
 const { modes, defaultMode } = require('./modes');
-const { retryParamsJoi, probeServerJoi, logJoiOptional, mongoJoi } =
+const { authJoi, retryParamsJoi, probeServerJoi, logJoiOptional, mongoJoi } =
     require('../../lib/config/configItems.joi');
 const { extensionConfigValidator } = require('../../lib/config/extensionConfigValidator');
 
@@ -10,7 +10,8 @@ const joiSchema = joi.object({
     topic: joi.string().required(),
     groupId: joi.string().required(),
     mode: joi.string().valid(...Object.keys(modes)).default(defaultMode),
-    mongodb: mongoJoi,
+    mongodb: mongoJoi.when('mode', { is: 'dr', then: joi.required() }),
+    auth: authJoi.when('mode', { is: 'dr', then: joi.required() }),
     retry: retryParamsJoi,
     concurrency: joi.number().greater(0).default(1),
     maxQueued: joi.number().greater(0).default(MAX_QUEUED_DEFAULT),

--- a/extensions/mongoProcessor/MongoProcessorConfigValidator.js
+++ b/extensions/mongoProcessor/MongoProcessorConfigValidator.js
@@ -1,4 +1,5 @@
 const joi = require('joi');
+const { modes, defaultMode } = require('./modes');
 const { retryParamsJoi, probeServerJoi, logJoiOptional, mongoJoi } =
     require('../../lib/config/configItems.joi');
 const { extensionConfigValidator } = require('../../lib/config/extensionConfigValidator');
@@ -8,6 +9,7 @@ const { MAX_QUEUED_DEFAULT }  = require('../../lib/constants').backbeatConsumer;
 const joiSchema = joi.object({
     topic: joi.string().required(),
     groupId: joi.string().required(),
+    mode: joi.string().valid(...Object.keys(modes)).default(defaultMode),
     mongodb: mongoJoi,
     retry: retryParamsJoi,
     concurrency: joi.number().greater(0).default(1),

--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -4,11 +4,10 @@ const async = require('async');
 
 const Logger = require('werelogs').Logger;
 const errors = require('arsenal').errors;
-const { replicationBackends, emptyFileMd5 } = require('arsenal').constants;
+const { replicationBackends } = require('arsenal').constants;
 const MongoClient = require('arsenal').storage
     .metadata.mongoclient.MongoClientInterface;
 const { ObjectMD, ReplicationConfiguration } = require('arsenal').models;
-const { VersionID } = require('arsenal').versioning;
 const { extractVersionId } = require('../../lib/util/versioning');
 
 const Config = require('../../lib/Config');
@@ -19,7 +18,7 @@ const ObjectQueueEntry = require('../../lib/models/ObjectQueueEntry');
 const MetricsProducer = require('../../lib/MetricsProducer');
 const { metricsExtension, metricsTypeCompleted, metricsTypePendingOnly } =
     require('../ingestion/constants');
-const getContentType = require('./utils/contentTypeHelper');
+const { modes, defaultMode } = require('./modes');
 const BucketMemState = require('./utils/BucketMemState');
 const MongoProcessorMetrics = require('./MongoProcessorMetrics');
 
@@ -76,6 +75,8 @@ class MongoQueueProcessor {
         this._bootstrapList = null;
         this.logger = new Logger('Backbeat:Ingestion:MongoProcessor');
         this.mongoClientConfig.logger = this.logger;
+        this._mode =
+            new modes[mongoProcessorConfig.mode ?? defaultMode]();
         this._mongoClient = new MongoClient(this.mongoClientConfig);
         this._bucketMemState = new BucketMemState(Config);
 
@@ -252,78 +253,6 @@ class MongoQueueProcessor {
     }
 
     /**
-     * Update ingested entry metadata fields: owner-id, owner-display-name
-     * @param {ObjectQueueEntry} entry - object queue entry object
-     * @param {BucketInfo} bucketInfo - bucket info object
-     * @return {undefined}
-     */
-    _updateOwnerMD(entry, bucketInfo) {
-        // zenko bucket owner information is being set on ingested md
-        entry.setOwnerDisplayName(bucketInfo.getOwnerDisplayName());
-        entry.setOwnerId(bucketInfo.getOwner());
-    }
-
-    /**
-     * Update ingested entry metadata fields: dataStoreName
-     * @param {ObjectQueueEntry} entry - object queue entry object
-     * @param {string} location - owner details
-     * @return {undefined}
-     */
-    _updateObjectDataStoreName(entry, location) {
-        entry.setDataStoreName(location);
-    }
-
-    /**
-     * Update ingested entry metadata location field. Each location change
-     * includes: key, dataStoreName, dataStoreType, dataStoreVersionId
-     * @param {ObjectQueueEntry} entry - object queue entry object
-     * @param {string} zenkoLocation - zenko storage location name
-     * @return {undefined}
-     */
-    _updateLocations(entry, zenkoLocation) {
-        const locations = entry.getLocation();
-        // if version id is undefined, we have a single null object.
-        // To hold reference to this null object, we need to encode "null"
-        // as its dataStoreVersionId
-        const dataStoreVersionId = entry.getVersionId() ?
-            entry.getEncodedVersionId() : 'null';
-        let zenkoDataLocations;
-        if (!locations || locations.length === 0) {
-            zenkoDataLocations = [{
-                key: entry.getObjectKey(),
-                size: 0,
-                start: 0,
-                dataStoreName: zenkoLocation,
-                dataStoreType: 'aws_s3',
-                dataStoreETag: `1:${emptyFileMd5}`,
-                dataStoreVersionId,
-            }];
-        } else {
-            zenkoDataLocations = [{
-                key: entry.getObjectKey(),
-                size: entry.getContentLength(),
-                start: 0,
-                dataStoreName: zenkoLocation,
-                dataStoreType: 'aws_s3',
-                dataStoreETag: `1:${entry.getContentMd5()}`,
-                dataStoreVersionId,
-            }];
-        }
-        entry.setLocation(zenkoDataLocations);
-    }
-
-    /**
-     * Update acl info on ingested object MD
-     * @param {ObjectQueueEntry} entry - object queue entry object
-     * @return {undefined}
-     */
-    _updateAcl(entry) {
-        // reset acl info
-        const objectMDModel = new ObjectMD();
-        entry.setAcl(objectMDModel.getAcl());
-    }
-
-    /**
      * Update replication info on ingested object MD to match Zenko defined
      * replication info.
      * @param {ObjectQueueEntry} entry - object queue entry object
@@ -382,29 +311,17 @@ class MongoQueueProcessor {
         const key = sourceEntry.getObjectKey();
         const entryVersionId = extractVersionId(sourceEntry.getObjectVersionedKey());
 
-        // Use x-amz-meta-scal-version-id if provided, instead of the actual versionId of the object.
-        // This should happen only for restored objects : in all other situations, both the source
-        // and ingested objects should have the same version id (and no x-amz-meta-scal-version-id
-        // metadata).
         const scalVersionId = sourceEntry.getOverheadField('x-amz-meta-scal-version-id');
-        const versionId = scalVersionId ? VersionID.decode(scalVersionId) : entryVersionId;
+        const versionId =
+            this._mode.resolveVersionId(scalVersionId, entryVersionId);
 
         this.logger.debug('processing object delete', { bucket, key, versionId });
 
         async.waterfall([
             cb => this._getZenkoObjectMetadata(log, sourceEntry, versionId, cb),
             (zenkoObjMd, cb) => {
-                // Skip if the object is in a different location, i.e. when the delete was caused
-                // by restored-object expiration or transition. It works because the dataStoreName
-                // is updated before actually sending the object to GC to effectively delete the
-                // data.
-                const encode = versionId => (versionId ? VersionID.encode(versionId) : 'null');
-                if (zenkoObjMd.dataStoreName !== location ||
-                    zenkoObjMd.location?.length !== 1 ||
-                    zenkoObjMd.location[0].dataStoreName !== location ||
-                    zenkoObjMd.location[0].key !== key ||
-                    (zenkoObjMd.location[0].dataStoreVersionId || 'null') !== encode(entryVersionId)
-                ) {
+                if (!this._mode.shouldProcessDelete(zenkoObjMd, location, key,
+                                                   entryVersionId)) {
                     log.end().info('ignore delete entry, transitioned to another location', {
                         entry: sourceEntry.getLogInfo(),
                         location,
@@ -482,19 +399,12 @@ class MongoQueueProcessor {
         this.logger.debug('processing object metadata', { bucket, key, scalVersionId });
 
         const maybeGetZenkoObjectMetadata = cb => {
-            // NOTE: ZenkoObjMD is used for updating replication info, as well as validating the
-            // `x-amz-meta-scal-version-id` header of restored objects. If the Zenko bucket does
-            // not have repInfo set and the header is not set, then we can skip fetching.
-            const bucketRepInfo = bucketInfo.getReplicationConfiguration();
-            if (!scalVersionId && !bucketRepInfo?.rules?.some(r => r.enabled)) {
+            if (!this._mode.needsExistingMetadata(sourceEntry, bucketInfo)) {
                 return cb();
             }
 
-            // Use x-amz-meta-scal-version-id if provided, instead of the actual versionId of the object.
-            // This should happen only for restored objects : in all other situations, both the source
-            // and ingested objects should have the same version id (and not x-amz-meta-scal-version-id
-            // metadata).
-            const versionId = scalVersionId ? VersionID.decode(scalVersionId) : sourceEntry.getVersionId();
+            const versionId = this._mode.resolveVersionId(scalVersionId,
+                sourceEntry.getVersionId());
             return this._getZenkoObjectMetadata(log, sourceEntry, versionId, cb);
         };
 
@@ -509,7 +419,8 @@ class MongoQueueProcessor {
                 return done(err);
             }
 
-            const content = getContentType(sourceEntry, zenkoObjMd);
+            const content =
+                this._mode.getChangedContent(sourceEntry, zenkoObjMd);
             if (content.length === 0) {
                 this._normalizePendingMetric(location);
                 log.end().debug('skipping duplicate entry', {
@@ -522,16 +433,10 @@ class MongoQueueProcessor {
             }
 
             if (zenkoObjMd) {
-                // Keep existing metadata fields, only need to update the tags
-                const tags = sourceEntry.getTags();
-                sourceEntry._data = { ...zenkoObjMd }; // eslint-disable-line no-param-reassign
-                sourceEntry.setTags(tags);
+                this._mode.mergeExistingMetadata(sourceEntry, zenkoObjMd);
             } else {
-                // Update necessary metadata fields before saving to Zenko MongoDB
-                this._updateOwnerMD(sourceEntry, bucketInfo);
-                this._updateObjectDataStoreName(sourceEntry, location);
-                this._updateLocations(sourceEntry, location);
-                this._updateAcl(sourceEntry);
+                this._mode.applyNewObjectMetadata(sourceEntry, location,
+                                                 bucketInfo);
             }
 
             // Try to update replication info, if applicable

--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -432,7 +432,8 @@ class MongoQueueProcessor {
                 return done();
             }
 
-            if (zenkoObjMd) {
+            if (zenkoObjMd &&
+                !this._mode.replacesExistingMetadata(sourceEntry, zenkoObjMd)) {
                 this._mode.mergeExistingMetadata(sourceEntry, zenkoObjMd);
             } else {
                 this._mode.applyNewObjectMetadata(sourceEntry, location,

--- a/extensions/mongoProcessor/modes/DRMode.js
+++ b/extensions/mongoProcessor/modes/DRMode.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const { ObjectMD } = require('arsenal').models;
+
+const locations = require('../../../lib/util/locations');
+const ProcessorMode = require('./ProcessorMode');
+const getContentType = require('../utils/contentTypeHelper');
+
+class DRMode extends ProcessorMode {
+    needsExistingMetadata(entry, bucketInfo) { // eslint-disable-line no-unused-vars
+        // always: only the stored document tells a first write from an update,
+        // and a source insert is redelivered on replay and overlaps the
+        // bootstrap dump
+        return true;
+    }
+
+    getChangedContent(entry, zenkoObjMd) {
+        // the shared diff only covers tags, while a replicated object can also
+        // change its object-lock state and, until localized, its placement
+        const content = getContentType(entry, zenkoObjMd);
+        if (!zenkoObjMd || content.length !== 0) {
+            return content;
+        }
+
+        return this._hasMutableChange(entry, zenkoObjMd) ? ['METADATA'] : [];
+    }
+
+    /**
+     * @param {ObjectQueueEntry} entry - object queue entry object
+     * @param {Object} zenkoObjMd - metadata fetched from mongo
+     * @return {boolean} true if the entry changes mutable metadata
+     */
+    _hasMutableChange(entry, zenkoObjMd) {
+        return entry.getRetentionMode() !== zenkoObjMd.retentionMode ||
+            entry.getRetentionDate() !== zenkoObjMd.retentionDate ||
+            entry.getLegalHold() !== !!zenkoObjMd.legalHold ||
+            (this._isNotLocalized(zenkoObjMd) &&
+                entry.getDataStoreName() !== zenkoObjMd.dataStoreName);
+    }
+
+    /**
+     * A version whose data still lives on the remote site.
+     *
+     * @param {Object} zenkoObjMd - metadata fetched from mongo
+     * @return {boolean} true if the stored version is not localized
+     */
+    _isNotLocalized(zenkoObjMd) {
+        return locations.isCRRLocation(zenkoObjMd.dataStoreName);
+    }
+
+    applyNewObjectMetadata(entry, location, bucketInfo) { // eslint-disable-line no-unused-vars
+        // the source-side pipeline shaped everything else this object keeps;
+        // ACLs are not replicated, so they reset as for an ingested object
+        entry.setAcl(new ObjectMD().getAcl());
+    }
+
+    mergeExistingMetadata(entry, zenkoObjMd) {
+        // an update brings tags and object-lock state, cleared values included
+        const tags = entry.getTags();
+        const retentionMode = entry.getRetentionMode();
+        const retentionDate = entry.getRetentionDate();
+        const legalHold = entry.getLegalHold();
+        const notLocalized = this._isNotLocalized(zenkoObjMd);
+        const dataStoreName = entry.getDataStoreName();
+        const location = entry.getLocation();
+
+        entry._data = { ...zenkoObjMd }; // eslint-disable-line no-param-reassign
+
+        entry.setTags(tags);
+        entry.setRetentionMode(retentionMode);
+        entry.setRetentionDate(retentionDate);
+        entry.setLegalHold(legalHold);
+
+        // a localized version keeps the placement the copy engine gave it; one
+        // still on the remote site takes the entry's
+        if (notLocalized) {
+            entry.setDataStoreName(dataStoreName);
+            entry.setLocation(location);
+        }
+    }
+
+    resolveVersionId(scalVersionId, versionId) {
+        // version ids are identical on both sides, so the entry's is
+        // authoritative; a scal version id names a version of another system
+        // entirely, the one an out-of-band production object was ingested from
+        return versionId;
+    }
+
+    shouldProcessDelete(zenkoObjMd, location, key, versionId) { // eslint-disable-line no-unused-vars
+        // always: a replicated object's location legitimately differs -- cold,
+        // on the source, or localized -- so the ingestion guard would ignore
+        // every deletion
+        return true;
+    }
+}
+
+module.exports = DRMode;

--- a/extensions/mongoProcessor/modes/DRMode.js
+++ b/extensions/mongoProcessor/modes/DRMode.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { isDeepStrictEqual } = require('util');
+
 const { ObjectMD } = require('arsenal').models;
 
 const locations = require('../../../lib/util/locations');
@@ -22,7 +24,38 @@ class DRMode extends ProcessorMode {
             return content;
         }
 
+        // a version is immutable, so the same version id over different
+        // content is an object overwritten in place -- in a bucket that is not
+        // versioned, or whose versioning is suspended
+        if (this.replacesExistingMetadata(entry, zenkoObjMd)) {
+            return this._replacesStoredDocument(entry, zenkoObjMd) ? ['METADATA'] : [];
+        }
+
         return this._hasMutableChange(entry, zenkoObjMd) ? ['METADATA'] : [];
+    }
+
+    /**
+     * Whether writing the entry would leave a different document behind. The
+     * fields compared are the ones the write carries, so a replayed entry is
+     * told from one that changes anything at all, down to a header the older
+     * diff never looked at.
+     *
+     * replicationInfo is left out: the processor resolves it against this
+     * site's own bucket configuration once the entry has been applied, so it is
+     * not a difference the entry answers for.
+     *
+     * @param {ObjectQueueEntry} entry - object queue entry object
+     * @param {Object} zenkoObjMd - metadata fetched from mongo
+     * @return {boolean} true if the stored document would change
+     */
+    _replacesStoredDocument(entry, zenkoObjMd) {
+        const written = { ...entry.getValue(), acl: new ObjectMD().getAcl() };
+        const stored = { ...zenkoObjMd };
+
+        delete written.replicationInfo;
+        delete stored.replicationInfo;
+
+        return !isDeepStrictEqual(written, stored);
     }
 
     /**
@@ -46,6 +79,20 @@ class DRMode extends ProcessorMode {
      */
     _isNotLocalized(zenkoObjMd) {
         return locations.isCRRLocation(zenkoObjMd.dataStoreName);
+    }
+
+    replacesExistingMetadata(entry, zenkoObjMd) { // eslint-disable-line no-unused-vars
+        // an object with no version of its own is rewritten in place, so the
+        // entry describes a document that replaced the stored one wholesale,
+        // as it did when the Kafka Connect sink applied it. A suspended bucket
+        // carries a version id on the master it writes in place, marked null.
+        //
+        // Nothing of the stored document is kept. Placement is the one field
+        // this site could own, and cannot here: a cold object holds what the
+        // source pipeline derives from its storage class, and clean room --
+        // which localizes placement -- replicates versioned buckets only. A
+        // guard would go here if that changed.
+        return !entry.getVersionId() || entry.getIsNull();
     }
 
     applyNewObjectMetadata(entry, location, bucketInfo) { // eslint-disable-line no-unused-vars

--- a/extensions/mongoProcessor/modes/IngestionMode.js
+++ b/extensions/mongoProcessor/modes/IngestionMode.js
@@ -1,0 +1,133 @@
+'use strict';
+
+const { emptyFileMd5 } = require('arsenal').constants;
+const { ObjectMD } = require('arsenal').models;
+const { VersionID } = require('arsenal').versioning;
+
+const ProcessorMode = require('./ProcessorMode');
+const getContentType = require('../utils/contentTypeHelper');
+
+class IngestionMode extends ProcessorMode {
+    needsExistingMetadata(entry, bucketInfo) {
+        // the stored document is only read to update replication info and to
+        // validate the `x-amz-meta-scal-version-id` header of a restored
+        // object, so with neither in play the fetch is skipped
+        const scalVersionId = entry.getValue()['x-amz-meta-scal-version-id'];
+        const bucketRepInfo = bucketInfo.getReplicationConfiguration();
+
+        return !!scalVersionId || !!bucketRepInfo?.rules?.some(r => r.enabled);
+    }
+
+    getChangedContent(entry, zenkoObjMd) {
+        return getContentType(entry, zenkoObjMd);
+    }
+
+    applyNewObjectMetadata(entry, location, bucketInfo) {
+        this._updateOwnerMD(entry, bucketInfo);
+        this._updateObjectDataStoreName(entry, location);
+        this._updateLocations(entry, location);
+        this._updateAcl(entry);
+    }
+
+    /**
+     * Update ingested entry metadata fields: owner-id, owner-display-name
+     * @param {ObjectQueueEntry} entry - object queue entry object
+     * @param {BucketInfo} bucketInfo - bucket info object
+     * @return {undefined}
+     */
+    _updateOwnerMD(entry, bucketInfo) {
+        // zenko bucket owner information is being set on ingested md
+        entry.setOwnerDisplayName(bucketInfo.getOwnerDisplayName());
+        entry.setOwnerId(bucketInfo.getOwner());
+    }
+
+    /**
+     * Update ingested entry metadata fields: dataStoreName
+     * @param {ObjectQueueEntry} entry - object queue entry object
+     * @param {string} location - owner details
+     * @return {undefined}
+     */
+    _updateObjectDataStoreName(entry, location) {
+        entry.setDataStoreName(location);
+    }
+
+    /**
+     * Update ingested entry metadata location field. Each location change
+     * includes: key, dataStoreName, dataStoreType, dataStoreVersionId
+     * @param {ObjectQueueEntry} entry - object queue entry object
+     * @param {string} zenkoLocation - zenko storage location name
+     * @return {undefined}
+     */
+    _updateLocations(entry, zenkoLocation) {
+        const locations = entry.getLocation();
+        // if version id is undefined, we have a single null object.
+        // To hold reference to this null object, we need to encode "null"
+        // as its dataStoreVersionId
+        const dataStoreVersionId = entry.getVersionId() ?
+            entry.getEncodedVersionId() : 'null';
+        let zenkoDataLocations;
+        if (!locations || locations.length === 0) {
+            zenkoDataLocations = [{
+                key: entry.getObjectKey(),
+                size: 0,
+                start: 0,
+                dataStoreName: zenkoLocation,
+                dataStoreType: 'aws_s3',
+                dataStoreETag: `1:${emptyFileMd5}`,
+                dataStoreVersionId,
+            }];
+        } else {
+            zenkoDataLocations = [{
+                key: entry.getObjectKey(),
+                size: entry.getContentLength(),
+                start: 0,
+                dataStoreName: zenkoLocation,
+                dataStoreType: 'aws_s3',
+                dataStoreETag: `1:${entry.getContentMd5()}`,
+                dataStoreVersionId,
+            }];
+        }
+        entry.setLocation(zenkoDataLocations);
+    }
+
+    /**
+     * Update acl info on ingested object MD
+     * @param {ObjectQueueEntry} entry - object queue entry object
+     * @return {undefined}
+     */
+    _updateAcl(entry) {
+        // reset acl info
+        const objectMDModel = new ObjectMD();
+        entry.setAcl(objectMDModel.getAcl());
+    }
+
+    mergeExistingMetadata(entry, zenkoObjMd) {
+        // Keep existing metadata fields, only need to update the tags
+        const tags = entry.getTags();
+        entry._data = { ...zenkoObjMd }; // eslint-disable-line no-param-reassign
+        entry.setTags(tags);
+    }
+
+    resolveVersionId(scalVersionId, versionId) {
+        // x-amz-meta-scal-version-id wins where it is set, which happens only
+        // for a restored object: otherwise the source and the ingested object
+        // carry the same version id and the header is absent
+        return scalVersionId ? VersionID.decode(scalVersionId) : versionId;
+    }
+
+    shouldProcessDelete(zenkoObjMd, location, key, versionId) {
+        // an object stored elsewhere is left alone: the delete was caused by
+        // restored-object expiration or transition, both of which update
+        // dataStoreName before sending the object to GC
+        const encode = vid => (vid ? VersionID.encode(vid) : 'null');
+
+        return zenkoObjMd.dataStoreName === location &&
+            zenkoObjMd.location?.length === 1 &&
+            zenkoObjMd.location[0].dataStoreName === location &&
+            zenkoObjMd.location[0].key === key &&
+            (zenkoObjMd.location[0].dataStoreVersionId || 'null') ===
+                encode(versionId);
+    }
+}
+
+module.exports = IngestionMode;

--- a/extensions/mongoProcessor/modes/IngestionMode.js
+++ b/extensions/mongoProcessor/modes/IngestionMode.js
@@ -101,6 +101,12 @@ class IngestionMode extends ProcessorMode {
         entry.setAcl(objectMDModel.getAcl());
     }
 
+    replacesExistingMetadata(entry, zenkoObjMd) { // eslint-disable-line no-unused-vars
+        // an ingested object is always merged into the one stored: out-of-band
+        // writes are not told apart here, as they were not before modes existed
+        return false;
+    }
+
     mergeExistingMetadata(entry, zenkoObjMd) {
         // Keep existing metadata fields, only need to update the tags
         const tags = entry.getTags();

--- a/extensions/mongoProcessor/modes/ProcessorMode.js
+++ b/extensions/mongoProcessor/modes/ProcessorMode.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const assert = require('assert');
+
+/**
+ * A processor mode holds the decisions that differ between the streams the
+ * mongo-processor writes: out-of-band ingestion, where identity and placement
+ * are rewritten to local values because the source system's accounts and
+ * locations do not exist here, and D/R, where they are replicated and so are
+ * applied as they arrive.
+ *
+ * Everything else about processing an entry is shared.
+ */
+class ProcessorMode {
+    /**
+     * Whether the entry's existing metadata has to be read before processing.
+     *
+     * This method must be implemented by subclasses of ProcessorMode
+     * @param {ObjectQueueEntry} entry - object queue entry object
+     * @param {BucketInfo} bucketInfo - bucket info object
+     * @return {boolean} true if the stored document is needed
+     */
+    needsExistingMetadata(entry, bucketInfo) { // eslint-disable-line no-unused-vars
+        assert(false,
+            'sub-classes of ProcessorMode must implement ' +
+            'the needsExistingMetadata() method');
+    }
+
+    /**
+     * What changed between the entry and the object already stored, as
+     * replicationInfo content values. An empty list means the entry carries no
+     * change and is not written.
+     *
+     * This method must be implemented by subclasses of ProcessorMode
+     * @param {ObjectQueueEntry} entry - object queue entry object
+     * @param {Object|undefined} zenkoObjMd - metadata fetched from mongo
+     * @return {Array} array of ReplicationInfo Content Type
+     */
+    getChangedContent(entry, zenkoObjMd) { // eslint-disable-line no-unused-vars
+        assert(false,
+            'sub-classes of ProcessorMode must implement ' +
+            'the getChangedContent() method');
+    }
+
+    /**
+     * Apply the metadata fields an object gets when it is first written here.
+     *
+     * This method must be implemented by subclasses of ProcessorMode
+     * @param {ObjectQueueEntry} entry - object queue entry object
+     * @param {string} location - zenko storage location name
+     * @param {BucketInfo} bucketInfo - bucket info object
+     * @return {undefined}
+     */
+    applyNewObjectMetadata(entry, location, bucketInfo) { // eslint-disable-line no-unused-vars
+        assert(false,
+            'sub-classes of ProcessorMode must implement ' +
+            'the applyNewObjectMetadata() method');
+    }
+
+    /**
+     * Merge the entry into the object already stored, deciding which fields the
+     * entry brings and which the stored document keeps.
+     *
+     * This method must be implemented by subclasses of ProcessorMode
+     * @param {ObjectQueueEntry} entry - object queue entry object
+     * @param {Object} zenkoObjMd - metadata fetched from mongo
+     * @return {undefined}
+     */
+    mergeExistingMetadata(entry, zenkoObjMd) { // eslint-disable-line no-unused-vars
+        assert(false,
+            'sub-classes of ProcessorMode must implement ' +
+            'the mergeExistingMetadata() method');
+    }
+
+    /**
+     * Which version of the object the entry acts on, given the version id it
+     * carries and the `x-amz-meta-scal-version-id` it may carry alongside.
+     *
+     * This method must be implemented by subclasses of ProcessorMode
+     * @param {string|undefined} scalVersionId - encoded scal version id
+     * @param {string|undefined} versionId - version id the entry carries
+     * @return {string|undefined} version id to act on
+     */
+    resolveVersionId(scalVersionId, versionId) { // eslint-disable-line no-unused-vars
+        assert(false,
+            'sub-classes of ProcessorMode must implement ' +
+            'the resolveVersionId() method');
+    }
+
+    /**
+     * Whether a delete entry still applies to the object as stored.
+     *
+     * This method must be implemented by subclasses of ProcessorMode
+     * @param {Object} zenkoObjMd - metadata fetched from mongo
+     * @param {string} location - zenko storage location name
+     * @param {string} key - object key
+     * @param {string|undefined} versionId - decoded version id of the entry
+     * @return {boolean} true if the object should be deleted
+     */
+    shouldProcessDelete(zenkoObjMd, location, key, versionId) { // eslint-disable-line no-unused-vars
+        assert(false,
+            'sub-classes of ProcessorMode must implement ' +
+            'the shouldProcessDelete() method');
+    }
+}
+
+module.exports = ProcessorMode;

--- a/extensions/mongoProcessor/modes/ProcessorMode.js
+++ b/extensions/mongoProcessor/modes/ProcessorMode.js
@@ -58,6 +58,21 @@ class ProcessorMode {
     }
 
     /**
+     * Whether the entry replaces the object already stored rather than
+     * updating it, in which case it is applied as a first write.
+     *
+     * This method must be implemented by subclasses of ProcessorMode
+     * @param {ObjectQueueEntry} entry - object queue entry object
+     * @param {Object} zenkoObjMd - metadata fetched from mongo
+     * @return {boolean} true if the entry replaces the stored object
+     */
+    replacesExistingMetadata(entry, zenkoObjMd) { // eslint-disable-line no-unused-vars
+        assert(false,
+            'sub-classes of ProcessorMode must implement ' +
+            'the replacesExistingMetadata() method');
+    }
+
+    /**
      * Merge the entry into the object already stored, deciding which fields the
      * entry brings and which the stored document keeps.
      *

--- a/extensions/mongoProcessor/modes/index.js
+++ b/extensions/mongoProcessor/modes/index.js
@@ -1,0 +1,10 @@
+const IngestionMode = require('./IngestionMode');
+
+const modes = {
+    ingestion: IngestionMode,
+};
+
+module.exports = {
+    modes,
+    defaultMode: 'ingestion',
+};

--- a/extensions/mongoProcessor/modes/index.js
+++ b/extensions/mongoProcessor/modes/index.js
@@ -1,7 +1,9 @@
+const DRMode = require('./DRMode');
 const IngestionMode = require('./IngestionMode');
 
 const modes = {
     ingestion: IngestionMode,
+    dr: DRMode,
 };
 
 module.exports = {

--- a/extensions/mongoProcessor/mongoProcessorTask.js
+++ b/extensions/mongoProcessor/mongoProcessorTask.js
@@ -18,9 +18,10 @@ const { startProbeServer } = require('../../lib/util/probe');
 const kafkaConfig = config.kafka;
 const mConfig = config.metrics;
 const mongoProcessorConfig = config.extensions.mongoProcessor;
-// TODO: consider whether we would want a separate mongo config
-// for the consumer side
-const mongoClientConfig = config.queuePopulator.mongo;
+// the queue populator's mongo config is the fallback for a deployment that
+// runs one beside this process; a D/R sink runs none, so it configures its own
+const mongoClientConfig =
+    mongoProcessorConfig.mongodb ?? config.queuePopulator?.mongo;
 
 const log = new werelogs.Logger('Backbeat:MongoProcessor:task');
 const mongoProcessorLogConfig = mongoProcessorConfig.log ?? config.log;

--- a/extensions/mongoProcessor/mongoProcessorTask.js
+++ b/extensions/mongoProcessor/mongoProcessorTask.js
@@ -64,10 +64,13 @@ async function handleMetrics(res, log) {
 }
 
 function loadManagementDatabase() {
-    const ingestionServiceAuth = config.extensions.ingestion.auth;
+    // the ingestion extension's auth is the fallback for a deployment that
+    // configures it; a D/R sink enables no extension but this one
+    const serviceAuth =
+        mongoProcessorConfig.auth ?? config.extensions.ingestion?.auth;
     initManagement({
         serviceName: 'md-ingestion',
-        serviceAccount: ingestionServiceAuth.account,
+        serviceAccount: serviceAuth.account,
     }, error => {
         if (error) {
             log.error('could not load management db', { error });

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -118,9 +118,11 @@ class Config extends EventEmitter {
 
         // whitelist IP, CIDR for health checks
         const defaultHealthChecks = ['127.0.0.1/8', '::1'];
-        const healthChecks = parsedConfig.server.healthChecks;
-        healthChecks.allowFrom =
-            healthChecks.allowFrom.concat(defaultHealthChecks);
+        const healthChecks = parsedConfig.server?.healthChecks;
+        if (healthChecks) {
+            healthChecks.allowFrom =
+                healthChecks.allowFrom.concat(defaultHealthChecks);
+        }
 
         // additional certs checks
         if (parsedConfig.certFilePaths) {

--- a/lib/util/locations.js
+++ b/lib/util/locations.js
@@ -1,0 +1,18 @@
+const locationsConfig = require('../../conf/locationConfig.json') || {};
+
+/**
+ * Tell whether a location holds data owned by a remote site.
+ *
+ * Data stored on such a location is remote production data: we may read it
+ * (e.g. to copy it locally), but we must never delete it.
+ *
+ * @param {String} dataStoreName - location name
+ * @return {Boolean} true if the location is a CRR (remote) location
+ */
+function isCRRLocation(dataStoreName) {
+    return Boolean(locationsConfig[dataStoreName]?.isCRR);
+}
+
+module.exports = {
+    isCRRLocation,
+};

--- a/tests/functional/ingestion/MongoQueueProcessor.js
+++ b/tests/functional/ingestion/MongoQueueProcessor.js
@@ -16,6 +16,7 @@ const authdata = require('../../../conf/authdata.json');
 const ObjectQueueEntry = require('../../../lib/models/ObjectQueueEntry');
 const DeleteOpQueueEntry = require('../../../lib/models/DeleteOpQueueEntry');
 const fakeLogger = require('../../utils/fakeLogger');
+const locations = require('../../../lib/util/locations');
 const { ObjectMDArchive, LifecycleConfiguration, NotificationConfiguration } = require('arsenal/build/lib/models');
 
 const kafkaConfig = config.kafka;
@@ -1066,6 +1067,242 @@ describe('MongoQueueProcessor', function mqp() {
                 assert.deepStrictEqual(repConfig, mockReplicationInfo);
                 done();
             });
+        });
+    });
+});
+
+describe('MongoQueueProcessor in dr mode', function drMode() {
+    this.timeout(5000);
+
+    let mqp;
+    let mongoClient;
+
+    before(() => {
+        mqp = new MongoQueueProcessorMock(kafkaConfig,
+            { ...mongoProcessorConfig, mode: 'dr' }, mongoClientConfig, mConfig);
+        mqp.start();
+
+        mongoClient = mqp._mongoClient;
+    });
+
+    afterEach(() => {
+        mqp.reset();
+        sinon.restore();
+    });
+
+    function processEntry(entry, next) {
+        return async.waterfall([
+            cb => mongoClient.getBucketAttributes(BUCKET, fakeLogger, cb),
+            (bucketInfo, cb) => mqp._processObjectQueueEntry(fakeLogger, entry,
+                LOCATION, bucketInfo, cb),
+        ], next);
+    }
+
+    it('should apply a new object as the source describes it', done => {
+        const key = 'dr-new-key';
+        const versionKey = `${key}${VID_SEP}${VERSION_ID}`;
+        const objmd = new ObjectMD()
+            .setKey(key)
+            .setVersionId(VERSION_ID)
+            .setOwnerId('source-owner-id')
+            .setOwnerDisplayName('source-owner')
+            .setDataStoreName('cold-location')
+            // ACLs are not replicated: the matrix in the design resets them
+            .setAcl({ Canned: '', FULL_CONTROL: ['source-grantee'],
+                WRITE_ACP: [], READ: [], READ_ACP: [] });
+        const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd);
+
+        processEntry(entry, err => {
+            assert.ifError(err);
+
+            const added = mqp.getAdded();
+            assert.strictEqual(added.length, 1);
+            const { objVal } = added[0];
+            assert.strictEqual(objVal['owner-id'], 'source-owner-id');
+            assert.strictEqual(objVal['owner-display-name'], 'source-owner');
+            assert.strictEqual(objVal.dataStoreName, 'cold-location');
+            assert.deepStrictEqual(objVal.acl, new ObjectMD().getAcl());
+            done();
+        });
+    });
+
+    it('should keep the stored placement when updating a localized object',
+    done => {
+        const versionKey = `${KEY}${VID_SEP}${VERSION_ID}`;
+        // the copy engine has since moved the object to a local location, so
+        // the entry's own placement must not be written back
+        const objmd = new ObjectMD()
+            .setKey(KEY)
+            .setVersionId(VERSION_ID)
+            .setTags({ mytag: 'mytags-value' })
+            .setDataStoreName('source-site')
+            .setLocation([{ key: KEY, dataStoreName: 'source-site' }])
+            .setLegalHold(true);
+        const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd);
+
+        processEntry(entry, err => {
+            assert.ifError(err);
+
+            const added = mqp.getAdded();
+            assert.strictEqual(added.length, 1);
+            const { objVal } = added[0];
+            // placement from the stored document
+            assert.strictEqual(objVal.dataStoreName, LOCATION);
+            assert.strictEqual(objVal.location[0].dataStoreName, LOCATION);
+            // mutable metadata from the entry
+            assert.strictEqual(objVal.legalHold, true);
+            done();
+        });
+    });
+
+    it('should skip a replayed entry that changes nothing', done => {
+        // at-least-once delivery means the same entry arrives twice; the second
+        // must be a no-op rather than another write
+        const versionKey = `${KEY}${VID_SEP}${VERSION_ID}`;
+        const objmd = new ObjectMD()
+            .setKey(KEY)
+            .setVersionId(VERSION_ID)
+            .setTags({ mytag: 'mytags-value' })
+            .setDataStoreName(LOCATION);
+        const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd);
+
+        processEntry(entry, err => {
+            assert.ifError(err);
+            assert.strictEqual(mqp.getAdded().length, 0);
+            done();
+        });
+    });
+
+    it('should take the entry placement for a version still on the source',
+    done => {
+        // not localized yet, so the source still describes where the data is:
+        // this is the production-side archive of an already-replicated version
+        sinon.stub(locations, 'isCRRLocation').returns(true);
+        const versionKey = `${KEY}${VID_SEP}${VERSION_ID}`;
+        const objmd = new ObjectMD()
+            .setKey(KEY)
+            .setVersionId(VERSION_ID)
+            .setTags({ mytag: 'mytags-value' })
+            .setDataStoreName('cold-location');
+        const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd);
+
+        processEntry(entry, err => {
+            assert.ifError(err);
+
+            const added = mqp.getAdded();
+            assert.strictEqual(added.length, 1);
+            assert.strictEqual(added[0].objVal.dataStoreName, 'cold-location');
+            done();
+        });
+    });
+
+    it('should not skip an update that only changes the object lock', done => {
+        const versionKey = `${KEY}${VID_SEP}${VERSION_ID}`;
+        // same tags as the stored object: the ingestion diff would call this a
+        // duplicate and drop the retention with it
+        const objmd = new ObjectMD()
+            .setKey(KEY)
+            .setVersionId(VERSION_ID)
+            .setTags({ mytag: 'mytags-value' })
+            .setRetentionMode('GOVERNANCE')
+            .setRetentionDate('2099-01-01T00:00:00.000Z');
+        const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd);
+
+        processEntry(entry, err => {
+            assert.ifError(err);
+
+            const added = mqp.getAdded();
+            assert.strictEqual(added.length, 1);
+            assert.strictEqual(added[0].objVal.retentionMode, 'GOVERNANCE');
+            assert.strictEqual(added[0].objVal.retentionDate,
+                '2099-01-01T00:00:00.000Z');
+            done();
+        });
+    });
+
+    it('should read the stored object even when the bucket has no ' +
+    'replication configuration', done => {
+        const getObject = sinon.spy(mongoClient, 'getObject');
+        const versionKey = `${KEY}${VID_SEP}${VERSION_ID}`;
+        const objmd = new ObjectMD()
+            .setKey(KEY)
+            .setVersionId(VERSION_ID)
+            .setTags({ mytag: 'mytags-value' })
+            .setLegalHold(true);
+        const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd);
+
+        async.waterfall([
+            cb => mongoClient.getBucketAttributes(BUCKET, fakeLogger, cb),
+            (bucketInfo, cb) => {
+                sinon.stub(bucketInfo, 'getReplicationConfiguration')
+                    .returns(null);
+                return mqp._processObjectQueueEntry(fakeLogger, entry, LOCATION,
+                    bucketInfo, cb);
+            },
+        ], err => {
+            assert.ifError(err);
+
+            sinon.assert.called(getObject);
+            // the merge happened, so the entry was recognised as an update
+            assert.strictEqual(mqp.getAdded()[0].objVal.dataStoreName,
+                LOCATION);
+            done();
+        });
+    });
+
+    it('should ignore a scal version id the source object carries', done => {
+        // production may itself have ingested or cold-restored this object, so
+        // it can carry a scal version id of its own; it names a version of the
+        // system production ingested from, not anything here
+        const versionKey = `${KEY}${VID_SEP}${VERSION_ID}`;
+        const objmd = new ObjectMD()
+            .setKey(KEY)
+            .setVersionId(VERSION_ID)
+            .setTags({ mytag: 'mytags-value' })
+            .setLegalHold(true)
+            .setUserMetadata({
+                'x-amz-meta-scal-version-id': encode(NEW_VERSION_ID),
+            });
+        const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd);
+        const getObject = sinon.spy(mongoClient, 'getObject');
+
+        processEntry(entry, err => {
+            assert.ifError(err);
+
+            // read, and written back, on the version the entry names
+            assert.strictEqual(getObject.getCall(0).args[2].versionId,
+                VERSION_ID);
+            assert.strictEqual(mqp.getAdded()[0].key,
+                `${KEY}${VID_SEP}${VERSION_ID}`);
+            done();
+        });
+    });
+
+    it('should delete an object whose location differs from the bucket\'s',
+    done => {
+        const versionKey = `${KEY}${VID_SEP}${VERSION_ID}`;
+        const entry = new DeleteOpQueueEntry(BUCKET, versionKey);
+        sinon.stub(mongoClient, 'getObject').callsFake((b, k, p, l, cb) =>
+            cb(null, new ObjectMD()
+                .setKey(KEY)
+                .setVersionId(VERSION_ID)
+                // cold, or still pointing at the source: never the bucket's
+                // own location constraint
+                .setDataStoreName('cold-location')
+                .setLocation(null)
+                ._data));
+
+        async.waterfall([
+            cb => mongoClient.getBucketAttributes(BUCKET, fakeLogger, cb),
+            (bucketInfo, cb) => mqp._processDeleteOpQueueEntry(fakeLogger,
+                entry, LOCATION, bucketInfo, cb),
+        ], err => {
+            assert.ifError(err);
+
+            const deleted = mqp.getDeleted();
+            assert.strictEqual(deleted.length, 1);
+            assert.strictEqual(deleted[0].versionId, VERSION_ID);
+            done();
         });
     });
 });

--- a/tests/functional/ingestion/MongoQueueProcessor.js
+++ b/tests/functional/ingestion/MongoQueueProcessor.js
@@ -1305,4 +1305,165 @@ describe('MongoQueueProcessor in dr mode', function drMode() {
             done();
         });
     });
+
+    // an object with no version of its own is rewritten in place, so the whole
+    // document the entry carries replaced the stored one on the source
+    function storeRewritten() {
+        sinon.stub(mongoClient, 'getObject').callsFake((b, k, p, l, cb) =>
+            cb(null, new ObjectMD()
+                .setKey(KEY)
+                .setContentMd5('7d793037a0760186574b0282f2f435e7')
+                .setContentType('text/plain')
+                .setUserMetadata({ 'x-amz-meta-colour': 'red' })
+                .setDataStoreName(LOCATION)
+                .setAmzRestore({ 'ongoing-request': false })
+                ._data));
+    }
+
+    it('should take every field of an object rewritten in place', done => {
+        storeRewritten();
+        const objmd = new ObjectMD()
+            .setKey(KEY)
+            .setContentMd5('9e107d9d372bb6826bd81d3542a419d6')
+            .setContentType('application/json')
+            .setUserMetadata({ 'x-amz-meta-colour': 'blue' })
+            .setDataStoreName(LOCATION);
+        const entry = new ObjectQueueEntry(BUCKET, KEY, objmd);
+
+        processEntry(entry, err => {
+            assert.ifError(err);
+
+            const added = mqp.getAdded();
+            assert.strictEqual(added.length, 1);
+            // written in place, under the object key alone
+            assert.strictEqual(added[0].key, KEY);
+            const { objVal } = added[0];
+            assert.strictEqual(objVal['content-md5'],
+                '9e107d9d372bb6826bd81d3542a419d6');
+            assert.strictEqual(objVal['content-type'], 'application/json');
+            assert.strictEqual(objVal['x-amz-meta-colour'], 'blue');
+            // a restore this site holds describes bytes that are gone
+            assert.strictEqual(objVal['x-amz-restore'], undefined);
+            assert.deepStrictEqual(objVal.acl, new ObjectMD().getAcl());
+            done();
+        });
+    });
+
+    it('should take a rewrite that kept the same bytes', done => {
+        storeRewritten();
+        // a PUT replaces the whole metadata whatever the content does, so the
+        // content md5 alone cannot tell a rewrite from an untouched object
+        const objmd = new ObjectMD()
+            .setKey(KEY)
+            .setContentMd5('7d793037a0760186574b0282f2f435e7')
+            .setContentType('application/json')
+            .setUserMetadata({ 'x-amz-meta-colour': 'red' })
+            .setDataStoreName(LOCATION);
+        const entry = new ObjectQueueEntry(BUCKET, KEY, objmd);
+
+        processEntry(entry, err => {
+            assert.ifError(err);
+
+            const added = mqp.getAdded();
+            assert.strictEqual(added.length, 1);
+            assert.strictEqual(added[0].objVal['content-type'],
+                'application/json');
+            done();
+        });
+    });
+
+    it('should take a rewrite that only moved user metadata', done => {
+        storeRewritten();
+        const objmd = new ObjectMD()
+            .setKey(KEY)
+            .setContentMd5('7d793037a0760186574b0282f2f435e7')
+            .setContentType('text/plain')
+            .setUserMetadata({ 'x-amz-meta-colour': 'green' })
+            .setDataStoreName(LOCATION);
+        const entry = new ObjectQueueEntry(BUCKET, KEY, objmd);
+
+        processEntry(entry, err => {
+            assert.ifError(err);
+
+            const added = mqp.getAdded();
+            assert.strictEqual(added.length, 1);
+            assert.strictEqual(added[0].objVal['x-amz-meta-colour'], 'green');
+            done();
+        });
+    });
+
+    it('should take the null version a suspended bucket rewrites', done => {
+        storeRewritten();
+        // versioning suspended: the master carries a version id and is marked
+        // null, and it is still the document that gets rewritten in place
+        const objmd = new ObjectMD()
+            .setKey(KEY)
+            .setVersionId(VERSION_ID)
+            .setIsNull(true)
+            .setContentMd5('9e107d9d372bb6826bd81d3542a419d6')
+            .setDataStoreName(LOCATION);
+        const entry = new ObjectQueueEntry(BUCKET, KEY, objmd);
+
+        processEntry(entry, err => {
+            assert.ifError(err);
+
+            const added = mqp.getAdded();
+            assert.strictEqual(added.length, 1);
+            assert.strictEqual(added[0].key, KEY);
+            assert.strictEqual(added[0].objVal['content-md5'],
+                '9e107d9d372bb6826bd81d3542a419d6');
+            done();
+        });
+    });
+
+    it('should keep merging an update to a version of its own', done => {
+        // a version is immutable, so an entry for one carries an update and not
+        // a rewrite: the stored document still decides what it keeps
+        const versionKey = `${KEY}${VID_SEP}${VERSION_ID}`;
+        sinon.stub(mongoClient, 'getObject').callsFake((b, k, p, l, cb) =>
+            cb(null, new ObjectMD()
+                .setKey(KEY)
+                .setVersionId(VERSION_ID)
+                .setUserMetadata({ 'x-amz-meta-colour': 'red' })
+                .setDataStoreName(LOCATION)
+                ._data));
+        const objmd = new ObjectMD()
+            .setKey(KEY)
+            .setVersionId(VERSION_ID)
+            .setTags({ mytag: 'mytags-value' })
+            .setUserMetadata({ 'x-amz-meta-colour': 'blue' })
+            .setDataStoreName(LOCATION);
+        const entry = new ObjectQueueEntry(BUCKET, versionKey, objmd);
+
+        processEntry(entry, err => {
+            assert.ifError(err);
+
+            const added = mqp.getAdded();
+            assert.strictEqual(added.length, 1);
+            const { objVal } = added[0];
+            assert.deepStrictEqual(objVal.tags, { mytag: 'mytags-value' });
+            // not a field an update brings
+            assert.strictEqual(objVal['x-amz-meta-colour'], 'red');
+            done();
+        });
+    });
+
+    it('should skip a replayed rewrite', done => {
+        const objmd = new ObjectMD()
+            .setKey(KEY)
+            .setContentMd5('9e107d9d372bb6826bd81d3542a419d6')
+            .setUserMetadata({ 'x-amz-meta-colour': 'blue' })
+            .setDataStoreName(LOCATION);
+        const entry = new ObjectQueueEntry(BUCKET, KEY, objmd);
+        // what the first delivery of this very entry left behind
+        const stored = { ...entry.getValue(), acl: new ObjectMD().getAcl() };
+        sinon.stub(mongoClient, 'getObject').callsFake((b, k, p, l, cb) =>
+            cb(null, stored));
+
+        processEntry(entry, err => {
+            assert.ifError(err);
+            assert.strictEqual(mqp.getAdded().length, 0);
+            done();
+        });
+    });
 });

--- a/tests/unit/lib/config/Config.spec.js
+++ b/tests/unit/lib/config/Config.spec.js
@@ -33,6 +33,12 @@ describe('Config', () => {
         assert.doesNotThrow(() => config._parseConfig(testConfig));
     });
 
+    it('should accept a config serving no API, as a D/R sink does', () => {
+        delete testConfig.server;
+        testConfig.extensions = { mongoProcessor: testConfig.extensions.mongoProcessor };
+        assert.doesNotThrow(() => config._parseConfig(testConfig));
+    });
+
     it('should accept a config publishing no metrics', () => {
         delete testConfig.metrics;
         assert.doesNotThrow(() => config._parseConfig(testConfig));

--- a/tests/unit/mongoProcessor/MongoProcessorConfigValidator.spec.js
+++ b/tests/unit/mongoProcessor/MongoProcessorConfigValidator.spec.js
@@ -9,6 +9,17 @@ const baseExtConfig = {
     probeServer: { port: 4000 },
 };
 
+const serviceAuth = { type: 'service', account: 'service-md-ingestion' };
+
+const mongodb = {
+    replicaSetHosts: 'mongo:27017',
+    database: 'datadb',
+    authCredentials: { username: 'u', password: 'p' },
+};
+
+// what a D/R sink configures: no other extension supplies these
+const drExtConfig = { ...baseExtConfig, mode: 'dr', auth: serviceAuth, mongodb };
+
 // the validated backbeat config, passed to every extension validator
 const globalConfig = { log: { logLevel: 'info', dumpLevel: 'trace' } };
 
@@ -22,7 +33,7 @@ describe('MongoProcessorConfigValidator log override', () => {
     });
 
     it('should leave log undefined when not set, deferring to global config.log', () => {
-        const validated = configValidator(globalConfig, baseExtConfig);
+        const validated = configValidator(globalConfig, { ...baseExtConfig });
         assert.strictEqual(validated.log, undefined);
     });
 
@@ -43,12 +54,6 @@ describe('MongoProcessorConfigValidator log override', () => {
 });
 
 describe('MongoProcessorConfigValidator mongodb', () => {
-    const mongodb = {
-        replicaSetHosts: 'mongo:27017',
-        database: 'datadb',
-        authCredentials: { username: 'u', password: 'p' },
-    };
-
     it('should accept a mongodb client config', () => {
         const validated = configValidator(globalConfig, { ...baseExtConfig, mongodb });
         assert.strictEqual(validated.mongodb.replicaSetHosts, 'mongo:27017');
@@ -59,8 +64,21 @@ describe('MongoProcessorConfigValidator mongodb', () => {
 
     it('should leave mongodb undefined when not set, deferring to the ' +
     'queue populator config', () => {
-        const validated = configValidator(globalConfig, baseExtConfig);
+        const validated = configValidator(globalConfig, { ...baseExtConfig });
         assert.strictEqual(validated.mongodb, undefined);
+    });
+
+    it('should require mongodb in dr mode, which runs no queue populator', () => {
+        let err;
+        try {
+            const noMongo = { ...drExtConfig };
+            delete noMongo.mongodb;
+            configValidator(globalConfig, noMongo);
+        } catch (e) {
+            err = e;
+        }
+        assert(err, 'expected configValidator to throw on dr mode with no mongodb');
+        assert.match(err.message, /mongodb/);
     });
 
     it('should reject credentials missing a password', () => {
@@ -79,19 +97,20 @@ describe('MongoProcessorConfigValidator mongodb', () => {
 
 describe('MongoProcessorConfigValidator mode', () => {
     it('should default to ingestion so an existing config is unchanged', () => {
-        const validated = configValidator(globalConfig, baseExtConfig);
+        const validated = configValidator(globalConfig, { ...baseExtConfig });
         assert.strictEqual(validated.mode, 'ingestion');
     });
 
     it('should accept the dr mode', () => {
-        const validated = configValidator(globalConfig, { ...baseExtConfig, mode: 'dr' });
+        const validated = configValidator(globalConfig, { ...drExtConfig });
         assert.strictEqual(validated.mode, 'dr');
     });
 
     it('should accept the mode from the environment', () => {
         process.env.EXTENSIONS_MONGO_PROCESSOR_MODE = 'dr';
         try {
-            const validated = configValidator(globalConfig, baseExtConfig);
+            const validated = configValidator(globalConfig,
+                { ...baseExtConfig, auth: serviceAuth, mongodb });
             assert.strictEqual(validated.mode, 'dr');
         } finally {
             delete process.env.EXTENSIONS_MONGO_PROCESSOR_MODE;
@@ -107,5 +126,44 @@ describe('MongoProcessorConfigValidator mode', () => {
         }
         assert(err, 'expected configValidator to throw on an unknown mode');
         assert.match(err.message, /mode/);
+    });
+});
+
+describe('MongoProcessorConfigValidator auth', () => {
+    it('should accept a service account', () => {
+        const validated = configValidator(globalConfig,
+            { ...baseExtConfig, auth: serviceAuth });
+        assert.strictEqual(validated.auth.type, 'service');
+        assert.strictEqual(validated.auth.account, 'service-md-ingestion');
+    });
+
+    it('should leave auth undefined when not set, deferring to the ' +
+    'ingestion extension config', () => {
+        const validated = configValidator(globalConfig, { ...baseExtConfig });
+        assert.strictEqual(validated.auth, undefined);
+    });
+
+    it('should require auth in dr mode, which enables no other extension', () => {
+        let err;
+        try {
+            const noAuth = { ...drExtConfig };
+            delete noAuth.auth;
+            configValidator(globalConfig, noAuth);
+        } catch (e) {
+            err = e;
+        }
+        assert(err, 'expected configValidator to throw on dr mode with no auth');
+        assert.match(err.message, /auth/);
+    });
+
+    it('should reject a service auth missing the account', () => {
+        let err;
+        try {
+            configValidator(globalConfig, { ...baseExtConfig, auth: { type: 'service' } });
+        } catch (e) {
+            err = e;
+        }
+        assert(err, 'expected configValidator to throw on a service auth with no account');
+        assert.match(err.message, /account/);
     });
 });

--- a/tests/unit/mongoProcessor/MongoProcessorConfigValidator.spec.js
+++ b/tests/unit/mongoProcessor/MongoProcessorConfigValidator.spec.js
@@ -83,6 +83,21 @@ describe('MongoProcessorConfigValidator mode', () => {
         assert.strictEqual(validated.mode, 'ingestion');
     });
 
+    it('should accept the dr mode', () => {
+        const validated = configValidator(globalConfig, { ...baseExtConfig, mode: 'dr' });
+        assert.strictEqual(validated.mode, 'dr');
+    });
+
+    it('should accept the mode from the environment', () => {
+        process.env.EXTENSIONS_MONGO_PROCESSOR_MODE = 'dr';
+        try {
+            const validated = configValidator(globalConfig, baseExtConfig);
+            assert.strictEqual(validated.mode, 'dr');
+        } finally {
+            delete process.env.EXTENSIONS_MONGO_PROCESSOR_MODE;
+        }
+    });
+
     it('should reject a mode with no implementation', () => {
         let err;
         try {

--- a/tests/unit/mongoProcessor/MongoProcessorConfigValidator.spec.js
+++ b/tests/unit/mongoProcessor/MongoProcessorConfigValidator.spec.js
@@ -41,3 +41,38 @@ describe('MongoProcessorConfigValidator log override', () => {
         }
     });
 });
+
+describe('MongoProcessorConfigValidator mongodb', () => {
+    const mongodb = {
+        replicaSetHosts: 'mongo:27017',
+        database: 'datadb',
+        authCredentials: { username: 'u', password: 'p' },
+    };
+
+    it('should accept a mongodb client config', () => {
+        const validated = configValidator(globalConfig, { ...baseExtConfig, mongodb });
+        assert.strictEqual(validated.mongodb.replicaSetHosts, 'mongo:27017');
+        assert.strictEqual(validated.mongodb.database, 'datadb');
+        assert.deepStrictEqual(validated.mongodb.authCredentials,
+            { username: 'u', password: 'p' });
+    });
+
+    it('should leave mongodb undefined when not set, deferring to the ' +
+    'queue populator config', () => {
+        const validated = configValidator(globalConfig, baseExtConfig);
+        assert.strictEqual(validated.mongodb, undefined);
+    });
+
+    it('should reject credentials missing a password', () => {
+        let err;
+        try {
+            configValidator(globalConfig, {
+                ...baseExtConfig,
+                mongodb: { ...mongodb, authCredentials: { username: 'u' } },
+            });
+        } catch (e) {
+            err = e;
+        }
+        assert(err, 'expected configValidator to throw on partial credentials');
+    });
+});

--- a/tests/unit/mongoProcessor/MongoProcessorConfigValidator.spec.js
+++ b/tests/unit/mongoProcessor/MongoProcessorConfigValidator.spec.js
@@ -76,3 +76,21 @@ describe('MongoProcessorConfigValidator mongodb', () => {
         assert(err, 'expected configValidator to throw on partial credentials');
     });
 });
+
+describe('MongoProcessorConfigValidator mode', () => {
+    it('should default to ingestion so an existing config is unchanged', () => {
+        const validated = configValidator(globalConfig, baseExtConfig);
+        assert.strictEqual(validated.mode, 'ingestion');
+    });
+
+    it('should reject a mode with no implementation', () => {
+        let err;
+        try {
+            configValidator(globalConfig, { ...baseExtConfig, mode: 'sideways' });
+        } catch (e) {
+            err = e;
+        }
+        assert(err, 'expected configValidator to throw on an unknown mode');
+        assert.match(err.message, /mode/);
+    });
+});

--- a/tests/unit/mongoProcessor/ProcessorMode.spec.js
+++ b/tests/unit/mongoProcessor/ProcessorMode.spec.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const assert = require('assert');
+
+const ProcessorMode =
+    require('../../../extensions/mongoProcessor/modes/ProcessorMode');
+
+describe('ProcessorMode', () => {
+    const mode = new ProcessorMode();
+
+    [
+        'needsExistingMetadata',
+        'getChangedContent',
+        'applyNewObjectMetadata',
+        'mergeExistingMetadata',
+        'resolveVersionId',
+        'shouldProcessDelete',
+    ].forEach(method => it(`should refuse to ${method}() without an ` +
+    'implementation', () => {
+        assert.throws(() => mode[method](),
+            new RegExp('sub-classes of ProcessorMode must implement the ' +
+                `${method}\\(\\) method`));
+    }));
+});

--- a/tests/unit/mongoProcessor/ProcessorMode.spec.js
+++ b/tests/unit/mongoProcessor/ProcessorMode.spec.js
@@ -12,6 +12,7 @@ describe('ProcessorMode', () => {
         'needsExistingMetadata',
         'getChangedContent',
         'applyNewObjectMetadata',
+        'replacesExistingMetadata',
         'mergeExistingMetadata',
         'resolveVersionId',
         'shouldProcessDelete',


### PR DESCRIPTION
The mongo-processor was written as the out-of-band ingestion consumer, and the D/R metadata sink now reuses it. The two disagree about most of what it does to an object: ingestion rewrites identity and placement to local values, because the source system's accounts and locations do not exist here, while D/R replicates both and so applies what the source-side pipeline sends.

Put those decisions behind a mode, following the shape the notification extension uses for its destinations — an abstract `ProcessorMode`, an implementation per mode, and an index mapping the configured name to the class. `IngestionMode` carries today's behaviour verbatim and `mode` defaults to `ingestion`, so nothing changes for an existing deployment.

### What the mongo-processor does

```mermaid
flowchart LR
    K[("Kafka topic")] --> E["read entry"]
    E --> B["look up the bucket"]
    B --> Z["read the stored object metadata"]
    Z --> A["apply the entry"]
    A --> M[("sink MongoDB")]
```

### Where the two modes diverge

Every decision the two modes disagree about is a hook on `ProcessorMode`, so the surrounding flow stays single-sourced.

```mermaid
flowchart TD
    E["entry"] --> T{"type"}

    T -->|del| G0["shouldProcessDelete"]
    G0 -->|ingestion| I0["only while the stored placement<br/>still matches the bucket"]
    G0 -->|D/R| D0["always"]
    I0 --> DEL[("delete in MongoDB")]
    D0 --> DEL

    T -->|put| G1["needsExistingMetadata"]
    G1 -->|ingestion| I1["only with a scal header or<br/>an enabled replication rule"]
    G1 -->|D/R| D1["always"]

    I1 --> G2["resolveVersionId"]
    D1 --> G2
    G2 -->|ingestion| I2["the scal version id when present"]
    G2 -->|D/R| D2["the entry's own"]

    I2 --> G3["getChangedContent"]
    D2 --> G3
    G3 -->|ingestion| I3["tags"]
    G3 -->|D/R| D3["tags, object lock, and placement<br/>while the data is still remote"]

    I3 --> S{"stored document"}
    D3 --> S

    S -->|absent| G4["applyNewObjectMetadata"]
    S -->|present| G6["replacesExistingMetadata"]
    G6 -->|ingestion| G5["mergeExistingMetadata"]
    G6 -->|"D/R, versioned"| G5
    G6 -->|"D/R, no version id<br/>or a null version"| G4

    G4 -->|ingestion| I4["local owner, location and data part,<br/>ACLs reset"]
    G4 -->|D/R| D4["ACLs reset"]
    G5 -->|ingestion| I5["keep the stored document,<br/>take the tags"]
    G5 -->|D/R| D5["keep the stored document, take tags<br/>and object lock, placement by locality"]

    I4 --> W[("write to MongoDB")]
    D4 --> W
    I5 --> W
    D5 --> W
```

### The hooks

| Hook | Ingestion | D/R | Beyond the ticket |
| --- | --- | --- | --- |
| `needsExistingMetadata` | Reads the stored document only when the entry carries a scal header or the bucket has an enabled replication rule | Always reads it | yes |
| `resolveVersionId` | The `x-amz-meta-scal-version-id` when present, otherwise the entry's | The entry's own, always † | yes |
| `getChangedContent` | Diffs tags only | Diffs tags, object-lock state, and placement while the data is still remote; compares the whole document when the entry replaces it, so a replay is still skipped | yes |
| `applyNewObjectMetadata` | Rewrites owner, `dataStoreName` and the data part to local values, resets ACLs | Resets ACLs, nothing else | no |
| `replacesExistingMetadata` | Never: a stored document is always merged into | True for a write carrying no version id, or a null version — the same key is being rewritten, so the entry replaces the document rather than merging into it | no |
| `mergeExistingMetadata` | Keeps the stored document, takes the entry's tags | Keeps the stored document, takes tags and object-lock state; keeps the stored placement for a localized version, takes the entry's for one still on the remote site | no |
| `shouldProcessDelete` | Skips the delete unless the stored placement still matches the bucket | Applies it always | yes |

The three marked *beyond the ticket* are not in the ticket text but follow from the design:

- **The stored document is always read.** Without it the merge is unreachable — the fetch is skipped when there is no scal header and no enabled replication rule, which is the normal D/R case, so every entry took the create path and an update overwrote the placement. The design requires the merge and asserts replay idempotence but never mentions the read; making it unconditional is our choice, at one `getObject` per entry.
- **Change detection covers the mutable set.** `getContentType` only diffs tags, so a retention or legal-hold change with unchanged tags was dropped as a duplicate before the merge could run. The requirement is the matrix's "Merged on update"; the mechanism is ours.
- **The delete guard is skipped.** Its five-way location test ignores every D/R deletion, since a replicated object's location legitimately differs — cold, on the source, or localized. The design endorses applying deletions directly: "the mongo-processor applies replicated operations -including version deletions- at the metadata level, below the S3 API enforcement".

† **The one decision the design does not cover.** `x-amz-meta-scal-version-id` is ignored in D/R mode. Both call sites used it mode-independently to choose which version to read and to delete. A production object that was itself OOB-ingested or cold-restored carries that header, naming a version of the system *production* ingested from — so honouring it here reads and deletes the wrong version. Version ids are the source's own and identical on both sides, so the entry's own id is authoritative. The design never considers a production site that itself ingests, so this is a guess, and the easiest thing in the PR to reverse.

### What happens to each field

| Field | Ingestion | D/R |
| --- | --- | --- |
| `owner-id`, `owner-display-name` | Replaced with the bucket owner | Kept as sent |
| `dataStoreName` | Replaced with the Zenko location | Kept as sent on a first write; on an update kept from the stored document for a localized version, taken from the entry for one still remote |
| `location` data parts | Rewritten to a single part pointing at the Zenko location | Kept as sent |
| `acl` | Reset to the defaults | Reset to the defaults |
| `tags` | Taken from the entry | Taken from the entry |
| `retentionMode`, `retentionDate`, `legalHold` | Not merged: only tags are | Taken from the entry, cleared values included |
| `versionId` | The scal version id when present | The entry's own |
| `x-amz-meta-scal-version-id` | Honoured | Ignored |
| `replicationInfo` | Reset, shared between the modes | Reset, shared between the modes |
| `content-length`, `content-md5`, and the rest | As sent | As sent |

### Configuration

The mongo-processor now reads two settings from its own extension config instead of from blocks it does not own: the mongo client config, so a D/R sink no longer carries a `queuePopulator` block it never runs, and the service account, so it no longer carries a partial `extensions.ingestion` block. The second was not optional — backbeat validates every extension listed under `extensions` against that extension's own schema, and the ingestion schema also requires a topic, a zookeeper path and a source list, so naming the account there made the whole configuration invalid. Both fall back to the old location for a deployment that enables both extensions, and `auth` is required in D/R mode, which enables no other extension.

Also stops extending the health-check address whitelist when no `server` section is configured. The section is optional, but it was dereferenced unconditionally, so a process serving no API exited before starting.

### Follow-ups and exclusions

| Topic | Ticket | Notes |
| --- | --- | --- |
| GC `deleteData` when a localized version is deleted | BB-813 / BB-815 | Worth being accurate: the design does *not* defer this. It states it as part of deletion handling and it appears in none of its lists of later increments |
| Circuit-breaker rules | BB-822 | The plumbing already exists; the design names the gating signal as local oplog and copy-queue lag |
| `__metastore` and Vault entities | OS-1110 | |
| `transitionInProgress` suppression | BB-819 | Depends on this merge. Keeping the stored document and overlaying a short list is what leaves it open; the non-localized branch restores placement specifically rather than wholesale, so BB-819 adds to a list that already exists |
| The operator's `locationConfig.json` has to stop being `{}` | ZKOP-566 | `isCRRLocation` reads it. Harmless for metadata-only D/R, where every lookup is false and every object is cold, which is the correct answer there |
| Duplicated `lib/util/locations.js` | #2828 | The first commit copies it byte-for-byte rather than stacking on a draft. Whichever of the two lands second has that commit dropped as already applied — verified by rebasing onto #2828 and watching git drop it |
| `replicationInfo` | none | Stays shared and unchanged: the source pipeline resets it and bucket workflows are stripped, so a correct sink bucket has no replication config and this reduces to a reset |
| Metadata RPO metric | none found | The observability section asks for the timestamp of the last metadata write replicated, and alerts on it. `MongoProcessorMetrics` has no such gauge. Every metric here is also `ingestion*`-prefixed, which will read oddly on a D/R dashboard |

Unblocks [ZKOP-562], whose generated configuration sets `mode`, `mongodb` and `auth`, and which cannot start a mongo-processor without this.

Issue: BB-811

[ZKOP-562]: https://scality.atlassian.net/browse/ZKOP-562

