### PR TITLE
Stop consuming once the shutdown has started

### DIFF
--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -438,6 +438,14 @@ class BackbeatConsumer extends EventEmitter {
             this._tryConsumedTimeout = null;
         }
 
+        // the shutdown drains what is already in flight, so fetching more
+        // only delays the departure and strands the extra work. This also
+        // ends the self-rescheduling loop, which would otherwise keep
+        // consuming against a closed client for the life of the process.
+        if (this._shuttingDown) {
+            return undefined;
+        }
+
         // use non-flowing mode of consumption to add some flow
         // control: explicit consumption of messages is required,
         // needs explicit polling to get new messages

--- a/tests/unit/backbeatConsumer.js
+++ b/tests/unit/backbeatConsumer.js
@@ -315,6 +315,37 @@ describe('backbeatConsumer', () => {
         });
     });
 
+    describe('_tryConsume', () => {
+        let consumer;
+
+        beforeEach(() => {
+            consumer = new BackbeatConsumerMock({
+                kafka,
+                groupId: 'unittest-group',
+                topic: 'my-test-topic',
+            });
+            consumer._processingQueue = {
+                length: () => 0,
+                running: () => 0,
+            };
+            consumer._consumer = { consume: sinon.stub() };
+        });
+
+        it('should fetch while the consumer is running', () => {
+            consumer._tryConsume();
+
+            assert.strictEqual(consumer._consumer.consume.calledOnce, true);
+        });
+
+        it('should not fetch once the shutdown has started', () => {
+            consumer._shuttingDown = true;
+
+            consumer._tryConsume();
+
+            assert.strictEqual(consumer._consumer.consume.called, false);
+        });
+    });
+
     describe('_getAvailableSlotsInPipeline', () => {
         let consumer;
 


### PR DESCRIPTION
`close()` drains the in-flight work before releasing the partitions, but nothing stopped the fetch loop while it waited. Every completed task re-armed `_tryConsume()`, so the pipeline refilled as fast as it emptied and the departure waited on work that arrived *after* the shutdown began.

```mermaid
flowchart TD
    C["close() begins draining"] --> W["wait for the queue to idle<br/>and the ledger to empty"]
    W --> T["a task completes"]
    T --> G{"shutting down?"}
    G -->|"before: not checked"| P["_tryConsume re-arms<br/>and fetches more"]
    P --> Q["queue refills as fast as it empties"]
    Q --> W
    G -->|"after: guard returns early"| S["fetch loop ends,<br/>queue drains to empty"]
    S --> L["departure proceeds"]
```

## Changes

`_tryConsume()` returns early once the shutdown has started. The work already in flight is still drained and its offsets still committed — only the refill stops.

Measured against a 3000 message backlog:

| concurrency | task | `close()` | tasks started after close |
| --- | --- | --- | --- |
| 10 | 200 ms | 6210 ms → **175 ms** | 301 → **0** |
| 10 | 50 ms | 9482 ms → **31 ms** | 1864 → **0** |

The same guard ends the self-rescheduling consume loop, which otherwise kept polling a closed client for the lifetime of the process.

## Verification

Two unit tests: the loop still fetches while the consumer is running, and stops once the shutdown has started. Both were checked against the previous implementation to confirm the second fails there.

End-to-end measurement of the whole stack is in #2819.

Issue: BB-833
