### PR TITLE
Answer every rebalance callback raised during shutdown

### DIFF
--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -819,9 +819,28 @@ class BackbeatConsumer extends EventEmitter {
         if (err.code === kafka.CODES.ERRORS.ERR__ASSIGN_PARTITIONS) {
             this._log.info('rdkafka.assign', { assignment });
 
-            if (!this._shuttingDown) {
-                this._setDrain(null);
+            // close() has already handed the partitions back. Accepting a
+            // fresh grant now leaves the client holding an assignment the
+            // disconnect has to revoke all over again, which wedges it and
+            // costs us the LeaveGroup the shutdown exists to send.
+            if (this._shuttingDown) {
+                // assign() is refused once disconnect() has started -- the
+                // binding gates it on isConnected(), which is already false --
+                // while unassign() is explicitly permitted while closing, and
+                // librdkafka coerces an assign into a full unassign during
+                // termination anyway. Leaving the callback unanswered is what
+                // parks the client in the rebalance.
+                this._bestEffort('assign.declined', () => {
+                    try {
+                        this._consumer.assign([]);
+                    } catch (e) { // eslint-disable-line no-unused-vars
+                        this._consumer.unassign();
+                    }
+                });
+                return;
             }
+
+            this._setDrain(null);
 
             try {
                 this._consumer.assign(assignment);
@@ -841,10 +860,16 @@ class BackbeatConsumer extends EventEmitter {
                 ledger: this._offsetLedger.getProcessingCount(this._topic),
             });
 
-            // close() owns the departure: it drains, then un-assigns, which
-            // is what answers this revoke. Releasing here would cut that drain
-            // short and strand the offsets it exists to commit.
+            // librdkafka requires every rebalance callback to be answered,
+            // and leaving this one to close() is not enough: a revoke raised
+            // after close() has already un-assigned has nothing left to answer
+            // it, so the client stays in the rebalance and the disconnect
+            // wedges on it. Answering here does not cut the drain short --
+            // close() still waits for the in-flight work, the partitions are
+            // simply given back sooner.
             if (this._shuttingDown) {
+                this._bestEffort('unassign.shutdown',
+                    () => this._consumer.unassign());
                 KafkaBacklogMetrics.onRebalance(
                     this._topic, this._groupId, unassignStatus.SHUTDOWN);
                 return;

--- a/tests/unit/backbeatConsumer.js
+++ b/tests/unit/backbeatConsumer.js
@@ -586,12 +586,39 @@ describe('backbeatConsumer', () => {
             }
         });
 
-        it('should leave a revoke arriving during shutdown to close()', () => {
+        it('should decline a partition grant arriving during shutdown', () => {
+            consumer._shuttingDown = true;
+            consumer._onRebalance(ASSIGN, partitions);
+
+            // taking the grant would leave the disconnect an assignment to
+            // revoke all over again, which is what wedges it
+            assert(consumer._consumer.assign.calledOnce);
+            assert.deepStrictEqual(
+                consumer._consumer.assign.firstCall.args[0], []);
+        });
+
+        it('should still answer the grant when assign is refused mid-close',
+        () => {
+            // the binding gates assign() on isConnected(), which is already
+            // false once disconnect() has started, so the decline throws;
+            // unassign() stays permitted and is a valid answer
+            consumer._shuttingDown = true;
+            consumer._consumer.assign = sinon.stub().throws(
+                new Error('KafkaConsumer is not connected'));
+
+            consumer._onRebalance(ASSIGN, partitions);
+
+            assert(consumer._consumer.unassign.calledOnce);
+        });
+
+        it('should answer a revoke arriving during shutdown', () => {
             consumer._shuttingDown = true;
             consumer._onRebalance(REVOKE, partitions);
 
-            // releasing here would cut short the drain close() is waiting on
-            assert(consumer._consumer.unassign.notCalled);
+            // an unanswered rebalance callback leaves the client in the
+            // rebalance and wedges the disconnect; close() cannot be relied
+            // on to answer one raised after it has already un-assigned
+            assert(consumer._consumer.unassign.calledOnce);
             assert.strictEqual(consumer._drainCallback, null);
             assert.strictEqual(consumer._drainProcessQueueTimeout, null);
             assert(KafkaBacklogMetrics.onRebalance.calledWith(
@@ -667,6 +694,7 @@ describe('backbeatConsumer', () => {
 
             onDisconnected = null;
             consumer._consumer = {
+                assign: sinon.stub(),
                 commit: sinon.stub(),
                 unassign: sinon.stub(),
                 unsubscribe: sinon.stub(),


### PR DESCRIPTION
librdkafka requires every rebalance callback to be answered, and the shutdown path answered none of them. Each case fails differently, and each leaves the client parked in the rebalance, so the disconnect wedges on it and the process can never exit.

```mermaid
flowchart TD
    R["rebalance callback raised<br/>after the shutdown began"] --> Q{"which"}
    Q -->|revoke| U["un-assign — answers it"]
    Q -->|grant| A["decline with an empty assign"]
    A --> F{"disconnect already started?"}
    F -->|"yes — assign is refused"| U2["un-assign — still permitted"]
    F -->|no| D["declined, nothing to revoke later"]
    U --> OK["client leaves the rebalance,<br/>disconnect completes"]
    U2 --> OK
    D --> OK
```

## Changes

**A revoke** was left for `close()` to answer by un-assigning later. That holds for the revoke `unsubscribe()` itself raises, but one arriving *after* `close()` has already un-assigned has nothing left to answer it. Answering here does not cut the drain short: `close()` still waits for the in-flight work, the partitions are just handed back sooner, and the offsets that drain exists to commit (BB-758) are unaffected.

**A grant** was accepted, which left the disconnect an assignment to revoke all over again. It is declined instead — but `assign()` is refused once `disconnect()` has started, since the binding gates it on `isConnected()` while permitting `unassign()` for the whole close, so the decline falls back to `unassign()`. librdkafka coerces an assign into a full unassign during termination anyway.

## Verification

Three unit tests: a grant during shutdown is declined, a grant is still answered when `assign()` is refused mid-close, and a revoke during shutdown is answered. Each was checked against the previous implementation to confirm it fails there.

This is the defect that decides whether the process exits at all, and it was found by measurement rather than review. Across 8 full runs of the lib suite per arm on CI:

| | before this PR | with it |
| --- | --- | --- |
| suite runs where the process exits | 1 / 8 | **8 / 8** (matches 9.5) |
| disconnect bound fires → process fails to exit | 40 / 40 | bound no longer fires |

The bounded disconnect was returning from `close()` looking successful while leaving a client whose destructor blocks. Answering the callbacks is what stops it firing, so the bound is a backstop rather than load-bearing.

The pod-level census found the grant case independently: the callback still accepted a partition grant *after* `close()` had handed the partitions back, so the disconnect had to revoke them again, wedged, hit its 5 s bound, and returned without a `LeaveGroup` — the surviving members then waited out `session.timeout.ms`. That was 6 of 69 iterations; declining took the SIGKILL rate to zero and halved the residual. No message was lost and nothing was committed past unprocessed work across 240 iterations.

End-to-end measurement of the whole stack is in #2819.

Issue: BB-833
