### PR TITLE
Answer every caller when close() is called more than once

### DIFF
--- a/lib/BackbeatConsumer.js
+++ b/lib/BackbeatConsumer.js
@@ -181,6 +181,7 @@ class BackbeatConsumer extends EventEmitter {
         // a deferred un-assign gives up when this no longer matches
         this._rebalanceId = 0;
         this._shuttingDown = false;
+        this._closeCallbacks = null;
 
         this._messagesConsumed = 0;
         // this variable represents how many kafka messages have been
@@ -1341,6 +1342,12 @@ class BackbeatConsumer extends EventEmitter {
      * @return {undefined}
      */
     close(cb) {
+        if (this._closeCallbacks) {
+            this._closeCallbacks.push(cb);
+            return undefined;
+        }
+        this._closeCallbacks = [cb];
+
         if (this._publishOffsetsCronTimer) {
             clearInterval(this._publishOffsetsCronTimer);
             this._publishOffsetsCronTimer = null;
@@ -1393,7 +1400,11 @@ class BackbeatConsumer extends EventEmitter {
                 this._consumer.disconnect();
                 return undefined;
             },
-        ], () => cb());
+        ], () => {
+            const callbacks = this._closeCallbacks;
+            this._closeCallbacks = null;
+            callbacks.forEach(done => done());
+        });
     }
 
     /**

--- a/tests/unit/backbeatConsumer.js
+++ b/tests/unit/backbeatConsumer.js
@@ -881,6 +881,33 @@ describe('backbeatConsumer', () => {
             });
         });
 
+        it('should answer every caller once when closed twice', done => {
+            queueIdle = false;
+            ledgerCount = 1;
+
+            let first = false;
+            let second = 0;
+            consumer.close(() => {
+                first = true;
+            });
+            consumer.close(() => {
+                second++;
+            });
+
+            setImmediate(() => {
+                queueIdle = true;
+                ledgerCount = 0;
+                drainCallbacks[drainCallbacks.length - 1]();
+
+                setTimeout(() => {
+                    assert.strictEqual(first, true);
+                    assert.strictEqual(second, 1);
+                    assert(consumer._consumer.disconnect.calledOnce);
+                    done();
+                }, 20);
+            });
+        });
+
         it('should not wait for the drain once the consumer is disconnected', done => {
             // the drain watchdog fires on a wedged task and disconnects, so the
             // work it is waiting on can never complete


### PR DESCRIPTION
The services install their SIGTERM handlers with `process.on` rather than `once`, so a repeated signal calls `close()` again. The second call started its own drain wait, overwriting the single drain slot the first was waiting on.

```mermaid
sequenceDiagram
    participant A as first caller
    participant C as BackbeatConsumer
    participant B as second caller
    A->>C: close()
    Note right of C: drain starts, first caller<br/>waits on the single drain slot
    B->>C: close() — SIGTERM repeated
    Note right of C: second wait overwrites the slot
    C-->>B: answered when the drain completes
    Note over A: never answered — released only by<br/>its own timeout, minutes after the<br/>consumer had already left the group
```

## Changes

Coalesce instead: the first call runs the shutdown, later ones attach to it, and every caller is answered once it completes.

## Verification

One unit test: closing twice answers both callers exactly once. It was checked against the previous implementation to confirm it fails there.

End-to-end measurement of the whole stack is in #2819.

Issue: BB-833
