### PR TITLE
Index ingestion readers by bucket and location

### DIFF
--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -496,28 +496,18 @@ class IngestionPopulator {
         // ]
 
         const buckets = config.getIngestionBuckets();
-        const configuredSources = Object.keys(this._ingestionSources);
+        const staleSources = new Set(Object.keys(this._ingestionSources));
         buckets.forEach(bucket => {
             const { zenkoBucket } = bucket;
-            // Get ingestion source information
             const sourceInfo = this._getSourceInformation(bucket);
-            // if the zenko bucket has already been setup and is already
-            // active, stop tracking bucket from `currentActiveSources`
-            const bucketIndex = configuredSources.indexOf(zenkoBucket);
-            const isAlreadyActive = bucketIndex >= 0;
-            if (isAlreadyActive) {
-                // remove from currentActiveSources
-                configuredSources.splice(bucketIndex, 1);
-                // check/refresh the IngestionReader if any changes
+            if (staleSources.delete(zenkoBucket)) {
                 this._ingestionSources[zenkoBucket].refresh(sourceInfo);
             } else {
                 this.addNewLogSource(sourceInfo);
             }
         });
 
-        // Any leftover `currentActiveSources` are no longer active and
-        // must be removed (including zookeeper state)
-        configuredSources.forEach(source => {
+        staleSources.forEach(source => {
             this._closeLogState(source);
         });
     }

--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -61,11 +61,11 @@ class IngestionPopulator {
 
         this.log = new Logger('Backbeat:IngestionPopulator');
 
-        // list of active log readers
-        this.logReaders = [];
+        // active log readers, i.e.: Map { zenko-bucket-name => IngestionReader() }
+        this.logReaders = new Map();
 
-        // list of updated log readers, if any
-        this.logReadersUpdate = [];
+        // updated log readers, if any, same structure
+        this.logReadersUpdate = new Map();
 
         // shared producer across readers
         this._producer = null;
@@ -75,12 +75,15 @@ class IngestionPopulator {
         this._mConsumer = null;
         this._redis = null;
 
-        // all ingestion readers (including paused ones)
-        // i.e.: { zenko-bucket-name: IngestionReader() }
-        this._ingestionSources = {};
+        // all ingestion readers (including paused ones), same structure
+        this._ingestionSources = new Map();
         // paused location constraints
-        // i.e.: { location-constraint: null || new schedule() }
-        this._pausedLocations = {};
+        // i.e.: Map { location-constraint => null || new schedule() }
+        this._pausedLocations = new Map();
+
+        // buckets of each location, as pause and resume act on a whole location
+        // i.e.: Map { location-constraint => Set { zenko-bucket-name } }
+        this._bucketsByLocation = new Map();
 
         this._circuitBreaker = new CircuitBreaker(ingestionConfig.circuitBreaker);
     }
@@ -245,13 +248,11 @@ class IngestionPopulator {
 
     setPausedLocationState(location, schedule) {
         // set paused location state for a location without a scheduled resume
-        this._pausedLocations[location] = schedule || null;
+        this._pausedLocations.set(location, schedule || null);
     }
 
     removePausedLocationState(location) {
-        if (Object.keys(this._pausedLocations).includes(location)) {
-            delete this._pausedLocations[location];
-        }
+        this._pausedLocations.delete(location);
     }
 
     /**
@@ -260,7 +261,7 @@ class IngestionPopulator {
      * @return {undefined}
      */
     _pauseService(location) {
-        const enabled = !Object.keys(this._pausedLocations).includes(location);
+        const enabled = !this._pausedLocations.has(location);
         if (enabled) {
             // if currently resumed/active, attempt to pause
             this._updateZkStateNode(location, 'paused', true, err => {
@@ -271,10 +272,8 @@ class IngestionPopulator {
                     });
                 } else {
                     // remove from this.logReaders
-                    const toPauseReaders = this.logReaders.filter(lr =>
-                        lr.getLocationConstraint() === location);
-                    toPauseReaders.forEach(reader => {
-                        const zenkoBucket = reader.getTargetZenkoBucketName();
+                    const buckets = this._getLocationBuckets(location);
+                    buckets.forEach(zenkoBucket => {
                         this._checkAndRemoveLogReader(zenkoBucket,
                             this.logReaders);
                         this.log.info('paused ingestion reader', {
@@ -297,7 +296,7 @@ class IngestionPopulator {
      * @return {undefined}
      */
     _resumeService(location, date) {
-        const enabled = !Object.keys(this._pausedLocations).includes(location);
+        const enabled = !this._pausedLocations.has(location);
         const now = new Date();
 
         if (enabled) {
@@ -319,20 +318,17 @@ class IngestionPopulator {
                 });
                 return;
             }
-            const zenkoBuckets = Object.keys(this._ingestionSources);
+            const zenkoBuckets = this._getLocationBuckets(location);
             this._deleteScheduledResumeService(location);
             zenkoBuckets.forEach(bucket => {
-                const reader = this._ingestionSources[bucket];
-                if (reader.getLocationConstraint() === location) {
-                    // add to this.logReaders
-                    this.logReaders.push(reader);
-                    // remove from this._pausedLocations
-                    this.removePausedLocationState(location);
-                    this.log.info('resumed ingestion reader', {
-                        zenkoBucket: bucket,
-                        locationConstraint: location,
-                    });
-                }
+                // add to this.logReaders
+                this.logReaders.set(bucket, this._ingestionSources.get(bucket));
+                // remove from this._pausedLocations
+                this.removePausedLocationState(location);
+                this.log.info('resumed ingestion reader', {
+                    zenkoBucket: bucket,
+                    locationConstraint: location,
+                });
             });
         });
     }
@@ -351,7 +347,7 @@ class IngestionPopulator {
                 });
                 return;
             }
-            const schedule = this._pausedLocations[location];
+            const schedule = this._pausedLocations.get(location);
             if (schedule) {
                 schedule.cancel();
                 this.setPausedLocationState(location);
@@ -380,7 +376,7 @@ class IngestionPopulator {
                         triggerResume.bind(this));
                     this.setPausedLocationState(location, scheduledResume);
                 } else {
-                    const scheduledResume = this._pausedLocations[location];
+                    const scheduledResume = this._pausedLocations.get(location);
                     if (scheduledResume) {
                         scheduledResume.cancel();
                     }
@@ -496,12 +492,12 @@ class IngestionPopulator {
         // ]
 
         const buckets = config.getIngestionBuckets();
-        const staleSources = new Set(Object.keys(this._ingestionSources));
+        const staleSources = new Set(this._ingestionSources.keys());
         buckets.forEach(bucket => {
             const { zenkoBucket } = bucket;
             const sourceInfo = this._getSourceInformation(bucket);
             if (staleSources.delete(zenkoBucket)) {
-                this._ingestionSources[zenkoBucket].refresh(sourceInfo);
+                this._ingestionSources.get(zenkoBucket).refresh(sourceInfo);
             } else {
                 this.addNewLogSource(sourceInfo);
             }
@@ -575,9 +571,47 @@ class IngestionPopulator {
         });
 
         // add to active ingestion sources list
-        this._ingestionSources[zenkoBucket] = newRaftReader;
+        this._ingestionSources.set(zenkoBucket, newRaftReader);
+        this._addLocationBucket(newRaftReader.getLocationConstraint(), zenkoBucket);
         // add to log readers update list
-        this.logReadersUpdate.push(newRaftReader);
+        this.logReadersUpdate.set(zenkoBucket, newRaftReader);
+    }
+
+    /**
+     * Get the buckets ingesting from a given location
+     * @param {String} location - location constraint
+     * @return {Set} zenko bucket names
+     */
+    _getLocationBuckets(location) {
+        return this._bucketsByLocation.get(location) || new Set();
+    }
+
+    /**
+     * Add a bucket to the buckets of a given location
+     * @param {String} location - location constraint
+     * @param {String} zenkoBucket - bucket name
+     * @return {undefined}
+     */
+    _addLocationBucket(location, zenkoBucket) {
+        let buckets = this._bucketsByLocation.get(location);
+        if (!buckets) {
+            buckets = new Set();
+            this._bucketsByLocation.set(location, buckets);
+        }
+        buckets.add(zenkoBucket);
+    }
+
+    /**
+     * Remove a bucket from the buckets of a given location
+     * @param {String} location - location constraint
+     * @param {String} zenkoBucket - bucket name
+     * @return {undefined}
+     */
+    _removeLocationBucket(location, zenkoBucket) {
+        const buckets = this._bucketsByLocation.get(location);
+        if (buckets && buckets.delete(zenkoBucket) && buckets.size === 0) {
+            this._bucketsByLocation.delete(location);
+        }
     }
 
     _loadExtension() {
@@ -604,13 +638,13 @@ class IngestionPopulator {
 
     _setupUpdatedReaders(done) {
         const newReaders = this.logReadersUpdate;
-        this.logReadersUpdate = [];
-        async.each(newReaders, (logReader, cb) => logReader.setup(err => {
+        this.logReadersUpdate = new Map();
+        async.each(newReaders.values(), (logReader, cb) => logReader.setup(err => {
             const zenkoBucket = logReader.getTargetZenkoBucketName();
             // The reader is in neither list while its setup is in flight, so
             // its source may have been removed or replaced in the meantime. It
             // must then neither be activated nor retried.
-            if (this._ingestionSources[zenkoBucket] !== logReader) {
+            if (this._ingestionSources.get(zenkoBucket) !== logReader) {
                 this.log.info('skipping log reader after setup: source was removed or replaced', {
                     method: 'IngestionPopulator._setupUpdatedReaders',
                     zenkoBucket,
@@ -630,9 +664,9 @@ class IngestionPopulator {
                 // Setup failures are usually transient (source unreachable,
                 // invalid credentials...): queue the reader again so that it
                 // is retried on the next cycle.
-                this.logReadersUpdate.push(logReader);
+                this.logReadersUpdate.set(zenkoBucket, logReader);
             } else {
-                this.logReaders.push(logReader);
+                this.logReaders.set(zenkoBucket, logReader);
             }
             return cb();
         }), done);
@@ -643,7 +677,7 @@ class IngestionPopulator {
      * @return {undefined}
      */
     _removePausedReaders() {
-        const locationsToPause = Object.keys(this._pausedLocations);
+        const locationsToPause = [...this._pausedLocations.keys()];
 
         this.log.debug('removing paused readers before processing log entries', {
             method: 'IngestionPopulator._removePausedReaders',
@@ -653,12 +687,8 @@ class IngestionPopulator {
         locationsToPause.forEach(location => {
             // if IngestionReader is a paused location, remove from active
             // IngestionReader list: this.logReaders
-            this.logReaders.forEach(lr => {
-                if (lr.getLocationConstraint() === location) {
-                    this._checkAndRemoveLogReader(
-                        lr.getTargetZenkoBucketName(), this.logReaders);
-                }
-            });
+            this._getLocationBuckets(location).forEach(zenkoBucket =>
+                this._checkAndRemoveLogReader(zenkoBucket, this.logReaders));
         });
     }
 
@@ -735,8 +765,8 @@ class IngestionPopulator {
         // Unregister the source first: a reader whose setup is in flight is in
         // neither list, and leaving its entry here would let it register itself
         // once the setup completes.
-        const reader = this._ingestionSources[key];
-        delete this._ingestionSources[key];
+        const reader = this._ingestionSources.get(key);
+        this._removeIngestionSource(key);
 
         if (this._checkAndRemoveLogReader(key, this.logReadersUpdate)) {
             // if removed from `this.logReadersUpdate`, zookeeper setup has not
@@ -760,21 +790,24 @@ class IngestionPopulator {
         }
     }
 
+    _removeIngestionSource(zenkoBucket) {
+        const reader = this._ingestionSources.get(zenkoBucket);
+        if (!reader) {
+            return;
+        }
+        this._ingestionSources.delete(zenkoBucket);
+        this._removeLocationBucket(reader.getLocationConstraint(), zenkoBucket);
+    }
+
     /**
-     * Helper method to check an array of logReaders to remove a given bucket
+     * Helper method to check a map of logReaders to remove a given bucket
      * name.
      * @param {String} name - bucket name
-     * @param {Array} list - list of logReaders
-     * @return {Boolean} true if something was removed from given list
+     * @param {Map} readers - logReaders, by bucket name
+     * @return {Boolean} true if something was removed from given map
      */
-    _checkAndRemoveLogReader(name, list) {
-        const index = list.findIndex(lr =>
-            lr.getTargetZenkoBucketName() === name);
-        if (index !== -1) {
-            list.splice(index, 1);
-            return true;
-        }
-        return false;
+    _checkAndRemoveLogReader(name, readers) {
+        return readers.delete(name);
     }
 
     _processLogReaderEntries(logReader, params, cb) {
@@ -798,7 +831,7 @@ class IngestionPopulator {
             return cb();
         }
         // skipping if location is paused
-        if (this._pausedLocations[logReader.getLocationConstraint()] !== undefined) {
+        if (this._pausedLocations.has(logReader.getLocationConstraint())) {
             this.log.debug('location paused, skipping', {
                 zenkoBucket: logReader.getTargetZenkoBucketName(),
                 location: logReader.getLocationConstraint(),
@@ -826,7 +859,7 @@ class IngestionPopulator {
 
     _processLogEntries(params, done) {
         const { maxParallelReaders } = this.ingestionConfig;
-        return async.eachLimit(this.logReaders, maxParallelReaders,
+        return async.eachLimit(this.logReaders.values(), maxParallelReaders,
             (logReader, cb) => {
                 this._processLogReaderEntries(logReader, params, cb);
             }, done);
@@ -835,7 +868,7 @@ class IngestionPopulator {
     processLogEntries(params, done) {
         return async.series([
             next => {
-                if (this.logReadersUpdate.length >= 1) {
+                if (this.logReadersUpdate.size >= 1) {
                     return this._setupUpdatedReaders(next);
                 }
                 return process.nextTick(next);

--- a/tests/functional/ingestion/pauseResumeState.js
+++ b/tests/functional/ingestion/pauseResumeState.js
@@ -90,15 +90,15 @@ class IngestionPopulatorMock extends IngestionPopulator {
     /* Getters for testing purposes */
 
     getIngestionSourceNames() {
-        return Object.keys(this._ingestionSources);
+        return [...this._ingestionSources.keys()];
     }
 
     getPausedLocations() {
-        return this._pausedLocations;
+        return Object.fromEntries(this._pausedLocations);
     }
 
     getPausedLocationNames() {
-        return Object.keys(this._pausedLocations);
+        return [...this._pausedLocations.keys()];
     }
 
     getZkClient() {

--- a/tests/unit/ingestion/IngestionPopulator.js
+++ b/tests/unit/ingestion/IngestionPopulator.js
@@ -114,6 +114,15 @@ class IngestionReaderMock extends IngestionReader {
     _setupIngestionProducer() {
         this._updated = true;
     }
+
+    /**
+     * Mock to avoid connecting to the source to resolve the raft session
+     * @param {Function} done - callback
+     * @return {undefined}
+     */
+    setup(done) {
+        return process.nextTick(done);
+    }
 }
 
 class IngestionPopulatorMock extends IngestionPopulator {
@@ -185,6 +194,7 @@ describe('Ingestion Populator', () => {
 
     beforeEach(() => {
         ip = new IngestionPopulatorMock(
+            null,
             zkConfig,
             kafkaConfig,
             qpConfig,
@@ -485,6 +495,18 @@ describe('Ingestion Populator', () => {
             assert.deepStrictEqual(populator._ingestionSources, new Map());
             assert.strictEqual(removeReaderState.called, false);
         });
+
+        it('should stop tracking a location once its last source is gone', () => {
+            const logReader = createReaderMock(ACTIVE_BUCKET);
+            logReader.getLocationConstraint.returns('active-ring');
+            populator._ingestionSources.set(ACTIVE_BUCKET, logReader);
+            populator._addLocationBucket('active-ring', ACTIVE_BUCKET);
+
+            populator._closeLogState(ACTIVE_BUCKET);
+
+            assert.deepStrictEqual(populator._getLocationBuckets('active-ring'),
+                new Set());
+        });
     });
 
     describe('_processLogReaderEntries', () => {
@@ -561,6 +583,93 @@ describe('Ingestion Populator', () => {
             ip._processLogReaderEntries(undefined, {}, err => {
                 assert.ifError(err);
                 done();
+            });
+        });
+    });
+
+    describe('pause/resume', () => {
+        const location = existingBucket.locationConstraint;
+
+        beforeEach(done => {
+            // stub out zookeeper state persistence, tested separately
+            sinon.stub(ip, '_updateZkStateNode').callsArgWith(3, null);
+            ip._setupUpdatedReaders(done);
+        });
+
+        afterEach(() => sinon.restore());
+
+        it('should remove the readers of a location on pause', () => {
+            assert(ip.logReaders.has(EXISTING_BUCKET));
+
+            ip._pauseService(location);
+
+            assert(!ip.logReaders.has(EXISTING_BUCKET));
+            assert(ip._pausedLocations.has(location));
+            // the reader itself is kept, to be restored on resume
+            assert(ip._ingestionSources.has(EXISTING_BUCKET));
+        });
+
+        it('should not pause an already paused location', () => {
+            ip.setPausedLocationState(location);
+
+            ip._pauseService(location);
+
+            assert(ip._updateZkStateNode.notCalled);
+        });
+
+        it('should restore the readers of a location on resume', () => {
+            ip._pauseService(location);
+            assert(!ip.logReaders.has(EXISTING_BUCKET));
+
+            ip._resumeService(location);
+
+            assert(ip.logReaders.has(EXISTING_BUCKET));
+            assert(!ip._pausedLocations.has(location));
+        });
+
+        it('should not resume a location that is not paused', () => {
+            ip._resumeService(location);
+
+            assert(ip._updateZkStateNode.notCalled);
+        });
+
+        it('should schedule a resume when given a future date', () => {
+            const date = new Date();
+            date.setHours(date.getHours() + 1);
+            ip._pauseService(location);
+
+            ip._resumeService(location, date);
+
+            const scheduled = ip._pausedLocations.get(location);
+            assert(scheduled);
+            scheduled.cancel();
+        });
+
+        it('should remove the readers of paused locations before processing', () => {
+            // a location may be paused without going through _pauseService,
+            // i.e. when restoring the state saved in zookeeper on startup
+            ip.setPausedLocationState(location);
+
+            ip._removePausedReaders();
+
+            assert(!ip.logReaders.has(EXISTING_BUCKET));
+        });
+    });
+
+    describe('_processLogEntries', () => {
+        it('should process every active reader', done => {
+            ip._setupUpdatedReaders(() => {
+                ip.logReaders.forEach(reader => {
+                    // eslint-disable-next-line no-param-reassign
+                    reader.processLogEntries = sinon.stub().yields(null, false);
+                });
+
+                ip._processLogEntries({}, err => {
+                    assert.ifError(err);
+                    ip.logReaders.forEach(reader =>
+                        assert(reader.processLogEntries.calledOnce));
+                    done();
+                });
             });
         });
     });

--- a/tests/unit/ingestion/IngestionPopulator.js
+++ b/tests/unit/ingestion/IngestionPopulator.js
@@ -120,7 +120,8 @@ class IngestionPopulatorMock extends IngestionPopulator {
     reset() {
         this._added = [];
         this._removed = [];
-        this._ingestionSources = {};
+        this._ingestionSources = new Map();
+        this._bucketsByLocation = new Map();
     }
 
     getAdded() {
@@ -133,9 +134,9 @@ class IngestionPopulatorMock extends IngestionPopulator {
 
     getUpdated() {
         const updated = [];
-        Object.keys(this._ingestionSources).forEach(s => {
-            if (this._ingestionSources[s].hasUpdated()) {
-                updated.push(s);
+        this._ingestionSources.forEach((reader, zenkoBucket) => {
+            if (reader.hasUpdated()) {
+                updated.push(zenkoBucket);
             }
         });
         return updated;
@@ -163,11 +164,14 @@ class IngestionPopulatorMock extends IngestionPopulator {
 
     addNewLogSource(newSource) {
         const zenkoBucket = newSource.name;
-        this._ingestionSources[zenkoBucket] = new IngestionReaderMock({
+        const reader = new IngestionReaderMock({
             bucketdConfig: newSource,
             logger: fakeLogger,
             ingestionConfig: {},
         });
+        this._ingestionSources.set(zenkoBucket, reader);
+        this._addLocationBucket(reader.getLocationConstraint(), zenkoBucket);
+        this.logReadersUpdate.set(zenkoBucket, reader);
         this._added.push(newSource);
     }
 
@@ -282,14 +286,14 @@ describe('Ingestion Populator', () => {
         function addLogReader(zenkoBucket) {
             const logReader = sinon.createStubInstance(IngestionReader);
             logReader.getTargetZenkoBucketName.returns(zenkoBucket);
-            ip._ingestionSources[zenkoBucket] = logReader;
-            ip.logReadersUpdate.push(logReader);
+            ip._ingestionSources.set(zenkoBucket, logReader);
+            ip.logReadersUpdate.set(zenkoBucket, logReader);
             return logReader;
         }
 
         beforeEach(() => {
-            ip.logReaders = [];
-            ip.logReadersUpdate = [];
+            ip.logReaders = new Map();
+            ip.logReadersUpdate = new Map();
         });
 
         it('should activate a log reader once its setup succeeds', done => {
@@ -298,8 +302,9 @@ describe('Ingestion Populator', () => {
 
             ip._setupUpdatedReaders(err => {
                 assert.ifError(err);
-                assert.deepStrictEqual(ip.logReaders, [logReader]);
-                assert.deepStrictEqual(ip.logReadersUpdate, []);
+                assert.deepStrictEqual(ip.logReaders,
+                    new Map([['bucket1', logReader]]));
+                assert.deepStrictEqual(ip.logReadersUpdate, new Map());
                 done();
             });
         });
@@ -310,8 +315,9 @@ describe('Ingestion Populator', () => {
 
             ip._setupUpdatedReaders(err => {
                 assert.ifError(err);
-                assert.deepStrictEqual(ip.logReaders, []);
-                assert.deepStrictEqual(ip.logReadersUpdate, [logReader]);
+                assert.deepStrictEqual(ip.logReaders, new Map());
+                assert.deepStrictEqual(ip.logReadersUpdate,
+                    new Map([['bucket1', logReader]]));
                 done();
             });
         });
@@ -320,12 +326,12 @@ describe('Ingestion Populator', () => {
         'its source is no longer configured', done => {
             const logReader = addLogReader('bucket1');
             logReader.setup.yieldsAsync(errors.InternalError);
-            delete ip._ingestionSources.bucket1;
+            ip._ingestionSources.delete('bucket1');
 
             ip._setupUpdatedReaders(err => {
                 assert.ifError(err);
-                assert.deepStrictEqual(ip.logReaders, []);
-                assert.deepStrictEqual(ip.logReadersUpdate, []);
+                assert.deepStrictEqual(ip.logReaders, new Map());
+                assert.deepStrictEqual(ip.logReadersUpdate, new Map());
                 done();
             });
         });
@@ -336,12 +342,12 @@ describe('Ingestion Populator', () => {
             staleReader.setup.yieldsAsync(errors.InternalError);
             const currentReader = sinon.createStubInstance(IngestionReader);
             currentReader.getTargetZenkoBucketName.returns('bucket1');
-            ip._ingestionSources.bucket1 = currentReader;
+            ip._ingestionSources.set('bucket1', currentReader);
 
             ip._setupUpdatedReaders(err => {
                 assert.ifError(err);
-                assert.deepStrictEqual(ip.logReaders, []);
-                assert.deepStrictEqual(ip.logReadersUpdate, []);
+                assert.deepStrictEqual(ip.logReaders, new Map());
+                assert.deepStrictEqual(ip.logReadersUpdate, new Map());
                 done();
             });
         });
@@ -350,12 +356,12 @@ describe('Ingestion Populator', () => {
         'its source is no longer configured', done => {
             const logReader = addLogReader('bucket1');
             logReader.setup.yieldsAsync(null);
-            delete ip._ingestionSources.bucket1;
+            ip._ingestionSources.delete('bucket1');
 
             ip._setupUpdatedReaders(err => {
                 assert.ifError(err);
-                assert.deepStrictEqual(ip.logReaders, []);
-                assert.deepStrictEqual(ip.logReadersUpdate, []);
+                assert.deepStrictEqual(ip.logReaders, new Map());
+                assert.deepStrictEqual(ip.logReadersUpdate, new Map());
                 done();
             });
         });
@@ -366,12 +372,12 @@ describe('Ingestion Populator', () => {
             staleReader.setup.yieldsAsync(null);
             const currentReader = sinon.createStubInstance(IngestionReader);
             currentReader.getTargetZenkoBucketName.returns('bucket1');
-            ip._ingestionSources.bucket1 = currentReader;
+            ip._ingestionSources.set('bucket1', currentReader);
 
             ip._setupUpdatedReaders(err => {
                 assert.ifError(err);
-                assert.deepStrictEqual(ip.logReaders, []);
-                assert.deepStrictEqual(ip.logReadersUpdate, []);
+                assert.deepStrictEqual(ip.logReaders, new Map());
+                assert.deepStrictEqual(ip.logReadersUpdate, new Map());
                 done();
             });
         });
@@ -384,8 +390,10 @@ describe('Ingestion Populator', () => {
 
             ip._setupUpdatedReaders(err => {
                 assert.ifError(err);
-                assert.deepStrictEqual(ip.logReaders, [workingReader]);
-                assert.deepStrictEqual(ip.logReadersUpdate, [failingReader]);
+                assert.deepStrictEqual(ip.logReaders,
+                    new Map([['bucket2', workingReader]]));
+                assert.deepStrictEqual(ip.logReadersUpdate,
+                    new Map([['bucket1', failingReader]]));
                 done();
             });
         });
@@ -429,13 +437,13 @@ describe('Ingestion Populator', () => {
         it('should unregister a source whose reader is still pending setup',
         () => {
             const logReader = createReaderMock(PENDING_BUCKET);
-            populator._ingestionSources[PENDING_BUCKET] = logReader;
-            populator.logReadersUpdate = [logReader];
+            populator._ingestionSources.set(PENDING_BUCKET, logReader);
+            populator.logReadersUpdate = new Map([[PENDING_BUCKET, logReader]]);
 
             populator._closeLogState(PENDING_BUCKET);
 
-            assert.deepStrictEqual(populator.logReadersUpdate, []);
-            assert.strictEqual(populator._ingestionSources[PENDING_BUCKET],
+            assert.deepStrictEqual(populator.logReadersUpdate, new Map());
+            assert.strictEqual(populator._ingestionSources.get(PENDING_BUCKET),
                 undefined);
             // zookeeper state is only created once the setup succeeded
             assert.strictEqual(removeReaderState.called, false);
@@ -444,13 +452,13 @@ describe('Ingestion Populator', () => {
         it('should unregister an active source and clean its zookeeper state',
         () => {
             const logReader = createReaderMock(ACTIVE_BUCKET);
-            populator._ingestionSources[ACTIVE_BUCKET] = logReader;
-            populator.logReaders = [logReader];
+            populator._ingestionSources.set(ACTIVE_BUCKET, logReader);
+            populator.logReaders = new Map([[ACTIVE_BUCKET, logReader]]);
 
             populator._closeLogState(ACTIVE_BUCKET);
 
-            assert.deepStrictEqual(populator.logReaders, []);
-            assert.strictEqual(populator._ingestionSources[ACTIVE_BUCKET],
+            assert.deepStrictEqual(populator.logReaders, new Map());
+            assert.strictEqual(populator._ingestionSources.get(ACTIVE_BUCKET),
                 undefined);
             // the reader is read before being unregistered, as
             // `_removeReaderState` polls it until its batch completes
@@ -462,11 +470,11 @@ describe('Ingestion Populator', () => {
 
         it('should unregister a source whose setup is still in flight', () => {
             const logReader = createReaderMock(PENDING_BUCKET);
-            populator._ingestionSources[PENDING_BUCKET] = logReader;
+            populator._ingestionSources.set(PENDING_BUCKET, logReader);
 
             populator._closeLogState(PENDING_BUCKET);
 
-            assert.strictEqual(populator._ingestionSources[PENDING_BUCKET],
+            assert.strictEqual(populator._ingestionSources.get(PENDING_BUCKET),
                 undefined);
             assert.strictEqual(removeReaderState.called, false);
         });
@@ -474,7 +482,7 @@ describe('Ingestion Populator', () => {
         it('should not throw when the source is unknown', () => {
             populator._closeLogState('never-configured-bucket');
 
-            assert.deepStrictEqual(populator._ingestionSources, {});
+            assert.deepStrictEqual(populator._ingestionSources, new Map());
             assert.strictEqual(removeReaderState.called, false);
         });
     });


### PR DESCRIPTION
`IngestionPopulator` held its readers in arrays, so every lookup was a
linear scan. Removing a source walked both reader lists; pausing or
resuming a location walked them again to match on location constraint.
With one bucket per location and deployments reaching thousands of
locations, a configuration change or a pause event became quadratic work
on the event loop.

Readers are now keyed by zenko bucket, with a separate index listing the
buckets of each location for the operations that act on a whole location.
`_pausedLocations` becomes a map as well, so membership tests stop
enumerating its keys. Every lookup, insertion and removal is now constant
time, and the logic of each code path is unchanged.

Two latent bugs disappear as a side effect: `_removePausedReaders()`
spliced `logReaders` while iterating it with `forEach`, skipping the
element after each removal, and `_resumeService()` could push a reader
that was already active. Both were masked by the one-bucket-per-location
deployment, but neither invariant was enforced anywhere; the map
representation makes them unrepresentable.

Issue: BB-865
