### PR TITLE
Publish no metrics when none are configured

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -311,3 +311,14 @@ A `BackbeatServer` (default port 8900) and `BackbeatAPI` expose these metrics
 stored in Redis by querying based on the prepended Redis keys. This data
 enables calculation of simple metrics like backlog, completion count,
 and throughput.
+
+## Disabling publication
+
+The whole chain above hangs off the `metrics` configuration section, which is
+optional: omit it, and no process publishes to the metrics topic, nor consumes
+it into Redis. The routes of this document then report nothing, and the
+Prometheus metrics served on the probe servers are unaffected.
+
+This is meant for a deployment holding no consumer for what it would publish,
+such as a metadata sink consuming a Kafka cluster it has no produce rights on.
+Anywhere the routes above are served, the section is required.

--- a/extensions/mongoProcessor/MongoQueueProcessor.js
+++ b/extensions/mongoProcessor/MongoQueueProcessor.js
@@ -63,7 +63,8 @@ class MongoQueueProcessor {
      *  backoff factor
      * @param {number} [mongoProcessorConfig.concurrency] - consumer concurrency
      * @param {Object} mongoClientConfig - config for connecting to mongo
-     * @param {Object} mConfig - metrics config
+     * @param {Object} [mConfig] - metrics config, no metrics are published
+     *   when omitted
      */
     constructor(kafkaConfig, mongoProcessorConfig, mongoClientConfig, mConfig) {
         this.kafkaConfig = kafkaConfig;
@@ -81,16 +82,30 @@ class MongoQueueProcessor {
         // in-mem batch of metrics, we only track total entry count by location
         // this._accruedMetrics = { zenko-location: 10 }
         this._accruedMetrics = {};
-
-        setInterval(() => {
-            this._sendMetrics();
-        }, METRIC_REPORT_INTERVAL_MS);
     }
 
     _setupMetricsClients(cb) {
         // Metrics Producer
         this._mProducer = new MetricsProducer(this.kafkaConfig, this._mConfig);
-        this._mProducer.setupProducer(cb);
+        this._mProducer.setupProducer(err => {
+            if (!err) {
+                this._startMetricsReporting();
+            }
+            return cb(err);
+        });
+    }
+
+    /**
+     * Start reporting the accrued metrics, unless none are published
+     * @return {undefined}
+     */
+    _startMetricsReporting() {
+        if (!this._mConfig?.topic) {
+            return;
+        }
+        setInterval(() => {
+            this._sendMetrics();
+        }, METRIC_REPORT_INTERVAL_MS);
     }
 
     /**

--- a/extensions/replication/ReplicationMetric.js
+++ b/extensions/replication/ReplicationMetric.js
@@ -69,6 +69,9 @@ class ReplicationMetric {
         if (this._isLifecycleAction()) {
             return undefined;
         }
+        if (!this._producer) {
+            return undefined;
+        }
         const message = this._createProducerMessage();
         return this._producer.send([{ message }], err => {
             if (err) {

--- a/lib/MetricsProducer.js
+++ b/lib/MetricsProducer.js
@@ -10,17 +10,24 @@ class MetricsProducer {
     /**
     * @constructor
     * @param {Object} kafkaConfig - kafka connection config
-    * @param {Object} mConfig - metrics configurations
+    * @param {Object} [mConfig] - metrics configurations. Publication is
+    *   disabled when omitted, for a deployment consuming a cluster it holds
+    *   no produce rights on, and whose metrics nothing reads.
     */
     constructor(kafkaConfig, mConfig) {
         this._kafkaConfig = kafkaConfig;
-        this._topic = mConfig.topic;
+        this._topic = mConfig?.topic;
 
         this._producer = null;
         this._log = new Logger('MetricsProducer');
     }
 
     setupProducer(done) {
+        if (!this._topic) {
+            this._log.info('metrics publication is disabled, no metrics ' +
+                           'topic is configured');
+            return process.nextTick(done);
+        }
         const producer = new BackbeatProducer({
             kafka: { hosts: this._kafkaConfig.hosts },
             maxRequestSize: this._kafkaConfig.maxRequestSize,
@@ -39,6 +46,7 @@ class MetricsProducer {
             this._producer = producer;
             done();
         });
+        return undefined;
     }
 
     getProducer() {
@@ -55,7 +63,10 @@ class MetricsProducer {
      * @return {undefined}
      */
     publishMetrics(extMetrics, type, ext, cb) {
-        async.each(Object.keys(extMetrics), (siteName, done) => {
+        if (!this._topic) {
+            return process.nextTick(cb);
+        }
+        return async.each(Object.keys(extMetrics), (siteName, done) => {
             const { ops, bytes, bucketName, objectKey, versionId } =
                 extMetrics[siteName];
             const message = new MetricsModel(ops, bytes, ext, type,
@@ -73,7 +84,10 @@ class MetricsProducer {
     }
 
     close(cb) {
-        this._producer.close(cb);
+        if (!this._producer) {
+            return process.nextTick(cb);
+        }
+        return this._producer.close(cb);
     }
 }
 

--- a/lib/queuePopulator/IngestionPopulator.js
+++ b/lib/queuePopulator/IngestionPopulator.js
@@ -39,7 +39,8 @@ class IngestionPopulator {
      * @param {String} kafkaConfig.hosts - kafka hosts list
      * as "host:port[,host:port...]"
      * @param {Object} qpConfig - queue populator configuration
-     * @param {Object} mConfig - metrics configuration object
+     * @param {Object} [mConfig] - metrics configuration object, no metrics
+     *   are published nor consumed when omitted
      * @param {String} mConfig.topic - metrics topic
      * @param {Object} rConfig - redis configuration object
      * @param {Object} ingestionConfig - ingestion extension configurations
@@ -144,9 +145,11 @@ class IngestionPopulator {
 
     _setupMetricsClients(cb) {
         // Metrics Consumer
-        this._mConsumer = new MetricsConsumer(this.rConfig, this.mConfig,
-            this.kafkaConfig, metricsExtension);
-        this._mConsumer.start();
+        if (this.mConfig) {
+            this._mConsumer = new MetricsConsumer(this.rConfig, this.mConfig,
+                this.kafkaConfig, metricsExtension);
+            this._mConsumer.start();
+        }
 
         // Metrics Producer
         this._mProducer = new MetricsProducer(this.kafkaConfig, this.mConfig);

--- a/lib/queuePopulator/QueuePopulator.js
+++ b/lib/queuePopulator/QueuePopulator.js
@@ -142,7 +142,8 @@ class QueuePopulator {
      * @param {String} [httpsConfig.key] - private key file path
      * @param {String} [httpsConfig.cert] - certificate file path
      * @param {String} [httpsConfig.ca] - CA file path
-     * @param {Object} mConfig - metrics configuration object
+     * @param {Object} [mConfig] - metrics configuration object, no metrics
+     *   are published nor consumed when omitted
      * @param {string} mConfig.topic - metrics topic
      * @param {Object} rConfig - redis ha configuration
      * @param {Object} vConfig - vault admin configuration
@@ -234,9 +235,11 @@ class QueuePopulator {
 
     _setupMetricsClients(cb) {
         // Metrics Consumer
-        this._mConsumer = new MetricsConsumer(this.rConfig,
-            this.mConfig, this.kafkaConfig, metricsExtension);
-        this._mConsumer.start();
+        if (this.mConfig) {
+            this._mConsumer = new MetricsConsumer(this.rConfig,
+                this.mConfig, this.kafkaConfig, metricsExtension);
+            this._mConsumer.start();
+        }
 
         // Metrics Producer
         this._mProducer = new MetricsProducer(this.kafkaConfig, this.mConfig);

--- a/tests/functional/ingestion/MongoQueueProcessor.js
+++ b/tests/functional/ingestion/MongoQueueProcessor.js
@@ -21,7 +21,7 @@ const { ObjectMDArchive, LifecycleConfiguration, NotificationConfiguration } = r
 const kafkaConfig = config.kafka;
 const mongoProcessorConfig = config.extensions.mongoProcessor;
 const mongoClientConfig = config.queuePopulator.mongo;
-const mConfig = {};
+const mConfig = { topic: 'backbeat-metrics' };
 
 const bootstrapList = config.extensions.replication.destination.bootstrapList;
 
@@ -171,6 +171,7 @@ class MongoQueueProcessorMock extends MongoQueueProcessor {
         };
         this._bootstrapList = bootstrapList;
         this._metricsStore = [];
+        this._startMetricsReporting();
     }
 
     sendMockEntry(entry, cb) {

--- a/tests/unit/QueuePopulator.spec.js
+++ b/tests/unit/QueuePopulator.spec.js
@@ -221,6 +221,22 @@ describe('QueuePopulator', () => {
         });
     });
 
+    describe('_setupMetricsClients', () => {
+        afterEach(() => {
+            sinon.restore();
+        });
+
+        it('should set up no metrics client when no metrics are configured',
+            done => {
+                qp._setupMetricsClients(err => {
+                    assert.ifError(err);
+                    assert.strictEqual(qp._mConsumer, null);
+                    assert.strictEqual(qp._mProducer.getProducer(), null);
+                    return done();
+                });
+            });
+    });
+
     describe('close', () => {
         let mockLogReader1;
         let mockLogReader2;

--- a/tests/unit/ReplicationMetric.js
+++ b/tests/unit/ReplicationMetric.js
@@ -79,6 +79,13 @@ describe('ReplicationMetric', () => {
         assert.strictEqual(sentMessages.length, 0);
     });
 
+    it('::publish should not send data to topic if metrics are disabled',
+        () => {
+            metric.withProducer(null);
+            metric.publish();
+            assert.strictEqual(sentMessages.length, 0);
+        });
+
     it('::publish should send data to topic', () => {
         metric.publish();
         assert.strictEqual(sentMessages.length, 1);

--- a/tests/unit/lib/MetricsProducer.spec.js
+++ b/tests/unit/lib/MetricsProducer.spec.js
@@ -1,0 +1,72 @@
+const assert = require('assert');
+const sinon = require('sinon');
+
+const MetricsProducer = require('../../../lib/MetricsProducer');
+
+const kafkaConfig = { hosts: 'localhost:9092' };
+const extMetrics = { 'us-east-1': { ops: 1, bytes: 128 } };
+
+describe('MetricsProducer', () => {
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    describe('with no metrics configured', () => {
+        let mProducer;
+
+        beforeEach(() => {
+            mProducer = new MetricsProducer(kafkaConfig, undefined);
+        });
+
+        it('should set up without connecting to kafka', done => {
+            mProducer.setupProducer(err => {
+                assert.ifError(err);
+                assert.strictEqual(mProducer.getProducer(), null);
+                return done();
+            });
+        });
+
+        it('should publish nothing', done => {
+            mProducer.setupProducer(err => {
+                assert.ifError(err);
+                return mProducer.publishMetrics(
+                    extMetrics, 'completed', 'crr', err => {
+                        assert.ifError(err);
+                        return done();
+                    });
+            });
+        });
+
+        it('should close without a producer to close', done => {
+            mProducer.close(err => {
+                assert.ifError(err);
+                return done();
+            });
+        });
+    });
+
+    describe('with a metrics topic configured', () => {
+        let mProducer;
+
+        beforeEach(() => {
+            mProducer = new MetricsProducer(kafkaConfig, { topic: 'metrics' });
+            mProducer._producer = { send: sinon.stub().yields() };
+        });
+
+        it('should publish to the metrics topic', done => {
+            mProducer.publishMetrics(extMetrics, 'completed', 'crr', err => {
+                assert.ifError(err);
+                sinon.assert.calledOnce(mProducer._producer.send);
+                const [[{ message }]] =
+                    mProducer._producer.send.firstCall.args;
+                const published = JSON.parse(message);
+                assert.strictEqual(published.site, 'us-east-1');
+                assert.strictEqual(published.ops, 1);
+                assert.strictEqual(published.bytes, 128);
+                assert.strictEqual(published.type, 'completed');
+                assert.strictEqual(published.extension, 'crr');
+                return done();
+            });
+        });
+    });
+});

--- a/tests/unit/lib/config/Config.spec.js
+++ b/tests/unit/lib/config/Config.spec.js
@@ -33,6 +33,11 @@ describe('Config', () => {
         assert.doesNotThrow(() => config._parseConfig(testConfig));
     });
 
+    it('should accept a config publishing no metrics', () => {
+        delete testConfig.metrics;
+        assert.doesNotThrow(() => config._parseConfig(testConfig));
+    });
+
     it('should throw an error when dataMoverTopic is not provided and transition is supported', () => {
         delete testConfig.extensions.replication.dataMoverTopic;
         testConfig.extensions.lifecycle.supportedLifecycleRules = [

--- a/tests/unit/mongoProcessor/MongoQueueProcessor.spec.js
+++ b/tests/unit/mongoProcessor/MongoQueueProcessor.spec.js
@@ -6,6 +6,7 @@ const MongoQueueProcessor =
 const ObjectQueueEntry =
     require('../../../lib/models/ObjectQueueEntry');
 const BackbeatConsumer = require('../../../lib/BackbeatConsumer');
+const MetricsProducer = require('../../../lib/MetricsProducer');
 const Config = require('../../../lib/Config');
 
 function _makeProcessor(bootstrapList) {
@@ -283,6 +284,70 @@ describe('MongoQueueProcessor.start', () => {
             assert.deepStrictEqual(proc._consumer._consumerParams,
                 { 'security.protocol': 'ssl' });
             done();
+        });
+    });
+});
+
+describe('MongoQueueProcessor metrics', () => {
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    function makeProcessor(mConfig) {
+        return new MongoQueueProcessor(
+            { hosts: 'localhost:9092' },
+            { topic: 'backbeat-ingestion' },
+            {},
+            mConfig);
+    }
+
+    it('reports periodically when a metrics topic is configured', done => {
+        sinon.stub(MetricsProducer.prototype, 'setupProducer').yields();
+        const clock = sinon.useFakeTimers({ toFake: ['setInterval'] });
+        const proc = makeProcessor({ topic: 'backbeat-metrics' });
+
+        proc._setupMetricsClients(err => {
+            assert.ifError(err);
+            assert.strictEqual(clock.countTimers(), 1);
+            return done();
+        });
+    });
+
+    it('does not report when no metrics topic is configured', done => {
+        const clock = sinon.useFakeTimers({ toFake: ['setInterval'] });
+        const proc = makeProcessor(undefined);
+
+        proc._setupMetricsClients(err => {
+            assert.ifError(err);
+            assert.strictEqual(clock.countTimers(), 0);
+            return done();
+        });
+    });
+
+    it('does not report when the producer fails to set up', done => {
+        const setupError = new Error('kafka is unreachable');
+        sinon.stub(MetricsProducer.prototype, 'setupProducer')
+            .yields(setupError);
+        const clock = sinon.useFakeTimers({ toFake: ['setInterval'] });
+        const proc = makeProcessor({ topic: 'backbeat-metrics' });
+
+        proc._setupMetricsClients(err => {
+            assert.strictEqual(err, setupError);
+            assert.strictEqual(clock.countTimers(), 0);
+            return done();
+        });
+    });
+
+    it('publishes nothing when no metrics topic is configured', done => {
+        const proc = makeProcessor(undefined);
+
+        proc._setupMetricsClients(err => {
+            assert.ifError(err);
+            proc._produceMetricCompletionEntry('us-east-1');
+            proc._sendMetrics();
+            proc._normalizePendingMetric('us-east-1');
+            assert.strictEqual(proc._mProducer.getProducer(), null);
+            return done();
         });
     });
 });


### PR DESCRIPTION
We now deploy mongo-processor for PRA, which is supposed to consume from the production Kafka instance it might only have **read access** to.

But currently it would try to setup automatically some metrics producer at startup, which are not used at all by it. (The metrics producer is normally used to write some metrics in a topic, then get them back later, put them into Redis, serve them for an API, but that's not used by the mongo processor).

So here we make the metrics producer entirely optional if the metrics configuration block is not passed. To avoid crashing the mongo processor.

## Why the producer is still constructed

Optional here means it connects to nothing and publishes nothing, rather than not existing. The producer is handed down to the replication tasks and the log readers, and `CopyLocationTask` pulls the raw `BackbeatProducer` out of it with `getProducer()` from its own constructor. Leaving it null instead would need a guard at ten call sites, one of them a constructor, and a missed one is a crash.

Three callers reach past `publishMetrics()` and are handled where they are: the mongo-processor schedules no reporting interval, the two populators start no `MetricsConsumer` (it needs a topic and a redis of its own), and `ReplicationMetric` sends nothing.

Issue: BB-853