### PR TITLE
Honor transitionOneDayEarlier in v1 lifecycle transitions

### DIFF
--- a/extensions/lifecycle/tasks/LifecycleTask.js
+++ b/extensions/lifecycle/tasks/LifecycleTask.js
@@ -816,9 +816,10 @@ class LifecycleTask extends BackbeatTask {
      * @param {number} daysSinceInitiated - Days passed since entity (object or version) last modified
      * NOTE: entity is not an in-progress MPU or a delete marker.
      * @param {number} currentDate - current date
+     * @param {string} lastModified - entity last modified date
      * @return {boolean} true if rule applies - false otherwise.
      */
-    _isRuleApplying(rule, daysSinceInitiated, currentDate) {
+    _isRuleApplying(rule, daysSinceInitiated, currentDate, lastModified) {
         if (rule.Expiration && this._supportedRules.includes('Expiration')) {
             if (rule.Expiration.Days !== undefined && daysSinceInitiated >= rule.Expiration.Days) {
                 return true;
@@ -835,14 +836,11 @@ class LifecycleTask extends BackbeatTask {
 
         if (rule.Transitions && rule.Transitions.length > 0
             && this._supportedRules.includes('Transition')) {
+            // Same computation as the apply stage, so that
+            // transitionOneDayEarlier is honored.
             return rule.Transitions.some(t => {
-                if (t.Days !== undefined && daysSinceInitiated >= t.Days) {
-                    return true;
-                }
-                if (t.Date && t.Date < currentDate) {
-                    return true;
-                }
-                return false;
+                const transitionTime = this._lifecycleDateTime.getTransitionTimestamp(t, lastModified);
+                return transitionTime !== null && transitionTime <= currentDate;
             });
         }
 
@@ -881,7 +879,7 @@ class LifecycleTask extends BackbeatTask {
 
             if (versioningStatus === 'Enabled' || versioningStatus === 'Suspended') {
                 if (entity.IsLatest) {
-                    return this._isRuleApplying(rule, daysSinceInitiated, currentDate);
+                    return this._isRuleApplying(rule, daysSinceInitiated, currentDate, entity.LastModified);
                 }
 
                 if (!staleDate) {
@@ -900,14 +898,17 @@ class LifecycleTask extends BackbeatTask {
 
                 if (rule.NoncurrentVersionTransitions && rule.NoncurrentVersionTransitions.length > 0
                     && this._supportedRules.includes('NoncurrentVersionTransition')) {
-                    return rule.NoncurrentVersionTransitions.some(t =>
-                        (t.NoncurrentDays !== undefined && daysSinceInitiated >= t.NoncurrentDays));
+                    return rule.NoncurrentVersionTransitions.some(t => {
+                        const transitionTime = this._lifecycleDateTime
+                            .getNCVTransitionTimestamp(t, entity.LastModified);
+                        return transitionTime !== undefined && transitionTime <= currentDate;
+                    });
                 }
 
                 return false;
             }
 
-            return this._isRuleApplying(rule, daysSinceInitiated, currentDate);
+            return this._isRuleApplying(rule, daysSinceInitiated, currentDate, entity.LastModified);
         });
     }
 
@@ -1356,12 +1357,15 @@ class LifecycleTask extends BackbeatTask {
      */
     _checkAndApplyNCVTransitionRule(bucketData, version, rules, log, cb) {
         const staleDate = version.staleDate;
-        const daysSinceInitiated = this._lifecycleDateTime.findDaysSince(new Date(staleDate));
         const ncvt = 'NoncurrentVersionTransition';
         const ncd = 'NoncurrentDays';
-        const doesNCVTransitionRuleApply = (rules[ncvt] &&
-            rules[ncvt][ncd] !== undefined &&
-            daysSinceInitiated >= rules[ncvt][ncd]);
+        // Same computation as getApplicableNCVTransition, so that
+        // transitionOneDayEarlier is honored.
+        const ncvTransitionTime = rules[ncvt] && rules[ncvt][ncd] !== undefined ?
+            this._lifecycleDateTime.getNCVTransitionTimestamp(rules[ncvt], staleDate) :
+            undefined;
+        const doesNCVTransitionRuleApply = ncvTransitionTime !== undefined &&
+            ncvTransitionTime <= this._lifecycleDateTime.getCurrentDate();
 
         if (doesNCVTransitionRuleApply) {
             this._applyTransitionRule({

--- a/tests/unit/lifecycle/LifecycleTask.spec.js
+++ b/tests/unit/lifecycle/LifecycleTask.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const { promisify } = require('util');
 const async = require('async');
 const sinon = require('sinon');
 const { errors } = require('arsenal');
@@ -1485,6 +1486,79 @@ describe('lifecycle task helper methods', () => {
 
             const result = lct._isEntityEligible(rules, nonCurrentDeleteMarker, versioningStatus);
             assert.strictEqual(result, true);
+        });
+
+        describe('with transitionOneDayEarlier', () => {
+            let lctEarlier;
+
+            before(() => {
+                lctEarlier = new LifecycleTask({
+                    getStateVars: () => ({
+                        ncvHeap: new Map(),
+                        lcOptions: { ...timeOptions, transitionOneDayEarlier: true },
+                        log: fakeLogger,
+                        supportedRules: ValidLifecycleRules,
+                    }),
+                });
+            });
+
+            const transitionRules = [
+                {
+                    ID: 'id1',
+                    Prefix: '',
+                    Status: 'Enabled',
+                    Transitions: [{ Days: 1, StorageClass: 'cold' }],
+                    NoncurrentVersionTransitions: [],
+                },
+            ];
+
+            it('should return false if 1 day transition rule on 1 hour old object without the flag', () => {
+                object.LastModified = new Date(Date.now() - HOUR).toISOString();
+
+                const result = lct._isEntityEligible(transitionRules, object, 'Disabled');
+                assert.strictEqual(result, false);
+            });
+
+            it('should return true if 1 day transition rule on 1 hour old object with the flag', () => {
+                object.LastModified = new Date(Date.now() - HOUR).toISOString();
+
+                const result = lctEarlier._isEntityEligible(transitionRules, object, 'Disabled');
+                assert.strictEqual(result, true);
+            });
+
+            it('should return true if 1 day ncv transition rule on 1 hour old version with the flag', () => {
+                const rules = [
+                    {
+                        ID: 'id1',
+                        Prefix: '',
+                        Status: 'Enabled',
+                        Transitions: [],
+                        NoncurrentVersionTransitions: [{ NoncurrentDays: 1, StorageClass: 'cold' }],
+                    },
+                ];
+                nonCurrentVersion.LastModified = new Date(Date.now() - HOUR).toISOString();
+                nonCurrentVersion.staleDate = new Date(Date.now() - HOUR).toISOString();
+
+                const result = lctEarlier._isEntityEligible(rules, nonCurrentVersion, 'Enabled');
+                assert.strictEqual(result, true);
+            });
+
+            it('should apply 1 day ncv transition rule on 1 hour old version with the flag', async () => {
+                const bucketData = { target: { owner: 'o', accountId: 'a', bucket: 'b' } };
+                const applicableRules = {
+                    NoncurrentVersionTransition: { NoncurrentDays: 1, StorageClass: 'cold' },
+                };
+                nonCurrentVersion.staleDate = new Date(Date.now() - HOUR).toISOString();
+                const applyStub = sinon.stub(lctEarlier, '_applyTransitionRule')
+                    .callsFake((params, log, cb) => cb());
+                const checkAndApplyNCVTransitionRule =
+                    promisify(lctEarlier._checkAndApplyNCVTransitionRule.bind(lctEarlier));
+
+                await checkAndApplyNCVTransitionRule(
+                    bucketData, nonCurrentVersion, applicableRules, fakeLogger);
+
+                assert.strictEqual(applyStub.calledOnce, true);
+            });
         });
     });
 


### PR DESCRIPTION
The v1 eligibility pre-filter and the noncurrent version transition apply compared raw rule days, ignoring transitionOneDayEarlier, so eligible objects were silently skipped while the current version apply stage honors the flag. Compute eligibility with LifecycleDateTime, as the apply stage does.

Issue: BB-867