### PR TITLE
Keep only the targeted backend in the replica metadata

### DIFF
--- a/lib/models/ObjectQueueEntry.js
+++ b/lib/models/ObjectQueueEntry.js
@@ -232,9 +232,15 @@ class ObjectQueueEntry extends ObjectMD {
 
     toReplicaEntry(backend) {
         const newEntry = this.clone();
+
+        // clone() shares replicationInfo with the source: detach before mutating.
+        newEntry.setReplicationInfo(this.getReplicationInfo());
+        const matched = newEntry._findBackend(backend);
+
         newEntry
             .setAccountId(this.getAccountId())
             .setBucket(this.getReplicationTargetBucket(backend))
+            .setReplicationBackends(matched ? [{ ...matched }] : [])
             .setReplicationSiteStatus(backend, 'REPLICA')
             .setReplicationStatus('REPLICA');
         return newEntry;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backbeat",
-  "version": "9.5.2",
+  "version": "9.5.3",
   "description": "Asynchronous queue and job manager",
   "main": "index.js",
   "scripts": {

--- a/tests/unit/lib/models/ObjectQueueEntry.spec.js
+++ b/tests/unit/lib/models/ObjectQueueEntry.spec.js
@@ -144,6 +144,21 @@ describe('ObjectQueueEntry', () => {
             assert.strictEqual(replicaA.getBucket(), 'bucket-a');
             assert.strictEqual(replicaB.getBucket(), 'bucket-b');
         });
+
+        it('toReplicaEntry drops the other destinations statuses', () => {
+            const entry = _makeEntryWithBackends([
+                { site: 'siteA', status: 'PENDING', dataStoreVersionId: '' },
+                { site: 'siteB', status: 'PENDING', dataStoreVersionId: '' },
+            ]);
+
+            const replica = entry.toReplicaEntry({ site: 'siteB' });
+            assert.deepStrictEqual(
+                replica.getReplicationBackends().map(b => b.site), ['siteB']);
+            assert.strictEqual(replica.getReplicationSiteStatus({ site: 'siteB' }), 'REPLICA');
+            assert.strictEqual(replica.getReplicationStatus(), 'REPLICA');
+            assert.strictEqual(entry.getReplicationBackends().length, 2);
+            assert.strictEqual(entry.getReplicationSiteStatus({ site: 'siteB' }), 'PENDING');
+        });
     });
 
     describe('same-site backend disambiguation', () => {


### PR DESCRIPTION
toReplicaEntry cloned the source entry and only updated the targeted backend, so the destination metadata inherited the statuses of the source's other destinations, frozen at queue time and never refreshed. Keep the targeted backend alone, copying it since clone() shares replicationInfo with the source.

Issue: BB-875